### PR TITLE
/user POST endpoint tests

### DIFF
--- a/api/endpoint-tests/auth/login.js
+++ b/api/endpoint-tests/auth/login.js
@@ -1,11 +1,10 @@
 const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
 const request = require('request'); // eslint-disable-line import/no-extraneous-dependencies
+const { getFullPath } = require('../utils');
 
 tap.test('login endpoint | /auth/login', loginTest => {
-  const url = `http://${process.env.API_HOST || 'localhost'}:${process.env
-    .API_PORT ||
-    process.env.PORT ||
-    8000}/auth/login`;
+  const url = getFullPath('/auth/login');
+  console.log(url);
 
   loginTest.test('with no post body at all', invalidTest => {
     request.post(url, (err, response) => {

--- a/api/endpoint-tests/auth/login.js
+++ b/api/endpoint-tests/auth/login.js
@@ -2,7 +2,10 @@ const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependen
 const request = require('request'); // eslint-disable-line import/no-extraneous-dependencies
 
 tap.test('login endpoint | /auth/login', loginTest => {
-  const url = `http://${process.env.API_HOST || 'localhost'}:${process.env.API_PORT || process.env.PORT || 8000}/auth/login`;
+  const url = `http://${process.env.API_HOST || 'localhost'}:${process.env
+    .API_PORT ||
+    process.env.PORT ||
+    8000}/auth/login`;
 
   loginTest.test('with no post body at all', invalidTest => {
     request.post(url, (err, response) => {
@@ -11,16 +14,20 @@ tap.test('login endpoint | /auth/login', loginTest => {
     });
   });
 
-  const invalidCases = [{
-    title: 'with a post body, but no username or password',
-    data: { }
-  }, {
-    title: 'with a post body, but no username',
-    data: { password: 'test-password' }
-  }, {
-    title: 'with a post body, but no password',
-    data: { username: 'test-username' }
-  }];
+  const invalidCases = [
+    {
+      title: 'with a post body, but no username or password',
+      data: {}
+    },
+    {
+      title: 'with a post body, but no username',
+      data: { password: 'test-password' }
+    },
+    {
+      title: 'with a post body, but no password',
+      data: { username: 'test-username' }
+    }
+  ];
 
   invalidCases.forEach(invalidCase => {
     loginTest.test(`Form body: ${invalidCase.title}`, invalidTest => {
@@ -38,25 +45,29 @@ tap.test('login endpoint | /auth/login', loginTest => {
     });
   });
 
-  const badCredentialsCases = [{
-    title: 'with invalid username, invalid password',
-    data: {
-      username: 'nobody',
-      password: 'nothing'
+  const badCredentialsCases = [
+    {
+      title: 'with invalid username, invalid password',
+      data: {
+        username: 'nobody',
+        password: 'nothing'
+      }
+    },
+    {
+      title: 'with invalid username, valid password',
+      data: {
+        username: 'nobody',
+        password: 'password'
+      }
+    },
+    {
+      title: 'with valid username, invalid password',
+      data: {
+        username: 'em@il.com',
+        password: 'nothing'
+      }
     }
-  }, {
-    title: 'with invalid username, valid password',
-    data: {
-      username: 'nobody',
-      password: 'password'
-    }
-  }, {
-    title: 'with valid username, invalid password',
-    data: {
-      username: 'em@il.com',
-      password: 'nothing'
-    }
-  }];
+  ];
 
   badCredentialsCases.forEach(badCredentialsCase => {
     loginTest.test(`Form body: ${badCredentialsCase.title}`, invalidTest => {
@@ -74,27 +85,53 @@ tap.test('login endpoint | /auth/login', loginTest => {
     });
   });
 
-  loginTest.test('Form body: with valid username and valid password', validTest => {
-    // isolate cookies, so request doesn't reuse them
-    const cookies = request.jar();
-    request.post(url, { jar: cookies, form: { username: 'em@il.com', password: 'password' } }, (err, response, body) => {
-      validTest.equal(response.statusCode, 200, 'gives a 200 status code');
-      validTest.ok(response.headers['set-cookie'].some(cookie => cookie.startsWith('session=') && cookie.endsWith('; httponly')), 'sends an http-only session cookie');
-      validTest.notOk(body, 'does not send a body');
-      validTest.done();
-    });
-  });
+  loginTest.test(
+    'Form body: with valid username and valid password',
+    validTest => {
+      // isolate cookies, so request doesn't reuse them
+      const cookies = request.jar();
+      request.post(
+        url,
+        { jar: cookies, form: { username: 'em@il.com', password: 'password' } },
+        (err, response, body) => {
+          validTest.equal(response.statusCode, 200, 'gives a 200 status code');
+          validTest.ok(
+            response.headers['set-cookie'].some(
+              cookie =>
+                cookie.startsWith('session=') && cookie.endsWith('; httponly')
+            ),
+            'sends an http-only session cookie'
+          );
+          validTest.notOk(body, 'does not send a body');
+          validTest.done();
+        }
+      );
+    }
+  );
 
-  loginTest.test('JSON body: with valid username and valid password', validTest => {
-    // isolate cookies, so request doesn't reuse them
-    const cookies = request.jar();
-    request.post(url, { jar: cookies, json: { username: 'em@il.com', password: 'password' } }, (err, response, body) => {
-      validTest.equal(response.statusCode, 200, 'gives a 200 status code');
-      validTest.ok(response.headers['set-cookie'].some(cookie => cookie.startsWith('session=') && cookie.endsWith('; httponly')), 'sends an http-only session cookie');
-      validTest.notOk(body, 'does not send a body');
-      validTest.done();
-    });
-  });
+  loginTest.test(
+    'JSON body: with valid username and valid password',
+    validTest => {
+      // isolate cookies, so request doesn't reuse them
+      const cookies = request.jar();
+      request.post(
+        url,
+        { jar: cookies, json: { username: 'em@il.com', password: 'password' } },
+        (err, response, body) => {
+          validTest.equal(response.statusCode, 200, 'gives a 200 status code');
+          validTest.ok(
+            response.headers['set-cookie'].some(
+              cookie =>
+                cookie.startsWith('session=') && cookie.endsWith('; httponly')
+            ),
+            'sends an http-only session cookie'
+          );
+          validTest.notOk(body, 'does not send a body');
+          validTest.done();
+        }
+      );
+    }
+  );
 
   loginTest.done();
 });

--- a/api/endpoint-tests/auth/login.js
+++ b/api/endpoint-tests/auth/login.js
@@ -4,7 +4,6 @@ const { getFullPath } = require('../utils');
 
 tap.test('login endpoint | /auth/login', loginTest => {
   const url = getFullPath('/auth/login');
-  console.log(url);
 
   loginTest.test('with no post body at all', invalidTest => {
     request.post(url, (err, response) => {

--- a/api/endpoint-tests/users/get.js
+++ b/api/endpoint-tests/users/get.js
@@ -6,11 +6,11 @@ const login = require('../utils').login;
 tap.test('users endpoint | GET /users', getUsersTest => {
   const url = getFullPath('/users');
 
-  getUsersTest.test('when unauthenticated', invalidTest => {
+  getUsersTest.test('when unauthenticated', unauthenticatedTest => {
     request.get(url, (err, response, body) => {
-      invalidTest.equal(response.statusCode, 403, 'gives a 403 status code');
-      invalidTest.notOk(body, 'does not send a body');
-      invalidTest.done();
+      unauthenticatedTest.equal(response.statusCode, 403, 'gives a 403 status code');
+      unauthenticatedTest.notOk(body, 'does not send a body');
+      unauthenticatedTest.done();
     });
   });
 
@@ -53,7 +53,7 @@ tap.test('users endpoint | GET /user/:userID', getUserTest => {
       login().then(cookies => {
         request.get(`${url}/random-id`, { jar: cookies, json: true }, (err, response, body) => {
           invalidTest.equal(response.statusCode, 400, 'gives a 400 status code');
-          invalidTest.equal(body, 'get-user-invalid', 'sends a token indicating the failure');
+          invalidTest.same(body, { error: 'get-user-invalid' }, 'sends a token indicating the failure');
           invalidTest.done();
         });
       });

--- a/api/endpoint-tests/users/get.js
+++ b/api/endpoint-tests/users/get.js
@@ -8,7 +8,11 @@ tap.test('users endpoint | GET /users', getUsersTest => {
 
   getUsersTest.test('when unauthenticated', unauthenticatedTest => {
     request.get(url, (err, response, body) => {
-      unauthenticatedTest.equal(response.statusCode, 403, 'gives a 403 status code');
+      unauthenticatedTest.equal(
+        response.statusCode,
+        403,
+        'gives a 403 status code'
+      );
       unauthenticatedTest.notOk(body, 'does not send a body');
       unauthenticatedTest.done();
     });
@@ -18,7 +22,11 @@ tap.test('users endpoint | GET /users', getUsersTest => {
     login().then(cookies => {
       request.get(url, { jar: cookies, json: true }, (err, response, body) => {
         validTest.equal(response.statusCode, 200, 'gives a 200 status code');
-        validTest.same(body, [{ id: 57, email: 'em@il.com' }], 'returns an array of known users');
+        validTest.same(
+          body,
+          [{ id: 57, email: 'em@il.com' }],
+          'returns an array of known users'
+        );
         validTest.done();
       });
     });
@@ -38,7 +46,11 @@ tap.test('users endpoint | GET /user/:userID', getUserTest => {
     ].forEach(situation => {
       unauthenticatedTests.test(situation.name, unauthentedTest => {
         request.get(`${url}/${situation.id}`, (err, response, body) => {
-          unauthentedTest.equal(response.statusCode, 403, 'gives a 403 status code');
+          unauthentedTest.equal(
+            response.statusCode,
+            403,
+            'gives a 403 status code'
+          );
           unauthentedTest.notOk(body, 'does not send a body');
           unauthentedTest.done();
         });
@@ -49,33 +61,71 @@ tap.test('users endpoint | GET /user/:userID', getUserTest => {
   });
 
   getUserTest.test('when authenticated', authenticatedTests => {
-    authenticatedTests.test('when requesting an invalid user ID', invalidTest => {
-      login().then(cookies => {
-        request.get(`${url}/random-id`, { jar: cookies, json: true }, (err, response, body) => {
-          invalidTest.equal(response.statusCode, 400, 'gives a 400 status code');
-          invalidTest.same(body, { error: 'get-user-invalid' }, 'sends a token indicating the failure');
-          invalidTest.done();
+    authenticatedTests.test(
+      'when requesting an invalid user ID',
+      invalidTest => {
+        login().then(cookies => {
+          request.get(
+            `${url}/random-id`,
+            { jar: cookies, json: true },
+            (err, response, body) => {
+              invalidTest.equal(
+                response.statusCode,
+                400,
+                'gives a 400 status code'
+              );
+              invalidTest.same(
+                body,
+                { error: 'get-user-invalid' },
+                'sends a token indicating the failure'
+              );
+              invalidTest.done();
+            }
+          );
         });
-      });
-    });
+      }
+    );
 
-    authenticatedTests.test('when requesting a non-existant user ID', invalidTest => {
-      login().then(cookies => {
-        request.get(`${url}/500`, { jar: cookies, json: true }, (err, response, body) => {
-          invalidTest.equal(response.statusCode, 404, 'gives a 404 status code');
-          invalidTest.notOk(body, 'does not send a body');
-          invalidTest.done();
+    authenticatedTests.test(
+      'when requesting a non-existant user ID',
+      invalidTest => {
+        login().then(cookies => {
+          request.get(
+            `${url}/500`,
+            { jar: cookies, json: true },
+            (err, response, body) => {
+              invalidTest.equal(
+                response.statusCode,
+                404,
+                'gives a 404 status code'
+              );
+              invalidTest.notOk(body, 'does not send a body');
+              invalidTest.done();
+            }
+          );
         });
-      });
-    });
+      }
+    );
 
     authenticatedTests.test('when requesting a valid user ID', validTest => {
       login().then(cookies => {
-        request.get(`${url}/57`, { jar: cookies, json: true }, (err, response, body) => {
-          validTest.equal(response.statusCode, 200, 'gives a 200 status code');
-          validTest.same(body, { id: 57, email: 'em@il.com' }, 'returns an object for the requested user');
-          validTest.done();
-        });
+        request.get(
+          `${url}/57`,
+          { jar: cookies, json: true },
+          (err, response, body) => {
+            validTest.equal(
+              response.statusCode,
+              200,
+              'gives a 200 status code'
+            );
+            validTest.same(
+              body,
+              { id: 57, email: 'em@il.com' },
+              'returns an object for the requested user'
+            );
+            validTest.done();
+          }
+        );
       });
     });
 

--- a/api/endpoint-tests/users/post.js
+++ b/api/endpoint-tests/users/post.js
@@ -1,0 +1,117 @@
+const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
+const request = require('request'); // eslint-disable-line import/no-extraneous-dependencies
+const { getFullPath, login } = require('../utils');
+
+tap.test('users endpoint | POST /user', postUsersTest => {
+  const url = getFullPath('/user');
+
+  const invalidCases = [
+    {
+      name: 'with no body'
+    },
+    {
+      name: 'with an invalid body',
+      body: { hello: 'world' }
+    },
+    {
+      name: 'with an email but no password',
+      body: { email: 'newuser@email.com' }
+    },
+    {
+      name: 'with a password but no email',
+      body: { password: 'newpassword' }
+    }
+  ];
+
+  postUsersTest.test('when unauthenticated', unauthenticatedTests => {
+    [
+      ...invalidCases,
+      {
+        name: 'with a valid body',
+        body: { email: 'newuser@email.com', password: 'newpassword' }
+      }
+    ].forEach(situation => {
+      unauthenticatedTests.test(situation.name, unauthenticatedTest => {
+        request.post(url, { json: situation.body }, (err, response, body) => {
+          unauthenticatedTest.equal(
+            response.statusCode,
+            403,
+            'gives a 403 status code'
+          );
+          unauthenticatedTest.notOk(body, 'does not send a body');
+          unauthenticatedTest.done();
+        });
+      });
+    });
+    unauthenticatedTests.done();
+  });
+
+  postUsersTest.test('when authenticated', authenticatedTests => {
+    login().then(cookies => {
+      invalidCases.forEach(situation => {
+        authenticatedTests.test(situation.name, invalidTest => {
+          request.post(
+            url,
+            { jar: cookies, json: situation.body || true },
+            (err, response, body) => {
+              invalidTest.equal(
+                response.statusCode,
+                400,
+                'gives a 400 status code'
+              );
+              invalidTest.same(
+                body,
+                { error: 'add-user-invalid' },
+                'sends a token indicating the failure'
+              );
+              invalidTest.done();
+            }
+          );
+        });
+      });
+
+      authenticatedTests.test('with existing email address', invalidTest => {
+        request.post(
+          url,
+          { jar: cookies, json: { email: 'em@il.com', password: 'anything' } },
+          (err, response, body) => {
+            invalidTest.equal(
+              response.statusCode,
+              400,
+              'gives a 400 status code'
+            );
+            invalidTest.same(
+              body,
+              { error: 'add-user-email-exists' },
+              'sends a token indicating the failure'
+            );
+            invalidTest.done();
+          }
+        );
+      });
+
+      authenticatedTests.test('with a valid new user', validTest => {
+        request.post(
+          url,
+          {
+            jar: cookies,
+            json: { email: 'newuser@email.com', password: 'newpassword' }
+          },
+          (err, response, body) => {
+            validTest.equal(
+              response.statusCode,
+              200,
+              'gives a 200 status code'
+            );
+            validTest.notOk(body, 'does not send a body');
+            validTest.done();
+          }
+        );
+      });
+
+      authenticatedTests.done();
+    });
+  });
+
+  postUsersTest.done();
+});

--- a/api/endpoint-tests/users/post.js
+++ b/api/endpoint-tests/users/post.js
@@ -1,6 +1,6 @@
 const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
 const request = require('request'); // eslint-disable-line import/no-extraneous-dependencies
-const { getFullPath, login } = require('../utils');
+const { db, getFullPath, login } = require('../utils');
 
 tap.test('users endpoint | POST /user', postUsersTest => {
   const url = getFullPath('/user');
@@ -104,7 +104,23 @@ tap.test('users endpoint | POST /user', postUsersTest => {
               'gives a 200 status code'
             );
             validTest.notOk(body, 'does not send a body');
-            validTest.done();
+
+            db()('users')
+              .where({ email: 'newuser@email.com' })
+              .first()
+              .then(user => {
+                validTest.ok(
+                  user,
+                  'a user object is inserted into the database'
+                );
+              })
+              .catch(() => {
+                validTest.fail('error');
+              })
+              .then(() => {
+                validTest.done();
+                // process.exit();
+              });
           }
         );
       });

--- a/api/endpoint-tests/utils.js
+++ b/api/endpoint-tests/utils.js
@@ -1,16 +1,24 @@
 const request = require('request'); // eslint-disable-line import/no-extraneous-dependencies
 
-const getFullPath = endpointPath => `http://${process.env.API_HOST || 'localhost'}:${process.env.API_PORT || process.env.PORT || 8000}${endpointPath}`;
+const getFullPath = endpointPath =>
+  `http://${process.env.API_HOST || 'localhost'}:${process.env.API_PORT ||
+    process.env.PORT ||
+    8000}${endpointPath}`;
 
-const login = () => new Promise((resolve, reject) => {
-  const cookies = request.jar();
-  request.post(getFullPath('/auth/login'), { jar: cookies, json: { username: 'em@il.com', password: 'password' } }, (err, response) => {
-    if (response.statusCode === 200) {
-      return resolve(cookies);
-    }
-    return reject(new Error('Failed to login'));
+const login = () =>
+  new Promise((resolve, reject) => {
+    const cookies = request.jar();
+    request.post(
+      getFullPath('/auth/login'),
+      { jar: cookies, json: { username: 'em@il.com', password: 'password' } },
+      (err, response) => {
+        if (response.statusCode === 200) {
+          return resolve(cookies);
+        }
+        return reject(new Error('Failed to login'));
+      }
+    );
   });
-});
 
 module.exports = {
   getFullPath,

--- a/api/routes/users/get.js
+++ b/api/routes/users/get.js
@@ -30,7 +30,7 @@ const oneUserHandler = (req, res, db) => {
   } else {
     res
       .status(400)
-      .send('get-user-invalid')
+      .send({ error: 'get-user-invalid' })
       .end();
   }
 };

--- a/api/routes/users/get.test.js
+++ b/api/routes/users/get.test.js
@@ -124,7 +124,7 @@ tap.test('user GET endpoint', endpointTest => {
           handler({ params: invalidCase.params }, res);
           invalidTest.ok(res.status.calledWith(400), 'HTTP status set to 400');
           invalidTest.ok(
-            res.send.calledWith('get-user-invalid'),
+            res.send.calledWith({ error: 'get-user-invalid' }),
             'sets an error message'
           );
           invalidTest.ok(res.end.called, 'response is terminated');


### PR DESCRIPTION
## Endpoint tests for `POST /user`

Adds a bunch of tests for this endpoint.  This should cover all of the endpoints we have right now.

## Database stuff in tests

Knex keeps database connections open indefinitely (probably all other database layers would do the same; doing otherwise would be silly), which is cool.  Tap (our testrunner) runs every test file in its own process, which is also cool (yay, test isolation!).  The problem here is that Tap expects the test processes to end on their own.  If they don't, it generates a timeout error and forcibly kills them, making it look like tests failed.

Tap has an event you can hook when it expects the test process to be finished - that is, all of the registered tests have been marked as done.  In that event handler, if you call `process.exit()`, that will move Tap along.  (It _should_ gracefully close the Knex connections, but also I guess who cares if it doesn't?  The process is gone, regardless.)

I added a helper method to the test utils to fetch a Knex object.  Calling this helper will also register a handler for Tap's `teardown` event that will exit the process.  This way, individual test files that use the database should ***NOT*** have to worry about killing their process.  It should just happen.

## Other stuff

* In `auth/login.js`, I modified it to use the `getFullPath` helper from test utils.  Everything else is the result of running prettier.
* In the `users/get` endpoint, its unit test, and its endpoint test, I addressed a bug where requesting an invalid user ID (i.e., non-numeric) would return a string rather than a JSON object