### PR TITLE
main -> div

### DIFF
--- a/web/src/components/App.js
+++ b/web/src/components/App.js
@@ -29,7 +29,7 @@ const App = () => (
       </NavLink>
     </Toolbar>
 
-    <Container is="main">
+    <Container>
       <Switch>
         <Route exact path="/" component={Demo} />
         <Route path="/activities-list" component={ActivitiesList} />

--- a/web/src/components/__snapshots__/App.test.js.snap
+++ b/web/src/components/__snapshots__/App.test.js.snap
@@ -35,9 +35,7 @@ ShallowWrapper {
             Get started
           </Styled(Styled(Base))>
         </Styled(Styled(Base))>,
-        <Styled(Styled(Base))
-          is="main"
-        >
+        <Styled(Styled(Base))>
           <Switch>
             <Route
               component={[Function]}
@@ -202,7 +200,6 @@ ShallowWrapper {
               component={[Function]}
             />
           </Switch>,
-          "is": "main",
         },
         "ref": null,
         "rendered": Object {
@@ -439,9 +436,7 @@ ShallowWrapper {
               Get started
             </Styled(Styled(Base))>
           </Styled(Styled(Base))>,
-          <Styled(Styled(Base))
-            is="main"
-          >
+          <Styled(Styled(Base))>
             <Switch>
               <Route
                 component={[Function]}
@@ -606,7 +601,6 @@ ShallowWrapper {
                 component={[Function]}
               />
             </Switch>,
-            "is": "main",
           },
           "ref": null,
           "rendered": Object {


### PR DESCRIPTION
The HTML5 `main` element is not supported by Internet Explorer, which was throwing off the container width and auto margin.

This should fix :)

More details: https://stackoverflow.com/a/35820454