### PR TITLE
configurable db host field

### DIFF
--- a/api/knexfile.js
+++ b/api/knexfile.js
@@ -2,7 +2,7 @@ module.exports = {
   development: {
     client: 'postgresql',
     connection: {
-      host: 'db',
+      host: process.env.DEV_DB_HOST || 'db',
       database: 'hitech_apd',
       user: 'postgres',
       password: 'cms'


### PR DESCRIPTION
To support differing host values (i.e., if not using docker)

Example: `DEV_DB_HOST='localhost' npm run migrate`