### PR TITLE
add (and run) prettier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
+# dependencies
 node_modules
+
+# misc
+.DS_Store
+
+npm-debug.log*

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -3840,6 +3840,14 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3848,14 +3856,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -6738,6 +6738,12 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.1.tgz",
+      "integrity": "sha512-oYpQsZk7/0o8+YJUB0LfjkTYQa79gUIF2ESeqvG23IzcgqqvmeOE4+lMG7E/UKX3q3RIj8JHSfhrXWhon1L+zA==",
+      "dev": true
+    },
     "pretty-format": {
       "version": "21.2.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
@@ -7689,6 +7695,15 @@
         "xtend": "4.0.1"
       }
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -7747,15 +7762,6 @@
             "ansi-regex": "3.0.0"
           }
         }
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,8 @@
     "build": "webpack -p",
     "lint": "eslint src/**/*.js",
     "start": "webpack-dev-server --host 0.0.0.0 --port 8000 --content-base src/",
-    "test": "jest"
+    "test": "jest",
+    "prettier": "prettier --single-quote --trailing-comma none --write \"src/**/*.js\""
   },
   "repository": {
     "type": "git",
@@ -51,6 +52,7 @@
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.5.1",
     "jest": "^21.2.1",
+    "prettier": "^1.9.1",
     "webpack": "^3.10.0",
     "webpack-dev-server": "^2.9.7"
   },

--- a/web/src/hello.js
+++ b/web/src/hello.js
@@ -1,9 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Hello = props => (
-  <div>Hello {props.name}!</div>
-);
+const Hello = props => <div>Hello {props.name}!</div>;
 
 Hello.propTypes = {
   name: PropTypes.string

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -12,7 +12,13 @@ module.exports = {
     rules: [
       {
         test: /\.jsx?$/,
-        use: ['babel-loader?presets=[]=env,presets[]=react']
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['env', 'react']
+          }
+        }
       }
     ]
   }


### PR DESCRIPTION
this PR adds [prettier](https://github.com/prettier/prettier), and subsequently runs prettier across all js files

prettier is a code formatter than ensures consistency and standardization around things like putting a semi-colon at the end of statements, proper indentation, maximum line width.

it can be run across all files via `npm run prettier`; you can also add a prettier extension to your code editor of choice (atom, sublime, etc) so that it auto-formats the file you're working on when you save (optional, though encouraged).