### PR TITLE
Log form values

### DIFF
--- a/api/_setup.test.js
+++ b/api/_setup.test.js
@@ -24,6 +24,7 @@ require('./routes');
 require('./routes/users');
 require('./routes/users/get');
 require('./routes/users/post');
+require('./routes/logForm');
 
 // fin
 

--- a/api/endpoint-tests/log-form/index.js
+++ b/api/endpoint-tests/log-form/index.js
@@ -1,0 +1,43 @@
+const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
+const {
+  request, getFullPath
+} = require('../utils');
+
+const url = getFullPath('/log-form');
+
+const testItem = {
+  user: 'Bob The Builder',
+  form: {
+    field1: 'value1',
+    field2: 'value2',
+    field3: {
+      field3a: [
+        'value3aa', 'value3ab', 'value3ac'
+      ]
+    }
+  }
+};
+
+tap.test('form logging endpoint | POST /log-form', async postTests => {
+  const { response, body } = await request.post(url, { json: testItem });
+
+  postTests.equal(response.statusCode, 200, 'gives a 200 status code');
+  postTests.notOk(body, 'sends an empty body');
+});
+
+tap.test('form logging endpoint | GET /log-form', async getTests => {
+  const { response, body } = await request.get(url);
+
+  getTests.equal(response.statusCode, 200, 'gives a 200 status code');
+  getTests.same(JSON.parse(body), {
+    'Bob The Builder': {
+      field1: 'value1',
+      field2: 'value2',
+      field3: {
+        field3a: [
+          'value3aa', 'value3ab', 'value3ac'
+        ]
+      }
+    }
+  }, 'sends back the body from the previous POST');
+});

--- a/api/endpoint-tests/log-form/index.js
+++ b/api/endpoint-tests/log-form/index.js
@@ -1,7 +1,5 @@
 const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
-const {
-  request, getFullPath
-} = require('../utils');
+const { request, getFullPath } = require('../utils');
 
 const url = getFullPath('/log-form');
 
@@ -11,9 +9,7 @@ const testItem = {
     field1: 'value1',
     field2: 'value2',
     field3: {
-      field3a: [
-        'value3aa', 'value3ab', 'value3ac'
-      ]
+      field3a: ['value3aa', 'value3ab', 'value3ac']
     }
   }
 };
@@ -29,15 +25,17 @@ tap.test('form logging endpoint | GET /log-form', async getTests => {
   const { response, body } = await request.get(url);
 
   getTests.equal(response.statusCode, 200, 'gives a 200 status code');
-  getTests.same(JSON.parse(body), {
-    'Bob The Builder': {
-      field1: 'value1',
-      field2: 'value2',
-      field3: {
-        field3a: [
-          'value3aa', 'value3ab', 'value3ac'
-        ]
+  getTests.same(
+    JSON.parse(body),
+    {
+      'Bob The Builder': {
+        field1: 'value1',
+        field2: 'value2',
+        field3: {
+          field3a: ['value3aa', 'value3ab', 'value3ac']
+        }
       }
-    }
-  }, 'sends back the body from the previous POST');
+    },
+    'sends back the body from the previous POST'
+  );
 });

--- a/api/routes/index.js
+++ b/api/routes/index.js
@@ -1,7 +1,7 @@
 const users = require('./users');
 const formLogger = require('./logForm');
 
-module.exports = (app, usersEndpoint = users) => {
+module.exports = (app, usersEndpoint = users, formLoggerEndopint = formLogger) => {
   usersEndpoint(app);
-  formLogger(app);
+  formLoggerEndopint(app);
 };

--- a/api/routes/index.js
+++ b/api/routes/index.js
@@ -1,5 +1,7 @@
 const users = require('./users');
+const formLogger = require('./logForm');
 
 module.exports = (app, usersEndpoint = users) => {
   usersEndpoint(app);
+  formLogger(app);
 };

--- a/api/routes/index.js
+++ b/api/routes/index.js
@@ -1,7 +1,11 @@
 const users = require('./users');
 const formLogger = require('./logForm');
 
-module.exports = (app, usersEndpoint = users, formLoggerEndopint = formLogger) => {
+module.exports = (
+  app,
+  usersEndpoint = users,
+  formLoggerEndopint = formLogger
+) => {
   usersEndpoint(app);
   formLoggerEndopint(app);
 };

--- a/api/routes/index.test.js
+++ b/api/routes/index.test.js
@@ -6,11 +6,16 @@ const endpointIndex = require('./index');
 tap.test('endpoint setup', async endpointTest => {
   const app = {};
   const usersEndpoint = sinon.spy();
+  const formLoggerEndpoint = sinon.spy();
 
-  endpointIndex(app, usersEndpoint);
+  endpointIndex(app, usersEndpoint, formLoggerEndpoint);
 
   endpointTest.ok(
     usersEndpoint.calledWith(app),
     'users endpoint is setup with the app'
+  );
+  endpointTest.ok(
+    formLoggerEndpoint.calledWith(app),
+    'form logger endpoint is setup with the app'
   );
 });

--- a/api/routes/logForm.js
+++ b/api/routes/logForm.js
@@ -1,4 +1,4 @@
-const forms = { };
+const forms = {};
 
 module.exports = app => {
   app.post('/log-form', async (req, res) => {

--- a/api/routes/logForm.js
+++ b/api/routes/logForm.js
@@ -1,0 +1,12 @@
+const forms = { };
+
+module.exports = app => {
+  app.post('/log-form', async (req, res) => {
+    forms[req.body.user] = req.body.form;
+    res.status(200).end();
+  });
+
+  app.get('/log-form', (req, res) => {
+    res.send(forms);
+  });
+};

--- a/api/routes/logForm.test.js
+++ b/api/routes/logForm.test.js
@@ -1,0 +1,79 @@
+const tap = require('tap');
+const sinon = require('sinon');
+
+const formLoggerEndpoint = require('./logForm');
+
+tap.test('form logger endpoint', async endpointTest => {
+  const sandbox = sinon.createSandbox();
+  const app = {
+    get: sandbox.stub(),
+    post: sandbox.stub()
+  };
+  const res = {
+    status: sandbox.stub(),
+    send: sandbox.stub(),
+    end: sandbox.stub()
+  };
+
+  let get;
+  let post;
+
+  endpointTest.beforeEach(done => {
+    sandbox.reset();
+
+    res.status.returns(res);
+    res.send.returns(res);
+    res.end.returns(res);
+
+    done();
+  });
+
+  endpointTest.test('setup', async setupTest => {
+    formLoggerEndpoint(app);
+
+    setupTest.ok(
+      app.get.calledWith('/log-form', sinon.match.func),
+      'form logs GET endpoint is registered'
+    );
+    setupTest.ok(
+      app.post.calledWith('/log-form', sinon.match.func),
+      'form logs POST endpoint is registered'
+    );
+
+    get = app.get.args[0][1];
+    post = app.post.args[0][1];
+  });
+
+  endpointTest.test('logger POST endpoint', async postTest => {
+    post({
+      body: {
+        user: 'theUser',
+        form: {
+          field1: 'value1',
+          field2: 'value2',
+          field3: [
+            'value3a', 'value3b', 'value3c'
+          ]
+        }
+      }
+    }, res);
+
+    postTest.ok(res.status.calledWith(200), 'sends a 200 HTTP status');
+    postTest.ok(res.end.calledOnce, 'response is ended');
+  });
+
+  endpointTest.test('logger GET endpont', async getTest => {
+    get(null, res);
+
+    getTest.ok(res.send.calledOnce, 'a response body is sent');
+    getTest.same(res.send.args[0][0], {
+      theUser: {
+        field1: 'value1',
+        field2: 'value2',
+        field3: [
+          'value3a', 'value3b', 'value3c'
+        ]
+      }
+    }, 'sends back the expected form content');
+  });
+});

--- a/api/routes/logForm.test.js
+++ b/api/routes/logForm.test.js
@@ -45,18 +45,19 @@ tap.test('form logger endpoint', async endpointTest => {
   });
 
   endpointTest.test('logger POST endpoint', async postTest => {
-    post({
-      body: {
-        user: 'theUser',
-        form: {
-          field1: 'value1',
-          field2: 'value2',
-          field3: [
-            'value3a', 'value3b', 'value3c'
-          ]
+    post(
+      {
+        body: {
+          user: 'theUser',
+          form: {
+            field1: 'value1',
+            field2: 'value2',
+            field3: ['value3a', 'value3b', 'value3c']
+          }
         }
-      }
-    }, res);
+      },
+      res
+    );
 
     postTest.ok(res.status.calledWith(200), 'sends a 200 HTTP status');
     postTest.ok(res.end.calledOnce, 'response is ended');
@@ -66,14 +67,16 @@ tap.test('form logger endpoint', async endpointTest => {
     get(null, res);
 
     getTest.ok(res.send.calledOnce, 'a response body is sent');
-    getTest.same(res.send.args[0][0], {
-      theUser: {
-        field1: 'value1',
-        field2: 'value2',
-        field3: [
-          'value3a', 'value3b', 'value3c'
-        ]
-      }
-    }, 'sends back the expected form content');
+    getTest.same(
+      res.send.args[0][0],
+      {
+        theUser: {
+          field1: 'value1',
+          field2: 'value2',
+          field3: ['value3a', 'value3b', 'value3c']
+        }
+      },
+      'sends back the expected form content'
+    );
   });
 });

--- a/bin/deploy-ux-testing.sh
+++ b/bin/deploy-ux-testing.sh
@@ -10,6 +10,9 @@ API="https://api.fr.cloud.gov"
 ORG="sandbox-gsa"
 SPACE="michael.walker"
 
+API_URL="https://hitech-api-ux.app.cloud.gov/"
+LOG_FORM_INTERACTIONS="true"
+
 # Install `cf` cli
 curl -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&source=github'
 dpkg -i cf-cli_amd64.deb

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -10,6 +10,8 @@ API="https://api.fr.cloud.gov"
 ORG="sandbox-gsa"
 SPACE="brendan.sudol"
 
+API_URL="https://hitech-api.app.cloud.gov/"
+
 # Install `cf` cli
 curl -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&source=github'
 dpkg -i cf-cli_amd64.deb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
 
   web:
     build: ./web
+    environment:
+      - API_URL=http://localhost:8081
     volumes:
       - ./web:/app
       - /app/node_modules

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -34,6 +34,15 @@ purple button you click when you want the UX testing instance to update.
 This allows us to put designers and UX testers in charge of that environment
 without requiring that they know git or Github.
 
+##### Form logging
+
+To help with UX testing, we log everything that users into into the forms
+as they go.  This is only enabled in the UX environment - in order to enable
+form logging on the frontend, the `LOG_FORM_INTERACTIONS` environment
+variable must be set to a truthy value when the frontend code is compiled.
+See our [front end build documentation](frontend-build.md) for more information
+about build-time environment variables.
+
 ### Staging instance
 
 The staging instance deploys automatically with every commit to the `master`

--- a/docs/frontend-build.md
+++ b/docs/frontend-build.md
@@ -1,0 +1,15 @@
+# Front end build
+
+Our front end is built using a pretty simple Webpack configuration.  We
+use the [babel-loader]() along with the [env](), [react](), and [stage-2]()
+Babel presets to build the app.
+
+Webpack also injects some environment variables into the front end code.  For
+example, in the code, references to `process.env.API_URL` are replaced at build
+time with the actual value of that environment variable.  Here's the full list
+of environment variables that gets replaced:
+
+|variable name|purpose|
+|---|---|
+|`API_URL`|The base URL to the API. **default**: `null`
+|`LOG_FORM_INTERACTIONS`|Whether to enable logging on user form interactions. Any truthy value will enable logging.  **default**: `false`

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,10 @@ libraries:
 * [Redux](https://redux.js.org/) for internal state management
 * [Webpack](https://webpack.js.org/) for bundling the app into a deliverable
 
+(We have more detailed
+[documentation about how our frontend build is configured](frontend-build.md),
+too).
+
 We use [Rebass](http://jxnblk.com/rebass/) as the foundation for styling, with
 custom [styled-components](https://www.styled-components.com/) for customization
 where appropriate.
@@ -33,6 +37,7 @@ The API is built on [Express](https://expressjs.com/) using a
   cookie-based sessions
 * [Passport](http://www.passportjs.org/) for authentication
 * [Knex](http://knexjs.org/) for interacting with the database
+* [Bookshelf.js](http://bookshelfjs.org) for managing database relationships
 
 For testing, we use [node-tap](http://www.node-tap.org/) as the runner and
 assertions, and [Sinon.JS](sinonjs.org) for mocking.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -483,6 +483,15 @@
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
       "dev": true
     },
+    "axios": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+      "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+      "requires": {
+        "follow-redirects": "1.4.1",
+        "is-buffer": "1.1.6"
+      }
+    },
     "axobject-query": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-0.1.0.tgz",
@@ -3384,6 +3393,24 @@
         "write": "0.2.1"
       }
     },
+    "follow-redirects": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
+      "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+      "requires": {
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -4214,14 +4241,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -4230,6 +4249,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -4941,8 +4968,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -6624,8 +6650,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multicast-dns": {
       "version": "6.2.1",
@@ -8396,15 +8421,6 @@
         "xtend": "4.0.1"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -8463,6 +8479,15 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/web/package.json
+++ b/web/package.json
@@ -35,6 +35,7 @@
   },
   "homepage": "https://github.com/18F/cms-hitech-apd#readme",
   "dependencies": {
+    "axios": "^0.17.1",
     "babel-polyfill": "^6.26.0",
     "history": "^4.7.2",
     "lodash.kebabcase": "^4.1.1",

--- a/web/src/components/FormActivitiesStart.js
+++ b/web/src/components/FormActivitiesStart.js
@@ -51,7 +51,8 @@ const formConfig = {
       'outreach',
       'design-and-development'
     ]
-  }
+  },
+  destroyOnUnmount: false
 };
 
 export default reduxForm(formConfig)(FormActivitiesStart);

--- a/web/src/components/FormApdOverview.js
+++ b/web/src/components/FormApdOverview.js
@@ -24,7 +24,8 @@ FormApdOverview.propTypes = {
 };
 
 const formConfig = {
-  form: 'apdOverview'
+  form: 'apdOverview',
+  destroyOnUnmount: false
 };
 
 export default reduxForm(formConfig)(FormApdOverview);

--- a/web/src/components/FormStateContacts.js
+++ b/web/src/components/FormStateContacts.js
@@ -123,7 +123,8 @@ const formConfig = {
       email: 'cory.gustafson@vermont.gov',
       phone: '802-879‐5901'
     }
-  }
+  },
+  destroyOnUnmount: false
 };
 
 export default reduxForm(formConfig)(FormStateContacts);

--- a/web/src/components/FormStateStart.js
+++ b/web/src/components/FormStateStart.js
@@ -57,7 +57,8 @@ const formConfig = {
     email: 'denise.nagelschmidt@vermont.gov',
     phone: '802-879-5900',
     stateName: 'vt'
-  }
+  },
+  destroyOnUnmount: false
 };
 
 export default reduxForm(formConfig)(FormStateStart);

--- a/web/src/containers/ActivitiesStart.js
+++ b/web/src/containers/ActivitiesStart.js
@@ -5,6 +5,7 @@ import { push } from 'react-router-redux';
 import { Box, Button, ButtonOutline, Divider, Heading } from 'rebass';
 import { bindActionCreators } from 'redux';
 
+import FormLogger from '../util/formLogger';
 import FormActivitiesStart from '../components/FormActivitiesStart';
 
 class ActivitiesStart extends Component {
@@ -17,6 +18,7 @@ class ActivitiesStart extends Component {
 
     return (
       <Box py={4}>
+        <FormLogger />
         <Heading mb={3}>Now let’s go over your program activities</Heading>
         <FormActivitiesStart onSubmit={this.showResults} />
         <Divider my={4} color="gray2" />

--- a/web/src/containers/ApdOverview.js
+++ b/web/src/containers/ApdOverview.js
@@ -5,6 +5,7 @@ import { push } from 'react-router-redux';
 import { Box, Button, ButtonOutline, Divider, Heading } from 'rebass';
 import { bindActionCreators } from 'redux';
 
+import FormLogger from '../util/formLogger';
 import FormApdOverview from '../components/FormApdOverview';
 
 class ApdOverview extends Component {
@@ -17,6 +18,7 @@ class ApdOverview extends Component {
 
     return (
       <Box py={4}>
+        <FormLogger />
         <Heading mb={3}>Tell us more about your HITECH program</Heading>
         <FormApdOverview onSubmit={this.showResults} />
         <Divider my={4} color="gray2" />

--- a/web/src/containers/StateContacts.js
+++ b/web/src/containers/StateContacts.js
@@ -5,6 +5,7 @@ import { push } from 'react-router-redux';
 import { Box, Button, ButtonOutline, Divider, Heading } from 'rebass';
 import { bindActionCreators } from 'redux';
 
+import FormLogger from '../util/formLogger';
 import FormStateContacts from '../components/FormStateContacts';
 
 class StateContacts extends Component {
@@ -17,6 +18,7 @@ class StateContacts extends Component {
 
     return (
       <Box py={4}>
+        <FormLogger />
         <Heading mb={3}>Review your state contact information</Heading>
         <FormStateContacts onSubmit={this.showResults} />
         <Divider my={4} color="gray2" />

--- a/web/src/containers/StatePersonnel.js
+++ b/web/src/containers/StatePersonnel.js
@@ -5,6 +5,7 @@ import { push } from 'react-router-redux';
 import { Box, Button, Divider, Heading } from 'rebass';
 import { bindActionCreators } from 'redux';
 
+import FormLogger from '../util/formLogger';
 import Dollars from '../components/Dollars';
 import PersonnelForm from '../components/FormPersonnel';
 
@@ -42,6 +43,7 @@ class StatePersonnel extends Component {
 
     return (
       <Box py={4}>
+        <FormLogger />
         <Heading>Personnel costs for Administration</Heading>
         Most activities include costs for state and contracting personnel. You
         may also want to hire consultants for legal services or outreach, for

--- a/web/src/containers/StateStart.js
+++ b/web/src/containers/StateStart.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
 import { Box, Button, Divider, Heading } from 'rebass';
 import { bindActionCreators } from 'redux';
+import FormLogger from '../util/formLogger';
 
 import FormStateStart from '../components/FormStateStart';
 
@@ -17,6 +18,7 @@ class StateStart extends Component {
 
     return (
       <Box py={4}>
+        <FormLogger />
         <Heading mb={3}>Let’s start by setting up your state profile</Heading>
         <FormStateStart onSubmit={this.showResults} />
         <Divider my={4} color="gray2" />
@@ -30,7 +32,6 @@ StateStart.propTypes = {
   goTo: PropTypes.func.isRequired
 };
 
-const mapDispatchToProps = dispatch =>
-  bindActionCreators({ goTo: path => push(path) }, dispatch);
+const mapDispatchToProps = dispatch => bindActionCreators({ goTo: path => push(path) }, dispatch);
 
 export default connect(null, mapDispatchToProps)(StateStart);

--- a/web/src/util/formLogger.js
+++ b/web/src/util/formLogger.js
@@ -1,0 +1,30 @@
+import { connect } from 'react-redux';
+import axios from 'axios';
+
+let timeout;
+const user = (new Date()).toString();
+const apiURL = 'http://localhost:8081';
+
+const FormLogger = ({ form }) => {
+  if (timeout) {
+    clearTimeout(timeout);
+  }
+  timeout = setTimeout(() => {
+    const formValues = {};
+    Object.keys(form).forEach(formKey => {
+      formValues[formKey] = form[formKey].values;
+    });
+
+    axios
+      .post(`${apiURL}/log-form`, { user, form: formValues })
+      .then(() => { timeout = null; })
+      .catch(() => { timeout = null; });
+  }, 2000);
+  return null;
+};
+
+const mapStateToProps = state => ({
+  form: state.form
+});
+
+export default connect(mapStateToProps)(FormLogger);

--- a/web/src/util/formLogger.js
+++ b/web/src/util/formLogger.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 
 let timeout;
 const user = (new Date()).toString();
-const apiURL = 'http://localhost:8081';
+const apiURL = process.env.API_URL;
 
 const FormLogger = ({ form }) => {
   if (timeout) {

--- a/web/src/util/formLogger.js
+++ b/web/src/util/formLogger.js
@@ -6,20 +6,22 @@ const user = (new Date()).toString();
 const apiURL = process.env.API_URL;
 
 const FormLogger = ({ form }) => {
-  if (timeout) {
-    clearTimeout(timeout);
-  }
-  timeout = setTimeout(() => {
-    const formValues = {};
-    Object.keys(form).forEach(formKey => {
-      formValues[formKey] = form[formKey].values;
-    });
+  if (process.env.LOG_FORM_INTERACTIONS) {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    timeout = setTimeout(() => {
+      const formValues = {};
+      Object.keys(form).forEach(formKey => {
+        formValues[formKey] = form[formKey].values;
+      });
 
-    axios
-      .post(`${apiURL}/log-form`, { user, form: formValues })
-      .then(() => { timeout = null; })
-      .catch(() => { timeout = null; });
-  }, 2000);
+      axios
+        .post(`${apiURL}/log-form`, { user, form: formValues })
+        .then(() => { timeout = null; })
+        .catch(() => { timeout = null; });
+    }, 2000);
+  }
   return null;
 };
 

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -19,6 +19,9 @@ module.exports = {
     ]
   },
   plugins: [
-    new webpack.EnvironmentPlugin(['API_URL'])
+    new webpack.EnvironmentPlugin({
+      API_URL: null,
+      LOG_FORM_INTERACTIONS: false
+    })
   ]
 };

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -1,3 +1,4 @@
+const webpack = require('webpack');
 const path = require('path');
 
 module.exports = {
@@ -16,5 +17,8 @@ module.exports = {
         use: { loader: 'babel-loader' }
       }
     ]
-  }
+  },
+  plugins: [
+    new webpack.EnvironmentPlugin(['API_URL'])
+  ]
 };


### PR DESCRIPTION
Per @nkkl's request, record the form values as they're being entered by the user.  Some notes:

* the API stores the form values in memory, so if the API restarts for some reason, the collected values will be reset
* the form values are stored in a JSON object, keyed on the timestamp of when the user first began interacting with the form
* if the user reloads their browser session, they'll get a new timestamp and they'll be represented twice in the logged results (I tried to get around this by stashing a cookie but it refused to work and I didn't want to spend any more time on it)
* logging is enabled or disabled at ***build*** time, using the `LOG_FORM_INTERACTIONS` environment variable - by default this is `false`, but if it is set to `true`, form interactions will be logged
* the API URL is inserted into the code at build time; the build process will replace occurrences of `process.env.API_URL` with the actual constant value stored in that environment variable
* I updated the deployment scripts to set the environment variables as appropriate (enabled for UX testing, disabled for staging)

Here's a sample of what the JSON looks like (please forgive the not-great form element names, they're interim!):

```json
{
  "Mon Feb 05 2018 11:33:04 GMT-0600 (CST)": {
    "stateStart": {
      "name": "Denise Nagelschmidt",
      "position": "Health Reform Portfolio Director",
      "email": "denise.nagelschmidt@vermont.gov",
      "phone": "802-879-5900",
      "stateName": "vt"
    },
    "stateContacts": {
      "medicaidOffice": {
        "address1": "Department of Vermont Health Access",
        "address2": "280 State Drive",
        "city": "Waterbury",
        "state": "Vermont",
        "zip": "05671-1010"
      },
      "medicaidDirector": {
        "name": "Cory Gustafson",
        "email": "cory.gustafson@vermont.gov",
        "phone": "802-879‐5901"
      }
    },
    "apdOverview": {
      "vision": "a vision statement here",
      "benefits": "and some benefits, too"
    },
    "form3": {
      "activities": [
        "administration",
        "strategic-planning",
        "outreach",
        "design-and-development"
      ]
    },
    "personnel": {
      "state": [
        {
          "name": "Alicia Axelrod",
          "jobTitle": "big cheese",
          "nextCompensation": 78400,
          "nextTime": 50,
          "nextNextTime": 30
        }
      ],
      "contracting": [
        {
          "name": "Barbara Bigelow",
          "jobTitle": "software engineer",
          "nextCompensation": 89324,
          "nextTime": 80,
          "nextNextTime": 80
        },
        {
          "name": "Chandra Cogsworth",
          "jobTitle": "content designer",
          "nextCompensation": 91535,
          "nextTime": 70,
          "nextNextTime": 80
        }
      ]
    }
  }
}
```

For now, logging is disabled by setting a constant at build time and then evaluating it at runtime.  Longer term, it would probably be nice to [use `IgnorePlugin` and `UglifyJSPlugin` to completely remove the logging module](https://remarkablemark.org/blog/2017/02/25/webpack-ignore-module/) at build time, so there aren't any runtime checks at all.

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- ~~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~~ N/A
- [x] The change has been documented

### This feature is done when...
- ~~Design has approved the experience~~ N/A
- [x] Product has approved the experience (@nkkl)
