### PR TITLE
Add authorization middleware

### DIFF
--- a/api/auth/middleware.js
+++ b/api/auth/middleware.js
@@ -1,7 +1,19 @@
 module.exports.loggedIn = (req, res, next) => {
-  if (!req.user) {
-    res.status(403).end();
-  } else {
+  if (req.user) {
     next();
+  } else {
+    res.status(403).end();
   }
+};
+
+module.exports.can = activity => (req, res, next) => {
+  // First check if they're logged in
+  module.exports.loggedIn(req, res, () => {
+    // Then check if they have the activity
+    if (req.user.activities.includes(activity)) {
+      next();
+    } else {
+      res.status(401).end();
+    }
+  });
 };

--- a/api/auth/middleware.test.js
+++ b/api/auth/middleware.test.js
@@ -52,3 +52,52 @@ tap.test('logged in middleware', loggedInMiddlewareTest => {
 
   loggedInMiddlewareTest.done();
 });
+
+tap.test('"can" middleware', canMiddlewareTest => {
+  const can = middleware.can;
+
+  canMiddlewareTest.test(
+    'rejects if the user is not logged in',
+    invalidTest => {
+      can('activity')({}, res, next);
+
+      invalidTest.ok(res.status.calledWith(403), 'HTTP status set to 403');
+      invalidTest.ok(res.end.called, 'response is terminated');
+      invalidTest.ok(
+        next.notCalled,
+        'endpoint handling chain is not continued'
+      );
+      invalidTest.done();
+    }
+  );
+
+  canMiddlewareTest.test(
+    'rejects if the user does not have the expected activity',
+    invalidTest => {
+      can('activity')({ user: { activities: [] } }, res, next);
+
+      invalidTest.ok(res.status.calledWith(401), 'HTTP status set to 401');
+      invalidTest.ok(res.end.called, 'response is terminated');
+      invalidTest.ok(
+        next.notCalled,
+        'endpoint handling chain is not continued'
+      );
+      invalidTest.done();
+    }
+  );
+
+  canMiddlewareTest.test(
+    'continues if the user has the expected activity',
+    validTest => {
+      can('activity')({ user: { activities: ['activity'] } }, res, next);
+
+      validTest.ok(res.send.notCalled, 'no body is sent');
+      validTest.ok(res.status.notCalled, 'HTTP status not set');
+      validTest.ok(res.end.notCalled, 'response is not terminated');
+      validTest.ok(next.called, 'endpoint handling chain is continued');
+      validTest.done();
+    }
+  );
+
+  canMiddlewareTest.done();
+});


### PR DESCRIPTION
### Updates user deserializer

Using the authorization data model created in #126, this updates the user deserializer to populate the `req.user` object with an `activities` array, indicating which activities the user is authorized to perform.  It does that by pulling the user's role from the database and then getting the list of activities that are mapped to that role.

This deserialization happens at the beginning of each inbound request, and the `req.user` object is fully populated and available to all endpoints.

### Adds `can` authorization middleware

This also adds a new middleware that endpoints can opt into called `can`.  The `can` middleware takes an activity as an argument and will stop the response flow if the user is not logged in or does not have permission for that activity.  It piggy backs on the `loggedIn` middleware for the first half, so we get a consistent experience for not-logged-in users.  For the second half, it basically just checks the `req.user.activities` array to see if it contains the requested activity.

The intent of putting this in middleware is to save us from having to write activity-checking code all over the place.  Instead, when we create an endpoint, we can just put the authorization requirement right there in the setup and trust that it'll be enforced:

```js
app.get('/my-endpoint-route/goes-here', can('look-at-things'), (req, res) => {
  // handle the response here; this handler won't even
  // be called if the requesting user does not have the
  // 'look-at-things' activity
  res.send('You can see things!');
});
```

This should be the last piece for #32 

---

**Future note:** @jeromeleecms had asked about being able to assign users one-off activities in addition to their role.  I think a good way to accomplish that will be something like a `auth_user_activity_mapping` table.  The deserializer would need to be updated again to pull additional activities from that mapping, but downstream stuff (like the middleware and the endpoints that use it) should not be affected.