### PR TITLE
Authentication scaffolding

### DIFF
--- a/api/.eslintrc.json
+++ b/api/.eslintrc.json
@@ -1,7 +1,8 @@
 {
   "extends": "airbnb-base",
   "rules": {
-    "comma-dangle": [1, "never"]
+    "comma-dangle": [1, "never"],
+    "prefer-destructuring": [0]
   },
   "env": {
     "node": true,

--- a/api/auth/authenticate.js
+++ b/api/auth/authenticate.js
@@ -1,0 +1,7 @@
+module.exports = (username, password, done) => {
+  if (username === 'hello' && password === 'world') {
+    done(null, { username, email: 'hello@world.com', id: 'user-id' });
+  } else {
+    done('Unknown user');
+  }
+};

--- a/api/auth/authenticate.js
+++ b/api/auth/authenticate.js
@@ -1,7 +1,10 @@
 module.exports = (username, password, done) => {
+  // Check the username and password.  If it's good, callback
+  // with a valid user object.
   if (username === 'hello' && password === 'world') {
     done(null, { username, email: 'hello@world.com', id: 'user-id' });
   } else {
+    // Otherwise, callback with an error.
     done('Unknown user');
   }
 };

--- a/api/auth/index.js
+++ b/api/auth/index.js
@@ -1,0 +1,48 @@
+const crypto = require('crypto');
+const sessions = require('client-sessions');
+const passport = require('passport');
+const LocalStrategy = require('passport-local');
+
+const session = sessions({
+  cookieName: 'user', // this is the cookie name passport writes to
+  secret: crypto.randomBytes(256),
+  duration: 14 * 24 * 60 * 60 * 1000, // session lifetime, in milliseconds
+  cookie: {
+    httpOnly: true
+  }
+});
+
+const authenticate = (username, password, done) => {
+  if (username === 'hello' && password === 'world') {
+    done(null, { username, email: 'hello@world.com', token: 'auth-token' });
+  } else {
+    done('No idea who that is');
+  }
+};
+
+const serializeUser = (user, done) => {
+  done(null, user.token);
+};
+
+const deserializeUser = (token, done) => {
+  done(null, { username: 'hello', email: 'hello@world.com', token });
+};
+
+module.exports.setup = function setup(app) {
+  passport.use(new LocalStrategy(authenticate));
+  passport.serializeUser(serializeUser);
+  passport.deserializeUser(deserializeUser);
+
+  app.use(session);
+  app.use(passport.initialize());
+  app.use(passport.session());
+
+  app.use((req, res, next) => {
+    req.user = req.headers.authorization;
+    next();
+  });
+
+  app.post('/auth/login', passport.authenticate('local'), (req, res) => {
+    res.send({ bearer: req.user.token });
+  });
+};

--- a/api/auth/index.js
+++ b/api/auth/index.js
@@ -5,25 +5,40 @@ const authenticate = require('./authenticate');
 const serialization = require('./serialization');
 const sessionFunction = require('./session').getSessionFunction();
 
-module.exports.strategies = [
+module.exports.defaultStrategies = [
   new LocalStrategy(authenticate)
 ];
+
+// This setup method configures passport and inserts it into
+// the express middleware. After a successful authentication,
+// passport will store a serialized representation of the user
+// in a session, which (as configured here, by default) is a
+// browser cookie.
+//
+// In endpoint handlers, the req.user variable will be set
+// to the deserialized user object if the user is
+// authenticated. Otherwise it will be null.
 
 module.exports.setup = function setup(
   app,
   passport = Passport,
-  strategies = module.exports.strategies,
+  strategies = module.exports.defaultStrategies,
   session = sessionFunction
 ) {
+  // Handle all of the authentication strategies that we support
   strategies.forEach(strategy => passport.use(strategy));
 
+  // Register our user serialization methods with passport
   passport.serializeUser(serialization.serializeUser);
   passport.deserializeUser(serialization.deserializeUser);
 
+  // Add our session function and passport to our app's
+  // middleware
   app.use(session);
   app.use(passport.initialize());
   app.use(passport.session());
 
+  // Add a local authentication endpoint
   app.post('/auth/login', passport.authenticate('local'), (req, res) => {
     res.send({ bearer: req.user.id });
   });

--- a/api/auth/serialization.js
+++ b/api/auth/serialization.js
@@ -1,0 +1,7 @@
+module.exports.serializeUser = (user, done) => {
+  done(null, user.id);
+};
+
+module.exports.deserializeUser = (userID, done) => {
+  done(null, { username: 'hello', email: 'hello@world.com', id: userID });
+};

--- a/api/auth/serialization.js
+++ b/api/auth/serialization.js
@@ -1,7 +1,11 @@
+// Serialize a user into a stringy type that will get
+// pushed into their session cookie.
 module.exports.serializeUser = (user, done) => {
   done(null, user.id);
 };
 
+// Deserialize a stringy from the user's session cookie
+// into a user object.
 module.exports.deserializeUser = (userID, done) => {
   done(null, { username: 'hello', email: 'hello@world.com', id: userID });
 };

--- a/api/auth/session.js
+++ b/api/auth/session.js
@@ -1,0 +1,12 @@
+const clientSessions = require('client-sessions');
+
+module.exports.getSessionFunction = function getSessionFunction(sessions = clientSessions) {
+  return sessions({
+    cookieName: 'user', // this is the cookie name passport writes to
+    secret: process.env.SESSION_SECRET,
+    duration: 14 * 24 * 60 * 60 * 1000, // session lifetime, in milliseconds
+    cookie: {
+      httpOnly: true
+    }
+  });
+};

--- a/api/auth/session.js
+++ b/api/auth/session.js
@@ -4,7 +4,7 @@ const clientSessions = require('client-sessions');
 // configures the cookie that will be used.
 module.exports.getSessionFunction = function getSessionFunction(sessions = clientSessions) {
   return sessions({
-    cookieName: 'user', // passport's session support writes to the 'user' cookie, so we have to use that name
+    cookieName: 'session', // passport's session support writes to the 'session' cookie, so we have to use that name
     secret: process.env.SESSION_SECRET, // crypto secret, used to encrypt the session cookie
     duration: 14 * 24 * 60 * 60 * 1000, // session lifetime, in milliseconds
     cookie: {

--- a/api/auth/session.js
+++ b/api/auth/session.js
@@ -1,9 +1,11 @@
 const clientSessions = require('client-sessions');
 
+// Sets up sessions to be stored in browser cookies.  This
+// configures the cookie that will be used.
 module.exports.getSessionFunction = function getSessionFunction(sessions = clientSessions) {
   return sessions({
-    cookieName: 'user', // this is the cookie name passport writes to
-    secret: process.env.SESSION_SECRET,
+    cookieName: 'user', // passport's session support writes to the 'user' cookie, so we have to use that name
+    secret: process.env.SESSION_SECRET, // crypto secret, used to encrypt the session cookie
     duration: 14 * 24 * 60 * 60 * 1000, // session lifetime, in milliseconds
     cookie: {
       httpOnly: true

--- a/api/env.js
+++ b/api/env.js
@@ -5,4 +5,9 @@ const defaults = {
 };
 
 dotenv.config();
-Object.assign(process.env, defaults);
+
+Object.keys(defaults).forEach((env) => {
+  if (!process.env[env]) {
+    process.env[env] = defaults[env];
+  }
+});

--- a/api/env.js
+++ b/api/env.js
@@ -7,9 +7,4 @@ const defaults = {
 };
 
 dotenv.config();
-
-Object.keys(defaults).forEach((env) => {
-  if (!process.env[env]) {
-    process.env[env] = defaults[env];
-  }
-});
+process.env = Object.assign({}, defaults, process.env);

--- a/api/env.js
+++ b/api/env.js
@@ -1,7 +1,9 @@
+const crypto = require('crypto');
 const dotenv = require('dotenv');
 
 const defaults = {
-  PORT: 8000
+  PORT: 8000,
+  SESSION_SECRET: crypto.randomBytes(32).toString('hex')
 };
 
 dotenv.config();

--- a/api/main.js
+++ b/api/main.js
@@ -1,7 +1,14 @@
 require('./env');
 const express = require('express');
+const auth = require('./auth');
 
 const server = express();
+
+server.use(express.urlencoded({
+  extended: true
+}));
+
+auth.setup(server);
 
 server.get('*', (req, res) => {
   res.send({ hello: 'world' });

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1252,6 +1252,14 @@
         "mime-types": "2.1.17"
       }
     },
+    "formatio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+      "requires": {
+        "samsam": "1.3.0"
+      }
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -2384,8 +2392,7 @@
     "has-flag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-      "dev": true
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
     },
     "hawk": {
       "version": "3.1.3",
@@ -2810,6 +2817,11 @@
         }
       }
     },
+    "just-extend": {
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
+      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g=="
+    },
     "keygrip": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.2.tgz",
@@ -2957,6 +2969,11 @@
         "lodash.restparam": "3.6.1"
       }
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -2991,6 +3008,11 @@
       "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
       "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
       "dev": true
+    },
+    "lolex": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.1.tgz",
+      "integrity": "sha512-mQuW55GhduF3ppo+ZRUTz1PRjEh1hS5BbqU7d8D0ez2OKxHDod7StPPeAVKisZR5aLkHZjdGWSL42LSONUJsZw=="
     },
     "lowercase-keys": {
       "version": "1.0.0",
@@ -3160,6 +3182,38 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+    },
+    "nise": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.0.tgz",
+      "integrity": "sha512-q9jXh3UNsMV28KeqI43ILz5+c3l+RiNW8mhurEwCKckuHQbL+hTJIKKTiUlCPKlgQ/OukFvSnKB/Jk3+sFbkGA==",
+      "requires": {
+        "formatio": "1.2.0",
+        "just-extend": "1.1.27",
+        "lolex": "1.6.0",
+        "path-to-regexp": "1.7.0",
+        "text-encoding": "0.6.4"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "lolex": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY="
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "nodemon": {
       "version": "1.12.7",
@@ -5444,6 +5498,11 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
+    "samsam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg=="
+    },
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
@@ -5521,6 +5580,35 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "sinon": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.1.3.tgz",
+      "integrity": "sha512-c7u0ZuvBRX1eXuB4jN3BRCAOGiUTlM8SE3TxbJHrNiHUKL7wonujMOB6Fi1gQc00U91IscFORQHDga/eccqpbw==",
+      "requires": {
+        "diff": "3.4.0",
+        "formatio": "1.2.0",
+        "lodash.get": "4.4.2",
+        "lolex": "2.3.1",
+        "nise": "1.2.0",
+        "supports-color": "4.5.0",
+        "type-detect": "4.0.5"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
+          "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA=="
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
     },
     "slice-ansi": {
       "version": "1.0.0",
@@ -5802,6 +5890,11 @@
         "execa": "0.7.0"
       }
     },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -5886,6 +5979,11 @@
       "requires": {
         "prelude-ls": "1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
+      "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ=="
     },
     "type-is": {
       "version": "1.6.15",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -451,6 +451,14 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
+    "client-sessions": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/client-sessions/-/client-sessions-0.8.0.tgz",
+      "integrity": "sha1-p9jFVYrV1W8qGZ81M+tlS134k/0=",
+      "requires": {
+        "cookies": "0.7.1"
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -549,6 +557,15 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cookies": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.7.1.tgz",
+      "integrity": "sha1-fIphX1SBxhq58WyDNzG8uPZjuZs=",
+      "requires": {
+        "depd": "1.1.1",
+        "keygrip": "1.0.2"
+      }
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -2793,6 +2810,11 @@
         }
       }
     },
+    "keygrip": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.2.tgz",
+      "integrity": "sha1-rTKXxVcGneqLz+ek+kkbdcXd65E="
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -4941,6 +4963,28 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
       "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
     },
+    "passport": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.0.tgz",
+      "integrity": "sha1-xQlWkTR71a07XhgCOMORTRbwWBE=",
+      "requires": {
+        "passport-strategy": "1.0.0",
+        "pause": "0.0.1"
+      }
+    },
+    "passport-local": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
+      "integrity": "sha1-H+YyaMkudWBmJkN+O5BmYsFbpu4=",
+      "requires": {
+        "passport-strategy": "1.0.0"
+      }
+    },
+    "passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+    },
     "path-exists": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
@@ -4987,6 +5031,11 @@
       "requires": {
         "pify": "2.3.0"
       }
+    },
+    "pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
     "pause-stream": {
       "version": "0.0.11",

--- a/api/package.json
+++ b/api/package.json
@@ -38,7 +38,8 @@
     "dotenv": "^4.0.0",
     "express": "^4.16.2",
     "passport": "^0.4.0",
-    "passport-local": "^1.0.0"
+    "passport-local": "^1.0.0",
+    "sinon": "^4.1.3"
   },
   "devDependencies": {
     "eslint": "^4.12.1",

--- a/api/package.json
+++ b/api/package.json
@@ -34,8 +34,11 @@
   },
   "homepage": "https://github.com/18F/cms-hitech-apd#readme",
   "dependencies": {
+    "client-sessions": "^0.8.0",
     "dotenv": "^4.0.0",
-    "express": "^4.16.2"
+    "express": "^4.16.2",
+    "passport": "^0.4.0",
+    "passport-local": "^1.0.0"
   },
   "devDependencies": {
     "eslint": "^4.12.1",

--- a/api/tests/auth/authenticate.js
+++ b/api/tests/auth/authenticate.js
@@ -1,0 +1,35 @@
+const tap = require('tap');
+const sinon = require('sinon');
+
+const auth = require('../../auth/authenticate.js');
+
+tap.test('local authentication', (authTest) => {
+  const doneCallback = sinon.spy();
+  authTest.beforeEach((done) => {
+    doneCallback.reset();
+    done();
+  });
+
+  authTest.test('with invalid username', (invalidTest) => {
+    auth(null, 'world', doneCallback);
+    invalidTest.equal(doneCallback.callCount, 1, 'called done callback once');
+    invalidTest.ok(doneCallback.calledWith(sinon.match.truthy), 'got an error message');
+    invalidTest.done();
+  });
+
+  authTest.test('with invalid password', (invalidTest) => {
+    auth('hello', null, doneCallback);
+    invalidTest.equal(doneCallback.callCount, 1, 'called done callback once');
+    invalidTest.ok(doneCallback.calledWith(sinon.match.truthy), 'got an error message');
+    invalidTest.done();
+  });
+
+  authTest.test('with invalid password', (validTest) => {
+    auth('hello', 'world', doneCallback);
+    validTest.equal(doneCallback.callCount, 1, 'called done callback once');
+    validTest.ok(doneCallback.calledWith(null, sinon.match.any), 'did not get an error message, did get a user object');
+    validTest.done();
+  });
+
+  authTest.done();
+});

--- a/api/tests/auth/index.js
+++ b/api/tests/auth/index.js
@@ -46,6 +46,8 @@ tap.test('authentication setup', (authTest) => {
     setupTest.ok(passport.deserializeUser.calledOnce, 'user deserialization function is set once');
 
     setupTest.ok(passport.authenticate.calledOnce, 'passport authenticate method is inserted one time');
+    setupTest.ok(passport.authenticate.calledWith('local'), 'passport local authentication method is used');
+
     setupTest.ok(app.post.calledOnce, 'a single POST endpoint is added to the app');
     setupTest.ok(app.post.calledWith('/auth/login', 'passport-authenticate', sinon.match.func));
 

--- a/api/tests/auth/index.js
+++ b/api/tests/auth/index.js
@@ -1,0 +1,82 @@
+const tap = require('tap');
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+
+process.env.SESSION_SECRET = 'secret';
+const authSetup = require('../../auth').setup;
+
+tap.test('authentication setup', (authTest) => {
+  const app = {
+    use: sandbox.spy(),
+    post: sandbox.spy()
+  };
+
+  const passport = {
+    use: sandbox.spy(),
+    serializeUser: sandbox.spy(),
+    deserializeUser: sandbox.spy(),
+    initialize: sandbox.stub().returns('passport-initialize'),
+    session: sandbox.stub().returns('passport-session'),
+    authenticate: sandbox.stub().returns('passport-authenticate')
+  };
+
+  const strategies = ['strategy1', 'strategy2'];
+
+  authTest.beforeEach((done) => {
+    sandbox.resetHistory();
+    done();
+  });
+
+  authTest.test('setup calls everything we expect it to', (setupTest) => {
+    authSetup(app, passport, strategies);
+
+    setupTest.equal(app.use.callCount, 3, 'three middleware functions added to app');
+    setupTest.ok(app.use.calledWith(sinon.match.func), 'adds session function to middleware');
+    setupTest.ok(app.use.calledWith('passport-initialize'), 'adds passport initialization to middleware');
+    setupTest.ok(app.use.calledWith('passport-session'), 'adds passport session to middleware');
+
+    setupTest.equal(passport.use.callCount, 2, 'two passport strategies are configured');
+    setupTest.ok(passport.use.calledWith('strategy1'), 'first strategy is registered');
+    setupTest.ok(passport.use.calledWith('strategy2'), 'second strategy is registered');
+
+    setupTest.ok(passport.initialize.calledOnce, 'passport is initialized');
+    setupTest.ok(passport.session.calledOnce, 'passport session is setup');
+
+    setupTest.ok(passport.serializeUser.calledOnce, 'user serialization function is set once');
+    setupTest.ok(passport.deserializeUser.calledOnce, 'user deserialization function is set once');
+
+    setupTest.ok(passport.authenticate.calledOnce, 'passport authenticate method is inserted one time');
+    setupTest.ok(app.post.calledOnce, 'a single POST endpoint is added to the app');
+    setupTest.ok(app.post.calledWith('/auth/login', 'passport-authenticate', sinon.match.func));
+
+    setupTest.done();
+  });
+
+  authTest.test('setup works with defaults, too', (setupTest) => {
+    authSetup(app);
+
+    setupTest.equal(app.use.callCount, 3, 'three middleware functions added to app');
+    setupTest.ok(app.post.calledOnce, 'a single POST endpoint is added to the app');
+    setupTest.ok(app.post.calledWith('/auth/login', sinon.match.func, sinon.match.func));
+
+    setupTest.done();
+  });
+
+  authTest.test('POST endpoint behaves as expected', (postTest) => {
+    authSetup(app, passport, strategies);
+    const post = app.post.args[0][2];
+
+    const res = {
+      send: sinon.spy()
+    };
+
+    post({ user: { id: 'test-user-id' } }, res);
+
+    postTest.ok(res.send.calledOnce, 'a response is sent once');
+    postTest.ok(res.send.calledWithMatch({ bearer: 'test-user-id' }), 'sends an object with a bearer property of the user ID');
+
+    postTest.done();
+  });
+
+  authTest.done();
+});

--- a/api/tests/auth/serialization.js
+++ b/api/tests/auth/serialization.js
@@ -1,0 +1,29 @@
+const tap = require('tap');
+const sinon = require('sinon');
+
+const serialization = require('../../auth/serialization');
+
+tap.test('passport serialization', (serializationTest) => {
+  const doneCallback = sinon.spy();
+  serializationTest.beforeEach((done) => {
+    doneCallback.reset();
+    done();
+  });
+
+  serializationTest.test('serialize a user', (serializeTest) => {
+    const user = { id: 'the-user-id' };
+    serialization.serializeUser(user, doneCallback);
+    serializeTest.ok(doneCallback.calledWith(null, 'the-user-id'), 'serializes the user object');
+    serializeTest.done();
+  });
+
+  serializationTest.test('deserialize a user', (deserializeTest) => {
+    const userID = 'the-user-id';
+    serialization.deserializeUser(userID, doneCallback);
+    deserializeTest.ok(doneCallback.calledWith(null, sinon.match.object), 'deserializes the user ID to an object');
+    deserializeTest.equal(doneCallback.args[0][1].id, userID, 'output user object ID matches input user ID');
+    deserializeTest.done();
+  });
+
+  serializationTest.done();
+});

--- a/api/tests/auth/session.js
+++ b/api/tests/auth/session.js
@@ -11,7 +11,7 @@ tap.test('session function', (sessionTest) => {
 
   sessionTest.ok(sessions.calledWith(sinon.match.object), 'called with a configuration object');
   const config = sessions.args[0][0];
-  sessionTest.equal(config.cookieName, 'user', 'session uses the "user" cookie - required by passport');
+  sessionTest.equal(config.cookieName, 'session', 'session uses the "user" cookie - required by passport');
   sessionTest.equal(config.cookie.httpOnly, true, 'session cookie is HTTP-only');
   sessionTest.equal(config.secret, 'secret', 'session secret is set from environment');
   sessionTest.ok(config.duration < 30 * 24 * 60 * 60 * 1000, 'session cookie lasts less than 30 days');

--- a/api/tests/auth/session.js
+++ b/api/tests/auth/session.js
@@ -1,0 +1,19 @@
+const tap = require('tap');
+const sinon = require('sinon');
+
+const getSessionFunction = require('../../auth/session').getSessionFunction;
+
+tap.test('session function', (sessionTest) => {
+  const sessions = sinon.spy();
+
+  process.env.SESSION_SECRET = 'secret';
+  getSessionFunction(sessions);
+
+  sessionTest.ok(sessions.calledWith(sinon.match.object), 'called with a configuration object');
+  const config = sessions.args[0][0];
+  sessionTest.equal(config.cookieName, 'user', 'session uses the "user" cookie - required by passport');
+  sessionTest.equal(config.cookie.httpOnly, true, 'session cookie is HTTP-only');
+  sessionTest.equal(config.secret, 'secret', 'session secret is set from environment');
+  sessionTest.ok(config.duration < 30 * 24 * 60 * 60 * 1000, 'session cookie lasts less than 30 days');
+  sessionTest.done();
+});

--- a/api/tests/env.js
+++ b/api/tests/env.js
@@ -8,7 +8,8 @@ tap.beforeEach((done) => {
 
 tap.test('environment setup', (envTest) => {
   const knownEnvironmentVariables = [
-    { name: 'PORT', type: 'number' }
+    { name: 'PORT', type: 'number' },
+    { name: 'SESSION_SECRET', type: 'string' }
   ];
 
   envTest.test('sets default values for known environment variables', (setsDefaultTest) => {

--- a/api/tests/env.js
+++ b/api/tests/env.js
@@ -1,26 +1,34 @@
 const tap = require('tap');
 
 tap.beforeEach((done) => {
+  delete require.cache[require.resolve('../env')];
   process.env = { };
   done();
 });
 
 tap.test('environment setup', (envTest) => {
-  envTest.test('handles the PORT environment variable', (hostTest) => {
-    hostTest.test('sets default', (defaultTest) => {
-      require('../env'); // eslint-disable-line global-require
-      defaultTest.type(process.env.PORT, 'number', 'sets the PORT to a number');
-      defaultTest.end();
-    });
+  const knownEnvironmentVariables = [
+    { name: 'PORT', type: 'number' }
+  ];
 
-    hostTest.test('does not override', (overrideTest) => {
-      process.env.PORT = 'test-value';
-      require('../env'); // eslint-disable-line global-require
-      overrideTest.same(process.env.PORT, 'test-value', 'does not override the PORT variable');
-      overrideTest.end();
+  envTest.test('sets default values for known environment variables', (setsDefaultTest) => {
+    require('../env'); // eslint-disable-line global-require
+    knownEnvironmentVariables.forEach((envVar) => {
+      setsDefaultTest.type(process.env[envVar.name], envVar.type, `sets the ${envVar.name} to a ${envVar.type}`);
     });
-
-    hostTest.end();
+    setsDefaultTest.end();
   });
-  envTest.end();
+
+  envTest.test('does not override environment variables that have been set externally', (doesNotOverrideTest) => {
+    knownEnvironmentVariables.forEach((envVar) => {
+      process.env[envVar.name] = 'test-value';
+    });
+
+    require('../env'); // eslint-disable-line global-require
+    knownEnvironmentVariables.forEach((envVar) => {
+      doesNotOverrideTest.same(process.env[envVar.name], 'test-value', `does not override the ${envVar.name} variable`);
+    });
+    doesNotOverrideTest.end();
+  });
+  envTest.done();
 });


### PR DESCRIPTION
- fixes a bug in the way default environment variable values were being set
- adds Passport for authentication
  - sets up a local strategy
  - sets up a hard-coded username/password (`hello`/`world`) to get started
  - stores serialized auth info in an encrypted client cookie
  - deserializes auth info before processing API endpoint requests
- adds an API endpoint at `POST: /auth/login` that takes a username and password as form-encoded variables and returns the generated user ID
  - **note**: this isn't strictly necessary; the status code should be sufficient. If the user is logged in, their session cookie will be set and there's no reason to send their ID.  This was mostly just for illustration
- adds a bunch of tests

closes #30
impacts #35 and #33