### PR TITLE
Remove sudo in deploy script

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -37,6 +37,9 @@
     "dotenv": "^4.0.0",
     "express": "^4.16.2"
   },
+  "engines": {
+    "node": "^8.9"
+  },
   "devDependencies": {
     "eslint": "^4.12.1",
     "eslint-config-airbnb-base": "^12.1.0",

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -12,7 +12,7 @@ SPACE="brendan.sudol"
 
 # Install `cf` cli
 curl -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&source=github'
-sudo dpkg -i cf-cli_amd64.deb
+dpkg -i cf-cli_amd64.deb
 rm cf-cli_amd64.deb
 
 # Install `autopilot` plugin


### PR DESCRIPTION
Because our CircleCI config uses the official Node images, we don't need `sudo`.  The official images run as root and don't switch users, so there's no `sudo` installed.

Also adds a Node version to the package.json `engines` property.  Otherwise cloud.gov gives us 4.8, which just plain ol' doesn't work. 😆 