### PR TITLE
Add API app to cloud.gov manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,6 +2,11 @@
 applications:
   - name: hitech-apd-frontend
     path: web/dist
-    memory: 128M
+    memory: 64M
     host: hitech-apd
     buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+  - name: hitech-apd-api
+    memory: 128M
+    path: api
+    host: hitech-api
+    buildpack: https://github.com/cloudfoundry/nodejs-buildpack.git


### PR DESCRIPTION
* Adds an app for the API to the cloud.gov manifest
* Lowers the memory quota for the frontend