### PR TITLE
add example new UI component

### DIFF
--- a/web/.eslintrc.json
+++ b/web/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": "airbnb",
   "rules": {
+    "arrow-parens": ["error", "as-needed"],
     "comma-dangle": [1, "never"],
     "react/jsx-filename-extension": 0,
     "jsx-a11y/anchor-is-valid": [

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -328,6 +328,12 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
+    "atob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
+      "integrity": "sha1-lfE2KbEsOlGl0hWr3OKqnzL4B3M=",
+      "dev": true
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -1817,6 +1823,29 @@
         "public-encrypt": "4.0.0",
         "randombytes": "2.0.5",
         "randomfill": "1.0.3"
+      }
+    },
+    "css": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
+      "integrity": "sha1-c6TIHehdtmTU7mdPfUcIXjstVdw=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "source-map": "0.1.43",
+        "source-map-resolve": "0.3.1",
+        "urix": "0.1.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
       }
     },
     "css-color-keywords": {
@@ -4123,7 +4152,7 @@
       "integrity": "sha512-+nRjHU+efD7PtzatdOEJfHuBwuFgx3o9a7k2r61RAPFXHLsat1y87HbLypoQkJbjUHvmCQqjDCXBjwGkEf0a7Q==",
       "requires": {
         "prop-types": "15.6.0",
-        "styled-components": "2.3.2",
+        "styled-components": "2.3.3",
         "styled-system": "1.1.1",
         "tag-hoc": "1.0.0"
       }
@@ -5559,6 +5588,15 @@
             "supports-color": "4.5.0"
           }
         }
+      }
+    },
+    "jest-styled-components": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/jest-styled-components/-/jest-styled-components-4.9.0.tgz",
+      "integrity": "sha1-RZzLN9D1cgAHyNujWL//k8jPSu0=",
+      "dev": true,
+      "requires": {
+        "css": "2.2.1"
       }
     },
     "jest-util": {
@@ -7284,7 +7322,7 @@
         "palx": "1.0.2",
         "prop-types": "15.6.0",
         "recompose": "0.23.5",
-        "styled-components": "2.3.2",
+        "styled-components": "2.3.3",
         "styled-system": "1.1.1",
         "tag-hoc": "1.0.0"
       }
@@ -7524,6 +7562,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
       "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg=="
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
     },
     "restore-cursor": {
       "version": "2.0.0",
@@ -7855,6 +7899,18 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
+    "source-map-resolve": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
+      "integrity": "sha1-YQ9hIqRFuN1RU1oqcbeD38Ekh2E=",
+      "dev": true,
+      "requires": {
+        "atob": "1.1.3",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.3.0",
+        "urix": "0.1.0"
+      }
+    },
     "source-map-support": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
@@ -7863,6 +7919,12 @@
       "requires": {
         "source-map": "0.5.7"
       }
+    },
+    "source-map-url": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
+      "integrity": "sha1-fsrxO1e80J2opAxdJp2zN5nUqvk=",
+      "dev": true
     },
     "spdx-correct": {
       "version": "1.0.2",
@@ -8077,9 +8139,9 @@
       "dev": true
     },
     "styled-components": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-2.3.2.tgz",
-      "integrity": "sha512-vX7l0HQ6i426d0cPLwQWLcFtg5BD7h5/P6w0e55XM3MuJlO5SrobBFEDp6TQzlLCAqMEc4fW4tQ87p6ds08F/g==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-2.3.3.tgz",
+      "integrity": "sha512-VdEBVplt2EDEvF107Zxh0+giYGgvzzZaDC6fuBiozDiQciii6xOGqMHLwLzkfX7Zvp1d4oaFY0uvVeoDbzK3Gw==",
       "requires": {
         "buffer": "5.0.8",
         "css-to-react-native": "2.0.4",
@@ -8492,6 +8554,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
     },
     "url": {
       "version": "0.11.0",

--- a/web/package.json
+++ b/web/package.json
@@ -43,7 +43,8 @@
     "react-router-dom": "^4.2.2",
     "react-router-redux": "^5.0.0-alpha.9",
     "rebass": "^1.0.4",
-    "redux": "^3.7.2"
+    "redux": "^3.7.2",
+    "styled-components": "^2.3.3"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",
@@ -59,7 +60,9 @@
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.5.1",
     "jest": "^21.2.1",
+    "jest-styled-components": "^4.9.0",
     "prettier": "^1.9.1",
+    "react-test-renderer": "^16.2.0",
     "redux-logger": "^3.0.6",
     "webpack": "^3.10.0",
     "webpack-dev-server": "^2.9.7"

--- a/web/src/components/Hello.js
+++ b/web/src/components/Hello.js
@@ -1,7 +1,18 @@
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
+import { Measure, Subhead } from 'rebass';
 
-const Hello = props => <h1>Hello {props.name}!</h1>;
+import Alert from '../styles/Alert';
+
+const Hello = props => (
+  <div>
+    <h1>Hello {props.name}!</h1>
+    <Alert kind="error">
+      <Subhead>Hey-oh!</Subhead>
+      <Measure>This is a fake alert :)</Measure>
+    </Alert>
+  </div>
+);
 
 Hello.propTypes = {
   name: PropTypes.string

--- a/web/src/components/Hello.test.js
+++ b/web/src/components/Hello.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { configure, mount } from 'enzyme';
+import { configure, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
 import Hello from './Hello';
@@ -8,12 +8,12 @@ configure({ adapter: new Adapter() });
 
 describe('the Hello component', () => {
   test('renders with a default name', () => {
-    const component = mount(<Hello />);
+    const component = shallow(<Hello />);
     expect(component).toMatchSnapshot();
   });
 
   test('renders with a provided name ', () => {
-    const component = mount(<Hello name="Test Person" />);
+    const component = shallow(<Hello name="Test Person" />);
     expect(component).toMatchSnapshot();
   });
 });

--- a/web/src/components/__snapshots__/Hello.test.js.snap
+++ b/web/src/components/__snapshots__/Hello.test.js.snap
@@ -1,8 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`the Hello component renders with a default name 1`] = `
-ReactWrapper {
+ShallowWrapper {
   "length": 1,
+  Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Hello
     name="Friend"
   />,
@@ -13,55 +14,33 @@ ReactWrapper {
     "simulateEvent": [Function],
     "unmount": [Function],
   },
-  Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__node__): Object {
     "instance": null,
     "key": undefined,
-    "nodeType": "function",
+    "nodeType": "host",
     "props": Object {
-      "name": "Friend",
-    },
-    "ref": null,
-    "rendered": Object {
-      "instance": <h1>
-        Hello 
-        Friend
-        !
-      </h1>,
-      "key": undefined,
-      "nodeType": "host",
-      "props": Object {
-        "children": Array [
-          "Hello ",
-          "Friend",
-          "!",
-        ],
-      },
-      "ref": null,
-      "rendered": Array [
-        "Hello ",
-        "Friend",
-        "!",
-      ],
-      "type": "h1",
-    },
-    "type": [Function],
-  },
-  Symbol(enzyme.__nodes__): Array [
-    Object {
-      "instance": null,
-      "key": undefined,
-      "nodeType": "function",
-      "props": Object {
-        "name": "Friend",
-      },
-      "ref": null,
-      "rendered": Object {
-        "instance": <h1>
+      "children": Array [
+        <h1>
           Hello 
           Friend
           !
         </h1>,
+        <Styled(Styled(Box))
+          kind="error"
+        >
+          <Styled(Styled(Base))>
+            Hey-oh!
+          </Styled(Styled(Base))>
+          <Styled(Styled(Base))>
+            This is a fake alert :)
+          </Styled(Styled(Base))>
+        </Styled(Styled(Box))>,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
         "key": undefined,
         "nodeType": "host",
         "props": Object {
@@ -79,7 +58,140 @@ ReactWrapper {
         ],
         "type": "h1",
       },
-      "type": [Function],
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "children": Array [
+            <Styled(Styled(Base))>
+              Hey-oh!
+            </Styled(Styled(Base))>,
+            <Styled(Styled(Base))>
+              This is a fake alert :)
+            </Styled(Styled(Base))>,
+          ],
+          "kind": "error",
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "children": "Hey-oh!",
+            },
+            "ref": null,
+            "rendered": "Hey-oh!",
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "children": "This is a fake alert :)",
+            },
+            "ref": null,
+            "rendered": "This is a fake alert :)",
+            "type": [Function],
+          },
+        ],
+        "type": [Function],
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <h1>
+            Hello 
+            Friend
+            !
+          </h1>,
+          <Styled(Styled(Box))
+            kind="error"
+          >
+            <Styled(Styled(Base))>
+              Hey-oh!
+            </Styled(Styled(Base))>
+            <Styled(Styled(Base))>
+              This is a fake alert :)
+            </Styled(Styled(Base))>
+          </Styled(Styled(Box))>,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              "Hello ",
+              "Friend",
+              "!",
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            "Hello ",
+            "Friend",
+            "!",
+          ],
+          "type": "h1",
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "children": Array [
+              <Styled(Styled(Base))>
+                Hey-oh!
+              </Styled(Styled(Base))>,
+              <Styled(Styled(Base))>
+                This is a fake alert :)
+              </Styled(Styled(Base))>,
+            ],
+            "kind": "error",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "children": "Hey-oh!",
+              },
+              "ref": null,
+              "rendered": "Hey-oh!",
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "children": "This is a fake alert :)",
+              },
+              "ref": null,
+              "rendered": "This is a fake alert :)",
+              "type": [Function],
+            },
+          ],
+          "type": [Function],
+        },
+      ],
+      "type": "div",
     },
   ],
   Symbol(enzyme.__options__): Object {
@@ -93,8 +205,9 @@ ReactWrapper {
 `;
 
 exports[`the Hello component renders with a provided name  1`] = `
-ReactWrapper {
+ShallowWrapper {
   "length": 1,
+  Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Hello
     name="Test Person"
   />,
@@ -105,55 +218,33 @@ ReactWrapper {
     "simulateEvent": [Function],
     "unmount": [Function],
   },
-  Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__node__): Object {
     "instance": null,
     "key": undefined,
-    "nodeType": "function",
+    "nodeType": "host",
     "props": Object {
-      "name": "Test Person",
-    },
-    "ref": null,
-    "rendered": Object {
-      "instance": <h1>
-        Hello 
-        Test Person
-        !
-      </h1>,
-      "key": undefined,
-      "nodeType": "host",
-      "props": Object {
-        "children": Array [
-          "Hello ",
-          "Test Person",
-          "!",
-        ],
-      },
-      "ref": null,
-      "rendered": Array [
-        "Hello ",
-        "Test Person",
-        "!",
-      ],
-      "type": "h1",
-    },
-    "type": [Function],
-  },
-  Symbol(enzyme.__nodes__): Array [
-    Object {
-      "instance": null,
-      "key": undefined,
-      "nodeType": "function",
-      "props": Object {
-        "name": "Test Person",
-      },
-      "ref": null,
-      "rendered": Object {
-        "instance": <h1>
+      "children": Array [
+        <h1>
           Hello 
           Test Person
           !
         </h1>,
+        <Styled(Styled(Box))
+          kind="error"
+        >
+          <Styled(Styled(Base))>
+            Hey-oh!
+          </Styled(Styled(Base))>
+          <Styled(Styled(Base))>
+            This is a fake alert :)
+          </Styled(Styled(Base))>
+        </Styled(Styled(Box))>,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
         "key": undefined,
         "nodeType": "host",
         "props": Object {
@@ -171,7 +262,140 @@ ReactWrapper {
         ],
         "type": "h1",
       },
-      "type": [Function],
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "children": Array [
+            <Styled(Styled(Base))>
+              Hey-oh!
+            </Styled(Styled(Base))>,
+            <Styled(Styled(Base))>
+              This is a fake alert :)
+            </Styled(Styled(Base))>,
+          ],
+          "kind": "error",
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "children": "Hey-oh!",
+            },
+            "ref": null,
+            "rendered": "Hey-oh!",
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "children": "This is a fake alert :)",
+            },
+            "ref": null,
+            "rendered": "This is a fake alert :)",
+            "type": [Function],
+          },
+        ],
+        "type": [Function],
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <h1>
+            Hello 
+            Test Person
+            !
+          </h1>,
+          <Styled(Styled(Box))
+            kind="error"
+          >
+            <Styled(Styled(Base))>
+              Hey-oh!
+            </Styled(Styled(Base))>
+            <Styled(Styled(Base))>
+              This is a fake alert :)
+            </Styled(Styled(Base))>
+          </Styled(Styled(Box))>,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              "Hello ",
+              "Test Person",
+              "!",
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            "Hello ",
+            "Test Person",
+            "!",
+          ],
+          "type": "h1",
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "children": Array [
+              <Styled(Styled(Base))>
+                Hey-oh!
+              </Styled(Styled(Base))>,
+              <Styled(Styled(Base))>
+                This is a fake alert :)
+              </Styled(Styled(Base))>,
+            ],
+            "kind": "error",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "children": "Hey-oh!",
+              },
+              "ref": null,
+              "rendered": "Hey-oh!",
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "children": "This is a fake alert :)",
+              },
+              "ref": null,
+              "rendered": "This is a fake alert :)",
+              "type": [Function],
+            },
+          ],
+          "type": [Function],
+        },
+      ],
+      "type": "div",
     },
   ],
   Symbol(enzyme.__options__): Object {

--- a/web/src/containers/Home.js
+++ b/web/src/containers/Home.js
@@ -5,8 +5,8 @@ import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
 import { ButtonOutline, Divider } from 'rebass';
 
-import Counter from '../components/Counter';
 import { decrement, increment } from '../actions';
+import Counter from '../components/Counter';
 
 const Home = ({ actions, total }) => (
   <div>

--- a/web/src/styles/Alert.js
+++ b/web/src/styles/Alert.js
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+import { Box } from 'rebass';
+
+export const alertColors = {
+  success: ['#e7f4e4', '#2e8540'],
+  warning: ['#fff1d2', '#fdb81e'],
+  error: ['#f9dede', '#e31c3d'],
+  info: ['#e1f3f8', '#02bfe7'],
+  fallback: ['#f1f1f1', '#8b8b8b']
+};
+
+const cssRules = kind => {
+  const colors = alertColors[kind] || alertColors.fallback;
+
+  return `
+    background-color: ${colors[0]};
+    border-left: 0.5rem solid ${colors[1]};
+  `;
+};
+
+const Alert = styled(Box)`
+  ${props => cssRules(props.kind)};
+  padding: 1rem;
+`;
+
+export default Alert;

--- a/web/src/styles/Alert.test.js
+++ b/web/src/styles/Alert.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+import 'jest-styled-components';
+
+import Alert, { alertColors as colors } from './Alert';
+
+describe('the Alert styled component', () => {
+  test('renders "success" alert', () => {
+    const tree = renderer.create(<Alert kind="success" />).toJSON();
+    expect(tree).toHaveStyleRule('background-color', colors.success[0]);
+  });
+
+  test('renders "warning" alert', () => {
+    const tree = renderer.create(<Alert kind="warning" />).toJSON();
+    expect(tree).toHaveStyleRule('background-color', colors.warning[0]);
+  });
+
+  test('renders "error" alert', () => {
+    const tree = renderer.create(<Alert kind="error" />).toJSON();
+    expect(tree).toHaveStyleRule('background-color', colors.error[0]);
+  });
+
+  test('renders fallback alert when unspecified', () => {
+    const tree = renderer.create(<Alert />).toJSON();
+    expect(tree).toHaveStyleRule('background-color', colors.fallback[0]);
+  });
+
+  test('renders fallback alert when type does not match', () => {
+    const tree = renderer.create(<Alert kind="foo" />).toJSON();
+    expect(tree).toHaveStyleRule('background-color', colors.fallback[0]);
+  });
+});


### PR DESCRIPTION
Added a new UI component -- an `Alert` box that extends Rebass's `Box` component.

It takes a `kind` parameter that can be `['success', 'warning', 'error', ...]`; these correspond with the USWDS alert names, and the output is a similarly styled element.

Preview:
<img width="1270" alt="preview" src="https://user-images.githubusercontent.com/1060893/34275597-030fd09a-e66c-11e7-8451-d56c83e7e4a3.png">
