### PR TITLE
Switch API to using await/async instead of promise syntax

### DIFF
--- a/api/auth/authenticate.js
+++ b/api/auth/authenticate.js
@@ -1,27 +1,25 @@
 const defaultDB = require('../db')();
 const defaultBcrypt = require('bcryptjs');
 
-module.exports = (db = defaultDB, bcrypt = defaultBcrypt) => (
+module.exports = (db = defaultDB, bcrypt = defaultBcrypt) => async (
   username,
   password,
   done
-) =>
-  db('users')
-    .where({ email: username })
-    .first()
-    .then(user => {
-      // If there is a matching user, return it
-      if (user && bcrypt.compareSync(password, user.password)) {
-        done(null, { username: user.email, id: user.id });
-      } else {
-        // Otherwise, callback with a false user.  If we
-        // send an error, Passport will send a status 500,
-        // but if we send no error and a false user, it will
-        // send a 401, which is what we really want.  So...
-        // I guess a failed login isn't an error. :P
-        done(null, false);
-      }
-    })
-    .catch(() => {
-      done('Database error');
-    });
+) => {
+  try {
+    const user = await db('users').where({ email: username }).first();
+    // If there is a matching user, return it
+    if (user && bcrypt.compareSync(password, user.password)) {
+      done(null, { username: user.email, id: user.id });
+    } else {
+      // Otherwise, callback with a false user.  If we
+      // send an error, Passport will send a status 500,
+      // but if we send no error and a false user, it will
+      // send a 401, which is what we really want.  So...
+      // I guess a failed login isn't an error. :P
+      done(null, false);
+    }
+  } catch (e) {
+    done('Database error');
+  }
+};

--- a/api/auth/authenticate.js
+++ b/api/auth/authenticate.js
@@ -7,7 +7,9 @@ module.exports = (db = defaultDB, bcrypt = defaultBcrypt) => async (
   done
 ) => {
   try {
-    const user = await db('users').where({ email: username }).first();
+    const user = await db('users')
+      .where({ email: username })
+      .first();
     // If there is a matching user, return it
     if (user && bcrypt.compareSync(password, user.password)) {
       done(null, { username: user.email, id: user.id });

--- a/api/auth/authenticate.test.js
+++ b/api/auth/authenticate.test.js
@@ -13,7 +13,7 @@ const bcrypt = {
 
 const auth = require('./authenticate.js')(db, bcrypt);
 
-tap.test('local authentication', authTest => {
+tap.test('local authentication', async authTest => {
   const doneCallback = sandbox.spy();
   authTest.beforeEach(done => {
     sandbox.reset();
@@ -43,8 +43,6 @@ tap.test('local authentication', authTest => {
       doneCallback.calledWith(sinon.match.truthy),
       'got an error message'
     );
-
-    errorTest.done();
   });
 
   authTest.test('with no valid users', async noUserTest => {
@@ -65,8 +63,6 @@ tap.test('local authentication', authTest => {
 
     noUserTest.equal(doneCallback.callCount, 1, 'called done callback once');
     noUserTest.ok(doneCallback.calledWith(null, false), 'got a false user');
-
-    noUserTest.done();
   });
 
   authTest.test('with invalid password', async invalidTest => {
@@ -99,8 +95,6 @@ tap.test('local authentication', authTest => {
 
     invalidTest.equal(doneCallback.callCount, 1, 'called done callback once');
     invalidTest.ok(doneCallback.calledWith(null, false), 'got a false user');
-
-    invalidTest.done();
   });
 
   authTest.test('with a valid user', async validTest => {
@@ -136,9 +130,5 @@ tap.test('local authentication', authTest => {
       doneCallback.calledWith(null, { username: 'hello@world', id: 57 }),
       'did not get an error message, did get a user object'
     );
-
-    validTest.done();
   });
-
-  authTest.done();
 });

--- a/api/auth/authenticate.test.js
+++ b/api/auth/authenticate.test.js
@@ -22,54 +22,54 @@ tap.test('local authentication', authTest => {
     done();
   });
 
-  authTest.test('with a database error', errorTest => {
+  authTest.test('with a database error', async errorTest => {
     first.rejects();
 
-    auth('user', 'password', doneCallback).then(() => {
-      errorTest.ok(db.calledOnce, 'a single table is queried');
-      errorTest.ok(db.calledWith('users'), 'it is the users table');
-      errorTest.ok(where.calledOnce, 'one set of WHERE clauses is added');
-      errorTest.ok(
-        where.calledWith({ email: 'user' }),
-        'it is the WHERE we expect'
-      );
-      errorTest.ok(first.calledOnce, 'the query is executed one time');
+    await auth('user', 'password', doneCallback);
 
-      errorTest.ok(bcrypt.compareSync.notCalled, 'does not compare passwords');
+    errorTest.ok(db.calledOnce, 'a single table is queried');
+    errorTest.ok(db.calledWith('users'), 'it is the users table');
+    errorTest.ok(where.calledOnce, 'one set of WHERE clauses is added');
+    errorTest.ok(
+      where.calledWith({ email: 'user' }),
+      'it is the WHERE we expect'
+    );
+    errorTest.ok(first.calledOnce, 'the query is executed one time');
 
-      errorTest.equal(doneCallback.callCount, 1, 'called done callback once');
-      errorTest.ok(
-        doneCallback.calledWith(sinon.match.truthy),
-        'got an error message'
-      );
+    errorTest.ok(bcrypt.compareSync.notCalled, 'does not compare passwords');
 
-      errorTest.done();
-    });
+    errorTest.equal(doneCallback.callCount, 1, 'called done callback once');
+    errorTest.ok(
+      doneCallback.calledWith(sinon.match.truthy),
+      'got an error message'
+    );
+
+    errorTest.done();
   });
 
-  authTest.test('with no valid users', noUserTest => {
+  authTest.test('with no valid users', async noUserTest => {
     first.resolves();
 
-    auth('user', 'password', doneCallback).then(() => {
-      noUserTest.ok(db.calledOnce, 'a single table is queried');
-      noUserTest.ok(db.calledWith('users'), 'it is the users table');
-      noUserTest.ok(where.calledOnce, 'one set of WHERE clauses is added');
-      noUserTest.ok(
-        where.calledWith({ email: 'user' }),
-        'it is the WHERE we expect'
-      );
-      noUserTest.ok(first.calledOnce, 'the query is executed one time');
+    await auth('user', 'password', doneCallback);
 
-      noUserTest.ok(bcrypt.compareSync.notCalled, 'does not compare password');
+    noUserTest.ok(db.calledOnce, 'a single table is queried');
+    noUserTest.ok(db.calledWith('users'), 'it is the users table');
+    noUserTest.ok(where.calledOnce, 'one set of WHERE clauses is added');
+    noUserTest.ok(
+      where.calledWith({ email: 'user' }),
+      'it is the WHERE we expect'
+    );
+    noUserTest.ok(first.calledOnce, 'the query is executed one time');
 
-      noUserTest.equal(doneCallback.callCount, 1, 'called done callback once');
-      noUserTest.ok(doneCallback.calledWith(null, false), 'got a false user');
+    noUserTest.ok(bcrypt.compareSync.notCalled, 'does not compare password');
 
-      noUserTest.done();
-    });
+    noUserTest.equal(doneCallback.callCount, 1, 'called done callback once');
+    noUserTest.ok(doneCallback.calledWith(null, false), 'got a false user');
+
+    noUserTest.done();
   });
 
-  authTest.test('with invalid password', invalidTest => {
+  authTest.test('with invalid password', async invalidTest => {
     first.resolves({
       email: 'hello@world',
       password: 'test-password',
@@ -77,33 +77,33 @@ tap.test('local authentication', authTest => {
     });
     bcrypt.compareSync.returns(false);
 
-    auth('user', 'password', doneCallback).then(() => {
-      invalidTest.ok(db.calledOnce, 'a single table is queried');
-      invalidTest.ok(db.calledWith('users'), 'it is the users table');
-      invalidTest.ok(where.calledOnce, 'one set of WHERE clauses is added');
-      invalidTest.ok(
-        where.calledWith({ email: 'user' }),
-        'it is the WHERE we expect'
-      );
-      invalidTest.ok(first.calledOnce, 'the query is executed one time');
+    await auth('user', 'password', doneCallback);
 
-      invalidTest.ok(
-        bcrypt.compareSync.calledOnce,
-        'password is compared one time'
-      );
-      invalidTest.ok(
-        bcrypt.compareSync.calledWith('password', 'test-password'),
-        'password is compared to database value'
-      );
+    invalidTest.ok(db.calledOnce, 'a single table is queried');
+    invalidTest.ok(db.calledWith('users'), 'it is the users table');
+    invalidTest.ok(where.calledOnce, 'one set of WHERE clauses is added');
+    invalidTest.ok(
+      where.calledWith({ email: 'user' }),
+      'it is the WHERE we expect'
+    );
+    invalidTest.ok(first.calledOnce, 'the query is executed one time');
 
-      invalidTest.equal(doneCallback.callCount, 1, 'called done callback once');
-      invalidTest.ok(doneCallback.calledWith(null, false), 'got a false user');
+    invalidTest.ok(
+      bcrypt.compareSync.calledOnce,
+      'password is compared one time'
+    );
+    invalidTest.ok(
+      bcrypt.compareSync.calledWith('password', 'test-password'),
+      'password is compared to database value'
+    );
 
-      invalidTest.done();
-    });
+    invalidTest.equal(doneCallback.callCount, 1, 'called done callback once');
+    invalidTest.ok(doneCallback.calledWith(null, false), 'got a false user');
+
+    invalidTest.done();
   });
 
-  authTest.test('with a valid user', validTest => {
+  authTest.test('with a valid user', async validTest => {
     first.resolves({
       email: 'hello@world',
       password: 'test-password',
@@ -111,33 +111,33 @@ tap.test('local authentication', authTest => {
     });
     bcrypt.compareSync.returns(true);
 
-    auth('user', 'password', doneCallback).then(() => {
-      validTest.ok(db.calledOnce, 'a single table is queried');
-      validTest.ok(db.calledWith('users'), 'it is the users table');
-      validTest.ok(where.calledOnce, 'one set of WHERE clauses is added');
-      validTest.ok(
-        where.calledWith({ email: 'user' }),
-        'it is the WHERE we expect'
-      );
-      validTest.ok(first.calledOnce, 'the query is executed one time');
+    await auth('user', 'password', doneCallback);
 
-      validTest.ok(
-        bcrypt.compareSync.calledOnce,
-        'password is compared one time'
-      );
-      validTest.ok(
-        bcrypt.compareSync.calledWith('password', 'test-password'),
-        'password is compared to database value'
-      );
+    validTest.ok(db.calledOnce, 'a single table is queried');
+    validTest.ok(db.calledWith('users'), 'it is the users table');
+    validTest.ok(where.calledOnce, 'one set of WHERE clauses is added');
+    validTest.ok(
+      where.calledWith({ email: 'user' }),
+      'it is the WHERE we expect'
+    );
+    validTest.ok(first.calledOnce, 'the query is executed one time');
 
-      validTest.equal(doneCallback.callCount, 1, 'called done callback once');
-      validTest.ok(
-        doneCallback.calledWith(null, { username: 'hello@world', id: 57 }),
-        'did not get an error message, did get a user object'
-      );
+    validTest.ok(
+      bcrypt.compareSync.calledOnce,
+      'password is compared one time'
+    );
+    validTest.ok(
+      bcrypt.compareSync.calledWith('password', 'test-password'),
+      'password is compared to database value'
+    );
 
-      validTest.done();
-    });
+    validTest.equal(doneCallback.callCount, 1, 'called done callback once');
+    validTest.ok(
+      doneCallback.calledWith(null, { username: 'hello@world', id: 57 }),
+      'did not get an error message, did get a user object'
+    );
+
+    validTest.done();
   });
 
   authTest.done();

--- a/api/auth/index.test.js
+++ b/api/auth/index.test.js
@@ -6,7 +6,7 @@ const sandbox = sinon.createSandbox();
 process.env.SESSION_SECRET = 'secret';
 const authSetup = require('./index').setup;
 
-tap.test('authentication setup', authTest => {
+tap.test('authentication setup', async authTest => {
   const app = {
     use: sandbox.spy(),
     get: sandbox.spy(),
@@ -29,7 +29,7 @@ tap.test('authentication setup', authTest => {
     done();
   });
 
-  authTest.test('setup calls everything we expect it to', setupTest => {
+  authTest.test('setup calls everything we expect it to', async setupTest => {
     authSetup(app, passport, strategies);
 
     setupTest.equal(
@@ -108,11 +108,9 @@ tap.test('authentication setup', authTest => {
       ),
       'adds a function handler to POST /auth/login using the passport authenticate middleware'
     );
-
-    setupTest.done();
   });
 
-  authTest.test('setup works with defaults, too', setupTest => {
+  authTest.test('setup works with defaults, too', async setupTest => {
     authSetup(app);
 
     setupTest.equal(
@@ -127,11 +125,9 @@ tap.test('authentication setup', authTest => {
     setupTest.ok(
       app.post.calledWith('/auth/login', sinon.match.func, sinon.match.func)
     );
-
-    setupTest.done();
   });
 
-  authTest.test('POST endpoint behaves as expected', postTest => {
+  authTest.test('POST endpoint behaves as expected', async postTest => {
     authSetup(app, passport, strategies);
     const post = app.post.args[0][2];
 
@@ -149,9 +145,5 @@ tap.test('authentication setup', authTest => {
     postTest.ok(res.status.calledWith(200), 'sets a 200 HTTP status');
     postTest.ok(res.send.notCalled, 'HTTP body is not sent');
     postTest.ok(res.end.calledOnce, 'response is ended one time');
-
-    postTest.done();
   });
-
-  authTest.done();
 });

--- a/api/auth/middleware.test.js
+++ b/api/auth/middleware.test.js
@@ -20,11 +20,11 @@ tap.beforeEach(done => {
   done();
 });
 
-tap.test('logged in middleware', loggedInMiddlewareTest => {
+tap.test('logged in middleware', async loggedInMiddlewareTest => {
   const loggedIn = middleware.loggedIn;
   loggedInMiddlewareTest.test(
     'rejects if the user is not logged in',
-    invalidTest => {
+    async invalidTest => {
       loggedIn({}, res, next);
 
       invalidTest.ok(res.status.calledWith(403), 'HTTP status set to 403');
@@ -33,32 +33,28 @@ tap.test('logged in middleware', loggedInMiddlewareTest => {
         next.notCalled,
         'endpoint handling chain is not continued'
       );
-      invalidTest.done();
     }
   );
 
   loggedInMiddlewareTest.test(
     'continues if the user is logged in',
-    validTest => {
+    async validTest => {
       loggedIn({ user: true }, res, next);
 
       validTest.ok(res.send.notCalled, 'no body is sent');
       validTest.ok(res.status.notCalled, 'HTTP status not set');
       validTest.ok(res.end.notCalled, 'response is not terminated');
       validTest.ok(next.called, 'endpoint handling chain is continued');
-      validTest.done();
     }
   );
-
-  loggedInMiddlewareTest.done();
 });
 
-tap.test('"can" middleware', canMiddlewareTest => {
+tap.test('"can" middleware', async canMiddlewareTest => {
   const can = middleware.can;
 
   canMiddlewareTest.test(
     'rejects if the user is not logged in',
-    invalidTest => {
+    async invalidTest => {
       can('activity')({}, res, next);
 
       invalidTest.ok(res.status.calledWith(403), 'HTTP status set to 403');
@@ -67,13 +63,12 @@ tap.test('"can" middleware', canMiddlewareTest => {
         next.notCalled,
         'endpoint handling chain is not continued'
       );
-      invalidTest.done();
     }
   );
 
   canMiddlewareTest.test(
     'rejects if the user does not have the expected activity',
-    invalidTest => {
+    async invalidTest => {
       can('activity')({ user: { activities: [] } }, res, next);
 
       invalidTest.ok(res.status.calledWith(401), 'HTTP status set to 401');
@@ -82,22 +77,18 @@ tap.test('"can" middleware', canMiddlewareTest => {
         next.notCalled,
         'endpoint handling chain is not continued'
       );
-      invalidTest.done();
     }
   );
 
   canMiddlewareTest.test(
     'continues if the user has the expected activity',
-    validTest => {
+    async validTest => {
       can('activity')({ user: { activities: ['activity'] } }, res, next);
 
       validTest.ok(res.send.notCalled, 'no body is sent');
       validTest.ok(res.status.notCalled, 'HTTP status not set');
       validTest.ok(res.end.notCalled, 'response is not terminated');
       validTest.ok(next.called, 'endpoint handling chain is continued');
-      validTest.done();
     }
   );
-
-  canMiddlewareTest.done();
 });

--- a/api/auth/serialization.js
+++ b/api/auth/serialization.js
@@ -8,43 +8,40 @@ module.exports.serializeUser = (user, done) => {
 
 // Deserialize a stringy from the user's session cookie
 // into a user object.
-module.exports.deserializeUser = (userID, done, db = defaultDB) =>
-  db('users')
-    .where({ id: userID })
-    .select()
-    .then(users => {
-      if (users.length) {
-        const role = users[0].auth_role;
-        if (role) {
-          db('auth_role_activity_mapping')
-            .fullOuterJoin(
-              'auth_roles',
-              'auth_roles.id',
-              'auth_role_activity_mapping.role_id'
-            )
-            .where({ 'auth_roles.name': role })
-            .innerJoin(
-              'auth_activities',
-              'auth_activities.id',
-              'auth_role_activity_mapping.activity_id'
-            )
-            .select()
-            .then(activityRows => {
-              const activities = activityRows.map(row => row.name);
-              done(null, {
-                username: users[0].email,
-                id: users[0].id,
-                activities
-              });
-            });
-        } else {
+module.exports.deserializeUser = async (userID, done, db = defaultDB) => {
+  try {
+    const users = await db('users').where({ id: userID }).select();
+    const role = users[0].auth_role;
+    if (role) {
+      db('auth_role_activity_mapping')
+        .fullOuterJoin(
+          'auth_roles',
+          'auth_roles.id',
+          'auth_role_activity_mapping.role_id'
+        )
+        .where({ 'auth_roles.name': role })
+        .innerJoin(
+          'auth_activities',
+          'auth_activities.id',
+          'auth_role_activity_mapping.activity_id'
+        )
+        .select()
+        .then(activityRows => {
+          const activities = activityRows.map(row => row.name);
           done(null, {
             username: users[0].email,
             id: users[0].id,
-            activities: []
+            activities
           });
-        }
-      } else {
-        done('Could not deserialize user');
-      }
-    });
+        });
+    } else {
+      done(null, {
+        username: users[0].email,
+        id: users[0].id,
+        activities: []
+      });
+    }
+  } catch (e) {
+    done('Could not deserialize user');
+  }
+};

--- a/api/auth/serialization.js
+++ b/api/auth/serialization.js
@@ -10,7 +10,9 @@ module.exports.serializeUser = (user, done) => {
 // into a user object.
 module.exports.deserializeUser = async (userID, done, db = defaultDB) => {
   try {
-    const users = await db('users').where({ id: userID }).select();
+    const users = await db('users')
+      .where({ id: userID })
+      .select();
     const role = users[0].auth_role;
     if (role) {
       const activityRows = await db('auth_role_activity_mapping')

--- a/api/auth/serialization.js
+++ b/api/auth/serialization.js
@@ -13,7 +13,7 @@ module.exports.deserializeUser = async (userID, done, db = defaultDB) => {
     const users = await db('users').where({ id: userID }).select();
     const role = users[0].auth_role;
     if (role) {
-      db('auth_role_activity_mapping')
+      const activityRows = await db('auth_role_activity_mapping')
         .fullOuterJoin(
           'auth_roles',
           'auth_roles.id',
@@ -25,15 +25,13 @@ module.exports.deserializeUser = async (userID, done, db = defaultDB) => {
           'auth_activities.id',
           'auth_role_activity_mapping.activity_id'
         )
-        .select()
-        .then(activityRows => {
-          const activities = activityRows.map(row => row.name);
-          done(null, {
-            username: users[0].email,
-            id: users[0].id,
-            activities
-          });
-        });
+        .select();
+      const activities = activityRows.map(row => row.name);
+      done(null, {
+        username: users[0].email,
+        id: users[0].id,
+        activities
+      });
     } else {
       done(null, {
         username: users[0].email,

--- a/api/auth/serialization.test.js
+++ b/api/auth/serialization.test.js
@@ -5,7 +5,7 @@ const sandbox = sinon.createSandbox();
 
 const serialization = require('./serialization');
 
-tap.test('passport serialization', serializationTest => {
+tap.test('passport serialization', async serializationTest => {
   const db = sandbox.stub();
   const where = sandbox.stub();
   const select = sandbox.stub();
@@ -31,17 +31,16 @@ tap.test('passport serialization', serializationTest => {
     done();
   });
 
-  serializationTest.test('serialize a user', serializeTest => {
+  serializationTest.test('serialize a user', async serializeTest => {
     const user = { id: 'the-user-id' };
     serialization.serializeUser(user, doneCallback);
     serializeTest.ok(
       doneCallback.calledWith(null, 'the-user-id'),
       'serializes the user object'
     );
-    serializeTest.done();
   });
 
-  serializationTest.test('deserialize a user', deserializeTest => {
+  serializationTest.test('deserialize a user', async deserializeTest => {
     const userID = 'the-user-id';
 
     deserializeTest.test('that is not in the database', async invalidTest => {
@@ -52,10 +51,9 @@ tap.test('passport serialization', serializationTest => {
         doneCallback.calledWith(sinon.match.string),
         'calls back with an error'
       );
-      invalidTest.done();
     });
 
-    deserializeTest.test('that is in the database', validTest => {
+    deserializeTest.test('that is in the database', async validTest => {
       validTest.test('with no role', async noRoleTest => {
         select.resolves([{ email: 'test-email', id: 'test-id', role: null }]);
 
@@ -69,7 +67,6 @@ tap.test('passport serialization', serializationTest => {
           }),
           'deserializes the user ID to an object'
         );
-        noRoleTest.done();
       });
 
       validTest.test('with a role', async adminRoleTest => {
@@ -96,14 +93,7 @@ tap.test('passport serialization', serializationTest => {
           }),
           'deserializes the user ID to an object'
         );
-        adminRoleTest.done();
       });
-
-      validTest.done();
     });
-
-    deserializeTest.done();
   });
-
-  serializationTest.done();
 });

--- a/api/auth/serialization.test.js
+++ b/api/auth/serialization.test.js
@@ -57,23 +57,23 @@ tap.test('passport serialization', serializationTest => {
     });
 
     deserializeTest.test('that is in the database', validTest => {
-      validTest.test('with no role', noRoleTest => {
+      validTest.test('with no role', async noRoleTest => {
         select.resolves([{ email: 'test-email', id: 'test-id', role: null }]);
 
-        serialization.deserializeUser(userID, doneCallback, db).then(() => {
-          noRoleTest.ok(
-            doneCallback.calledWith(null, {
-              username: 'test-email',
-              id: 'test-id',
-              activities: sinon.match.array.deepEquals([])
-            }),
-            'deserializes the user ID to an object'
-          );
-          noRoleTest.done();
-        });
+        await serialization.deserializeUser(userID, doneCallback, db);
+
+        noRoleTest.ok(
+          doneCallback.calledWith(null, {
+            username: 'test-email',
+            id: 'test-id',
+            activities: sinon.match.array.deepEquals([])
+          }),
+          'deserializes the user ID to an object'
+        );
+        noRoleTest.done();
       });
 
-      validTest.test('with a role', adminRoleTest => {
+      validTest.test('with a role', async adminRoleTest => {
         select
           .onFirstCall()
           .resolves([
@@ -84,20 +84,20 @@ tap.test('passport serialization', serializationTest => {
           .onSecondCall()
           .resolves([{ name: 'activity 1' }, { name: 'activity 2' }]);
 
-        serialization.deserializeUser(userID, doneCallback, db).then(() => {
-          adminRoleTest.ok(
-            doneCallback.calledWith(null, {
-              username: 'test-email',
-              id: 'test-id',
-              activities: sinon.match.array.deepEquals([
-                'activity 1',
-                'activity 2'
-              ])
-            }),
-            'deserializes the user ID to an object'
-          );
-          adminRoleTest.done();
-        });
+        await serialization.deserializeUser(userID, doneCallback, db);
+
+        adminRoleTest.ok(
+          doneCallback.calledWith(null, {
+            username: 'test-email',
+            id: 'test-id',
+            activities: sinon.match.array.deepEquals([
+              'activity 1',
+              'activity 2'
+            ])
+          }),
+          'deserializes the user ID to an object'
+        );
+        adminRoleTest.done();
       });
 
       validTest.done();

--- a/api/auth/serialization.test.js
+++ b/api/auth/serialization.test.js
@@ -44,16 +44,15 @@ tap.test('passport serialization', serializationTest => {
   serializationTest.test('deserialize a user', deserializeTest => {
     const userID = 'the-user-id';
 
-    deserializeTest.test('that is not in the database', invalidTest => {
+    deserializeTest.test('that is not in the database', async invalidTest => {
       select.resolves([]);
 
-      serialization.deserializeUser(userID, doneCallback, db).then(() => {
-        invalidTest.ok(
-          doneCallback.calledWith(sinon.match.string),
-          'calls back with an error'
-        );
-        invalidTest.done();
-      });
+      await serialization.deserializeUser(userID, doneCallback, db);
+      invalidTest.ok(
+        doneCallback.calledWith(sinon.match.string),
+        'calls back with an error'
+      );
+      invalidTest.done();
     });
 
     deserializeTest.test('that is in the database', validTest => {

--- a/api/auth/session.test.js
+++ b/api/auth/session.test.js
@@ -3,7 +3,7 @@ const sinon = require('sinon');
 
 const getSessionFunction = require('./session').getSessionFunction;
 
-tap.test('session function', sessionTest => {
+tap.test('session function', async sessionTest => {
   const sessions = sinon.spy();
 
   process.env.SESSION_SECRET = 'secret';
@@ -33,5 +33,4 @@ tap.test('session function', sessionTest => {
     config.duration < 30 * 24 * 60 * 60 * 1000,
     'session cookie lasts less than 30 days'
   );
-  sessionTest.done();
 });

--- a/api/db.test.js
+++ b/api/db.test.js
@@ -3,7 +3,7 @@ const sinon = require('sinon');
 
 const db = require('./db');
 
-tap.test('database object module', dbTest => {
+tap.test('database object module', async dbTest => {
   const knex = sinon.stub().returns({
     thisIs: 'a database'
   });
@@ -24,5 +24,4 @@ tap.test('database object module', dbTest => {
   );
 
   process.env.NODE_ENV = nodeEnv;
-  dbTest.done();
 });

--- a/api/endpoint-tests/auth/login.js
+++ b/api/endpoint-tests/auth/login.js
@@ -61,15 +61,25 @@ tap.test('login endpoint | /auth/login', async loginTest => {
   ];
 
   badCredentialsCases.forEach(badCredentialsCase => {
-    loginTest.test(`Form body: ${badCredentialsCase.title}`, async invalidTest => {
-      const { response } = await request.post(url, { form: badCredentialsCase.data });
-      invalidTest.equal(response.statusCode, 401, 'gives a 401 status code');
-    });
+    loginTest.test(
+      `Form body: ${badCredentialsCase.title}`,
+      async invalidTest => {
+        const { response } = await request.post(url, {
+          form: badCredentialsCase.data
+        });
+        invalidTest.equal(response.statusCode, 401, 'gives a 401 status code');
+      }
+    );
 
-    loginTest.test(`JSON body: ${badCredentialsCase.title}`, async invalidTest => {
-      const { response } = await request.post(url, { json: badCredentialsCase.data });
-      invalidTest.equal(response.statusCode, 401, 'gives a 401 status code');
-    });
+    loginTest.test(
+      `JSON body: ${badCredentialsCase.title}`,
+      async invalidTest => {
+        const { response } = await request.post(url, {
+          json: badCredentialsCase.data
+        });
+        invalidTest.equal(response.statusCode, 401, 'gives a 401 status code');
+      }
+    );
   });
 
   loginTest.test(
@@ -77,9 +87,10 @@ tap.test('login endpoint | /auth/login', async loginTest => {
     async validTest => {
       // isolate cookies, so request doesn't reuse them
       const cookies = request.jar();
-      const { response, body } = await request.post(
-        url,
-        { jar: cookies, form: { username: 'em@il.com', password: 'password' } });
+      const { response, body } = await request.post(url, {
+        jar: cookies,
+        form: { username: 'em@il.com', password: 'password' }
+      });
 
       validTest.equal(response.statusCode, 200, 'gives a 200 status code');
       validTest.ok(
@@ -98,9 +109,10 @@ tap.test('login endpoint | /auth/login', async loginTest => {
     async validTest => {
       // isolate cookies, so request doesn't reuse them
       const cookies = request.jar();
-      const { response, body } = await request.post(
-        url,
-        { jar: cookies, json: { username: 'em@il.com', password: 'password' } });
+      const { response, body } = await request.post(url, {
+        jar: cookies,
+        json: { username: 'em@il.com', password: 'password' }
+      });
 
       validTest.equal(response.statusCode, 200, 'gives a 200 status code');
       validTest.ok(

--- a/api/endpoint-tests/auth/login.js
+++ b/api/endpoint-tests/auth/login.js
@@ -1,15 +1,12 @@
 const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
-const request = require('request'); // eslint-disable-line import/no-extraneous-dependencies
-const { getFullPath } = require('../utils');
+const { request, getFullPath } = require('../utils');
 
-tap.test('login endpoint | /auth/login', loginTest => {
+tap.test('login endpoint | /auth/login', async loginTest => {
   const url = getFullPath('/auth/login');
 
-  loginTest.test('with no post body at all', invalidTest => {
-    request.post(url, (err, response) => {
-      invalidTest.equal(response.statusCode, 400, 'gives a 400 status code');
-      invalidTest.done();
-    });
+  loginTest.test('with no post body at all', async invalidTest => {
+    const { response } = await request.post(url);
+    invalidTest.equal(response.statusCode, 400, 'gives a 400 status code');
   });
 
   const invalidCases = [
@@ -28,18 +25,14 @@ tap.test('login endpoint | /auth/login', loginTest => {
   ];
 
   invalidCases.forEach(invalidCase => {
-    loginTest.test(`Form body: ${invalidCase.title}`, invalidTest => {
-      request.post(url, { form: invalidCase.data }, (err, response) => {
-        invalidTest.equal(response.statusCode, 400, 'gives a 400 status code');
-        invalidTest.done();
-      });
+    loginTest.test(`Form body: ${invalidCase.title}`, async invalidTest => {
+      const { response } = await request.post(url, { form: invalidCase.data });
+      invalidTest.equal(response.statusCode, 400, 'gives a 400 status code');
     });
 
-    loginTest.test(`JSON body: ${invalidCase.title}`, invalidTest => {
-      request.post(url, { json: invalidCase.data }, (err, response) => {
-        invalidTest.equal(response.statusCode, 400, 'gives a 400 status code');
-        invalidTest.done();
-      });
+    loginTest.test(`JSON body: ${invalidCase.title}`, async invalidTest => {
+      const { response } = await request.post(url, { json: invalidCase.data });
+      invalidTest.equal(response.statusCode, 400, 'gives a 400 status code');
     });
   });
 
@@ -68,68 +61,56 @@ tap.test('login endpoint | /auth/login', loginTest => {
   ];
 
   badCredentialsCases.forEach(badCredentialsCase => {
-    loginTest.test(`Form body: ${badCredentialsCase.title}`, invalidTest => {
-      request.post(url, { form: badCredentialsCase.data }, (err, response) => {
-        invalidTest.equal(response.statusCode, 401, 'gives a 401 status code');
-        invalidTest.done();
-      });
+    loginTest.test(`Form body: ${badCredentialsCase.title}`, async invalidTest => {
+      const { response } = await request.post(url, { form: badCredentialsCase.data });
+      invalidTest.equal(response.statusCode, 401, 'gives a 401 status code');
     });
 
-    loginTest.test(`JSON body: ${badCredentialsCase.title}`, invalidTest => {
-      request.post(url, { json: badCredentialsCase.data }, (err, response) => {
-        invalidTest.equal(response.statusCode, 401, 'gives a 401 status code');
-        invalidTest.done();
-      });
+    loginTest.test(`JSON body: ${badCredentialsCase.title}`, async invalidTest => {
+      const { response } = await request.post(url, { json: badCredentialsCase.data });
+      invalidTest.equal(response.statusCode, 401, 'gives a 401 status code');
     });
   });
 
   loginTest.test(
     'Form body: with valid username and valid password',
-    validTest => {
+    async validTest => {
       // isolate cookies, so request doesn't reuse them
       const cookies = request.jar();
-      request.post(
+      const { response, body } = await request.post(
         url,
-        { jar: cookies, form: { username: 'em@il.com', password: 'password' } },
-        (err, response, body) => {
-          validTest.equal(response.statusCode, 200, 'gives a 200 status code');
-          validTest.ok(
-            response.headers['set-cookie'].some(
-              cookie =>
-                cookie.startsWith('session=') && cookie.endsWith('; httponly')
-            ),
-            'sends an http-only session cookie'
-          );
-          validTest.notOk(body, 'does not send a body');
-          validTest.done();
-        }
+        { jar: cookies, form: { username: 'em@il.com', password: 'password' } });
+
+      validTest.equal(response.statusCode, 200, 'gives a 200 status code');
+      validTest.ok(
+        response.headers['set-cookie'].some(
+          cookie =>
+            cookie.startsWith('session=') && cookie.endsWith('; httponly')
+        ),
+        'sends an http-only session cookie'
       );
+      validTest.notOk(body, 'does not send a body');
     }
   );
 
   loginTest.test(
     'JSON body: with valid username and valid password',
-    validTest => {
+    async validTest => {
       // isolate cookies, so request doesn't reuse them
       const cookies = request.jar();
-      request.post(
+      const { response, body } = await request.post(
         url,
-        { jar: cookies, json: { username: 'em@il.com', password: 'password' } },
-        (err, response, body) => {
-          validTest.equal(response.statusCode, 200, 'gives a 200 status code');
-          validTest.ok(
-            response.headers['set-cookie'].some(
-              cookie =>
-                cookie.startsWith('session=') && cookie.endsWith('; httponly')
-            ),
-            'sends an http-only session cookie'
-          );
-          validTest.notOk(body, 'does not send a body');
-          validTest.done();
-        }
+        { jar: cookies, json: { username: 'em@il.com', password: 'password' } });
+
+      validTest.equal(response.statusCode, 200, 'gives a 200 status code');
+      validTest.ok(
+        response.headers['set-cookie'].some(
+          cookie =>
+            cookie.startsWith('session=') && cookie.endsWith('; httponly')
+        ),
+        'sends an http-only session cookie'
       );
+      validTest.notOk(body, 'does not send a body');
     }
   );
-
-  loginTest.done();
 });

--- a/api/endpoint-tests/auth/logout.js
+++ b/api/endpoint-tests/auth/logout.js
@@ -35,8 +35,7 @@ tap.test('logout endpoint | /auth/logout', async logoutTest => {
     test.equal(response.statusCode, 200, 'gives a 200 status code');
     test.ok(
       response.headers['set-cookie'].some(
-        cookie =>
-          cookie.startsWith('session=') && cookie.endsWith('; httponly')
+        cookie => cookie.startsWith('session=') && cookie.endsWith('; httponly')
       ),
       'sends a new http-only session cookie'
     );

--- a/api/endpoint-tests/auth/logout.js
+++ b/api/endpoint-tests/auth/logout.js
@@ -1,55 +1,50 @@
 const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
-const request = require('request'); // eslint-disable-line import/no-extraneous-dependencies
-const { getFullPath } = require('../utils');
+const { request, getFullPath } = require('../utils');
 
-tap.test('logout endpoint | /auth/logout', logoutTest => {
+tap.test('logout endpoint | /auth/logout', async logoutTest => {
   const url = getFullPath('/auth/logout');
 
-  logoutTest.test('not already logged in', test => {
+  logoutTest.test('not already logged in', async test => {
     const cookies = request.jar();
 
-    request.get(url, { jar: cookies }, (err, response) => {
-      test.equal(response.statusCode, 200, 'gives a 200 status code');
+    const { response } = await request.get(url, { jar: cookies });
 
-      // It might be valid for the API to set some header other than
-      // the session cookie, but it might also be valid for it to set
-      // no headers at all.
-      if (response.headers['set-cookie']) {
-        test.ok(
-          response.headers['set-cookie'].every(
-            cookie => !cookie.startsWith('session=')
-          ),
-          'does not set a session cookie'
-        );
-      } else {
-        test.pass('does not set a session cookie');
-      }
-      test.done();
-    });
+    test.equal(response.statusCode, 200, 'gives a 200 status code');
+
+    // It might be valid for the API to set some header other than
+    // the session cookie, but it might also be valid for it to set
+    // no headers at all.
+    if (response.headers['set-cookie']) {
+      test.ok(
+        response.headers['set-cookie'].every(
+          cookie => !cookie.startsWith('session=')
+        ),
+        'does not set a session cookie'
+      );
+    } else {
+      test.pass('does not set a session cookie');
+    }
   });
 
-  logoutTest.test('already logged in', test => {
+  logoutTest.test('already logged in', async test => {
     const cookies = request.jar();
     cookies.setCookie('session=this-is-my-session', url);
 
-    request.get(url, { jar: cookies }, (err, response) => {
-      test.equal(response.statusCode, 200, 'gives a 200 status code');
-      test.ok(
-        response.headers['set-cookie'].some(
-          cookie =>
-            cookie.startsWith('session=') && cookie.endsWith('; httponly')
-        ),
-        'sends a new http-only session cookie'
-      );
-      test.ok(
-        response.headers['set-cookie'].every(
-          cookie => !cookie.startsWith('session=this-is-my-session')
-        ),
-        'does not just send back the same session cookie'
-      );
-      test.done();
-    });
-  });
+    const { response } = await request.get(url, { jar: cookies });
 
-  logoutTest.done();
+    test.equal(response.statusCode, 200, 'gives a 200 status code');
+    test.ok(
+      response.headers['set-cookie'].some(
+        cookie =>
+          cookie.startsWith('session=') && cookie.endsWith('; httponly')
+      ),
+      'sends a new http-only session cookie'
+    );
+    test.ok(
+      response.headers['set-cookie'].every(
+        cookie => !cookie.startsWith('session=this-is-my-session')
+      ),
+      'does not just send back the same session cookie'
+    );
+  });
 });

--- a/api/endpoint-tests/users/get.js
+++ b/api/endpoint-tests/users/get.js
@@ -1,136 +1,109 @@
 const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
-const request = require('request'); // eslint-disable-line import/no-extraneous-dependencies
 const getFullPath = require('../utils').getFullPath;
 const login = require('../utils').login;
+const request = require('../utils').request;
 
-tap.test('users endpoint | GET /users', getUsersTest => {
+tap.test('users endpoint | GET /users', async getUsersTest => {
   const url = getFullPath('/users');
 
-  getUsersTest.test('when unauthenticated', unauthenticatedTest => {
-    request.get(url, (err, response, body) => {
-      unauthenticatedTest.equal(
-        response.statusCode,
-        403,
-        'gives a 403 status code'
-      );
-      unauthenticatedTest.notOk(body, 'does not send a body');
-      unauthenticatedTest.done();
-    });
+  getUsersTest.test('when unauthenticated', async unauthenticatedTest => {
+    const { response, body } = await request.get(url);
+    unauthenticatedTest.equal(
+      response.statusCode,
+      403,
+      'gives a 403 status code'
+    );
+    unauthenticatedTest.notOk(body, 'does not send a body');
   });
 
-  getUsersTest.test('when authenticated', validTest => {
-    login().then(cookies => {
-      request.get(url, { jar: cookies, json: true }, (err, response, body) => {
-        validTest.equal(response.statusCode, 200, 'gives a 200 status code');
-        validTest.same(
-          body,
-          [{ id: 57, email: 'em@il.com' }],
-          'returns an array of known users'
-        );
-        validTest.done();
-      });
-    });
-  });
+  getUsersTest.test('when authenticated', async validTest => {
+    const cookies = await login();
+    const { response, body } = await request.get(url, { jar: cookies, json: true });
 
-  getUsersTest.done();
+    validTest.equal(response.statusCode, 200, 'gives a 200 status code');
+    validTest.same(
+      body,
+      [{ id: 57, email: 'em@il.com' }],
+      'returns an array of known users'
+    );
+  });
 });
 
-tap.test('users endpoint | GET /user/:userID', getUserTest => {
+tap.test('users endpoint | GET /user/:userID', async getUserTest => {
   const url = getFullPath('/user');
 
-  getUserTest.test('when unauthenticated', unauthenticatedTests => {
+  getUserTest.test('when unauthenticated', async unauthenticatedTests => {
     [
       { name: 'when requesting an invalid user ID', id: 'random-id' },
       { name: 'when requesting a non-existing user ID', id: 500 },
       { name: 'when requesting a valid user ID', id: 57 }
     ].forEach(situation => {
-      unauthenticatedTests.test(situation.name, unauthentedTest => {
-        request.get(`${url}/${situation.id}`, (err, response, body) => {
-          unauthentedTest.equal(
-            response.statusCode,
-            403,
-            'gives a 403 status code'
-          );
-          unauthentedTest.notOk(body, 'does not send a body');
-          unauthentedTest.done();
-        });
+      unauthenticatedTests.test(situation.name, async unauthentedTest => {
+        const { response, body } = await request.get(`${url}/${situation.id}`);
+        unauthentedTest.equal(
+          response.statusCode,
+          403,
+          'gives a 403 status code'
+        );
+        unauthentedTest.notOk(body, 'does not send a body');
       });
     });
-
-    unauthenticatedTests.done();
   });
 
-  getUserTest.test('when authenticated', authenticatedTests => {
+  getUserTest.test('when authenticated', async authenticatedTests => {
     authenticatedTests.test(
       'when requesting an invalid user ID',
-      invalidTest => {
-        login().then(cookies => {
-          request.get(
-            `${url}/random-id`,
-            { jar: cookies, json: true },
-            (err, response, body) => {
-              invalidTest.equal(
-                response.statusCode,
-                400,
-                'gives a 400 status code'
-              );
-              invalidTest.same(
-                body,
-                { error: 'get-user-invalid' },
-                'sends a token indicating the failure'
-              );
-              invalidTest.done();
-            }
-          );
-        });
+      async invalidTest => {
+        const cookies = await login();
+        const { response, body } = await request.get(
+          `${url}/random-id`,
+          { jar: cookies, json: true });
+
+        invalidTest.equal(
+          response.statusCode,
+          400,
+          'gives a 400 status code'
+        );
+        invalidTest.same(
+          body,
+          { error: 'get-user-invalid' },
+          'sends a token indicating the failure'
+        );
       }
     );
 
     authenticatedTests.test(
       'when requesting a non-existant user ID',
-      invalidTest => {
-        login().then(cookies => {
-          request.get(
-            `${url}/500`,
-            { jar: cookies, json: true },
-            (err, response, body) => {
-              invalidTest.equal(
-                response.statusCode,
-                404,
-                'gives a 404 status code'
-              );
-              invalidTest.notOk(body, 'does not send a body');
-              invalidTest.done();
-            }
-          );
-        });
+      async invalidTest => {
+        const cookies = await login();
+        const { response, body } = await request.get(
+          `${url}/500`,
+          { jar: cookies, json: true });
+
+        invalidTest.equal(
+          response.statusCode,
+          404,
+          'gives a 404 status code'
+        );
+        invalidTest.notOk(body, 'does not send a body');
       }
     );
 
-    authenticatedTests.test('when requesting a valid user ID', validTest => {
-      login().then(cookies => {
-        request.get(
-          `${url}/57`,
-          { jar: cookies, json: true },
-          (err, response, body) => {
-            validTest.equal(
-              response.statusCode,
-              200,
-              'gives a 200 status code'
-            );
-            validTest.same(
-              body,
-              { id: 57, email: 'em@il.com' },
-              'returns an object for the requested user'
-            );
-            validTest.done();
-          }
-        );
-      });
+    authenticatedTests.test('when requesting a valid user ID', async validTest => {
+      const cookies = await login();
+      const { response, body } = await request.get(
+        `${url}/57`,
+        { jar: cookies, json: true });
+      validTest.equal(
+        response.statusCode,
+        200,
+        'gives a 200 status code'
+      );
+      validTest.same(
+        body,
+        { id: 57, email: 'em@il.com' },
+        'returns an object for the requested user'
+      );
     });
-
-    authenticatedTests.done();
   });
-
-  getUserTest.done();
 });

--- a/api/endpoint-tests/users/get.js
+++ b/api/endpoint-tests/users/get.js
@@ -18,7 +18,10 @@ tap.test('users endpoint | GET /users', async getUsersTest => {
 
   getUsersTest.test('when authenticated', async validTest => {
     const cookies = await login();
-    const { response, body } = await request.get(url, { jar: cookies, json: true });
+    const { response, body } = await request.get(url, {
+      jar: cookies,
+      json: true
+    });
 
     validTest.equal(response.statusCode, 200, 'gives a 200 status code');
     validTest.same(
@@ -55,15 +58,12 @@ tap.test('users endpoint | GET /user/:userID', async getUserTest => {
       'when requesting an invalid user ID',
       async invalidTest => {
         const cookies = await login();
-        const { response, body } = await request.get(
-          `${url}/random-id`,
-          { jar: cookies, json: true });
+        const { response, body } = await request.get(`${url}/random-id`, {
+          jar: cookies,
+          json: true
+        });
 
-        invalidTest.equal(
-          response.statusCode,
-          400,
-          'gives a 400 status code'
-        );
+        invalidTest.equal(response.statusCode, 400, 'gives a 400 status code');
         invalidTest.same(
           body,
           { error: 'get-user-invalid' },
@@ -76,34 +76,31 @@ tap.test('users endpoint | GET /user/:userID', async getUserTest => {
       'when requesting a non-existant user ID',
       async invalidTest => {
         const cookies = await login();
-        const { response, body } = await request.get(
-          `${url}/500`,
-          { jar: cookies, json: true });
+        const { response, body } = await request.get(`${url}/500`, {
+          jar: cookies,
+          json: true
+        });
 
-        invalidTest.equal(
-          response.statusCode,
-          404,
-          'gives a 404 status code'
-        );
+        invalidTest.equal(response.statusCode, 404, 'gives a 404 status code');
         invalidTest.notOk(body, 'does not send a body');
       }
     );
 
-    authenticatedTests.test('when requesting a valid user ID', async validTest => {
-      const cookies = await login();
-      const { response, body } = await request.get(
-        `${url}/57`,
-        { jar: cookies, json: true });
-      validTest.equal(
-        response.statusCode,
-        200,
-        'gives a 200 status code'
-      );
-      validTest.same(
-        body,
-        { id: 57, email: 'em@il.com' },
-        'returns an object for the requested user'
-      );
-    });
+    authenticatedTests.test(
+      'when requesting a valid user ID',
+      async validTest => {
+        const cookies = await login();
+        const { response, body } = await request.get(`${url}/57`, {
+          jar: cookies,
+          json: true
+        });
+        validTest.equal(response.statusCode, 200, 'gives a 200 status code');
+        validTest.same(
+          body,
+          { id: 57, email: 'em@il.com' },
+          'returns an object for the requested user'
+        );
+      }
+    );
   });
 });

--- a/api/endpoint-tests/users/post.js
+++ b/api/endpoint-tests/users/post.js
@@ -1,10 +1,5 @@
 const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
-const {
-  db,
-  request,
-  getFullPath,
-  login
-} = require('../utils');
+const { db, request, getFullPath, login } = require('../utils');
 
 tap.test('users endpoint | POST /user', async postUsersTest => {
   const url = getFullPath('/user');
@@ -36,7 +31,9 @@ tap.test('users endpoint | POST /user', async postUsersTest => {
       }
     ].forEach(situation => {
       unauthenticatedTests.test(situation.name, async unauthenticatedTest => {
-        const { response, body } = await request.post(url, { json: situation.body });
+        const { response, body } = await request.post(url, {
+          json: situation.body
+        });
         unauthenticatedTest.equal(
           response.statusCode,
           403,
@@ -52,14 +49,11 @@ tap.test('users endpoint | POST /user', async postUsersTest => {
 
     invalidCases.forEach(situation => {
       authenticatedTests.test(situation.name, async invalidTest => {
-        const { response, body } = await request.post(
-          url,
-          { jar: cookies, json: situation.body || true });
-        invalidTest.equal(
-          response.statusCode,
-          400,
-          'gives a 400 status code'
-        );
+        const { response, body } = await request.post(url, {
+          jar: cookies,
+          json: situation.body || true
+        });
+        invalidTest.equal(response.statusCode, 400, 'gives a 400 status code');
         invalidTest.same(
           body,
           { error: 'add-user-invalid' },
@@ -68,45 +62,36 @@ tap.test('users endpoint | POST /user', async postUsersTest => {
       });
     });
 
-    authenticatedTests.test('with existing email address', async invalidTest => {
-      const { response, body } = await request.post(
-        url,
-        { jar: cookies, json: { email: 'em@il.com', password: 'anything' } });
-      invalidTest.equal(
-        response.statusCode,
-        400,
-        'gives a 400 status code'
-      );
-      invalidTest.same(
-        body,
-        { error: 'add-user-email-exists' },
-        'sends a token indicating the failure'
-      );
-    });
+    authenticatedTests.test(
+      'with existing email address',
+      async invalidTest => {
+        const { response, body } = await request.post(url, {
+          jar: cookies,
+          json: { email: 'em@il.com', password: 'anything' }
+        });
+        invalidTest.equal(response.statusCode, 400, 'gives a 400 status code');
+        invalidTest.same(
+          body,
+          { error: 'add-user-email-exists' },
+          'sends a token indicating the failure'
+        );
+      }
+    );
 
     authenticatedTests.test('with a valid new user', async validTest => {
-      const { response, body } = await request.post(
-        url,
-        {
-          jar: cookies,
-          json: { email: 'newuser@email.com', password: 'newpassword' }
-        });
+      const { response, body } = await request.post(url, {
+        jar: cookies,
+        json: { email: 'newuser@email.com', password: 'newpassword' }
+      });
 
-      validTest.equal(
-        response.statusCode,
-        200,
-        'gives a 200 status code'
-      );
+      validTest.equal(response.statusCode, 200, 'gives a 200 status code');
       validTest.notOk(body, 'does not send a body');
 
       const user = await db()('users')
         .where({ email: 'newuser@email.com' })
         .first();
 
-      validTest.ok(
-        user,
-        'a user object is inserted into the database'
-      );
+      validTest.ok(user, 'a user object is inserted into the database');
     });
   });
 });

--- a/api/endpoint-tests/users/post.js
+++ b/api/endpoint-tests/users/post.js
@@ -1,5 +1,7 @@
 const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
-const { db, request, getFullPath, login } = require('../utils');
+const {
+  db, request, getFullPath, login
+} = require('../utils');
 
 tap.test('users endpoint | POST /user', async postUsersTest => {
   const url = getFullPath('/user');

--- a/api/endpoint-tests/users/post.js
+++ b/api/endpoint-tests/users/post.js
@@ -1,8 +1,12 @@
 const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
-const request = require('request'); // eslint-disable-line import/no-extraneous-dependencies
-const { db, getFullPath, login } = require('../utils');
+const {
+  db,
+  request,
+  getFullPath,
+  login
+} = require('../utils');
 
-tap.test('users endpoint | POST /user', postUsersTest => {
+tap.test('users endpoint | POST /user', async postUsersTest => {
   const url = getFullPath('/user');
 
   const invalidCases = [
@@ -23,7 +27,7 @@ tap.test('users endpoint | POST /user', postUsersTest => {
     }
   ];
 
-  postUsersTest.test('when unauthenticated', unauthenticatedTests => {
+  postUsersTest.test('when unauthenticated', async unauthenticatedTests => {
     [
       ...invalidCases,
       {
@@ -31,103 +35,78 @@ tap.test('users endpoint | POST /user', postUsersTest => {
         body: { email: 'newuser@email.com', password: 'newpassword' }
       }
     ].forEach(situation => {
-      unauthenticatedTests.test(situation.name, unauthenticatedTest => {
-        request.post(url, { json: situation.body }, (err, response, body) => {
-          unauthenticatedTest.equal(
-            response.statusCode,
-            403,
-            'gives a 403 status code'
-          );
-          unauthenticatedTest.notOk(body, 'does not send a body');
-          unauthenticatedTest.done();
-        });
-      });
-    });
-    unauthenticatedTests.done();
-  });
-
-  postUsersTest.test('when authenticated', authenticatedTests => {
-    login().then(cookies => {
-      invalidCases.forEach(situation => {
-        authenticatedTests.test(situation.name, invalidTest => {
-          request.post(
-            url,
-            { jar: cookies, json: situation.body || true },
-            (err, response, body) => {
-              invalidTest.equal(
-                response.statusCode,
-                400,
-                'gives a 400 status code'
-              );
-              invalidTest.same(
-                body,
-                { error: 'add-user-invalid' },
-                'sends a token indicating the failure'
-              );
-              invalidTest.done();
-            }
-          );
-        });
-      });
-
-      authenticatedTests.test('with existing email address', invalidTest => {
-        request.post(
-          url,
-          { jar: cookies, json: { email: 'em@il.com', password: 'anything' } },
-          (err, response, body) => {
-            invalidTest.equal(
-              response.statusCode,
-              400,
-              'gives a 400 status code'
-            );
-            invalidTest.same(
-              body,
-              { error: 'add-user-email-exists' },
-              'sends a token indicating the failure'
-            );
-            invalidTest.done();
-          }
+      unauthenticatedTests.test(situation.name, async unauthenticatedTest => {
+        const { response, body } = await request.post(url, { json: situation.body });
+        unauthenticatedTest.equal(
+          response.statusCode,
+          403,
+          'gives a 403 status code'
         );
+        unauthenticatedTest.notOk(body, 'does not send a body');
       });
-
-      authenticatedTests.test('with a valid new user', validTest => {
-        request.post(
-          url,
-          {
-            jar: cookies,
-            json: { email: 'newuser@email.com', password: 'newpassword' }
-          },
-          (err, response, body) => {
-            validTest.equal(
-              response.statusCode,
-              200,
-              'gives a 200 status code'
-            );
-            validTest.notOk(body, 'does not send a body');
-
-            db()('users')
-              .where({ email: 'newuser@email.com' })
-              .first()
-              .then(user => {
-                validTest.ok(
-                  user,
-                  'a user object is inserted into the database'
-                );
-              })
-              .catch(() => {
-                validTest.fail('error');
-              })
-              .then(() => {
-                validTest.done();
-                // process.exit();
-              });
-          }
-        );
-      });
-
-      authenticatedTests.done();
     });
   });
 
-  postUsersTest.done();
+  postUsersTest.test('when authenticated', async authenticatedTests => {
+    const cookies = await login();
+
+    invalidCases.forEach(situation => {
+      authenticatedTests.test(situation.name, async invalidTest => {
+        const { response, body } = await request.post(
+          url,
+          { jar: cookies, json: situation.body || true });
+        invalidTest.equal(
+          response.statusCode,
+          400,
+          'gives a 400 status code'
+        );
+        invalidTest.same(
+          body,
+          { error: 'add-user-invalid' },
+          'sends a token indicating the failure'
+        );
+      });
+    });
+
+    authenticatedTests.test('with existing email address', async invalidTest => {
+      const { response, body } = await request.post(
+        url,
+        { jar: cookies, json: { email: 'em@il.com', password: 'anything' } });
+      invalidTest.equal(
+        response.statusCode,
+        400,
+        'gives a 400 status code'
+      );
+      invalidTest.same(
+        body,
+        { error: 'add-user-email-exists' },
+        'sends a token indicating the failure'
+      );
+    });
+
+    authenticatedTests.test('with a valid new user', async validTest => {
+      const { response, body } = await request.post(
+        url,
+        {
+          jar: cookies,
+          json: { email: 'newuser@email.com', password: 'newpassword' }
+        });
+
+      validTest.equal(
+        response.statusCode,
+        200,
+        'gives a 200 status code'
+      );
+      validTest.notOk(body, 'does not send a body');
+
+      const user = await db()('users')
+        .where({ email: 'newuser@email.com' })
+        .first();
+
+      validTest.ok(
+        user,
+        'a user object is inserted into the database'
+      );
+    });
+  });
 });

--- a/api/endpoint-tests/utils.js
+++ b/api/endpoint-tests/utils.js
@@ -8,20 +8,34 @@ const getFullPath = endpointPath =>
     process.env.PORT ||
     8000}${endpointPath}`;
 
-const login = () =>
-  new Promise((resolve, reject) => {
-    const cookies = request.jar();
-    request.post(
-      getFullPath('/auth/login'),
-      { jar: cookies, json: { username: 'em@il.com', password: 'password' } },
-      (err, response) => {
-        if (response.statusCode === 200) {
-          return resolve(cookies);
-        }
-        return reject(new Error('Failed to login'));
-      }
-    );
+const get = async (...args) => new Promise(resolve => {
+  request.get(...args, (err, response, body) => {
+    resolve({ err, response, body });
   });
+});
+
+const post = async (...args) => new Promise(resolve => {
+  request.post(...args, (err, response, body) => {
+    resolve({ err, response, body });
+  });
+});
+
+const login = async () => {
+  const cookies = request.jar();
+
+  const { response } = await post(
+    getFullPath('/auth/login'),
+    {
+      jar: cookies,
+      json: { username: 'em@il.com', password: 'password' }
+    }
+  );
+
+  if (response.statusCode === 200) {
+    return cookies;
+  }
+  throw new Error('Failed to login');
+};
 
 const db = () => {
   // tap runs each test file in its own process, which is awesome for
@@ -40,6 +54,7 @@ const db = () => {
 
 module.exports = {
   db,
+  request: { get, post, jar: request.jar },
   getFullPath,
   login
 };

--- a/api/endpoint-tests/utils.js
+++ b/api/endpoint-tests/utils.js
@@ -8,28 +8,27 @@ const getFullPath = endpointPath =>
     process.env.PORT ||
     8000}${endpointPath}`;
 
-const get = async (...args) => new Promise(resolve => {
-  request.get(...args, (err, response, body) => {
-    resolve({ err, response, body });
+const get = async (...args) =>
+  new Promise(resolve => {
+    request.get(...args, (err, response, body) => {
+      resolve({ err, response, body });
+    });
   });
-});
 
-const post = async (...args) => new Promise(resolve => {
-  request.post(...args, (err, response, body) => {
-    resolve({ err, response, body });
+const post = async (...args) =>
+  new Promise(resolve => {
+    request.post(...args, (err, response, body) => {
+      resolve({ err, response, body });
+    });
   });
-});
 
 const login = async () => {
   const cookies = request.jar();
 
-  const { response } = await post(
-    getFullPath('/auth/login'),
-    {
-      jar: cookies,
-      json: { username: 'em@il.com', password: 'password' }
-    }
-  );
+  const { response } = await post(getFullPath('/auth/login'), {
+    jar: cookies,
+    json: { username: 'em@il.com', password: 'password' }
+  });
 
   if (response.statusCode === 200) {
     return cookies;

--- a/api/env.test.js
+++ b/api/env.test.js
@@ -6,7 +6,7 @@ tap.beforeEach(done => {
   done();
 });
 
-tap.test('environment setup', envTest => {
+tap.test('environment setup', async envTest => {
   const knownEnvironmentVariables = [
     { name: 'PORT', type: 'number' },
     { name: 'SESSION_SECRET', type: 'string' }
@@ -45,5 +45,4 @@ tap.test('environment setup', envTest => {
       doesNotOverrideTest.end();
     }
   );
-  envTest.done();
 });

--- a/api/migrations/20180117155746_add-authorization-models.js
+++ b/api/migrations/20180117155746_add-authorization-models.js
@@ -1,42 +1,40 @@
-exports.up = knex =>
-  knex.schema
-    .createTable('auth_roles', rolesTable => {
-      rolesTable.increments('id');
-      rolesTable.string('name', 64); // I reckon a 64-character role name is enough...
-      rolesTable.index('name');
-      rolesTable.unique('name');
-    })
-    .then(() =>
-      knex.schema.createTable('auth_activities', activitiesTable => {
-        activitiesTable.increments('id');
-        activitiesTable.string('name', 64); // I reckon the same for activity names
-        activitiesTable.unique('name');
-      })
-    )
-    .then(() =>
-      knex.schema.createTable('auth_role_activity_mapping', mappingTable => {
-        mappingTable.integer('role_id');
-        mappingTable.integer('activity_id');
+exports.up = async knex => {
+  await knex.schema.createTable('auth_roles', rolesTable => {
+    rolesTable.increments('id');
+    rolesTable.string('name', 64); // I reckon a 64-character role name is enough...
+    rolesTable.index('name');
+    rolesTable.unique('name');
+  });
 
-        mappingTable.index(['role_id', 'activity_id']);
+  await knex.schema.createTable('auth_activities', activitiesTable => {
+    activitiesTable.increments('id');
+    activitiesTable.string('name', 64); // I reckon the same for activity names
+    activitiesTable.unique('name');
+  });
 
-        mappingTable.foreign('role_id').references('auth_roles.id');
-        mappingTable.foreign('activity_id').references('auth_activities.id');
-      })
-    )
-    .then(() =>
-      knex.schema.alterTable('users', usersTable => {
-        usersTable.string('auth_role', 64);
-        usersTable.foreign('auth_role').references('auth_roles.name');
-      })
-    );
+  await knex.schema.createTable('auth_role_activity_mapping', mappingTable => {
+    mappingTable.integer('role_id');
+    mappingTable.integer('activity_id');
 
-exports.down = knex =>
-  knex.schema
-    .alterTable('users', usersTable => {
-      usersTable.dropForeign('auth_role');
-      usersTable.dropColumn('auth_role');
-    })
-    .then(() => knex.schema.dropTable('auth_role_activity_mapping'))
-    .then(() => knex.schema.dropTable('auth_activities'))
-    .then(() => knex.schema.dropTable('auth_roles'));
+    mappingTable.index(['role_id', 'activity_id']);
+
+    mappingTable.foreign('role_id').references('auth_roles.id');
+    mappingTable.foreign('activity_id').references('auth_activities.id');
+  });
+
+  await knex.schema.alterTable('users', usersTable => {
+    usersTable.string('auth_role', 64);
+    usersTable.foreign('auth_role').references('auth_roles.name');
+  });
+};
+
+exports.down = async knex => {
+  await knex.schema.alterTable('users', usersTable => {
+    usersTable.dropForeign('auth_role');
+    usersTable.dropColumn('auth_role');
+  });
+
+  await knex.schema.dropTable('auth_role_activity_mapping');
+  await knex.schema.dropTable('auth_activities');
+  await knex.schema.dropTable('auth_roles');
+};

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -5943,27 +5943,6 @@
         "uuid": "3.1.0"
       }
     },
-    "request-promise": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
-      "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
-      "dev": true,
-      "requires": {
-        "bluebird": "3.5.1",
-        "request-promise-core": "1.1.1",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.3.3"
-      }
-    },
-    "request-promise-core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
-      "dev": true,
-      "requires": {
-        "lodash": "4.17.4"
-      }
-    },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
@@ -6256,12 +6235,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
-    },
-    "stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-      "dev": true
     },
     "stream-combiner": {
       "version": "0.0.4",

--- a/api/package.json
+++ b/api/package.json
@@ -58,7 +58,6 @@
     "nodemon": "^1.12.7",
     "prettier": "^1.9.2",
     "request": "^2.83.0",
-    "request-promise": "^4.2.2",
     "sinon": "^4.1.3",
     "tap": "^11.0.0"
   }

--- a/api/routes/index.test.js
+++ b/api/routes/index.test.js
@@ -3,7 +3,7 @@ const sinon = require('sinon');
 
 const endpointIndex = require('./index');
 
-tap.test('endpoint setup', endpointTest => {
+tap.test('endpoint setup', async endpointTest => {
   const app = {};
   const usersEndpoint = sinon.spy();
 
@@ -13,5 +13,4 @@ tap.test('endpoint setup', endpointTest => {
     usersEndpoint.calledWith(app),
     'users endpoint is setup with the app'
   );
-  endpointTest.done();
 });

--- a/api/routes/users/get.js
+++ b/api/routes/users/get.js
@@ -1,32 +1,30 @@
 const defaultDB = require('../../db')();
 const loggedIn = require('../../auth/middleware').loggedIn;
 
-const allUsersHandler = (req, res, db) => {
-  db('users')
-    .select('id', 'email')
-    .then(users => {
-      res.send(users);
-    })
-    .catch(() => {
-      res.status(500).end();
-    });
+const allUsersHandler = async (req, res, db) => {
+  try {
+    const users = await db('users')
+      .select('id', 'email');
+    res.send(users);
+  } catch (e) {
+    res.status(500).end();
+  }
 };
 
-const oneUserHandler = (req, res, db) => {
+const oneUserHandler = async (req, res, db) => {
   if (req.params.id && !Number.isNaN(Number(req.params.id))) {
-    db('users')
-      .where({ id: Number(req.params.id) })
-      .first('id', 'email')
-      .then(user => {
-        if (user) {
-          res.send(user);
-        } else {
-          res.status(404).end();
-        }
-      })
-      .catch(() => {
-        res.status(500).end();
-      });
+    try {
+      const user = await db('users')
+        .where({ id: Number(req.params.id) })
+        .first('id', 'email');
+      if (user) {
+        res.send(user);
+      } else {
+        res.status(404).end();
+      }
+    } catch (e) {
+      res.status(500).end();
+    }
   } else {
     res
       .status(400)

--- a/api/routes/users/get.js
+++ b/api/routes/users/get.js
@@ -3,8 +3,7 @@ const loggedIn = require('../../auth/middleware').loggedIn;
 
 const allUsersHandler = async (req, res, db) => {
   try {
-    const users = await db('users')
-      .select('id', 'email');
+    const users = await db('users').select('id', 'email');
     res.send(users);
   } catch (e) {
     res.status(500).end();

--- a/api/routes/users/get.test.js
+++ b/api/routes/users/get.test.js
@@ -56,44 +56,40 @@ tap.test('user GET endpoint', endpointTest => {
 
     handlerTest.test(
       'sends a server error code if there is a database error',
-      invalidTest => {
+      async invalidTest => {
         select.rejects();
 
-        handler({}, res);
+        await handler({}, res);
 
-        setTimeout(() => {
-          invalidTest.ok(db.calledWith('users'), 'queries the users table');
-          invalidTest.ok(
-            select.calledWith('id', 'email'),
-            'selects only user ID and email'
-          );
-          invalidTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
-          invalidTest.ok(res.send.notCalled, 'no body is sent');
-          invalidTest.ok(res.end.called, 'response is terminated');
-          invalidTest.done();
-        }, 20);
-      }
-    );
-
-    handlerTest.test('sends back a list of users', validTest => {
-      const users = [{ id: 1, email: 'hi' }, { id: 2, email: 'bye' }];
-      select.resolves(users);
-
-      handler({}, res);
-
-      setTimeout(() => {
-        validTest.ok(db.calledWith('users'), 'queries the users table');
-        validTest.ok(
+        invalidTest.ok(db.calledWith('users'), 'queries the users table');
+        invalidTest.ok(
           select.calledWith('id', 'email'),
           'selects only user ID and email'
         );
-        validTest.ok(res.status.notCalled, 'HTTP status is not explicitly set');
-        validTest.ok(
-          res.send.calledWith(users),
-          'body is set to the list of users'
-        );
-        validTest.done();
-      }, 20);
+        invalidTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
+        invalidTest.ok(res.send.notCalled, 'no body is sent');
+        invalidTest.ok(res.end.called, 'response is terminated');
+        invalidTest.done();
+      }
+    );
+
+    handlerTest.test('sends back a list of users', async validTest => {
+      const users = [{ id: 1, email: 'hi' }, { id: 2, email: 'bye' }];
+      select.resolves(users);
+
+      await handler({}, res);
+
+      validTest.ok(db.calledWith('users'), 'queries the users table');
+      validTest.ok(
+        select.calledWith('id', 'email'),
+        'selects only user ID and email'
+      );
+      validTest.ok(res.status.notCalled, 'HTTP status is not explicitly set');
+      validTest.ok(
+        res.send.calledWith(users),
+        'body is set to the list of users'
+      );
+      validTest.done();
     });
 
     handlerTest.done();
@@ -137,74 +133,68 @@ tap.test('user GET endpoint', endpointTest => {
 
     handlerTest.test(
       'sends a server error code if there is a database error',
-      invalidTest => {
+      async invalidTest => {
         first.rejects();
 
-        handler({ params: { id: 1 } }, res);
+        await handler({ params: { id: 1 } }, res);
 
-        setTimeout(() => {
-          invalidTest.ok(db.calledWith('users'), 'queries the users table');
-          invalidTest.ok(
-            where.calledWith({ id: 1 }),
-            'looks for only the specific user'
-          );
-          invalidTest.ok(
-            first.calledWith('id', 'email'),
-            'selects only user ID and email'
-          );
-          invalidTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
-          invalidTest.ok(res.send.notCalled, 'no body is sent');
-          invalidTest.ok(res.end.called, 'response is terminated');
-          invalidTest.done();
-        }, 20);
+        invalidTest.ok(db.calledWith('users'), 'queries the users table');
+        invalidTest.ok(
+          where.calledWith({ id: 1 }),
+          'looks for only the specific user'
+        );
+        invalidTest.ok(
+          first.calledWith('id', 'email'),
+          'selects only user ID and email'
+        );
+        invalidTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
+        invalidTest.ok(res.send.notCalled, 'no body is sent');
+        invalidTest.ok(res.end.called, 'response is terminated');
+        invalidTest.done();
       }
     );
 
     handlerTest.test(
       'sends a not-found error if the requested user does not exist',
-      invalidTest => {
+      async invalidTest => {
         first.resolves();
-        handler({ params: { id: 1 } }, res);
+        await handler({ params: { id: 1 } }, res);
 
-        setTimeout(() => {
-          invalidTest.ok(db.calledWith('users'), 'queries the users table');
-          invalidTest.ok(
-            where.calledWith({ id: 1 }),
-            'looks for only the specific user'
-          );
-          invalidTest.ok(
-            first.calledWith('id', 'email'),
-            'selects only user ID and email'
-          );
-          invalidTest.ok(res.status.calledWith(404), 'HTTP status set to 404');
-          invalidTest.ok(res.send.notCalled, 'no body is sent');
-          invalidTest.ok(res.end.called, 'response is terminated');
-          invalidTest.done();
-        }, 20);
-      }
-    );
-
-    handlerTest.test('sends the requested user', validTest => {
-      first.resolves({ id: 1, email: 'test-email@dotcom.com' });
-      handler({ params: { id: 1 } }, res);
-
-      setTimeout(() => {
-        validTest.ok(db.calledWith('users'), 'queries the users table');
-        validTest.ok(
+        invalidTest.ok(db.calledWith('users'), 'queries the users table');
+        invalidTest.ok(
           where.calledWith({ id: 1 }),
           'looks for only the specific user'
         );
-        validTest.ok(
+        invalidTest.ok(
           first.calledWith('id', 'email'),
           'selects only user ID and email'
         );
-        validTest.ok(res.status.notCalled, 'HTTP status is not explicitly set');
-        validTest.ok(
-          res.send.calledWith({ id: 1, email: 'test-email@dotcom.com' }),
-          'requested user is sent'
-        );
-        validTest.done();
-      }, 20);
+        invalidTest.ok(res.status.calledWith(404), 'HTTP status set to 404');
+        invalidTest.ok(res.send.notCalled, 'no body is sent');
+        invalidTest.ok(res.end.called, 'response is terminated');
+        invalidTest.done();
+      }
+    );
+
+    handlerTest.test('sends the requested user', async validTest => {
+      first.resolves({ id: 1, email: 'test-email@dotcom.com' });
+      await handler({ params: { id: 1 } }, res);
+
+      validTest.ok(db.calledWith('users'), 'queries the users table');
+      validTest.ok(
+        where.calledWith({ id: 1 }),
+        'looks for only the specific user'
+      );
+      validTest.ok(
+        first.calledWith('id', 'email'),
+        'selects only user ID and email'
+      );
+      validTest.ok(res.status.notCalled, 'HTTP status is not explicitly set');
+      validTest.ok(
+        res.send.calledWith({ id: 1, email: 'test-email@dotcom.com' }),
+        'requested user is sent'
+      );
+      validTest.done();
     });
 
     handlerTest.done();

--- a/api/routes/users/get.test.js
+++ b/api/routes/users/get.test.js
@@ -4,7 +4,7 @@ const sinon = require('sinon');
 const loggedInMiddleware = require('../../auth/middleware').loggedIn;
 const getEndpoint = require('./get');
 
-tap.test('user GET endpoint', endpointTest => {
+tap.test('user GET endpoint', async endpointTest => {
   const sandbox = sinon.createSandbox();
   const app = {
     get: sandbox.stub()
@@ -32,7 +32,7 @@ tap.test('user GET endpoint', endpointTest => {
     done();
   });
 
-  endpointTest.test('setup', setupTest => {
+  endpointTest.test('setup', async setupTest => {
     getEndpoint(app, db);
 
     setupTest.ok(
@@ -43,10 +43,9 @@ tap.test('user GET endpoint', endpointTest => {
       app.get.calledWith('/users', loggedInMiddleware, sinon.match.func),
       'all users GET endpoint is registered'
     );
-    setupTest.done();
   });
 
-  endpointTest.test('get all users handler', handlerTest => {
+  endpointTest.test('get all users handler', async handlerTest => {
     let handler;
     handlerTest.beforeEach(done => {
       getEndpoint(app, db);
@@ -69,7 +68,6 @@ tap.test('user GET endpoint', endpointTest => {
         invalidTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
         invalidTest.ok(res.send.notCalled, 'no body is sent');
         invalidTest.ok(res.end.called, 'response is terminated');
-        invalidTest.done();
       }
     );
 
@@ -89,13 +87,10 @@ tap.test('user GET endpoint', endpointTest => {
         res.send.calledWith(users),
         'body is set to the list of users'
       );
-      validTest.done();
     });
-
-    handlerTest.done();
   });
 
-  endpointTest.test('get single user handler', handlerTest => {
+  endpointTest.test('get single user handler', async handlerTest => {
     let handler;
     handlerTest.beforeEach(done => {
       getEndpoint(app, db);
@@ -103,7 +98,7 @@ tap.test('user GET endpoint', endpointTest => {
       done();
     });
 
-    handlerTest.test('rejects invalid requests', invalidTests => {
+    handlerTest.test('rejects invalid requests', async invalidTests => {
       const invalidCases = [
         {
           title: 'no user ID',
@@ -116,7 +111,7 @@ tap.test('user GET endpoint', endpointTest => {
       ];
 
       invalidCases.forEach(invalidCase => {
-        invalidTests.test(invalidCase.title, invalidTest => {
+        invalidTests.test(invalidCase.title, async invalidTest => {
           handler({ params: invalidCase.params }, res);
           invalidTest.ok(res.status.calledWith(400), 'HTTP status set to 400');
           invalidTest.ok(
@@ -124,11 +119,8 @@ tap.test('user GET endpoint', endpointTest => {
             'sets an error message'
           );
           invalidTest.ok(res.end.called, 'response is terminated');
-          invalidTest.done();
         });
       });
-
-      invalidTests.done();
     });
 
     handlerTest.test(
@@ -150,7 +142,6 @@ tap.test('user GET endpoint', endpointTest => {
         invalidTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
         invalidTest.ok(res.send.notCalled, 'no body is sent');
         invalidTest.ok(res.end.called, 'response is terminated');
-        invalidTest.done();
       }
     );
 
@@ -172,7 +163,6 @@ tap.test('user GET endpoint', endpointTest => {
         invalidTest.ok(res.status.calledWith(404), 'HTTP status set to 404');
         invalidTest.ok(res.send.notCalled, 'no body is sent');
         invalidTest.ok(res.end.called, 'response is terminated');
-        invalidTest.done();
       }
     );
 
@@ -194,11 +184,6 @@ tap.test('user GET endpoint', endpointTest => {
         res.send.calledWith({ id: 1, email: 'test-email@dotcom.com' }),
         'requested user is sent'
       );
-      validTest.done();
     });
-
-    handlerTest.done();
   });
-
-  endpointTest.done();
 });

--- a/api/routes/users/index.test.js
+++ b/api/routes/users/index.test.js
@@ -3,7 +3,7 @@ const sinon = require('sinon');
 
 const usersIndex = require('./index');
 
-tap.test('users endpoint setup', endpointTest => {
+tap.test('users endpoint setup', async endpointTest => {
   const app = {};
   const postEndpoint = sinon.spy();
   const getEndpoint = sinon.spy();
@@ -18,5 +18,4 @@ tap.test('users endpoint setup', endpointTest => {
     getEndpoint.calledWith(app),
     'users GET endpoint is setup with the app'
   );
-  endpointTest.done();
 });

--- a/api/routes/users/post.js
+++ b/api/routes/users/post.js
@@ -26,7 +26,10 @@ module.exports = (app, db = defaultDB) => {
           await insert(req.body.email, req.body.password, db);
           res.status(200).end();
         } else {
-          res.status(400).send({ error: 'add-user-email-exists' }).end();
+          res
+            .status(400)
+            .send({ error: 'add-user-email-exists' })
+            .end();
         }
       } catch (e) {
         // 👆 eventually we should catch errors here and log

--- a/api/routes/users/post.js
+++ b/api/routes/users/post.js
@@ -2,39 +2,37 @@ const bcrypt = require('bcryptjs');
 const defaultDB = require('../../db')();
 const loggedIn = require('../../auth/middleware').loggedIn;
 
-const ifUserIsNew = (email, res, db) =>
-  db('users')
+const userIsNew = async (email, db) => {
+  const user = await db('users')
     .where({ email })
-    .first()
-    .then(user => {
-      if (user) {
-        res
-          .status(400)
-          .send({ error: 'add-user-email-exists' })
-          .end();
-        return Promise.reject();
-      }
-      return Promise.resolve();
-    });
+    .first();
 
-const insert = (email, password, db) => {
+  if (user) {
+    return false;
+  }
+  return true;
+};
+
+const insert = async (email, password, db) => {
   const hashed = bcrypt.hashSync(password);
-  return db('users').insert({ email, password: hashed });
+  await db('users').insert({ email, password: hashed });
 };
 
 module.exports = (app, db = defaultDB) => {
-  app.post('/user', loggedIn, (req, res) => {
+  app.post('/user', loggedIn, async (req, res) => {
     if (req.body.email && req.body.password) {
-      ifUserIsNew(req.body.email, res, db)
-        .then(() => insert(req.body.email, req.body.password, db))
-        .then(() => {
+      try {
+        if (await userIsNew(req.body.email, db)) {
+          await insert(req.body.email, req.body.password, db);
           res.status(200).end();
-        })
-        .catch(() => {
-          // 👆 eventually we should catch errors here and log
-          // them somewhere.  For now... just eating them.
-          res.status(500).end();
-        });
+        } else {
+          res.status(400).send({ error: 'add-user-email-exists' }).end();
+        }
+      } catch (e) {
+        // 👆 eventually we should catch errors here and log
+        // them somewhere.  For now... just eating them.
+        res.status(500).end();
+      }
     } else {
       res
         .status(400)

--- a/api/routes/users/post.test.js
+++ b/api/routes/users/post.test.js
@@ -92,69 +92,61 @@ tap.test('user POST endpoint', endpointTest => {
       invalidTests.done();
     });
 
-    handlerTest.test('rejects inserting an existing user', invalidTest => {
+    handlerTest.test('rejects inserting an existing user', async invalidTest => {
       first.resolves({});
 
-      handler({ body: { email: 'em@il.com', password: 'password' } }, res);
+      await handler({ body: { email: 'em@il.com', password: 'password' } }, res);
 
-      setTimeout(() => {
-        invalidTest.ok(res.status.calledWith(400), 'HTTP status set to 400');
-        invalidTest.ok(
-          res.send.calledWith({ error: 'add-user-email-exists' }),
-          'sets an error message'
-        );
-        invalidTest.ok(res.end.called, 'response is terminated');
-        invalidTest.done();
-      }, 20);
+      invalidTest.ok(res.status.calledWith(400), 'HTTP status set to 400');
+      invalidTest.ok(
+        res.send.calledWith({ error: 'add-user-email-exists' }),
+        'sets an error message'
+      );
+      invalidTest.ok(res.end.called, 'response is terminated');
+      invalidTest.done();
     });
 
     handlerTest.test(
       'sends a server error code if there is a database error checking for an existing user',
-      invalidTest => {
+      async invalidTest => {
         first.rejects();
 
-        handler({ body: { email: 'em@il.com', password: 'password' } }, res);
+        await handler({ body: { email: 'em@il.com', password: 'password' } }, res);
 
-        setTimeout(() => {
-          invalidTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
-          invalidTest.ok(res.send.notCalled, 'does not send a message');
-          invalidTest.ok(res.end.called, 'response is terminated');
-          invalidTest.done();
-        }, 20);
+        invalidTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
+        invalidTest.ok(res.send.notCalled, 'does not send a message');
+        invalidTest.ok(res.end.called, 'response is terminated');
+        invalidTest.done();
       }
     );
 
     handlerTest.test(
       'sends a server error code if there is a database error inserting a new user',
-      invalidTest => {
+      async invalidTest => {
         first.resolves();
         insert.rejects();
 
-        handler({ body: { email: 'em@il.com', password: 'password' } }, res);
+        await handler({ body: { email: 'em@il.com', password: 'password' } }, res);
 
-        setTimeout(() => {
-          invalidTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
-          invalidTest.ok(res.send.notCalled, 'does not send a message');
-          invalidTest.ok(res.end.called, 'response is terminated');
-          invalidTest.done();
-        }, 20);
+        invalidTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
+        invalidTest.ok(res.send.notCalled, 'does not send a message');
+        invalidTest.ok(res.end.called, 'response is terminated');
+        invalidTest.done();
       }
     );
 
     handlerTest.test(
       'inserts a new user and returns a success for a valid, new user',
-      validTest => {
+      async validTest => {
         first.resolves();
         insert.resolves();
 
-        handler({ body: { email: 'em@il.com', password: 'password' } }, res);
+        await handler({ body: { email: 'em@il.com', password: 'password' } }, res);
 
-        setTimeout(() => {
-          validTest.ok(res.status.calledWith(200), 'HTTP status set to 200');
-          validTest.ok(res.send.notCalled, 'does not send a message');
-          validTest.ok(res.end.called, 'response is terminated');
-          validTest.done();
-        }, 20);
+        validTest.ok(res.status.calledWith(200), 'HTTP status set to 200');
+        validTest.ok(res.send.notCalled, 'does not send a message');
+        validTest.ok(res.end.called, 'response is terminated');
+        validTest.done();
       }
     );
 

--- a/api/routes/users/post.test.js
+++ b/api/routes/users/post.test.js
@@ -92,26 +92,35 @@ tap.test('user POST endpoint', endpointTest => {
       invalidTests.done();
     });
 
-    handlerTest.test('rejects inserting an existing user', async invalidTest => {
-      first.resolves({});
+    handlerTest.test(
+      'rejects inserting an existing user',
+      async invalidTest => {
+        first.resolves({});
 
-      await handler({ body: { email: 'em@il.com', password: 'password' } }, res);
+        await handler(
+          { body: { email: 'em@il.com', password: 'password' } },
+          res
+        );
 
-      invalidTest.ok(res.status.calledWith(400), 'HTTP status set to 400');
-      invalidTest.ok(
-        res.send.calledWith({ error: 'add-user-email-exists' }),
-        'sets an error message'
-      );
-      invalidTest.ok(res.end.called, 'response is terminated');
-      invalidTest.done();
-    });
+        invalidTest.ok(res.status.calledWith(400), 'HTTP status set to 400');
+        invalidTest.ok(
+          res.send.calledWith({ error: 'add-user-email-exists' }),
+          'sets an error message'
+        );
+        invalidTest.ok(res.end.called, 'response is terminated');
+        invalidTest.done();
+      }
+    );
 
     handlerTest.test(
       'sends a server error code if there is a database error checking for an existing user',
       async invalidTest => {
         first.rejects();
 
-        await handler({ body: { email: 'em@il.com', password: 'password' } }, res);
+        await handler(
+          { body: { email: 'em@il.com', password: 'password' } },
+          res
+        );
 
         invalidTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
         invalidTest.ok(res.send.notCalled, 'does not send a message');
@@ -126,7 +135,10 @@ tap.test('user POST endpoint', endpointTest => {
         first.resolves();
         insert.rejects();
 
-        await handler({ body: { email: 'em@il.com', password: 'password' } }, res);
+        await handler(
+          { body: { email: 'em@il.com', password: 'password' } },
+          res
+        );
 
         invalidTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
         invalidTest.ok(res.send.notCalled, 'does not send a message');
@@ -141,7 +153,10 @@ tap.test('user POST endpoint', endpointTest => {
         first.resolves();
         insert.resolves();
 
-        await handler({ body: { email: 'em@il.com', password: 'password' } }, res);
+        await handler(
+          { body: { email: 'em@il.com', password: 'password' } },
+          res
+        );
 
         validTest.ok(res.status.calledWith(200), 'HTTP status set to 200');
         validTest.ok(res.send.notCalled, 'does not send a message');

--- a/api/routes/users/post.test.js
+++ b/api/routes/users/post.test.js
@@ -4,7 +4,7 @@ const sinon = require('sinon');
 const loggedInMiddleware = require('../../auth/middleware').loggedIn;
 const postEndpoint = require('./post');
 
-tap.test('user POST endpoint', endpointTest => {
+tap.test('user POST endpoint', async endpointTest => {
   const sandbox = sinon.createSandbox();
   const app = {
     post: sandbox.stub()
@@ -32,17 +32,16 @@ tap.test('user POST endpoint', endpointTest => {
     done();
   });
 
-  endpointTest.test('setup', setupTest => {
+  endpointTest.test('setup', async setupTest => {
     postEndpoint(app, db);
 
     setupTest.ok(
       app.post.calledWith('/user', loggedInMiddleware, sinon.match.func),
       'user POST endpoint is registered'
     );
-    setupTest.done();
   });
 
-  endpointTest.test('handler', handlerTest => {
+  endpointTest.test('handler', async handlerTest => {
     let handler;
 
     handlerTest.beforeEach(done => {
@@ -51,7 +50,7 @@ tap.test('user POST endpoint', endpointTest => {
       done();
     });
 
-    handlerTest.test('rejects invalid requests', invalidTests => {
+    handlerTest.test('rejects invalid requests', async invalidTests => {
       const invalidCases = [
         {
           title: 'no email or password',
@@ -76,7 +75,7 @@ tap.test('user POST endpoint', endpointTest => {
       ];
 
       invalidCases.forEach(invalidCase => {
-        invalidTests.test(invalidCase.title, invalidTest => {
+        invalidTests.test(invalidCase.title, async invalidTest => {
           handler({ body: invalidCase.body }, res);
 
           invalidTest.ok(res.status.calledWith(400), 'HTTP status set to 400');
@@ -85,11 +84,8 @@ tap.test('user POST endpoint', endpointTest => {
             'sets an error message'
           );
           invalidTest.ok(res.end.called, 'response is terminated');
-          invalidTest.done();
         });
       });
-
-      invalidTests.done();
     });
 
     handlerTest.test(
@@ -108,7 +104,6 @@ tap.test('user POST endpoint', endpointTest => {
           'sets an error message'
         );
         invalidTest.ok(res.end.called, 'response is terminated');
-        invalidTest.done();
       }
     );
 
@@ -125,7 +120,6 @@ tap.test('user POST endpoint', endpointTest => {
         invalidTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
         invalidTest.ok(res.send.notCalled, 'does not send a message');
         invalidTest.ok(res.end.called, 'response is terminated');
-        invalidTest.done();
       }
     );
 
@@ -143,7 +137,6 @@ tap.test('user POST endpoint', endpointTest => {
         invalidTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
         invalidTest.ok(res.send.notCalled, 'does not send a message');
         invalidTest.ok(res.end.called, 'response is terminated');
-        invalidTest.done();
       }
     );
 
@@ -161,12 +154,7 @@ tap.test('user POST endpoint', endpointTest => {
         validTest.ok(res.status.calledWith(200), 'HTTP status set to 200');
         validTest.ok(res.send.notCalled, 'does not send a message');
         validTest.ok(res.end.called, 'response is terminated');
-        validTest.done();
       }
     );
-
-    handlerTest.done();
   });
-
-  endpointTest.done();
 });

--- a/api/seeds/00-delete-everything.js
+++ b/api/seeds/00-delete-everything.js
@@ -1,10 +1,10 @@
-exports.seed = knex =>
+exports.seed = async knex => {
   // has a foreign key relationship on auth_roles
-  knex('users')
-    .del()
+  await knex('users').del();
 
-    // has a foreign key relationship on auth_roles and auth_activities
-    .then(() => knex('auth_role_activity_mapping').del())
+  // has a foreign key relationship on auth_roles and auth_activities
+  await knex('auth_role_activity_mapping').del();
 
-    .then(() => knex('auth_roles').del())
-    .then(() => knex('auth_activities').del());
+  await knex('auth_roles').del();
+  await knex('auth_activities').del();
+};

--- a/api/seeds/01-roles-and-activities.js
+++ b/api/seeds/01-roles-and-activities.js
@@ -1,34 +1,37 @@
-const setupActivities = activitiesTable =>
-  activitiesTable
-    .insert({ id: 1, name: 'view-all-apds' })
-    .then(() => activitiesTable.insert({ id: 2, name: 'comment-on-apd' }))
-    .then(() => activitiesTable.insert({ id: 3, name: 'send-apd-to-state' }))
-    .then(() => activitiesTable.insert({ id: 4, name: 'view-own-apds' }))
-    .then(() => activitiesTable.insert({ id: 5, name: 'create-apd' }));
+const setupActivities = async activitiesTable => {
+  await activitiesTable.insert({ id: 1, name: 'view-all-apds' });
+  await activitiesTable.insert({ id: 2, name: 'comment-on-apd' });
+  await activitiesTable.insert({ id: 3, name: 'send-apd-to-state' });
+  await activitiesTable.insert({ id: 4, name: 'view-own-apds' });
+  await activitiesTable.insert({ id: 5, name: 'create-apd' });
+};
 
-const setupRoles = rolesTable =>
-  rolesTable
-    .insert({ id: 1, name: 'admin' })
-    .then(() => rolesTable.insert({ id: 2, name: 'cms-reviewer' }))
-    .then(() => rolesTable.insert({ id: 3, name: 'state-submitter' }));
+const setupRoles = async rolesTable => {
+  await rolesTable.insert({ id: 1, name: 'admin' });
+  await rolesTable.insert({ id: 2, name: 'cms-reviewer' });
+  await rolesTable.insert({ id: 3, name: 'state-submitter' });
+};
 
-const setupMappings = mappingTable =>
+const setupMappings = async mappingTable => {
   // Admins
-  mappingTable
-    .insert({ role_id: 1, activity_id: 1 })
-    .then(() => mappingTable.insert({ role_id: 1, activity_id: 2 }))
-    .then(() => mappingTable.insert({ role_id: 1, activity_id: 3 }))
-    .then(() => mappingTable.insert({ role_id: 1, activity_id: 4 }))
-    .then(() => mappingTable.insert({ role_id: 1, activity_id: 5 }))
-    // CMS reviewers
-    .then(() => mappingTable.insert({ role_id: 2, activity_id: 1 }))
-    .then(() => mappingTable.insert({ role_id: 2, activity_id: 2 }))
-    .then(() => mappingTable.insert({ role_id: 2, activity_id: 3 }))
-    // State submitters
-    .then(() => mappingTable.insert({ role_id: 3, activity_id: 4 }))
-    .then(() => mappingTable.insert({ role_id: 3, activity_id: 5 }));
+  await mappingTable.insert({ role_id: 1, activity_id: 1 });
+  await mappingTable.insert({ role_id: 1, activity_id: 2 });
+  await mappingTable.insert({ role_id: 1, activity_id: 3 });
+  await mappingTable.insert({ role_id: 1, activity_id: 4 });
+  await mappingTable.insert({ role_id: 1, activity_id: 5 });
 
-exports.seed = knex =>
-  setupActivities(knex('auth_activities'))
-    .then(() => setupRoles(knex('auth_roles')))
-    .then(() => setupMappings(knex('auth_role_activity_mapping')));
+  // CMS reviewers
+  await mappingTable.insert({ role_id: 2, activity_id: 1 });
+  await mappingTable.insert({ role_id: 2, activity_id: 2 });
+  await mappingTable.insert({ role_id: 2, activity_id: 3 });
+
+  // State submitters
+  await mappingTable.insert({ role_id: 3, activity_id: 4 });
+  await mappingTable.insert({ role_id: 3, activity_id: 5 });
+};
+
+exports.seed = async knex => {
+  await setupActivities(knex('auth_activities'));
+  await setupRoles(knex('auth_roles'));
+  await setupMappings(knex('auth_role_activity_mapping'));
+};

--- a/api/seeds/10-development.js
+++ b/api/seeds/10-development.js
@@ -1,11 +1,11 @@
 const users = require('./development/users');
 
-exports.seed = knex => {
+exports.seed = async knex => {
   // Don't seed this data if we're not in a development environment.
   if (process.env.NODE_ENV !== 'development') {
-    return Promise.resolve();
+    return;
   }
 
-  // Chain together specific seeds from here.
-  return users.seed(knex);
+  // Call specific seeds from here.
+  await users.seed(knex);
 };

--- a/api/seeds/10-test.js
+++ b/api/seeds/10-test.js
@@ -1,11 +1,11 @@
 const users = require('./test/users');
 
-exports.seed = knex => {
+exports.seed = async knex => {
   // Don't seed this data if we're not in a test environment.
   if (process.env.NODE_ENV !== 'test') {
-    return Promise.resolve();
+    return;
   }
 
-  // Chain together specific seeds from here.
-  return users.seed(knex);
+  // Call specific seeds from here.
+  await users.seed(knex);
 };

--- a/api/seeds/development/users.js
+++ b/api/seeds/development/users.js
@@ -1,8 +1,8 @@
 const bcrypt = require('bcryptjs');
 
 // Deletes ALL existing entries
-exports.seed = knex =>
-  knex('users').insert([
+exports.seed = async knex => {
+  await knex('users').insert([
     {
       id: 57,
       email: 'em@il.com',
@@ -10,3 +10,4 @@ exports.seed = knex =>
       auth_role: 'admin'
     }
   ]);
+};

--- a/api/seeds/test/users.js
+++ b/api/seeds/test/users.js
@@ -1,8 +1,8 @@
 const bcrypt = require('bcryptjs');
 
 // Deletes ALL existing entries
-exports.seed = knex =>
-  knex('users').insert([
+exports.seed = async knex => {
+  await knex('users').insert([
     {
       id: 57,
       email: 'em@il.com',
@@ -10,3 +10,4 @@ exports.seed = knex =>
       auth_role: 'admin'
     }
   ]);
+};


### PR DESCRIPTION
Switches from using promises directly, with the sometimes-gnarly `.then()` code, to using the `await` and `async` syntactic sugar.  There are a couple of things worth pointing out specifically:

- all tests are updated to use `async` methods, which always return a promise; this way, we rely on tap's native promise support instead of having to remember to manually call `done()` on the tests
- the `request-promise` library does something weird when I use it with `await`: it prints the response object to the console and doesn't resolve like it's supposed to; as a temporary workaround, I added async wrapper methods to the endpoint test utils class

There's also a CodeClimate error that I think is valid, but I recommend that we ignore it for now because it should be cleaned up when we pick a DB relational layer.