### PR TITLE
Adds a personnel form

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -4194,14 +4194,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -4210,6 +4202,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -6783,6 +6783,11 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
+    "numeral": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
+      "integrity": "sha1-StCAk21EPCVhrtnyGX7//iX05QY="
+    },
     "nwmatcher": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
@@ -8372,15 +8377,6 @@
         "xtend": "4.0.1"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -8439,6 +8435,15 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/web/package.json
+++ b/web/package.json
@@ -36,6 +36,7 @@
   "homepage": "https://github.com/18F/cms-hitech-apd#readme",
   "dependencies": {
     "history": "^4.7.2",
+    "numeral": "^2.0.6",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",

--- a/web/src/components/App.js
+++ b/web/src/components/App.js
@@ -7,6 +7,7 @@ import DevProvider from './DevProvider';
 import ApdOverview from '../containers/ApdOverview';
 import StateContacts from '../containers/StateContacts';
 import StateStart from '../containers/StateStart';
+import StatePersonnel from '../containers/StatePersonnel';
 
 const Wrapper = process.env.NODE_ENV !== 'production' ? DevProvider : Provider;
 
@@ -26,6 +27,7 @@ const App = () => (
       <Route path="/apd-overview" component={ApdOverview} />
       <Route path="/state-start" component={StateStart} />
       <Route path="/state-contacts" component={StateContacts} />
+      <Route path="/state-personnel" component={StatePersonnel} />
     </Container>
   </Wrapper>
 );

--- a/web/src/components/Dollars.js
+++ b/web/src/components/Dollars.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import numeral from 'numeral';
+
+const formats = {
+  cents: '$0,0.00',
+  noCents: '$0,0'
+};
+
+export default function Dollars(props) {
+  return (
+    <span className={`dollar ${props.className}`}>
+      {numeral(props.value).format(props.hideCents ? formats.noCents : formats.cents)}
+    </span>
+  );
+}
+
+Dollars.propTypes = {
+  value: PropTypes.number.isRequired,
+  hideCents: PropTypes.bool,
+  className: PropTypes.string
+};
+
+Dollars.defaultProps = {
+  hideCents: false,
+  className: ''
+};

--- a/web/src/components/Dollars.js
+++ b/web/src/components/Dollars.js
@@ -10,7 +10,9 @@ const formats = {
 export default function Dollars(props) {
   return (
     <span className={`dollar ${props.className}`}>
-      {numeral(props.value).format(props.hideCents ? formats.noCents : formats.cents)}
+      {numeral(props.value).format(
+        props.hideCents ? formats.noCents : formats.cents
+      )}
     </span>
   );
 }

--- a/web/src/components/FormPersonnel.js
+++ b/web/src/components/FormPersonnel.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { Button } from 'rebass';
 import { Field, FieldArray, reduxForm } from 'redux-form';
 
-import Input from './Input';
+import { Input } from './Inputs';
 
 const PersonnelList = ({ fields, meta: { error, submitFailed } }) => (
   <div>
@@ -56,6 +56,7 @@ const PersonnelList = ({ fields, meta: { error, submitFailed } }) => (
                 name={`${person}.nextCompensation`}
                 component={Input}
                 parse={value => Number(value)}
+                format={value => `${value}`}
                 type="number"
               />
             </td>
@@ -66,6 +67,7 @@ const PersonnelList = ({ fields, meta: { error, submitFailed } }) => (
                 name={`${person}.nextTime`}
                 component={Input}
                 parse={value => Number(value)}
+                format={value => `${value}`}
                 type="number"
               />
             </td>
@@ -77,6 +79,7 @@ const PersonnelList = ({ fields, meta: { error, submitFailed } }) => (
                 name={`${person}.nextNextTime`}
                 component={Input}
                 parse={value => Number(value)}
+                format={value => `${value}`}
                 type="number"
               />
             </td>
@@ -95,7 +98,7 @@ const PersonnelList = ({ fields, meta: { error, submitFailed } }) => (
       </tbody>
     </table>
     <Button
-      bg="green"
+      bg="black"
       onClick={() =>
         fields.push({ nextCompensation: 0, nextTime: 0, nextNextTime: 0 })
       }
@@ -122,7 +125,28 @@ PersonnelForm.propTypes = {
 
 const formConfig = {
   form: 'personnel',
-  initialValues: {}
+  initialValues: {
+    state: [{
+      name: 'Alicia Axelrod',
+      jobTitle: 'big cheese',
+      nextCompensation: 78400,
+      nextTime: 50,
+      nextNextTime: 30
+    }],
+    contracting: [{
+      name: 'Barbara Bigelow',
+      jobTitle: 'software engineer',
+      nextCompensation: 89324,
+      nextTime: 80,
+      nextNextTime: 80
+    }, {
+      name: 'Chandra Cogsworth',
+      jobTitle: 'content designer',
+      nextCompensation: 91535,
+      nextTime: 70,
+      nextNextTime: 80
+    }]
+  }
 };
 
 export default reduxForm(formConfig)(PersonnelForm);

--- a/web/src/components/FormPersonnel.js
+++ b/web/src/components/FormPersonnel.js
@@ -126,26 +126,31 @@ PersonnelForm.propTypes = {
 const formConfig = {
   form: 'personnel',
   initialValues: {
-    state: [{
-      name: 'Alicia Axelrod',
-      jobTitle: 'big cheese',
-      nextCompensation: 78400,
-      nextTime: 50,
-      nextNextTime: 30
-    }],
-    contracting: [{
-      name: 'Barbara Bigelow',
-      jobTitle: 'software engineer',
-      nextCompensation: 89324,
-      nextTime: 80,
-      nextNextTime: 80
-    }, {
-      name: 'Chandra Cogsworth',
-      jobTitle: 'content designer',
-      nextCompensation: 91535,
-      nextTime: 70,
-      nextNextTime: 80
-    }]
+    state: [
+      {
+        name: 'Alicia Axelrod',
+        jobTitle: 'big cheese',
+        nextCompensation: 78400,
+        nextTime: 50,
+        nextNextTime: 30
+      }
+    ],
+    contracting: [
+      {
+        name: 'Barbara Bigelow',
+        jobTitle: 'software engineer',
+        nextCompensation: 89324,
+        nextTime: 80,
+        nextNextTime: 80
+      },
+      {
+        name: 'Chandra Cogsworth',
+        jobTitle: 'content designer',
+        nextCompensation: 91535,
+        nextTime: 70,
+        nextNextTime: 80
+      }
+    ]
   }
 };
 

--- a/web/src/components/FormPersonnel.js
+++ b/web/src/components/FormPersonnel.js
@@ -1,0 +1,128 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Button } from 'rebass';
+import { Field, FieldArray, reduxForm } from 'redux-form';
+
+import Input from './Input';
+
+const PersonnelList = ({ fields, meta: { error, submitFailed } }) => (
+  <div>
+    <div>{submitFailed && error && <span>{error}</span>}</div>
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Job title</th>
+          <th>Job description</th>
+          <th>2019 compensation</th>
+          <th>2019 percentage of time</th>
+          <th>2019 cost to activity</th>
+          <th>2020 percentage of time</th>
+          <th>2020 cost to activity</th>
+          <th />
+        </tr>
+      </thead>
+      <tbody>
+        {fields.map((person, idx) => (
+          <tr key={person}>
+            <td>
+              <Field
+                hideLabel
+                label="personnel name"
+                name={`${person}.name`}
+                component={Input}
+              />
+            </td>
+            <td>
+              <Field
+                hideLabel
+                label="job title"
+                name={`${person}.jobTitle`}
+                component={Input}
+              />
+            </td>
+            <td>
+              <Field
+                hideLabel
+                label="job description"
+                name={`${person}.jobDescription`}
+                component={Input}
+              />
+            </td>
+            <td>
+              <Field
+                hideLabel
+                label="2019 compensation"
+                name={`${person}.nextCompensation`}
+                component={Input}
+                parse={value => Number(value)}
+                type="number"
+              />
+            </td>
+            <td>
+              <Field
+                hideLabel
+                label="2019 percentage time"
+                name={`${person}.nextTime`}
+                component={Input}
+                parse={value => Number(value)}
+                type="number"
+              />
+            </td>
+            <td>0</td>
+            <td>
+              <Field
+                hideLabel
+                label="2020 percentage time"
+                name={`${person}.nextNextTime`}
+                component={Input}
+                parse={value => Number(value)}
+                type="number"
+              />
+            </td>
+            <td>0</td>
+            <td>
+              <button
+                type="button"
+                title="Remove Contact"
+                onClick={() => fields.remove(idx)}
+              >
+                Remove
+              </button>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+    <Button
+      bg="green"
+      onClick={() =>
+        fields.push({ nextCompensation: 0, nextTime: 0, nextNextTime: 0 })
+      }
+    >
+      Add Contact
+    </Button>
+  </div>
+);
+
+PersonnelList.propTypes = {
+  fields: PropTypes.object.isRequired,
+  meta: PropTypes.object.isRequired
+};
+
+const PersonnelForm = ({ personnelType }) => (
+  <form onSubmit={e => e.preventDefault()}>
+    <FieldArray name={`${personnelType}`} component={PersonnelList} />
+  </form>
+);
+
+PersonnelForm.propTypes = {
+  personnelType: PropTypes.string.isRequired
+};
+
+const formConfig = {
+  form: 'personnel',
+  initialValues: {}
+};
+
+export default reduxForm(formConfig)(PersonnelForm);

--- a/web/src/components/FormPersonnel.js
+++ b/web/src/components/FormPersonnel.js
@@ -55,7 +55,7 @@ const PersonnelList = ({ fields, meta: { error, submitFailed } }) => (
                 label="2019 compensation"
                 name={`${person}.nextCompensation`}
                 component={Input}
-                parse={value => Number(value)}
+                parse={value => +value}
                 format={value => `${value}`}
                 type="number"
               />
@@ -66,7 +66,7 @@ const PersonnelList = ({ fields, meta: { error, submitFailed } }) => (
                 label="2019 percentage time"
                 name={`${person}.nextTime`}
                 component={Input}
-                parse={value => Number(value)}
+                parse={value => +value}
                 format={value => `${value}`}
                 type="number"
               />
@@ -78,7 +78,7 @@ const PersonnelList = ({ fields, meta: { error, submitFailed } }) => (
                 label="2020 percentage time"
                 name={`${person}.nextNextTime`}
                 component={Input}
-                parse={value => Number(value)}
+                parse={value => +value}
                 format={value => `${value}`}
                 type="number"
               />

--- a/web/src/components/Inputs.js
+++ b/web/src/components/Inputs.js
@@ -30,7 +30,7 @@ const makeInput = InputInner => {
     input: PropTypes.object.isRequired,
     meta: PropTypes.object.isRequired,
     label: PropTypes.string.isRequired,
-    hideLabel: PropTypes.bool.isRequired,
+    hideLabel: PropTypes.bool,
     type: PropTypes.string
   };
 

--- a/web/src/components/Inputs.js
+++ b/web/src/components/Inputs.js
@@ -13,7 +13,9 @@ const makeInput = InputInner => {
     type
   }) => (
     <Box mb={3}>
-      <Label htmlFor={name} className={hideLabel ? 'sr-only' : ''}>{label}</Label>
+      <Label htmlFor={name} className={hideLabel ? 'sr-only' : ''}>
+        {label}
+      </Label>
       <InputInner id={name} type={type} {...rest} />
       {touched && error && <span>{error}</span>}
     </Box>

--- a/web/src/components/Inputs.js
+++ b/web/src/components/Inputs.js
@@ -9,10 +9,11 @@ const makeInput = InputInner => {
     input: { name, ...rest },
     meta: { touched, error },
     label,
+    hideLabel,
     type
   }) => (
     <Box mb={3}>
-      <Label htmlFor={name}>{label}</Label>
+      { hideLabel ? '' : (<Label htmlFor={name}>{label}</Label>) }
       <InputInner id={name} type={type} {...rest} />
       {touched && error && <span>{error}</span>}
     </Box>
@@ -22,11 +23,13 @@ const makeInput = InputInner => {
     input: PropTypes.object.isRequired,
     meta: PropTypes.object.isRequired,
     label: PropTypes.string.isRequired,
+    hideLabel: PropTypes.bool.isRequired,
     type: PropTypes.string
   };
 
   InputHolder.defaultProps = {
-    type: 'text'
+    type: 'text',
+    hideLabel: false
   };
 
   return InputHolder;

--- a/web/src/components/Inputs.js
+++ b/web/src/components/Inputs.js
@@ -2,6 +2,13 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Box, Input, Label, Textarea } from 'rebass';
 
+const offscreenStyle = {
+  position: 'absolute',
+  left: '-1000em',
+  width: '1em',
+  overflow: 'hidden'
+};
+
 // a HOC for Text / Textarea input that includes
 // rebass components and accompanying label
 const makeInput = InputInner => {
@@ -13,7 +20,7 @@ const makeInput = InputInner => {
     type
   }) => (
     <Box mb={3}>
-      { hideLabel ? '' : (<Label htmlFor={name}>{label}</Label>) }
+      <Label htmlFor={name} style={hideLabel ? offscreenStyle : { }}>{label}</Label>
       <InputInner id={name} type={type} {...rest} />
       {touched && error && <span>{error}</span>}
     </Box>

--- a/web/src/components/Inputs.js
+++ b/web/src/components/Inputs.js
@@ -2,13 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Box, Input, Label, Textarea } from 'rebass';
 
-const offscreenStyle = {
-  position: 'absolute',
-  left: '-1000em',
-  width: '1em',
-  overflow: 'hidden'
-};
-
 // a HOC for Text / Textarea input that includes
 // rebass components and accompanying label
 const makeInput = InputInner => {
@@ -20,7 +13,7 @@ const makeInput = InputInner => {
     type
   }) => (
     <Box mb={3}>
-      <Label htmlFor={name} style={hideLabel ? offscreenStyle : { }}>{label}</Label>
+      <Label htmlFor={name} className={hideLabel ? 'sr-only' : ''}>{label}</Label>
       <InputInner id={name} type={type} {...rest} />
       {touched && error && <span>{error}</span>}
     </Box>

--- a/web/src/components/__snapshots__/App.test.js.snap
+++ b/web/src/components/__snapshots__/App.test.js.snap
@@ -59,6 +59,10 @@ ShallowWrapper {
             component={[Function]}
             path="/state-contacts"
           />
+          <Route
+            component={[Function]}
+            path="/state-personnel"
+          />
         </Styled(Styled(Base))>,
       ],
     },
@@ -145,6 +149,10 @@ ShallowWrapper {
               component={[Function]}
               path="/state-contacts"
             />,
+            <Route
+              component={[Function]}
+              path="/state-personnel"
+            />,
           ],
           "is": "main",
         },
@@ -211,6 +219,18 @@ ShallowWrapper {
             "rendered": null,
             "type": [Function],
           },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "component": [Function],
+              "path": "/state-personnel",
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
         ],
         "type": [Function],
       },
@@ -264,6 +284,10 @@ ShallowWrapper {
             <Route
               component={[Function]}
               path="/state-contacts"
+            />
+            <Route
+              component={[Function]}
+              path="/state-personnel"
             />
           </Styled(Styled(Base))>,
         ],
@@ -351,6 +375,10 @@ ShallowWrapper {
                 component={[Function]}
                 path="/state-contacts"
               />,
+              <Route
+                component={[Function]}
+                path="/state-personnel"
+              />,
             ],
             "is": "main",
           },
@@ -412,6 +440,18 @@ ShallowWrapper {
               "props": Object {
                 "component": [Function],
                 "path": "/state-contacts",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "component": [Function],
+                "path": "/state-personnel",
               },
               "ref": null,
               "rendered": null,

--- a/web/src/containers/ApdOverview.js
+++ b/web/src/containers/ApdOverview.js
@@ -20,7 +20,7 @@ class ApdOverview extends Component {
         <Heading>Tell us more about your HITECH program</Heading>
         <FormApdOverview onSubmit={this.showResults} />
         <Divider my={4} color="gray2" />
-        <Button onClick={() => goTo('/state-start')}>Continue</Button>
+        <Button onClick={() => goTo('/state-personnel')}>Continue</Button>
       </Box>
     );
   }

--- a/web/src/containers/StatePersonnel.js
+++ b/web/src/containers/StatePersonnel.js
@@ -1,0 +1,110 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { push } from 'react-router-redux';
+import { Box, Button, Divider, Heading } from 'rebass';
+import { bindActionCreators } from 'redux';
+
+import PersonnelForm from '../components/FormPersonnel';
+
+class StatePersonnel extends Component {
+  showResults = data => {
+    console.log(data);
+  };
+
+  render() {
+    const { goTo } = this.props;
+    const { statePersonnel, contractingPersonnel } = this.props;
+
+    const stateNextTotal = statePersonnel.reduce(
+      (total, personnel) =>
+        total + ((personnel.nextCompensation * personnel.nextTime) / 100),
+      0
+    );
+    const stateNextNextTotal = statePersonnel.reduce(
+      (total, personnel) =>
+        total +
+        ((personnel.nextCompensation * personnel.nextNextTime * 1.03) / 100),
+      0
+    );
+    const contractingNextTotal = contractingPersonnel.reduce(
+      (total, personnel) =>
+        total + ((personnel.nextCompensation * personnel.nextTime) / 100),
+      0
+    );
+    const contractingNextNextTotal = contractingPersonnel.reduce(
+      (total, personnel) =>
+        total +
+        ((personnel.nextCompensation * personnel.nextNextTime * 1.03) / 100),
+      0
+    );
+
+    return (
+      <Box py={4}>
+        <Heading>Personnel costs for Administration</Heading>
+        Most activities include costs for state and contracting personnel. You
+        may also want to hire consultants for legal services or outreach, for
+        example. We’ll go over other miscellaneous expenses like software
+        licenses and supplies in the next section.
+        <table>
+          <tbody>
+            <tr>
+              <td>
+                <li />
+              </td>
+              <td>State personnel</td>
+              <td>2019</td>
+              <td>{stateNextTotal}</td>
+              <td>2020</td>
+              <td>{stateNextNextTotal}</td>
+            </tr>
+            <tr>
+              <td>
+                <li />
+              </td>
+              <td>Contracting personnel</td>
+              <td>2019</td>
+              <td>{contractingNextTotal}</td>
+              <td>2020</td>
+              <td>{contractingNextNextTotal}</td>
+            </tr>
+          </tbody>
+        </table>
+        {/* <Form onSubmit={this.showResults} /> */}
+        <Heading>State personnel</Heading>
+        <PersonnelForm personnelType="state" />
+        <Divider my={4} color="gray2" />
+        <Heading>Contracting personnel</Heading>
+        <PersonnelForm personnelType="contracting" />
+        <Divider my={4} color="gray2" />
+        <Button onClick={() => goTo('/state-start')}>Continue</Button>
+      </Box>
+    );
+  }
+}
+
+StatePersonnel.propTypes = {
+  goTo: PropTypes.func.isRequired,
+  statePersonnel: PropTypes.array.isRequired,
+  contractingPersonnel: PropTypes.array.isRequired
+};
+
+const mapDispatchToProps = dispatch =>
+  bindActionCreators({ goTo: path => push(path) }, dispatch);
+
+const mapStateToProps = state => {
+  let contractingArray;
+  let stateArray;
+
+  if (state.form.personnel) {
+    contractingArray = state.form.personnel.values.contracting;
+    stateArray = state.form.personnel.values.state;
+  }
+
+  return {
+    contractingPersonnel: contractingArray || [],
+    statePersonnel: stateArray || []
+  };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(StatePersonnel);

--- a/web/src/containers/StatePersonnel.js
+++ b/web/src/containers/StatePersonnel.js
@@ -55,9 +55,13 @@ class StatePersonnel extends Component {
               </td>
               <td>State personnel</td>
               <td>2019</td>
-              <td><Dollars value={stateNextTotal} hideCents /></td>
+              <td>
+                <Dollars value={stateNextTotal} hideCents />
+              </td>
               <td>2020</td>
-              <td><Dollars value={stateNextNextTotal} hideCents /></td>
+              <td>
+                <Dollars value={stateNextNextTotal} hideCents />
+              </td>
             </tr>
             <tr>
               <td>
@@ -65,9 +69,13 @@ class StatePersonnel extends Component {
               </td>
               <td>Contracting personnel</td>
               <td>2019</td>
-              <td><Dollars value={contractingNextTotal} hideCents /></td>
+              <td>
+                <Dollars value={contractingNextTotal} hideCents />
+              </td>
               <td>2020</td>
-              <td><Dollars value={contractingNextNextTotal} hideCents /></td>
+              <td>
+                <Dollars value={contractingNextNextTotal} hideCents />
+              </td>
             </tr>
           </tbody>
         </table>

--- a/web/src/containers/StatePersonnel.js
+++ b/web/src/containers/StatePersonnel.js
@@ -5,6 +5,7 @@ import { push } from 'react-router-redux';
 import { Box, Button, Divider, Heading } from 'rebass';
 import { bindActionCreators } from 'redux';
 
+import Dollars from '../components/Dollars';
 import PersonnelForm from '../components/FormPersonnel';
 
 class StatePersonnel extends Component {
@@ -54,9 +55,9 @@ class StatePersonnel extends Component {
               </td>
               <td>State personnel</td>
               <td>2019</td>
-              <td>{stateNextTotal}</td>
+              <td><Dollars value={stateNextTotal} hideCents /></td>
               <td>2020</td>
-              <td>{stateNextNextTotal}</td>
+              <td><Dollars value={stateNextNextTotal} hideCents /></td>
             </tr>
             <tr>
               <td>
@@ -64,9 +65,9 @@ class StatePersonnel extends Component {
               </td>
               <td>Contracting personnel</td>
               <td>2019</td>
-              <td>{contractingNextTotal}</td>
+              <td><Dollars value={contractingNextTotal} hideCents /></td>
               <td>2020</td>
-              <td>{contractingNextNextTotal}</td>
+              <td><Dollars value={contractingNextNextTotal} hideCents /></td>
             </tr>
           </tbody>
         </table>

--- a/web/src/styles/base.js
+++ b/web/src/styles/base.js
@@ -95,4 +95,15 @@ injectGlobal`
   button {
     cursor: pointer;
   }
+
+  .sr-only {
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+  }
 `;


### PR DESCRIPTION
Adds a form for entering state and contracting personnel and computes what those personnel will cost.  This closes #150.

* Adds the `/state-personnel` route
* Updates the APD overview page to go to the personnel page next
* Updates the `Input` component to add an option to turn labels off
  - labels are pushed offscreen so screen readers will still read them
  - we should discuss this approach more; are there cases where the labels should also be  hidden from screen readers?
* Adds a `<Dollars>` component for formatting numbers into dollars for display

This is pretty ugly, IMO, but it's a prototype...  Also a good excuse to play with redux-forms.  😄 

### This pull request is ready to merge when...
- [x] ~~Tests have been updated (and~~ all tests are passing ~~)~~
  - foregoing ***new*** tests on the prototype UI components
- [x] This code has been reviewed by someone other than the original author
- [x] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This feature is done when...
- Design has approved the experience
  - N/A - design will definitely not approve this experience, but that's intentional!
- Product has approved the experience
  - N/A - same
