### PR TITLE
run prettier on api directory

### DIFF
--- a/api/.eslintrc.json
+++ b/api/.eslintrc.json
@@ -1,7 +1,9 @@
 {
   "extends": "airbnb-base",
   "rules": {
+    "arrow-parens": ["error", "as-needed"],
     "comma-dangle": [1, "never"],
+    "function-paren-newline": [0],
     "prefer-destructuring": [0]
   },
   "env": {

--- a/api/auth/authenticate.js
+++ b/api/auth/authenticate.js
@@ -1,28 +1,27 @@
 const defaultDB = require('../db')();
 const defaultBcrypt = require('bcryptjs');
 
-module.exports = (
-  db = defaultDB,
-  bcrypt = defaultBcrypt
-) => ((username, password, done) => db('users')
-  .where({
-    email: username
-  })
-  .first()
-  .then((user) => {
-    // If there is a matching user, return it
-    if (user && bcrypt.compareSync(password, user.password)) {
-      done(null, { username: user.email, id: user.id });
-    } else {
-      // Otherwise, callback with a false user.  If we
-      // send an error, Passport will send a status 500,
-      // but if we send no error and a false user, it will
-      // send a 401, which is what we really want.  So...
-      // I guess a failed login isn't an error. :P
-      done(null, false);
-    }
-  })
-  .catch(() => {
-    done('Database error');
-  })
-);
+module.exports = (db = defaultDB, bcrypt = defaultBcrypt) => (
+  username,
+  password,
+  done
+) =>
+  db('users')
+    .where({ email: username })
+    .first()
+    .then(user => {
+      // If there is a matching user, return it
+      if (user && bcrypt.compareSync(password, user.password)) {
+        done(null, { username: user.email, id: user.id });
+      } else {
+        // Otherwise, callback with a false user.  If we
+        // send an error, Passport will send a status 500,
+        // but if we send no error and a false user, it will
+        // send a 401, which is what we really want.  So...
+        // I guess a failed login isn't an error. :P
+        done(null, false);
+      }
+    })
+    .catch(() => {
+      done('Database error');
+    });

--- a/api/auth/index.js
+++ b/api/auth/index.js
@@ -5,9 +5,7 @@ const authenticate = require('./authenticate')();
 const serialization = require('./serialization');
 const sessionFunction = require('./session').getSessionFunction();
 
-const defaultStrategies = [
-  new LocalStrategy(authenticate)
-];
+const defaultStrategies = [new LocalStrategy(authenticate)];
 
 // This setup method configures passport and inserts it into
 // the express middleware. After a successful authentication,

--- a/api/auth/serialization.js
+++ b/api/auth/serialization.js
@@ -8,13 +8,14 @@ module.exports.serializeUser = (user, done) => {
 
 // Deserialize a stringy from the user's session cookie
 // into a user object.
-module.exports.deserializeUser = (userID, done, db = defaultDB) => db('users')
-  .where({ id: userID })
-  .select()
-  .then((users) => {
-    if (users.length) {
-      done(null, { username: users[0].email, id: users[0].id });
-    } else {
-      done('Could not deserialize user');
-    }
-  });
+module.exports.deserializeUser = (userID, done, db = defaultDB) =>
+  db('users')
+    .where({ id: userID })
+    .select()
+    .then(users => {
+      if (users.length) {
+        done(null, { username: users[0].email, id: users[0].id });
+      } else {
+        done('Could not deserialize user');
+      }
+    });

--- a/api/auth/session.js
+++ b/api/auth/session.js
@@ -2,7 +2,9 @@ const clientSessions = require('client-sessions');
 
 // Sets up sessions to be stored in browser cookies.  This
 // configures the cookie that will be used.
-module.exports.getSessionFunction = function getSessionFunction(sessions = clientSessions) {
+module.exports.getSessionFunction = function getSessionFunction(
+  sessions = clientSessions
+) {
   return sessions({
     // Passport's session support writes to the 'session'
     // cookie, so we have to use that name

--- a/api/db.js
+++ b/api/db.js
@@ -1,4 +1,5 @@
 const defaultKnex = require('knex');
 const defaultConfig = require('./knexfile');
 
-module.exports = (knex = defaultKnex, config = defaultConfig) => knex(config[process.env.NODE_ENV]);
+module.exports = (knex = defaultKnex, config = defaultConfig) =>
+  knex(config[process.env.NODE_ENV]);

--- a/api/main.js
+++ b/api/main.js
@@ -4,9 +4,7 @@ const auth = require('./auth');
 
 const server = express();
 
-server.use(express.urlencoded({
-  extended: true
-}));
+server.use(express.urlencoded({ extended: true }));
 
 auth.setup(server);
 

--- a/api/migrations/20171218182739_initial.js
+++ b/api/migrations/20171218182739_initial.js
@@ -1,8 +1,8 @@
+exports.up = knex =>
+  knex.schema.createTable('users', table => {
+    table.increments();
+    table.text('email'); // who knows how long an email address might be
+    table.string('password', 60); // bcrypt hashes are 60 characters
+  });
 
-exports.up = knex => knex.schema.createTable('users', (table) => {
-  table.increments();
-  table.text('email'); // who knows how long an email address might be
-  table.string('password', 60); // bcrypt hashes are 60 characters
-});
-
-exports.down = knex => knex.schema.dropTable('users', () => { });
+exports.down = knex => knex.schema.dropTable('users', () => {});

--- a/api/seeds/development.js
+++ b/api/seeds/development.js
@@ -1,6 +1,6 @@
 const users = require('./development/users');
 
-exports.seed = (knex) => {
+exports.seed = knex => {
   // Don't seed this data if we're not in a development environment.
   if (process.env.NODE_ENV !== 'development') {
     return Promise.resolve();

--- a/api/seeds/development/users.js
+++ b/api/seeds/development/users.js
@@ -1,7 +1,11 @@
 const bcrypt = require('bcryptjs');
 
 // Deletes ALL existing entries
-exports.seed = knex => knex('users').del()
-  .then(() => knex('users').insert([
-    { id: 57, email: 'em@il.com', password: bcrypt.hashSync('password') }
-  ]));
+exports.seed = knex =>
+  knex('users')
+    .del()
+    .then(() =>
+      knex('users').insert([
+        { id: 57, email: 'em@il.com', password: bcrypt.hashSync('password') }
+      ])
+    );

--- a/api/seeds/test.js
+++ b/api/seeds/test.js
@@ -1,6 +1,6 @@
 const users = require('./test/users');
 
-exports.seed = (knex) => {
+exports.seed = knex => {
   // Don't seed this data if we're not in a test environment.
   if (process.env.NODE_ENV !== 'test') {
     return Promise.resolve();

--- a/api/seeds/test/users.js
+++ b/api/seeds/test/users.js
@@ -1,7 +1,11 @@
 const bcrypt = require('bcryptjs');
 
 // Deletes ALL existing entries
-exports.seed = knex => knex('users').del()
-  .then(() => knex('users').insert([
-    { id: 57, email: 'em@il.com', password: bcrypt.hashSync('password') }
-  ]));
+exports.seed = knex =>
+  knex('users')
+    .del()
+    .then(() =>
+      knex('users').insert([
+        { id: 57, email: 'em@il.com', password: bcrypt.hashSync('password') }
+      ])
+    );

--- a/api/tests/auth/authenticate.js
+++ b/api/tests/auth/authenticate.js
@@ -13,56 +13,63 @@ const bcrypt = {
 
 const auth = require('../../auth/authenticate.js')(db, bcrypt);
 
-tap.test('local authentication', (authTest) => {
+tap.test('local authentication', authTest => {
   const doneCallback = sandbox.spy();
-  authTest.beforeEach((done) => {
+  authTest.beforeEach(done => {
     sandbox.reset();
     db.returns({ first, where });
     where.returns({ first, where });
     done();
   });
 
-  authTest.test('with a database error', (errorTest) => {
+  authTest.test('with a database error', errorTest => {
     first.rejects();
 
-    auth('user', 'password', doneCallback)
-      .then(() => {
-        errorTest.ok(db.calledOnce, 'a single table is queried');
-        errorTest.ok(db.calledWith('users'), 'it is the users table');
-        errorTest.ok(where.calledOnce, 'one set of WHERE clauses is added');
-        errorTest.ok(where.calledWith({ email: 'user' }), 'it is the WHERE we expect');
-        errorTest.ok(first.calledOnce, 'the query is executed one time');
+    auth('user', 'password', doneCallback).then(() => {
+      errorTest.ok(db.calledOnce, 'a single table is queried');
+      errorTest.ok(db.calledWith('users'), 'it is the users table');
+      errorTest.ok(where.calledOnce, 'one set of WHERE clauses is added');
+      errorTest.ok(
+        where.calledWith({ email: 'user' }),
+        'it is the WHERE we expect'
+      );
+      errorTest.ok(first.calledOnce, 'the query is executed one time');
 
-        errorTest.ok(bcrypt.compareSync.notCalled, 'does not compare passwords');
+      errorTest.ok(bcrypt.compareSync.notCalled, 'does not compare passwords');
 
-        errorTest.equal(doneCallback.callCount, 1, 'called done callback once');
-        errorTest.ok(doneCallback.calledWith(sinon.match.truthy), 'got an error message');
+      errorTest.equal(doneCallback.callCount, 1, 'called done callback once');
+      errorTest.ok(
+        doneCallback.calledWith(sinon.match.truthy),
+        'got an error message'
+      );
 
-        errorTest.done();
-      });
+      errorTest.done();
+    });
   });
 
-  authTest.test('with no valid users', (noUserTest) => {
+  authTest.test('with no valid users', noUserTest => {
     first.resolves();
 
-    auth('user', 'password', doneCallback)
-      .then(() => {
-        noUserTest.ok(db.calledOnce, 'a single table is queried');
-        noUserTest.ok(db.calledWith('users'), 'it is the users table');
-        noUserTest.ok(where.calledOnce, 'one set of WHERE clauses is added');
-        noUserTest.ok(where.calledWith({ email: 'user' }), 'it is the WHERE we expect');
-        noUserTest.ok(first.calledOnce, 'the query is executed one time');
+    auth('user', 'password', doneCallback).then(() => {
+      noUserTest.ok(db.calledOnce, 'a single table is queried');
+      noUserTest.ok(db.calledWith('users'), 'it is the users table');
+      noUserTest.ok(where.calledOnce, 'one set of WHERE clauses is added');
+      noUserTest.ok(
+        where.calledWith({ email: 'user' }),
+        'it is the WHERE we expect'
+      );
+      noUserTest.ok(first.calledOnce, 'the query is executed one time');
 
-        noUserTest.ok(bcrypt.compareSync.notCalled, 'does not compare password');
+      noUserTest.ok(bcrypt.compareSync.notCalled, 'does not compare password');
 
-        noUserTest.equal(doneCallback.callCount, 1, 'called done callback once');
-        noUserTest.ok(doneCallback.calledWith(null, false), 'got a false user');
+      noUserTest.equal(doneCallback.callCount, 1, 'called done callback once');
+      noUserTest.ok(doneCallback.calledWith(null, false), 'got a false user');
 
-        noUserTest.done();
-      });
+      noUserTest.done();
+    });
   });
 
-  authTest.test('with invalid password', (invalidTest) => {
+  authTest.test('with invalid password', invalidTest => {
     first.resolves({
       email: 'hello@world',
       password: 'test-password',
@@ -70,25 +77,33 @@ tap.test('local authentication', (authTest) => {
     });
     bcrypt.compareSync.returns(false);
 
-    auth('user', 'password', doneCallback)
-      .then(() => {
-        invalidTest.ok(db.calledOnce, 'a single table is queried');
-        invalidTest.ok(db.calledWith('users'), 'it is the users table');
-        invalidTest.ok(where.calledOnce, 'one set of WHERE clauses is added');
-        invalidTest.ok(where.calledWith({ email: 'user' }), 'it is the WHERE we expect');
-        invalidTest.ok(first.calledOnce, 'the query is executed one time');
+    auth('user', 'password', doneCallback).then(() => {
+      invalidTest.ok(db.calledOnce, 'a single table is queried');
+      invalidTest.ok(db.calledWith('users'), 'it is the users table');
+      invalidTest.ok(where.calledOnce, 'one set of WHERE clauses is added');
+      invalidTest.ok(
+        where.calledWith({ email: 'user' }),
+        'it is the WHERE we expect'
+      );
+      invalidTest.ok(first.calledOnce, 'the query is executed one time');
 
-        invalidTest.ok(bcrypt.compareSync.calledOnce, 'password is compared one time');
-        invalidTest.ok(bcrypt.compareSync.calledWith('password', 'test-password'), 'password is compared to database value');
+      invalidTest.ok(
+        bcrypt.compareSync.calledOnce,
+        'password is compared one time'
+      );
+      invalidTest.ok(
+        bcrypt.compareSync.calledWith('password', 'test-password'),
+        'password is compared to database value'
+      );
 
-        invalidTest.equal(doneCallback.callCount, 1, 'called done callback once');
-        invalidTest.ok(doneCallback.calledWith(null, false), 'got a false user');
+      invalidTest.equal(doneCallback.callCount, 1, 'called done callback once');
+      invalidTest.ok(doneCallback.calledWith(null, false), 'got a false user');
 
-        invalidTest.done();
-      });
+      invalidTest.done();
+    });
   });
 
-  authTest.test('with a valid user', (validTest) => {
+  authTest.test('with a valid user', validTest => {
     first.resolves({
       email: 'hello@world',
       password: 'test-password',
@@ -96,22 +111,33 @@ tap.test('local authentication', (authTest) => {
     });
     bcrypt.compareSync.returns(true);
 
-    auth('user', 'password', doneCallback)
-      .then(() => {
-        validTest.ok(db.calledOnce, 'a single table is queried');
-        validTest.ok(db.calledWith('users'), 'it is the users table');
-        validTest.ok(where.calledOnce, 'one set of WHERE clauses is added');
-        validTest.ok(where.calledWith({ email: 'user' }), 'it is the WHERE we expect');
-        validTest.ok(first.calledOnce, 'the query is executed one time');
+    auth('user', 'password', doneCallback).then(() => {
+      validTest.ok(db.calledOnce, 'a single table is queried');
+      validTest.ok(db.calledWith('users'), 'it is the users table');
+      validTest.ok(where.calledOnce, 'one set of WHERE clauses is added');
+      validTest.ok(
+        where.calledWith({ email: 'user' }),
+        'it is the WHERE we expect'
+      );
+      validTest.ok(first.calledOnce, 'the query is executed one time');
 
-        validTest.ok(bcrypt.compareSync.calledOnce, 'password is compared one time');
-        validTest.ok(bcrypt.compareSync.calledWith('password', 'test-password'), 'password is compared to database value');
+      validTest.ok(
+        bcrypt.compareSync.calledOnce,
+        'password is compared one time'
+      );
+      validTest.ok(
+        bcrypt.compareSync.calledWith('password', 'test-password'),
+        'password is compared to database value'
+      );
 
-        validTest.equal(doneCallback.callCount, 1, 'called done callback once');
-        validTest.ok(doneCallback.calledWith(null, { username: 'hello@world', id: 57 }), 'did not get an error message, did get a user object');
+      validTest.equal(doneCallback.callCount, 1, 'called done callback once');
+      validTest.ok(
+        doneCallback.calledWith(null, { username: 'hello@world', id: 57 }),
+        'did not get an error message, did get a user object'
+      );
 
-        validTest.done();
-      });
+      validTest.done();
+    });
   });
 
   authTest.done();

--- a/api/tests/auth/index.js
+++ b/api/tests/auth/index.js
@@ -6,7 +6,7 @@ const sandbox = sinon.createSandbox();
 process.env.SESSION_SECRET = 'secret';
 const authSetup = require('../../auth').setup;
 
-tap.test('authentication setup', (authTest) => {
+tap.test('authentication setup', authTest => {
   const app = {
     use: sandbox.spy(),
     post: sandbox.spy()
@@ -23,49 +23,102 @@ tap.test('authentication setup', (authTest) => {
 
   const strategies = ['strategy1', 'strategy2'];
 
-  authTest.beforeEach((done) => {
+  authTest.beforeEach(done => {
     sandbox.resetHistory();
     done();
   });
 
-  authTest.test('setup calls everything we expect it to', (setupTest) => {
+  authTest.test('setup calls everything we expect it to', setupTest => {
     authSetup(app, passport, strategies);
 
-    setupTest.equal(app.use.callCount, 3, 'three middleware functions added to app');
-    setupTest.ok(app.use.calledWith(sinon.match.func), 'adds session function to middleware');
-    setupTest.ok(app.use.calledWith('passport-initialize'), 'adds passport initialization to middleware');
-    setupTest.ok(app.use.calledWith('passport-session'), 'adds passport session to middleware');
+    setupTest.equal(
+      app.use.callCount,
+      3,
+      'three middleware functions added to app'
+    );
+    setupTest.ok(
+      app.use.calledWith(sinon.match.func),
+      'adds session function to middleware'
+    );
+    setupTest.ok(
+      app.use.calledWith('passport-initialize'),
+      'adds passport initialization to middleware'
+    );
+    setupTest.ok(
+      app.use.calledWith('passport-session'),
+      'adds passport session to middleware'
+    );
 
-    setupTest.equal(passport.use.callCount, 2, 'two passport strategies are configured');
-    setupTest.ok(passport.use.calledWith('strategy1'), 'first strategy is registered');
-    setupTest.ok(passport.use.calledWith('strategy2'), 'second strategy is registered');
+    setupTest.equal(
+      passport.use.callCount,
+      2,
+      'two passport strategies are configured'
+    );
+    setupTest.ok(
+      passport.use.calledWith('strategy1'),
+      'first strategy is registered'
+    );
+    setupTest.ok(
+      passport.use.calledWith('strategy2'),
+      'second strategy is registered'
+    );
 
     setupTest.ok(passport.initialize.calledOnce, 'passport is initialized');
     setupTest.ok(passport.session.calledOnce, 'passport session is setup');
 
-    setupTest.ok(passport.serializeUser.calledOnce, 'user serialization function is set once');
-    setupTest.ok(passport.deserializeUser.calledOnce, 'user deserialization function is set once');
+    setupTest.ok(
+      passport.serializeUser.calledOnce,
+      'user serialization function is set once'
+    );
+    setupTest.ok(
+      passport.deserializeUser.calledOnce,
+      'user deserialization function is set once'
+    );
 
-    setupTest.ok(passport.authenticate.calledOnce, 'passport authenticate method is inserted one time');
-    setupTest.ok(passport.authenticate.calledWith('local'), 'passport local authentication method is used');
+    setupTest.ok(
+      passport.authenticate.calledOnce,
+      'passport authenticate method is inserted one time'
+    );
+    setupTest.ok(
+      passport.authenticate.calledWith('local'),
+      'passport local authentication method is used'
+    );
 
-    setupTest.ok(app.post.calledOnce, 'a single POST endpoint is added to the app');
-    setupTest.ok(app.post.calledWith('/auth/login', 'passport-authenticate', sinon.match.func));
+    setupTest.ok(
+      app.post.calledOnce,
+      'a single POST endpoint is added to the app'
+    );
+    setupTest.ok(
+      app.post.calledWith(
+        '/auth/login',
+        'passport-authenticate',
+        sinon.match.func
+      )
+    );
 
     setupTest.done();
   });
 
-  authTest.test('setup works with defaults, too', (setupTest) => {
+  authTest.test('setup works with defaults, too', setupTest => {
     authSetup(app);
 
-    setupTest.equal(app.use.callCount, 3, 'three middleware functions added to app');
-    setupTest.ok(app.post.calledOnce, 'a single POST endpoint is added to the app');
-    setupTest.ok(app.post.calledWith('/auth/login', sinon.match.func, sinon.match.func));
+    setupTest.equal(
+      app.use.callCount,
+      3,
+      'three middleware functions added to app'
+    );
+    setupTest.ok(
+      app.post.calledOnce,
+      'a single POST endpoint is added to the app'
+    );
+    setupTest.ok(
+      app.post.calledWith('/auth/login', sinon.match.func, sinon.match.func)
+    );
 
     setupTest.done();
   });
 
-  authTest.test('POST endpoint behaves as expected', (postTest) => {
+  authTest.test('POST endpoint behaves as expected', postTest => {
     authSetup(app, passport, strategies);
     const post = app.post.args[0][2];
 

--- a/api/tests/auth/serialization.js
+++ b/api/tests/auth/serialization.js
@@ -5,49 +5,59 @@ const sandbox = sinon.createSandbox();
 
 const serialization = require('../../auth/serialization');
 
-tap.test('passport serialization', (serializationTest) => {
+tap.test('passport serialization', serializationTest => {
   const db = sandbox.stub();
   const where = sandbox.stub();
   const select = sandbox.stub();
   const doneCallback = sandbox.stub().returns('hi');
 
-  serializationTest.beforeEach((done) => {
+  serializationTest.beforeEach(done => {
     sandbox.reset();
     done();
   });
 
-  serializationTest.test('serialize a user', (serializeTest) => {
+  serializationTest.test('serialize a user', serializeTest => {
     const user = { id: 'the-user-id' };
     serialization.serializeUser(user, doneCallback);
-    serializeTest.ok(doneCallback.calledWith(null, 'the-user-id'), 'serializes the user object');
+    serializeTest.ok(
+      doneCallback.calledWith(null, 'the-user-id'),
+      'serializes the user object'
+    );
     serializeTest.done();
   });
 
-  serializationTest.test('deserialize a user', (deserializeTest) => {
+  serializationTest.test('deserialize a user', deserializeTest => {
     const userID = 'the-user-id';
 
-    deserializeTest.test('that is not in the database', (invalidTest) => {
+    deserializeTest.test('that is not in the database', invalidTest => {
       db.returns({ where, select });
       where.returns({ where, select });
       select.resolves([]);
 
-      serialization.deserializeUser(userID, doneCallback, db)
-        .then(() => {
-          invalidTest.ok(doneCallback.calledWith(sinon.match.string), 'calls back with an error');
-          invalidTest.done();
-        });
+      serialization.deserializeUser(userID, doneCallback, db).then(() => {
+        invalidTest.ok(
+          doneCallback.calledWith(sinon.match.string),
+          'calls back with an error'
+        );
+        invalidTest.done();
+      });
     });
 
-    deserializeTest.test('that is in the database', (validTest) => {
+    deserializeTest.test('that is in the database', validTest => {
       db.returns({ where, select });
       where.returns({ where, select });
       select.resolves([{ email: 'test-email', id: 'test-id' }]);
 
-      serialization.deserializeUser(userID, doneCallback, db)
-        .then(() => {
-          validTest.ok(doneCallback.calledWith(null, { username: 'test-email', id: 'test-id' }), 'deserializes the user ID to an object');
-          validTest.done();
-        });
+      serialization.deserializeUser(userID, doneCallback, db).then(() => {
+        validTest.ok(
+          doneCallback.calledWith(null, {
+            username: 'test-email',
+            id: 'test-id'
+          }),
+          'deserializes the user ID to an object'
+        );
+        validTest.done();
+      });
     });
 
     deserializeTest.done();

--- a/api/tests/auth/session.js
+++ b/api/tests/auth/session.js
@@ -3,17 +3,35 @@ const sinon = require('sinon');
 
 const getSessionFunction = require('../../auth/session').getSessionFunction;
 
-tap.test('session function', (sessionTest) => {
+tap.test('session function', sessionTest => {
   const sessions = sinon.spy();
 
   process.env.SESSION_SECRET = 'secret';
   getSessionFunction(sessions);
 
-  sessionTest.ok(sessions.calledWith(sinon.match.object), 'called with a configuration object');
+  sessionTest.ok(
+    sessions.calledWith(sinon.match.object),
+    'called with a configuration object'
+  );
   const config = sessions.args[0][0];
-  sessionTest.equal(config.cookieName, 'session', 'session uses the "user" cookie - required by passport');
-  sessionTest.equal(config.cookie.httpOnly, true, 'session cookie is HTTP-only');
-  sessionTest.equal(config.secret, 'secret', 'session secret is set from environment');
-  sessionTest.ok(config.duration < 30 * 24 * 60 * 60 * 1000, 'session cookie lasts less than 30 days');
+  sessionTest.equal(
+    config.cookieName,
+    'session',
+    'session uses the "user" cookie - required by passport'
+  );
+  sessionTest.equal(
+    config.cookie.httpOnly,
+    true,
+    'session cookie is HTTP-only'
+  );
+  sessionTest.equal(
+    config.secret,
+    'secret',
+    'session secret is set from environment'
+  );
+  sessionTest.ok(
+    config.duration < 30 * 24 * 60 * 60 * 1000,
+    'session cookie lasts less than 30 days'
+  );
   sessionTest.done();
 });

--- a/api/tests/db.js
+++ b/api/tests/db.js
@@ -3,7 +3,7 @@ const sinon = require('sinon');
 
 const db = require('../db');
 
-tap.test('database object module', (dbTest) => {
+tap.test('database object module', dbTest => {
   const knex = sinon.stub().returns({
     thisIs: 'a database'
   });
@@ -13,8 +13,15 @@ tap.test('database object module', (dbTest) => {
   const result = db(knex, { env1: 'environment 1', env2: 'environment 2' });
 
   dbTest.ok(knex.calledOnce, 'knex is configured');
-  dbTest.ok(knex.calledWith('environment 2'), 'knex is configured with the passed value');
-  dbTest.same(result, { thisIs: 'a database' }, 'returns the expected object based on env');
+  dbTest.ok(
+    knex.calledWith('environment 2'),
+    'knex is configured with the passed value'
+  );
+  dbTest.same(
+    result,
+    { thisIs: 'a database' },
+    'returns the expected object based on env'
+  );
 
   process.env.NODE_ENV = nodeEnv;
   dbTest.done();

--- a/api/tests/env.js
+++ b/api/tests/env.js
@@ -1,35 +1,49 @@
 const tap = require('tap');
 
-tap.beforeEach((done) => {
+tap.beforeEach(done => {
   delete require.cache[require.resolve('../env')];
-  process.env = { };
+  process.env = {};
   done();
 });
 
-tap.test('environment setup', (envTest) => {
+tap.test('environment setup', envTest => {
   const knownEnvironmentVariables = [
     { name: 'PORT', type: 'number' },
     { name: 'SESSION_SECRET', type: 'string' }
   ];
 
-  envTest.test('sets default values for known environment variables', (setsDefaultTest) => {
-    require('../env'); // eslint-disable-line global-require
-    knownEnvironmentVariables.forEach((envVar) => {
-      setsDefaultTest.type(process.env[envVar.name], envVar.type, `sets the ${envVar.name} to a ${envVar.type}`);
-    });
-    setsDefaultTest.end();
-  });
+  envTest.test(
+    'sets default values for known environment variables',
+    setsDefaultTest => {
+      require('../env'); // eslint-disable-line global-require
+      knownEnvironmentVariables.forEach(envVar => {
+        setsDefaultTest.type(
+          process.env[envVar.name],
+          envVar.type,
+          `sets the ${envVar.name} to a ${envVar.type}`
+        );
+      });
+      setsDefaultTest.end();
+    }
+  );
 
-  envTest.test('does not override environment variables that have been set externally', (doesNotOverrideTest) => {
-    knownEnvironmentVariables.forEach((envVar) => {
-      process.env[envVar.name] = 'test-value';
-    });
+  envTest.test(
+    'does not override environment variables that have been set externally',
+    doesNotOverrideTest => {
+      knownEnvironmentVariables.forEach(envVar => {
+        process.env[envVar.name] = 'test-value';
+      });
 
-    require('../env'); // eslint-disable-line global-require
-    knownEnvironmentVariables.forEach((envVar) => {
-      doesNotOverrideTest.same(process.env[envVar.name], 'test-value', `does not override the ${envVar.name} variable`);
-    });
-    doesNotOverrideTest.end();
-  });
+      require('../env'); // eslint-disable-line global-require
+      knownEnvironmentVariables.forEach(envVar => {
+        doesNotOverrideTest.same(
+          process.env[envVar.name],
+          'test-value',
+          `does not override the ${envVar.name} variable`
+        );
+      });
+      doesNotOverrideTest.end();
+    }
+  );
   envTest.done();
 });


### PR DESCRIPTION
Ensures consistent formatting across codebase

Two eslint rules affected: `function-paren-newline` and `arrow-parens` because they're unnecessary / conflict with prettier (i.e., function parens newlines are determined based on if maximum line length is crossed) 