### PR TITLE
Add Staticfile w/ pushstate enabled

### DIFF
--- a/Staticfile
+++ b/Staticfile
@@ -1,0 +1,1 @@
+pushstate: enabled

--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "description": "APD app for CMS HITECH program",
   "main": "app.js",
   "scripts": {
-    "scaffold": "mkdir -p dist && cp src/index.html dist/",
+    "scaffold": "mkdir -p dist && cp src/index.html dist/ && cp ../Staticfile dist/",
     "build": "npm run scaffold && NODE_ENV=production webpack -p",
     "lint": "eslint 'src/**/*.js'",
     "start": "webpack-dev-server --host 0.0.0.0 --port 8001 --history-api-fallback --content-base src/",


### PR DESCRIPTION
I __think__ this may fix our front-end bug where non-root paths are 404ing (instead of using index.html and letting SPA handle routing) based on:

* https://github.com/cloudfoundry/staticfile-buildpack/issues/77
* https://docs.cloudfoundry.org/buildpacks/staticfile/index.html#pushstate

If this doesn't work, we'll have to muck around with `nginx.conf` but one step at a time...