### PR TITLE
Add endpoints for local user management

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -8,7 +8,4 @@ ADD ./package-lock.json .
 
 RUN npm install
 
-RUN npm run migrate
-RUN npm run seed
-
 CMD npm run start-dev

--- a/api/auth/middleware.js
+++ b/api/auth/middleware.js
@@ -1,0 +1,7 @@
+module.exports.loggedIn = (req, res, next) => {
+  if (!req.user) {
+    res.status(403).end();
+  } else {
+    next();
+  }
+};

--- a/api/main.js
+++ b/api/main.js
@@ -1,5 +1,5 @@
 require('./env');
-
+1;
 const express = require('express');
 const cors = require('cors');
 const bodyParser = require('body-parser');

--- a/api/main.js
+++ b/api/main.js
@@ -2,18 +2,22 @@ require('./env');
 
 const express = require('express');
 const cors = require('cors');
-
+const bodyParser = require('body-parser');
 const auth = require('./auth');
+const routes = require('./routes');
 
 const server = express();
 
 server.use(express.urlencoded({ extended: true }));
 server.use(cors());
+server.use(bodyParser.json());
 
 auth.setup(server);
 
 server.get('*', (req, res) => {
   res.send({ hello: 'world' });
 });
+
+routes(server);
 
 server.listen(process.env.PORT);

--- a/api/main.js
+++ b/api/main.js
@@ -14,10 +14,6 @@ server.use(bodyParser.json());
 
 auth.setup(server);
 
-server.get('*', (req, res) => {
-  res.send({ hello: 'world' });
-});
-
 routes(server);
 
 server.listen(process.env.PORT);

--- a/api/main.js
+++ b/api/main.js
@@ -1,5 +1,5 @@
 require('./env');
-1;
+
 const express = require('express');
 const cors = require('cors');
 const bodyParser = require('body-parser');

--- a/api/migrations/20171221233429_unique-email.js
+++ b/api/migrations/20171221233429_unique-email.js
@@ -1,0 +1,8 @@
+
+exports.up = knex => knex.schema.alterTable('users', (table) => {
+  table.unique('email');
+});
+
+exports.down = knex => knex.schema.alterTable('users', (table) => {
+  table.dropUnique('email');
+});

--- a/api/migrations/20171221233429_unique-email.js
+++ b/api/migrations/20171221233429_unique-email.js
@@ -1,8 +1,9 @@
+exports.up = knex =>
+  knex.schema.alterTable('users', table => {
+    table.unique('email');
+  });
 
-exports.up = knex => knex.schema.alterTable('users', (table) => {
-  table.unique('email');
-});
-
-exports.down = knex => knex.schema.alterTable('users', (table) => {
-  table.dropUnique('email');
-});
+exports.down = knex =>
+  knex.schema.alterTable('users', table => {
+    table.dropUnique('email');
+  });

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -2143,14 +2143,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -2159,6 +2151,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -6115,14 +6115,6 @@
         "duplexer": "0.1.1"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -6131,6 +6123,14 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/api/package.json
+++ b/api/package.json
@@ -37,6 +37,7 @@
   "homepage": "https://github.com/18F/cms-hitech-apd#readme",
   "dependencies": {
     "bcryptjs": "^2.4.3",
+    "body-parser": "^1.18.2",
     "client-sessions": "^0.8.0",
     "cors": "^2.8.4",
     "dotenv": "^4.0.0",

--- a/api/routes/index.js
+++ b/api/routes/index.js
@@ -1,5 +1,5 @@
 const users = require('./users');
 
-module.exports = (app) => {
-  users(app);
+module.exports = (app, usersEndpoint = users) => {
+  usersEndpoint(app);
 };

--- a/api/routes/index.js
+++ b/api/routes/index.js
@@ -1,0 +1,5 @@
+const users = require('./users');
+
+module.exports = (app) => {
+  users(app);
+};

--- a/api/routes/users/get.js
+++ b/api/routes/users/get.js
@@ -1,38 +1,41 @@
 const defaultDB = require('../../db')();
 const loggedIn = require('../../auth/middleware').loggedIn;
 
-module.exports = (app, db = defaultDB) => {
-  app.get('/users', loggedIn, (req, res) => {
+const allUsersHandler = (req, res, db) => {
+  db('users')
+    .select('id', 'email')
+    .then(users => {
+      res.send(users);
+    })
+    .catch(() => {
+      res.status(500).end();
+    });
+};
+
+const oneUserHandler = (req, res, db) => {
+  if (req.params.id && !Number.isNaN(Number(req.params.id))) {
     db('users')
-      .select('id', 'email')
-      .then(users => {
-        res.send(users);
+      .where({ id: Number(req.params.id) })
+      .first('id', 'email')
+      .then(user => {
+        if (user) {
+          res.send(user);
+        } else {
+          res.status(404).end();
+        }
       })
       .catch(() => {
         res.status(500).end();
       });
-  });
+  } else {
+    res
+      .status(400)
+      .send('get-user-invalid')
+      .end();
+  }
+};
 
-  app.get('/user/:id', loggedIn, (req, res) => {
-    if (req.params.id && !Number.isNaN(Number(req.params.id))) {
-      db('users')
-        .where({ id: Number(req.params.id) })
-        .first('id', 'email')
-        .then(user => {
-          if (user) {
-            res.send(user);
-          } else {
-            res.status(404).end();
-          }
-        })
-        .catch(() => {
-          res.status(500).end();
-        });
-    } else {
-      res
-        .status(400)
-        .send('get-user-invalid')
-        .end();
-    }
-  });
+module.exports = (app, db = defaultDB) => {
+  app.get('/users', loggedIn, (req, res) => allUsersHandler(req, res, db));
+  app.get('/user/:id', loggedIn, (req, res) => oneUserHandler(req, res, db));
 };

--- a/api/routes/users/get.js
+++ b/api/routes/users/get.js
@@ -1,0 +1,31 @@
+const defaultDB = require('../../db')();
+const loggedIn = require('../../auth/middleware').loggedIn;
+
+const ifUserIsNew = (email, res, db) =>
+  db('users')
+    .where({ email })
+    .first()
+    .then(user => {
+      if (user) {
+        res
+          .status(400)
+          .send({ error: 'add-user-email-exists' })
+          .end();
+        return Promise.reject();
+      }
+      return Promise.resolve();
+    });
+
+const insert = (email, password, db) => {
+  const hashed = bcrypt.hashSync(password);
+  return db('users').insert({ email, password: hashed });
+};
+
+module.exports = (app, db = defaultDB) => {
+  app.get('/users', loggedIn, (req, res) => {
+    res
+      .status(400)
+      .send({ error: 'add-user-invalid' })
+      .end();
+  });
+};

--- a/api/routes/users/index.js
+++ b/api/routes/users/index.js
@@ -1,5 +1,7 @@
 const post = require('./post');
+const get = require('./get');
 
-module.exports = (app, postEndpoint = post) => {
+module.exports = (app, postEndpoint = post, getEndpoint = get) => {
   postEndpoint(app);
+  getEndpoint(app);
 };

--- a/api/routes/users/index.js
+++ b/api/routes/users/index.js
@@ -1,5 +1,5 @@
 const post = require('./post');
 
-module.exports = (app) => {
-  post(app);
+module.exports = (app, postEndpoint = post) => {
+  postEndpoint(app);
 };

--- a/api/routes/users/index.js
+++ b/api/routes/users/index.js
@@ -1,0 +1,5 @@
+const post = require('./post');
+
+module.exports = (app) => {
+  post(app);
+};

--- a/api/routes/users/post.js
+++ b/api/routes/users/post.js
@@ -1,0 +1,37 @@
+const bcrypt = require('bcryptjs');
+const db = require('../../db')();
+const loggedIn = require('../../auth/middleware').loggedIn;
+
+const ifUserIsNew = (email, res) => db('users')
+  .where({ email }).first()
+  .then((user) => {
+    if (user) {
+      res.status(400).send({ error: 'add-user-email-exists' }).end();
+      return Promise.reject();
+    }
+    return Promise.resolve();
+  });
+
+const insert = (email, password) => {
+  const hashed = bcrypt.hashSync(password);
+  return db('users').insert({ email, password: hashed });
+};
+
+module.exports = (app) => {
+  app.post('/user', loggedIn, (req, res) => {
+    if (req.body.email && req.body.password) {
+      ifUserIsNew(req.body.email, res)
+        .then(() => insert(req.body.email, req.body.password))
+        .then(() => {
+          res.status(200).end();
+        })
+        .catch(() => {
+          // 👆 eventually we should catch errors here and log
+          // them somewhere.  For now... just eating them.
+          res.status(500).end();
+        });
+    } else {
+      res.status(400).send({ error: 'add-user-invalid' }).end();
+    }
+  });
+};

--- a/api/routes/users/post.js
+++ b/api/routes/users/post.js
@@ -2,15 +2,20 @@ const bcrypt = require('bcryptjs');
 const defaultDB = require('../../db')();
 const loggedIn = require('../../auth/middleware').loggedIn;
 
-const ifUserIsNew = (email, res, db) => db('users')
-  .where({ email }).first()
-  .then((user) => {
-    if (user) {
-      res.status(400).send({ error: 'add-user-email-exists' }).end();
-      return Promise.reject();
-    }
-    return Promise.resolve();
-  });
+const ifUserIsNew = (email, res, db) =>
+  db('users')
+    .where({ email })
+    .first()
+    .then(user => {
+      if (user) {
+        res
+          .status(400)
+          .send({ error: 'add-user-email-exists' })
+          .end();
+        return Promise.reject();
+      }
+      return Promise.resolve();
+    });
 
 const insert = (email, password, db) => {
   const hashed = bcrypt.hashSync(password);
@@ -31,7 +36,10 @@ module.exports = (app, db = defaultDB) => {
           res.status(500).end();
         });
     } else {
-      res.status(400).send({ error: 'add-user-invalid' }).end();
+      res
+        .status(400)
+        .send({ error: 'add-user-invalid' })
+        .end();
     }
   });
 };

--- a/api/routes/users/post.js
+++ b/api/routes/users/post.js
@@ -1,8 +1,8 @@
 const bcrypt = require('bcryptjs');
-const db = require('../../db')();
+const defaultDB = require('../../db')();
 const loggedIn = require('../../auth/middleware').loggedIn;
 
-const ifUserIsNew = (email, res) => db('users')
+const ifUserIsNew = (email, res, db) => db('users')
   .where({ email }).first()
   .then((user) => {
     if (user) {
@@ -12,16 +12,16 @@ const ifUserIsNew = (email, res) => db('users')
     return Promise.resolve();
   });
 
-const insert = (email, password) => {
+const insert = (email, password, db) => {
   const hashed = bcrypt.hashSync(password);
   return db('users').insert({ email, password: hashed });
 };
 
-module.exports = (app) => {
+module.exports = (app, db = defaultDB) => {
   app.post('/user', loggedIn, (req, res) => {
     if (req.body.email && req.body.password) {
-      ifUserIsNew(req.body.email, res)
-        .then(() => insert(req.body.email, req.body.password))
+      ifUserIsNew(req.body.email, res, db)
+        .then(() => insert(req.body.email, req.body.password, db))
         .then(() => {
           res.status(200).end();
         })

--- a/api/tests/auth/middleware.js
+++ b/api/tests/auth/middleware.js
@@ -10,7 +10,7 @@ const res = {
 };
 const next = sandbox.spy();
 
-tap.beforeEach((done) => {
+tap.beforeEach(done => {
   sandbox.reset();
 
   res.status.returns(res);
@@ -20,26 +20,35 @@ tap.beforeEach((done) => {
   done();
 });
 
-tap.test('logged in middleware', (loggedInMiddlewareTest) => {
+tap.test('logged in middleware', loggedInMiddlewareTest => {
   const loggedIn = middleware.loggedIn;
-  loggedInMiddlewareTest.test('rejects if the user is not logged in', (invalidTest) => {
-    loggedIn({ }, res, next);
+  loggedInMiddlewareTest.test(
+    'rejects if the user is not logged in',
+    invalidTest => {
+      loggedIn({}, res, next);
 
-    invalidTest.ok(res.status.calledWith(403), 'HTTP status set to 403');
-    invalidTest.ok(res.end.called, 'response is terminated');
-    invalidTest.ok(next.notCalled, 'endpoint handling chain is not continued');
-    invalidTest.done();
-  });
+      invalidTest.ok(res.status.calledWith(403), 'HTTP status set to 403');
+      invalidTest.ok(res.end.called, 'response is terminated');
+      invalidTest.ok(
+        next.notCalled,
+        'endpoint handling chain is not continued'
+      );
+      invalidTest.done();
+    }
+  );
 
-  loggedInMiddlewareTest.test('continues if the user is logged in', (validTest) => {
-    loggedIn({ user: true }, res, next);
+  loggedInMiddlewareTest.test(
+    'continues if the user is logged in',
+    validTest => {
+      loggedIn({ user: true }, res, next);
 
-    validTest.ok(res.send.notCalled, 'no body is sent');
-    validTest.ok(res.status.notCalled, 'HTTP status not set');
-    validTest.ok(res.end.notCalled, 'response is not terminated');
-    validTest.ok(next.called, 'endpoint handling chain is continued');
-    validTest.done();
-  });
+      validTest.ok(res.send.notCalled, 'no body is sent');
+      validTest.ok(res.status.notCalled, 'HTTP status not set');
+      validTest.ok(res.end.notCalled, 'response is not terminated');
+      validTest.ok(next.called, 'endpoint handling chain is continued');
+      validTest.done();
+    }
+  );
 
   loggedInMiddlewareTest.done();
 });

--- a/api/tests/auth/middleware.js
+++ b/api/tests/auth/middleware.js
@@ -1,0 +1,45 @@
+const tap = require('tap');
+const sandbox = require('sinon').createSandbox();
+
+const middleware = require('../../auth/middleware');
+
+const res = {
+  status: sandbox.stub(),
+  send: sandbox.stub(),
+  end: sandbox.stub()
+};
+const next = sandbox.spy();
+
+tap.beforeEach((done) => {
+  sandbox.reset();
+
+  res.status.returns(res);
+  res.send.returns(res);
+  res.end.returns(res);
+
+  done();
+});
+
+tap.test('logged in middleware', (loggedInMiddlewareTest) => {
+  const loggedIn = middleware.loggedIn;
+  loggedInMiddlewareTest.test('rejects if the user is not logged in', (invalidTest) => {
+    loggedIn({ }, res, next);
+
+    invalidTest.ok(res.status.calledWith(403), 'HTTP status set to 403');
+    invalidTest.ok(res.end.called, 'response is terminated');
+    invalidTest.ok(next.notCalled, 'endpoint handling chain is not continued');
+    invalidTest.done();
+  });
+
+  loggedInMiddlewareTest.test('continues if the user is logged in', (validTest) => {
+    loggedIn({ user: true }, res, next);
+
+    validTest.ok(res.send.notCalled, 'no body is sent');
+    validTest.ok(res.status.notCalled, 'HTTP status not set');
+    validTest.ok(res.end.notCalled, 'response is not terminated');
+    validTest.ok(next.called, 'endpoint handling chain is continued');
+    validTest.done();
+  });
+
+  loggedInMiddlewareTest.done();
+});

--- a/api/tests/routes/index.js
+++ b/api/tests/routes/index.js
@@ -1,0 +1,14 @@
+const tap = require('tap');
+const sinon = require('sinon');
+
+const endpointIndex = require('../../routes');
+
+tap.test('endpoint setup', (endpointTest) => {
+  const app = { };
+  const usersEndpoint = sinon.spy();
+
+  endpointIndex(app, usersEndpoint);
+
+  endpointTest.ok(usersEndpoint.calledWith(app), 'users endpoint is setup with the app');
+  endpointTest.done();
+});

--- a/api/tests/routes/index.js
+++ b/api/tests/routes/index.js
@@ -3,12 +3,15 @@ const sinon = require('sinon');
 
 const endpointIndex = require('../../routes');
 
-tap.test('endpoint setup', (endpointTest) => {
-  const app = { };
+tap.test('endpoint setup', endpointTest => {
+  const app = {};
   const usersEndpoint = sinon.spy();
 
   endpointIndex(app, usersEndpoint);
 
-  endpointTest.ok(usersEndpoint.calledWith(app), 'users endpoint is setup with the app');
+  endpointTest.ok(
+    usersEndpoint.calledWith(app),
+    'users endpoint is setup with the app'
+  );
   endpointTest.done();
 });

--- a/api/tests/routes/users/get.js
+++ b/api/tests/routes/users/get.js
@@ -1,0 +1,214 @@
+const tap = require('tap');
+const sinon = require('sinon');
+
+const loggedInMiddleware = require('../../../auth/middleware').loggedIn;
+const getEndpoint = require('../../../routes/users/get');
+
+tap.test('user GET endpoint', endpointTest => {
+  const sandbox = sinon.createSandbox();
+  const app = {
+    get: sandbox.stub()
+  };
+  const db = sandbox.stub();
+  const where = sandbox.stub();
+  const select = sandbox.stub();
+  const first = sandbox.stub();
+  const res = {
+    status: sandbox.stub(),
+    send: sandbox.stub(),
+    end: sandbox.stub()
+  };
+
+  endpointTest.beforeEach(done => {
+    sandbox.reset();
+
+    res.status.returns(res);
+    res.send.returns(res);
+    res.end.returns(res);
+
+    db.returns({ where, select, first });
+    where.returns({ where, select, first });
+
+    done();
+  });
+
+  endpointTest.test('setup', setupTest => {
+    getEndpoint(app, db);
+
+    setupTest.ok(
+      app.get.calledWith('/user/:id', loggedInMiddleware, sinon.match.func),
+      'single user GET endpoint is registered'
+    );
+    setupTest.ok(
+      app.get.calledWith('/users', loggedInMiddleware, sinon.match.func),
+      'all users GET endpoint is registered'
+    );
+    setupTest.done();
+  });
+
+  endpointTest.test('get all users handler', handlerTest => {
+    let handler;
+    handlerTest.beforeEach(done => {
+      getEndpoint(app, db);
+      handler = app.get.args.find(args => args[0] === '/users')[2];
+      done();
+    });
+
+    handlerTest.test(
+      'sends a server error code if there is a database error',
+      invalidTest => {
+        select.rejects();
+
+        handler({}, res);
+
+        setTimeout(() => {
+          invalidTest.ok(db.calledWith('users'), 'queries the users table');
+          invalidTest.ok(
+            select.calledWith('id', 'email'),
+            'selects only user ID and email'
+          );
+          invalidTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
+          invalidTest.ok(res.send.notCalled, 'no body is sent');
+          invalidTest.ok(res.end.called, 'response is terminated');
+          invalidTest.done();
+        }, 20);
+      }
+    );
+
+    handlerTest.test('sends back a list of users', validTest => {
+      const users = [{ id: 1, email: 'hi' }, { id: 2, email: 'bye' }];
+      select.resolves(users);
+
+      handler({}, res);
+
+      setTimeout(() => {
+        validTest.ok(db.calledWith('users'), 'queries the users table');
+        validTest.ok(
+          select.calledWith('id', 'email'),
+          'selects only user ID and email'
+        );
+        validTest.ok(res.status.notCalled, 'HTTP status is not explicitly set');
+        validTest.ok(
+          res.send.calledWith(users),
+          'body is set to the list of users'
+        );
+        validTest.done();
+      }, 20);
+    });
+
+    handlerTest.done();
+  });
+
+  endpointTest.test('get single user handler', handlerTest => {
+    let handler;
+    handlerTest.beforeEach(done => {
+      getEndpoint(app, db);
+      handler = app.get.args.find(args => args[0] === '/user/:id')[2];
+      done();
+    });
+
+    handlerTest.test('rejects invalid requests', invalidTests => {
+      const invalidCases = [
+        {
+          title: 'no user ID',
+          params: {}
+        },
+        {
+          title: 'non-numeric ID',
+          params: { id: 'letters' }
+        }
+      ];
+
+      invalidCases.forEach(invalidCase => {
+        invalidTests.test(invalidCase.title, invalidTest => {
+          handler({ params: invalidCase.params }, res);
+          invalidTest.ok(res.status.calledWith(400), 'HTTP status set to 400');
+          invalidTest.ok(
+            res.send.calledWith('get-user-invalid'),
+            'sets an error message'
+          );
+          invalidTest.ok(res.end.called, 'response is terminated');
+          invalidTest.done();
+        });
+      });
+
+      invalidTests.done();
+    });
+
+    handlerTest.test(
+      'sends a server error code if there is a database error',
+      invalidTest => {
+        first.rejects();
+
+        handler({ params: { id: 1 } }, res);
+
+        setTimeout(() => {
+          invalidTest.ok(db.calledWith('users'), 'queries the users table');
+          invalidTest.ok(
+            where.calledWith({ id: 1 }),
+            'looks for only the specific user'
+          );
+          invalidTest.ok(
+            first.calledWith('id', 'email'),
+            'selects only user ID and email'
+          );
+          invalidTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
+          invalidTest.ok(res.send.notCalled, 'no body is sent');
+          invalidTest.ok(res.end.called, 'response is terminated');
+          invalidTest.done();
+        }, 20);
+      }
+    );
+
+    handlerTest.test(
+      'sends a not-found error if the requested user does not exist',
+      invalidTest => {
+        first.resolves();
+        handler({ params: { id: 1 } }, res);
+
+        setTimeout(() => {
+          invalidTest.ok(db.calledWith('users'), 'queries the users table');
+          invalidTest.ok(
+            where.calledWith({ id: 1 }),
+            'looks for only the specific user'
+          );
+          invalidTest.ok(
+            first.calledWith('id', 'email'),
+            'selects only user ID and email'
+          );
+          invalidTest.ok(res.status.calledWith(404), 'HTTP status set to 404');
+          invalidTest.ok(res.send.notCalled, 'no body is sent');
+          invalidTest.ok(res.end.called, 'response is terminated');
+          invalidTest.done();
+        }, 20);
+      }
+    );
+
+    handlerTest.test('sends the requested user', validTest => {
+      first.resolves({ id: 1, email: 'test-email@dotcom.com' });
+      handler({ params: { id: 1 } }, res);
+
+      setTimeout(() => {
+        validTest.ok(db.calledWith('users'), 'queries the users table');
+        validTest.ok(
+          where.calledWith({ id: 1 }),
+          'looks for only the specific user'
+        );
+        validTest.ok(
+          first.calledWith('id', 'email'),
+          'selects only user ID and email'
+        );
+        validTest.ok(res.status.notCalled, 'HTTP status is not explicitly set');
+        validTest.ok(
+          res.send.calledWith({ id: 1, email: 'test-email@dotcom.com' }),
+          'requested user is sent'
+        );
+        validTest.done();
+      }, 20);
+    });
+
+    handlerTest.done();
+  });
+
+  endpointTest.done();
+});

--- a/api/tests/routes/users/index.js
+++ b/api/tests/routes/users/index.js
@@ -1,0 +1,14 @@
+const tap = require('tap');
+const sinon = require('sinon');
+
+const usersIndex = require('../../../routes/users');
+
+tap.test('users endpoint setup', (endpointTest) => {
+  const app = { };
+  const postEndpoint = sinon.spy();
+
+  usersIndex(app, postEndpoint);
+
+  endpointTest.ok(postEndpoint.calledWith(app), 'users POST endpoint is setup with the app');
+  endpointTest.done();
+});

--- a/api/tests/routes/users/index.js
+++ b/api/tests/routes/users/index.js
@@ -6,12 +6,17 @@ const usersIndex = require('../../../routes/users');
 tap.test('users endpoint setup', endpointTest => {
   const app = {};
   const postEndpoint = sinon.spy();
+  const getEndpoint = sinon.spy();
 
-  usersIndex(app, postEndpoint);
+  usersIndex(app, postEndpoint, getEndpoint);
 
   endpointTest.ok(
     postEndpoint.calledWith(app),
     'users POST endpoint is setup with the app'
+  );
+  endpointTest.ok(
+    getEndpoint.calledWith(app),
+    'users GET endpoint is setup with the app'
   );
   endpointTest.done();
 });

--- a/api/tests/routes/users/index.js
+++ b/api/tests/routes/users/index.js
@@ -3,12 +3,15 @@ const sinon = require('sinon');
 
 const usersIndex = require('../../../routes/users');
 
-tap.test('users endpoint setup', (endpointTest) => {
-  const app = { };
+tap.test('users endpoint setup', endpointTest => {
+  const app = {};
   const postEndpoint = sinon.spy();
 
   usersIndex(app, postEndpoint);
 
-  endpointTest.ok(postEndpoint.calledWith(app), 'users POST endpoint is setup with the app');
+  endpointTest.ok(
+    postEndpoint.calledWith(app),
+    'users POST endpoint is setup with the app'
+  );
   endpointTest.done();
 });

--- a/api/tests/routes/users/post.js
+++ b/api/tests/routes/users/post.js
@@ -1,0 +1,141 @@
+const tap = require('tap');
+const sinon = require('sinon');
+
+const loggedInMiddleware = require('../../../auth/middleware').loggedIn;
+const postEndpoint = require('../../../routes/users/post');
+
+tap.test('user POST endpoint', (endpointTest) => {
+  const sandbox = sinon.createSandbox();
+  const app = {
+    post: sandbox.stub()
+  };
+  const db = sandbox.stub();
+  const where = sandbox.stub();
+  const first = sandbox.stub();
+  const insert = sandbox.stub();
+  const res = {
+    status: sandbox.stub(),
+    send: sandbox.stub(),
+    end: sandbox.stub()
+  };
+
+  endpointTest.beforeEach((done) => {
+    sandbox.reset();
+
+    res.status.returns(res);
+    res.send.returns(res);
+    res.end.returns(res);
+
+    db.returns({ where, first, insert });
+    where.returns({ where, first, insert });
+
+    done();
+  });
+
+  endpointTest.test('setup', (setupTest) => {
+    postEndpoint(app, db);
+
+    setupTest.ok(app.post.calledWith('/user', loggedInMiddleware, sinon.match.func), 'user POST endpoint is registered');
+    setupTest.done();
+  });
+
+  endpointTest.test('handler', (handlerTest) => {
+    let handler;
+
+    handlerTest.beforeEach((done) => {
+      postEndpoint(app, db);
+      handler = app.post.args[0][2];
+      done();
+    });
+
+    handlerTest.test('rejects invalid requests', (invalidTests) => {
+      const invalidCases = [{
+        title: 'no email or password',
+        body: { }
+      }, {
+        title: 'email, but no password',
+        body: { email: 'em@il.com' }
+      }, {
+        title: 'no email, but password',
+        body: { password: 'password' }
+      }, {
+        title: 'email exists but is blank, valid password',
+        body: { email: '', password: 'password' }
+      }, {
+        title: 'valid email, password exists but is blank',
+        body: { email: 'em@il.com', password: '' }
+      }];
+
+      invalidCases.forEach((invalidCase) => {
+        invalidTests.test(invalidCase.title, (invalidTest) => {
+          handler({ body: invalidCase.body }, res);
+
+          invalidTest.ok(res.status.calledWith(400), 'HTTP status set to 400');
+          invalidTest.ok(res.send.calledWith({ error: 'add-user-invalid' }), 'sets an error message');
+          invalidTest.ok(res.end.called, 'response is terminated');
+          invalidTest.done();
+        });
+      });
+
+      invalidTests.done();
+    });
+
+    handlerTest.test('rejects inserting an existing user', (invalidTest) => {
+      first.resolves({ });
+
+      handler({ body: { email: 'em@il.com', password: 'password' } }, res);
+
+      setTimeout(() => {
+        invalidTest.ok(res.status.calledWith(400), 'HTTP status set to 400');
+        invalidTest.ok(res.send.calledWith({ error: 'add-user-email-exists' }), 'sets an error message');
+        invalidTest.ok(res.end.called, 'response is terminated');
+        invalidTest.done();
+      }, 20);
+    });
+
+    handlerTest.test('sends an server error code if there is a database error checking for an existing user', (invalidTest) => {
+      first.rejects();
+
+      handler({ body: { email: 'em@il.com', password: 'password' } }, res);
+
+      setTimeout(() => {
+        invalidTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
+        invalidTest.ok(res.send.notCalled, 'does not send a message');
+        invalidTest.ok(res.end.called, 'response is terminated');
+        invalidTest.done();
+      }, 20);
+    });
+
+    handlerTest.test('sends an server error code if there is a database error inserting a new user', (invalidTest) => {
+      first.resolves();
+      insert.rejects();
+
+      handler({ body: { email: 'em@il.com', password: 'password' } }, res);
+
+      setTimeout(() => {
+        invalidTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
+        invalidTest.ok(res.send.notCalled, 'does not send a message');
+        invalidTest.ok(res.end.called, 'response is terminated');
+        invalidTest.done();
+      }, 20);
+    });
+
+    handlerTest.test('inserts a new user and returns a success for a valid, new user', (validTest) => {
+      first.resolves();
+      insert.resolves();
+
+      handler({ body: { email: 'em@il.com', password: 'password' } }, res);
+
+      setTimeout(() => {
+        validTest.ok(res.status.calledWith(200), 'HTTP status set to 200');
+        validTest.ok(res.send.notCalled, 'does not send a message');
+        validTest.ok(res.end.called, 'response is terminated');
+        validTest.done();
+      }, 20);
+    });
+
+    handlerTest.done();
+  });
+
+  endpointTest.done();
+});

--- a/api/tests/routes/users/post.js
+++ b/api/tests/routes/users/post.js
@@ -4,7 +4,7 @@ const sinon = require('sinon');
 const loggedInMiddleware = require('../../../auth/middleware').loggedIn;
 const postEndpoint = require('../../../routes/users/post');
 
-tap.test('user POST endpoint', (endpointTest) => {
+tap.test('user POST endpoint', endpointTest => {
   const sandbox = sinon.createSandbox();
   const app = {
     post: sandbox.stub()
@@ -19,7 +19,7 @@ tap.test('user POST endpoint', (endpointTest) => {
     end: sandbox.stub()
   };
 
-  endpointTest.beforeEach((done) => {
+  endpointTest.beforeEach(done => {
     sandbox.reset();
 
     res.status.returns(res);
@@ -32,46 +32,58 @@ tap.test('user POST endpoint', (endpointTest) => {
     done();
   });
 
-  endpointTest.test('setup', (setupTest) => {
+  endpointTest.test('setup', setupTest => {
     postEndpoint(app, db);
 
-    setupTest.ok(app.post.calledWith('/user', loggedInMiddleware, sinon.match.func), 'user POST endpoint is registered');
+    setupTest.ok(
+      app.post.calledWith('/user', loggedInMiddleware, sinon.match.func),
+      'user POST endpoint is registered'
+    );
     setupTest.done();
   });
 
-  endpointTest.test('handler', (handlerTest) => {
+  endpointTest.test('handler', handlerTest => {
     let handler;
 
-    handlerTest.beforeEach((done) => {
+    handlerTest.beforeEach(done => {
       postEndpoint(app, db);
       handler = app.post.args[0][2];
       done();
     });
 
-    handlerTest.test('rejects invalid requests', (invalidTests) => {
-      const invalidCases = [{
-        title: 'no email or password',
-        body: { }
-      }, {
-        title: 'email, but no password',
-        body: { email: 'em@il.com' }
-      }, {
-        title: 'no email, but password',
-        body: { password: 'password' }
-      }, {
-        title: 'email exists but is blank, valid password',
-        body: { email: '', password: 'password' }
-      }, {
-        title: 'valid email, password exists but is blank',
-        body: { email: 'em@il.com', password: '' }
-      }];
+    handlerTest.test('rejects invalid requests', invalidTests => {
+      const invalidCases = [
+        {
+          title: 'no email or password',
+          body: {}
+        },
+        {
+          title: 'email, but no password',
+          body: { email: 'em@il.com' }
+        },
+        {
+          title: 'no email, but password',
+          body: { password: 'password' }
+        },
+        {
+          title: 'email exists but is blank, valid password',
+          body: { email: '', password: 'password' }
+        },
+        {
+          title: 'valid email, password exists but is blank',
+          body: { email: 'em@il.com', password: '' }
+        }
+      ];
 
-      invalidCases.forEach((invalidCase) => {
-        invalidTests.test(invalidCase.title, (invalidTest) => {
+      invalidCases.forEach(invalidCase => {
+        invalidTests.test(invalidCase.title, invalidTest => {
           handler({ body: invalidCase.body }, res);
 
           invalidTest.ok(res.status.calledWith(400), 'HTTP status set to 400');
-          invalidTest.ok(res.send.calledWith({ error: 'add-user-invalid' }), 'sets an error message');
+          invalidTest.ok(
+            res.send.calledWith({ error: 'add-user-invalid' }),
+            'sets an error message'
+          );
           invalidTest.ok(res.end.called, 'response is terminated');
           invalidTest.done();
         });
@@ -80,59 +92,71 @@ tap.test('user POST endpoint', (endpointTest) => {
       invalidTests.done();
     });
 
-    handlerTest.test('rejects inserting an existing user', (invalidTest) => {
-      first.resolves({ });
+    handlerTest.test('rejects inserting an existing user', invalidTest => {
+      first.resolves({});
 
       handler({ body: { email: 'em@il.com', password: 'password' } }, res);
 
       setTimeout(() => {
         invalidTest.ok(res.status.calledWith(400), 'HTTP status set to 400');
-        invalidTest.ok(res.send.calledWith({ error: 'add-user-email-exists' }), 'sets an error message');
+        invalidTest.ok(
+          res.send.calledWith({ error: 'add-user-email-exists' }),
+          'sets an error message'
+        );
         invalidTest.ok(res.end.called, 'response is terminated');
         invalidTest.done();
       }, 20);
     });
 
-    handlerTest.test('sends an server error code if there is a database error checking for an existing user', (invalidTest) => {
-      first.rejects();
+    handlerTest.test(
+      'sends an server error code if there is a database error checking for an existing user',
+      invalidTest => {
+        first.rejects();
 
-      handler({ body: { email: 'em@il.com', password: 'password' } }, res);
+        handler({ body: { email: 'em@il.com', password: 'password' } }, res);
 
-      setTimeout(() => {
-        invalidTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
-        invalidTest.ok(res.send.notCalled, 'does not send a message');
-        invalidTest.ok(res.end.called, 'response is terminated');
-        invalidTest.done();
-      }, 20);
-    });
+        setTimeout(() => {
+          invalidTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
+          invalidTest.ok(res.send.notCalled, 'does not send a message');
+          invalidTest.ok(res.end.called, 'response is terminated');
+          invalidTest.done();
+        }, 20);
+      }
+    );
 
-    handlerTest.test('sends an server error code if there is a database error inserting a new user', (invalidTest) => {
-      first.resolves();
-      insert.rejects();
+    handlerTest.test(
+      'sends an server error code if there is a database error inserting a new user',
+      invalidTest => {
+        first.resolves();
+        insert.rejects();
 
-      handler({ body: { email: 'em@il.com', password: 'password' } }, res);
+        handler({ body: { email: 'em@il.com', password: 'password' } }, res);
 
-      setTimeout(() => {
-        invalidTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
-        invalidTest.ok(res.send.notCalled, 'does not send a message');
-        invalidTest.ok(res.end.called, 'response is terminated');
-        invalidTest.done();
-      }, 20);
-    });
+        setTimeout(() => {
+          invalidTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
+          invalidTest.ok(res.send.notCalled, 'does not send a message');
+          invalidTest.ok(res.end.called, 'response is terminated');
+          invalidTest.done();
+        }, 20);
+      }
+    );
 
-    handlerTest.test('inserts a new user and returns a success for a valid, new user', (validTest) => {
-      first.resolves();
-      insert.resolves();
+    handlerTest.test(
+      'inserts a new user and returns a success for a valid, new user',
+      validTest => {
+        first.resolves();
+        insert.resolves();
 
-      handler({ body: { email: 'em@il.com', password: 'password' } }, res);
+        handler({ body: { email: 'em@il.com', password: 'password' } }, res);
 
-      setTimeout(() => {
-        validTest.ok(res.status.calledWith(200), 'HTTP status set to 200');
-        validTest.ok(res.send.notCalled, 'does not send a message');
-        validTest.ok(res.end.called, 'response is terminated');
-        validTest.done();
-      }, 20);
-    });
+        setTimeout(() => {
+          validTest.ok(res.status.calledWith(200), 'HTTP status set to 200');
+          validTest.ok(res.send.notCalled, 'does not send a message');
+          validTest.ok(res.end.called, 'response is terminated');
+          validTest.done();
+        }, 20);
+      }
+    );
 
     handlerTest.done();
   });

--- a/api/tests/routes/users/post.js
+++ b/api/tests/routes/users/post.js
@@ -109,7 +109,7 @@ tap.test('user POST endpoint', endpointTest => {
     });
 
     handlerTest.test(
-      'sends an server error code if there is a database error checking for an existing user',
+      'sends a server error code if there is a database error checking for an existing user',
       invalidTest => {
         first.rejects();
 
@@ -125,7 +125,7 @@ tap.test('user POST endpoint', endpointTest => {
     );
 
     handlerTest.test(
-      'sends an server error code if there is a database error inserting a new user',
+      'sends a server error code if there is a database error inserting a new user',
       invalidTest => {
         first.resolves();
         insert.rejects();


### PR DESCRIPTION
## The endpoints

### Create a new user

An HTTP `POST` to `/user` allows an authenticated user to add a new user.  Expects a JSON body with an email address and password.  The password will be hashed with bcrypt before it is stored.  Sends an HTTP status 400 if the body is invalid or if the email address already exists in the database along with an error message token.  Otherwise it sends back an HTTP status 200 and an empty body.  Relies on the `loggedIn` middleware.

### Get a list of all users

An HTTP `GET` to `/users` allows an authenticated user to get a list of all users.  Sends the results back as JSON.  Relies on the `loggedIn` middleware.

### Get a specific user

An HTTP `GET` to `/users/:id` allows an authenticated user to get the user specified by the `:id` parameter (e.g., `/users/57` would get the user whose ID is 57).  Sends an HTTP status 400 if the ID is invalid (e.g., missing or not a number) along with an error message token.  Sends a status 404 and empty body if the user ID is not found.  Otherwise it sends back the user as JSON.  Relies on the `loggedIn` middleware.

## Middleware

To make it easier to lock routes to only authenticated users (and hopefully, down the road, to let us specific authorization requirements), I've added a `loggedIn` middleware.  Inserting this into the list of endpoint handlers will make sure the "main" handler is only called if the user is logged in.  E.g.:

```js
app.post('/user', loggedIn, (req, res) => { ...`
```

In the future, I'm envisioning extending this model so we also have an `authenticated` (or something else; I'm not a fan of that name, but can't think of a better one offhand) middleware:

```js
app.post('/user', authenticated('admin'), (req, res) => { ...`
```

The idea is simply that the various endpoint handlers shouldn't have to check user credentials themselves - that should be centralized.

## Error message tokens

This is me just making stuff up.  Instead of sending back full English strings describing the errors, I've made these endpoints send back token-ish strings like `add-user-email-exists`.  The idea is that it's readable for debugging purposes, but for displaying to users, it can be mapped to localized strings in the client.  This feels like an experiment to me.  Feedback welcomed and encouraged.  😆 

If we decide this is a good approach, we should probably capture all of the error "tokens" in a doc somewhere.  For #45, I was planning to create a `docs` folder to put development documentation in.  That might be a place for it.  However we do it, let's keep it lightweight.  😬 

## Random fixes

* The email field in the users table was not unique.  Oops!  There's a new migration to handle that.
* The API dockerfile tried to helpful migrate and seed the database with dev data on *build*, but that didn't work because the local development volume isn't mounted into the container until the container is *started*.  So knex was complaining that it couldn't find its config file and that was breaking the entire container build.  For now, migrations and seeds will just have to be run manually.  That's not too hard, though: once the containers are running, you can do:
   ```bash
   docker-compose exec api npm run migrate
   docker-compose exec api npm run seed
   ```
   For folks not using docker...  no change.  😉 

## Tasks

* Closes #33