### PR TITLE
Fix deployment scripts

### DIFF
--- a/bin/deploy-ux-testing.sh
+++ b/bin/deploy-ux-testing.sh
@@ -10,8 +10,8 @@ API="https://api.fr.cloud.gov"
 ORG="sandbox-gsa"
 SPACE="michael.walker"
 
-API_URL="https://hitech-api-ux.app.cloud.gov/"
-LOG_FORM_INTERACTIONS="true"
+export API_URL="https://hitech-api-ux.app.cloud.gov/"
+export LOG_FORM_INTERACTIONS="true"
 
 # Install `cf` cli
 curl -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&source=github'

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -10,7 +10,7 @@ API="https://api.fr.cloud.gov"
 ORG="sandbox-gsa"
 SPACE="brendan.sudol"
 
-API_URL="https://hitech-api.app.cloud.gov/"
+export API_URL="https://hitech-api.app.cloud.gov/"
 
 # Install `cf` cli
 curl -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&source=github'


### PR DESCRIPTION
`npm run` executes scripts in an isolated environment.  In order to get the constituent parts of an npm script to have the same environment variables, those variables must be exported to the parent environment.  We'll have to wait and see if this actually works, but it looks highly probable from my local testing.

This needs to be merged into master and then the UX deploy needs to be manually approved in order to fully test this.

### This pull request is ready to merge when...
- [ ] This code has been reviewed by someone other than the original author

### This feature is done when...
- ~~Design has approved the experience~~
- ~~Product has approved the experience~~
