### PR TITLE
Fix README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-[![CircleCI](https://circleci.com/gh/18F/cms-hitech-apd.svg?style=svg)](https://circleci.com/gh/18F/cms-hitech-apd)
-[![Maintainability](https://api.codeclimate.com/v1/badges/e5baeb5a72cd0db71894/maintainability)](https://codeclimate.com/github/18F/cms-hitech-apd/maintainability)
-[![codecov](https://codecov.io/gh/18F/cms-hitech-apd/branch/master/graph/badge.svg)](https://codecov.io/gh/18F/cms-hitech-apd)
+[![Build status](https://img.shields.io/circleci/project/github/18F/cms-hitech-apd.svg)](https://circleci.com/gh/18F/cms-hitech-apd)
+[![Maintainability](https://img.shields.io/codeclimate/maintainability/18F/cms-hitech-apd.svg)](https://codeclimate.com/github/18F/cms-hitech-apd/maintainability)
+[![Test coverage](https://img.shields.io/codecov/c/github/18F/cms-hitech-apd.svg)](https://codecov.io/gh/18F/cms-hitech-apd)
+[![Dependency status](https://img.shields.io/gemnasium/18F/cms-hitech-apd.svg)](https://gemnasium.com/github.com/18F/cms-hitech-apd)
 
 # CMS HITECH APD app
 


### PR DESCRIPTION
* Switch badges to shield.io so they are visually consistent and cache properly
  * the CircleCI badge looks different from all the others and the CodeClimate badge is broken in Github cache
* Add a badge for Gemnasium dependency checking
  * at the time of opening this PR, the Gemnasium build was still queued, so the badge may appear gray for a while)

~~Hold this PR until Gemnasium is synced, just in case there's anything wrong with the config that still needs to be banged out.~~  Scratch that, Gemnasium won't update until `master` is changed, which means merging a PR, so let's go for it.