### PR TITLE
Add logout endpoint

### DIFF
--- a/api/auth/index.js
+++ b/api/auth/index.js
@@ -36,6 +36,11 @@ module.exports.setup = function setup(
   app.use(passport.initialize());
   app.use(passport.session());
 
+  app.get('/auth/logout', (req, res) => {
+    req.logout();
+    res.status(200).end();
+  });
+
   // Add a local authentication endpoint
   app.post('/auth/login', passport.authenticate('local'), (req, res) => {
     res.status(200).end();

--- a/api/auth/index.test.js
+++ b/api/auth/index.test.js
@@ -9,6 +9,7 @@ const authSetup = require('./index').setup;
 tap.test('authentication setup', authTest => {
   const app = {
     use: sandbox.spy(),
+    get: sandbox.spy(),
     post: sandbox.spy()
   };
 
@@ -85,6 +86,17 @@ tap.test('authentication setup', authTest => {
     );
 
     setupTest.ok(
+      app.get.calledOnce,
+      'a single GET endpoint is added to the app'
+    );
+    setupTest.ok(
+      app.get.calledWith,
+      '/auth/logout',
+      sinon.match.func,
+      'adds a function handler to GET /auth/logout'
+    );
+
+    setupTest.ok(
       app.post.calledOnce,
       'a single POST endpoint is added to the app'
     );
@@ -93,7 +105,8 @@ tap.test('authentication setup', authTest => {
         '/auth/login',
         'passport-authenticate',
         sinon.match.func
-      )
+      ),
+      'adds a function handler to POST /auth/login using the passport authenticate middleware'
     );
 
     setupTest.done();

--- a/api/endpoint-tests/auth/logout.js
+++ b/api/endpoint-tests/auth/logout.js
@@ -1,0 +1,55 @@
+const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
+const request = require('request'); // eslint-disable-line import/no-extraneous-dependencies
+const { getFullPath } = require('../utils');
+
+tap.test('logout endpoint | /auth/logout', logoutTest => {
+  const url = getFullPath('/auth/logout');
+
+  logoutTest.test('not already logged in', test => {
+    const cookies = request.jar();
+
+    request.get(url, { jar: cookies }, (err, response) => {
+      test.equal(response.statusCode, 200, 'gives a 200 status code');
+
+      // It might be valid for the API to set some header other than
+      // the session cookie, but it might also be valid for it to set
+      // no headers at all.
+      if (response.headers['set-cookie']) {
+        test.ok(
+          response.headers['set-cookie'].every(
+            cookie => !cookie.startsWith('session=')
+          ),
+          'does not set a session cookie'
+        );
+      } else {
+        test.pass('does not set a session cookie');
+      }
+      test.done();
+    });
+  });
+
+  logoutTest.test('already logged in', test => {
+    const cookies = request.jar();
+    cookies.setCookie('session=this-is-my-session', url);
+
+    request.get(url, { jar: cookies }, (err, response) => {
+      test.equal(response.statusCode, 200, 'gives a 200 status code');
+      test.ok(
+        response.headers['set-cookie'].some(
+          cookie =>
+            cookie.startsWith('session=') && cookie.endsWith('; httponly')
+        ),
+        'sends a new http-only session cookie'
+      );
+      test.ok(
+        response.headers['set-cookie'].every(
+          cookie => !cookie.startsWith('session=this-is-my-session')
+        ),
+        'does not just send back the same session cookie'
+      );
+      test.done();
+    });
+  });
+
+  logoutTest.done();
+});


### PR DESCRIPTION
Adds a `GET` endpoint at `/auth/logout` and associated tests.  This is in service to #32.