### PR TITLE
user login beginnings

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -492,6 +492,15 @@
         "is-buffer": "1.1.6"
       }
     },
+    "axios-mock-adapter": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.13.1.tgz",
+      "integrity": "sha1-Bag7D6X+Itde+++vEl9l1tlBOnI=",
+      "dev": true,
+      "requires": {
+        "deep-equal": "1.0.1"
+      }
+    },
     "axobject-query": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-0.1.0.tgz",
@@ -3298,24 +3307,6 @@
         "ua-parser-js": "0.7.17"
       }
     },
-    "fetch-mock": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-6.0.0.tgz",
-      "integrity": "sha512-xbQ+zQClDhnzPMoerhkRv6hTN9doVRxOeHRqeSHPFwxTuMo5ufGU383ByoeS3FmuXMS86I4Bz0Rj5Y1vZ8DTUw==",
-      "dev": true,
-      "requires": {
-        "glob-to-regexp": "0.3.0",
-        "path-to-regexp": "2.1.0"
-      },
-      "dependencies": {
-        "path-to-regexp": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.1.0.tgz",
-          "integrity": "sha512-dZY7QPCPp5r9cnNuQ955mOv4ZFVDXY/yvqeV7Y1W2PJA3PEFcuow9xKFfJxbBj1pIjOAP+M2B4/7xubmykLrXw==",
-          "dev": true
-        }
-      }
-    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -4471,12 +4462,6 @@
       "requires": {
         "is-glob": "2.0.1"
       }
-    },
-    "glob-to-regexp": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
-      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
-      "dev": true
     },
     "globals": {
       "version": "9.18.0",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -3298,6 +3298,24 @@
         "ua-parser-js": "0.7.17"
       }
     },
+    "fetch-mock": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-6.0.0.tgz",
+      "integrity": "sha512-xbQ+zQClDhnzPMoerhkRv6hTN9doVRxOeHRqeSHPFwxTuMo5ufGU383ByoeS3FmuXMS86I4Bz0Rj5Y1vZ8DTUw==",
+      "dev": true,
+      "requires": {
+        "glob-to-regexp": "0.3.0",
+        "path-to-regexp": "2.1.0"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.1.0.tgz",
+          "integrity": "sha512-dZY7QPCPp5r9cnNuQ955mOv4ZFVDXY/yvqeV7Y1W2PJA3PEFcuow9xKFfJxbBj1pIjOAP+M2B4/7xubmykLrXw==",
+          "dev": true
+        }
+      }
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -4453,6 +4471,12 @@
       "requires": {
         "is-glob": "2.0.1"
       }
+    },
+    "glob-to-regexp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+      "dev": true
     },
     "globals": {
       "version": "9.18.0",
@@ -7767,9 +7791,9 @@
       }
     },
     "redux-mock-store": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.4.0.tgz",
-      "integrity": "sha512-y+SGh/SONWwqs4DiyHjd0H6NMgz368wXDiUjSHuOnMEr4dN9PmjV6N3bNvxoILaIQ7zeVKclLyxsCQ2TwGZfEw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.1.tgz",
+      "integrity": "sha512-B+iZ98ESHw4EAWVLKUknQlop1OdLKOayGRmd6KavNtC0zoSsycD8hTt0hEr1eUTw2gmYJOdfBY5QAgZweTUcLQ==",
       "dev": true,
       "requires": {
         "lodash.isplainobject": "4.0.6"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7775,6 +7775,11 @@
         "lodash.isplainobject": "4.0.6"
       }
     },
+    "redux-thunk": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.2.0.tgz",
+      "integrity": "sha1-5hWhbha0ehmlFXZhM9Hj6Zt4UuU="
+    },
     "regenerate": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,8 @@
     "build": "npm run scaffold && NODE_ENV=production webpack -p",
     "lint": "eslint 'src/**/*.js'",
     "start": "webpack-dev-server --host 0.0.0.0 --port 8001 --history-api-fallback --content-base src/",
-    "test": "jest",
+    "test": "jest --collectCoverage",
+    "test-watch": "jest --watch",
     "prettier": "prettier --single-quote --trailing-comma none --write \"src/**/*.js\""
   },
   "repository": {
@@ -68,12 +69,13 @@
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.5.1",
+    "fetch-mock": "^6.0.0",
     "jest": "^21.2.1",
     "jest-styled-components": "^4.9.0",
     "prettier": "^1.9.1",
     "react-test-renderer": "^16.2.0",
     "redux-logger": "^3.0.6",
-    "redux-mock-store": "^1.4.0",
+    "redux-mock-store": "^1.5.1",
     "webpack": "^3.10.0",
     "webpack-dev-server": "^2.9.7"
   },
@@ -85,7 +87,6 @@
     ]
   },
   "jest": {
-    "collectCoverage": true,
     "coverageDirectory": "../coverage",
     "rootDir": "src",
     "setupFiles": [

--- a/web/package.json
+++ b/web/package.json
@@ -50,6 +50,7 @@
     "rebass": "^1.0.4",
     "redux": "^3.7.2",
     "redux-form": "^7.2.1",
+    "redux-thunk": "^2.2.0",
     "styled-components": "^2.3.3"
   },
   "devDependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -55,6 +55,7 @@
     "styled-components": "^2.3.3"
   },
   "devDependencies": {
+    "axios-mock-adapter": "^1.13.1",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.1.2",
     "babel-jest": "^21.2.0",
@@ -69,7 +70,6 @@
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.5.1",
-    "fetch-mock": "^6.0.0",
     "jest": "^21.2.1",
     "jest-styled-components": "^4.9.0",
     "prettier": "^1.9.1",

--- a/web/src/actions/auth.js
+++ b/web/src/actions/auth.js
@@ -1,0 +1,16 @@
+export const LOGIN_REQUEST = 'LOGIN_REQUEST';
+export const LOGIN_SUCCESS = 'LOGIN_SUCCESS';
+export const LOGIN_FAILURE = 'LOGIN_FAILURE';
+
+export const requestLogin = () => ({ type: LOGIN_REQUEST });
+export const completeLogin = user => ({ type: LOGIN_SUCCESS, user });
+export const failLogin = error => ({ type: LOGIN_FAILURE, error });
+
+export const attemptLogin = (user, pw) => dispatch => {
+  dispatch(requestLogin());
+  console.log(`user: ${user} pw: ${pw}`);
+
+  setTimeout(() => {
+    dispatch(completeLogin({ id: 1 }));
+  }, 1000);
+};

--- a/web/src/actions/auth.js
+++ b/web/src/actions/auth.js
@@ -1,16 +1,25 @@
+import axios from 'axios';
+
+const API_URL = 'http://localhost:8000';
+
 export const LOGIN_REQUEST = 'LOGIN_REQUEST';
 export const LOGIN_SUCCESS = 'LOGIN_SUCCESS';
 export const LOGIN_FAILURE = 'LOGIN_FAILURE';
+export const LOGOUT_SUCCESS = 'LOGOUT_SUCCESS';
 
 export const requestLogin = () => ({ type: LOGIN_REQUEST });
-export const completeLogin = user => ({ type: LOGIN_SUCCESS, user });
+export const completeLogin = () => ({ type: LOGIN_SUCCESS });
 export const failLogin = error => ({ type: LOGIN_FAILURE, error });
+export const logout = () => ({ type: LOGOUT_SUCCESS });
 
-export const attemptLogin = (user, pw) => dispatch => {
+export const attemptLogin = (username, password) => dispatch => {
   dispatch(requestLogin());
-  console.log(`user: ${user} pw: ${pw}`);
 
-  setTimeout(() => {
-    dispatch(completeLogin({ id: 1 }));
-  }, 1000);
+  return axios
+    .post(`${API_URL}/auth/login`, { username, password })
+    .then(() => dispatch(completeLogin()))
+    .catch(error => {
+      const reason = error.response.statusText;
+      dispatch(failLogin(reason));
+    });
 };

--- a/web/src/actions/auth.js
+++ b/web/src/actions/auth.js
@@ -19,7 +19,7 @@ export const attemptLogin = (username, password) => dispatch => {
     .post(`${API_URL}/auth/login`, { username, password })
     .then(() => dispatch(completeLogin()))
     .catch(error => {
-      const reason = error.response.statusText;
+      const reason = error.response.data || 'N/A';
       dispatch(failLogin(reason));
     });
 };

--- a/web/src/actions/auth.js
+++ b/web/src/actions/auth.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_URL = 'http://localhost:8000';
+const API_URL = process.env.API_URL || 'http://localhost:8000';
 
 export const LOGIN_REQUEST = 'LOGIN_REQUEST';
 export const LOGIN_SUCCESS = 'LOGIN_SUCCESS';

--- a/web/src/actions/auth.test.js
+++ b/web/src/actions/auth.test.js
@@ -1,0 +1,42 @@
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import * as actions from './auth';
+
+const mockStore = configureStore([thunk]);
+
+describe('auth actions', () => {
+  it('requestLogin should create LOGIN_REQUEST action', () => {
+    expect(actions.requestLogin()).toEqual({ type: actions.LOGIN_REQUEST });
+  });
+
+  it('completeLogin should create LOGIN_SUCCESS action', () => {
+    expect(actions.completeLogin()).toEqual({ type: actions.LOGIN_SUCCESS });
+  });
+
+  it('failLogin should create LOGIN_FAILURE action', () => {
+    expect(actions.failLogin('foo')).toEqual({
+      type: actions.LOGIN_FAILURE,
+      error: 'foo'
+    });
+  });
+
+  it('logout should create LOGOUT_SUCCESS action', () => {
+    expect(actions.logout()).toEqual({ type: actions.LOGOUT_SUCCESS });
+  });
+
+  describe('attemptLogin (async)', () => {
+    it('creates LOGIN_SUCCESS after successful auth', () => {
+      const store = mockStore({});
+
+      const expectedActions = [
+        { type: actions.LOGIN_REQUEST },
+        { type: actions.LOGIN_FAILURE }
+      ];
+
+      return store.dispatch(actions.attemptLogin()).then(() => {
+        expect(store.getActions()).toEqual(expectedActions);
+      });
+    });
+  });
+});

--- a/web/src/actions/auth.test.js
+++ b/web/src/actions/auth.test.js
@@ -1,9 +1,12 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import * as actions from './auth';
 
 const mockStore = configureStore([thunk]);
+const fetchMock = new MockAdapter(axios);
 
 describe('auth actions', () => {
   it('requestLogin should create LOGIN_REQUEST action', () => {
@@ -26,12 +29,31 @@ describe('auth actions', () => {
   });
 
   describe('attemptLogin (async)', () => {
+    afterEach(() => {
+      fetchMock.reset();
+    });
+
     it('creates LOGIN_SUCCESS after successful auth', () => {
       const store = mockStore({});
+      fetchMock.onPost().reply(200);
 
       const expectedActions = [
         { type: actions.LOGIN_REQUEST },
-        { type: actions.LOGIN_FAILURE }
+        { type: actions.LOGIN_SUCCESS }
+      ];
+
+      return store.dispatch(actions.attemptLogin()).then(() => {
+        expect(store.getActions()).toEqual(expectedActions);
+      });
+    });
+
+    it('creates LOGIN_FAILURE after unsuccessful auth', () => {
+      const store = mockStore({});
+      fetchMock.onPost().reply(401, 'foo');
+
+      const expectedActions = [
+        { type: actions.LOGIN_REQUEST },
+        { type: actions.LOGIN_FAILURE, error: 'foo' }
       ];
 
       return store.dispatch(actions.attemptLogin()).then(() => {

--- a/web/src/app.js
+++ b/web/src/app.js
@@ -6,8 +6,7 @@ import { render } from 'react-dom';
 import { routerMiddleware } from 'react-router-redux';
 import { createStore, applyMiddleware } from 'redux';
 import { createLogger } from 'redux-logger'; // eslint-disable-line import/no-extraneous-dependencies
-// 👆 eslint complains that 'redux-logger' should be in dependencies rather
-// that devDependencies, but the module is only used in development
+import thunk from 'redux-thunk';
 
 import reducer from './reducers';
 import Root from './components/Root';
@@ -15,7 +14,7 @@ import './styles/base';
 
 const history = createHistory();
 
-const middleware = [routerMiddleware(history)];
+const middleware = [thunk, routerMiddleware(history)];
 if (process.env.NODE_ENV !== 'production') {
   middleware.push(createLogger());
 }

--- a/web/src/components/App.js
+++ b/web/src/components/App.js
@@ -11,6 +11,7 @@ import ActivityApproach from '../containers/ActivityApproach';
 import ActivityGoals from '../containers/ActivityGoals';
 import ActivityOverview from '../containers/ActivityOverview';
 import ApdOverview from '../containers/ApdOverview';
+import Login from '../containers/Login';
 import StateContacts from '../containers/StateContacts';
 import StateStart from '../containers/StateStart';
 import StatePersonnel from '../containers/StatePersonnel';
@@ -32,6 +33,8 @@ const App = () => (
     <Container>
       <Switch>
         <Route exact path="/" component={Demo} />
+        <Route path="/login" component={Login} />
+
         <Route path="/activities-list" component={ActivitiesList} />
         <Route path="/activities-start" component={ActivitiesStart} />
         <Route path="/activity-approach" component={ActivityApproach} />
@@ -42,6 +45,7 @@ const App = () => (
         <Route path="/state-contacts" component={StateContacts} />
         <Route path="/state-personnel" component={StatePersonnel} />
         <Route path="/state-start" component={StateStart} />
+
         <Route component={NoMatch} />
       </Switch>
     </Container>

--- a/web/src/components/__snapshots__/App.test.js.snap
+++ b/web/src/components/__snapshots__/App.test.js.snap
@@ -44,6 +44,10 @@ ShallowWrapper {
             />
             <Route
               component={[Function]}
+              path="/login"
+            />
+            <Route
+              component={[Function]}
               path="/activities-list"
             />
             <Route
@@ -158,6 +162,10 @@ ShallowWrapper {
             />
             <Route
               component={[Function]}
+              path="/login"
+            />
+            <Route
+              component={[Function]}
               path="/activities-list"
             />
             <Route
@@ -215,6 +223,10 @@ ShallowWrapper {
               />,
               <Route
                 component={[Function]}
+                path="/login"
+              />,
+              <Route
+                component={[Function]}
                 path="/activities-list"
               />,
               <Route
@@ -268,6 +280,18 @@ ShallowWrapper {
                 "component": [Function],
                 "exact": true,
                 "path": "/",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "component": [Function],
+                "path": "/login",
               },
               "ref": null,
               "rendered": null,
@@ -445,6 +469,10 @@ ShallowWrapper {
               />
               <Route
                 component={[Function]}
+                path="/login"
+              />
+              <Route
+                component={[Function]}
                 path="/activities-list"
               />
               <Route
@@ -559,6 +587,10 @@ ShallowWrapper {
               />
               <Route
                 component={[Function]}
+                path="/login"
+              />
+              <Route
+                component={[Function]}
                 path="/activities-list"
               />
               <Route
@@ -616,6 +648,10 @@ ShallowWrapper {
                 />,
                 <Route
                   component={[Function]}
+                  path="/login"
+                />,
+                <Route
+                  component={[Function]}
                   path="/activities-list"
                 />,
                 <Route
@@ -669,6 +705,18 @@ ShallowWrapper {
                   "component": [Function],
                   "exact": true,
                   "path": "/",
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "component": [Function],
+                  "path": "/login",
                 },
                 "ref": null,
                 "rendered": null,

--- a/web/src/containers/Login.js
+++ b/web/src/containers/Login.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Redirect } from 'react-router-dom';
-import { Box, Button, Code, Heading, Input, Label, Message } from 'rebass';
+import { Box, Button, Heading, Input, Label, Message } from 'rebass';
 import { attemptLogin } from '../actions/auth';
 
 class Login extends Component {
@@ -38,7 +38,7 @@ class Login extends Component {
           )}
           <form onSubmit={this.handleSubmit}>
             <Box mb={3}>
-              <Label>Username</Label>
+              <Label>Email</Label>
               <Input
                 name="username"
                 value={username}
@@ -59,7 +59,6 @@ class Login extends Component {
             </Button>
           </form>
         </Box>
-        <Code>{JSON.stringify({ fetching, error, authenticated })}</Code>
       </Box>
     );
   }
@@ -72,7 +71,12 @@ Login.propTypes = {
   attemptLogin: PropTypes.func.isRequired
 };
 
-const mapStateToProps = ({ auth }) => ({ ...auth });
+const mapStateToProps = ({ auth: { authenticated, error, fetching } }) => ({
+  authenticated,
+  error,
+  fetching
+});
+
 const mapDispatchToProps = { attemptLogin };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Login);

--- a/web/src/containers/Login.js
+++ b/web/src/containers/Login.js
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { Box, Button, Code, Heading, Input, Label } from 'rebass';
+import { Redirect } from 'react-router-dom';
+import { Box, Button, Code, Heading, Input, Label, Message } from 'rebass';
 import { attemptLogin } from '../actions/auth';
 
 class Login extends Component {
@@ -22,10 +23,19 @@ class Login extends Component {
     const { fetching, error, authenticated } = this.props;
     const { username, password } = this.state;
 
+    if (authenticated) {
+      return <Redirect to="/" />;
+    }
+
     return (
       <Box py={4}>
         <Heading mb={3}>Please log in.</Heading>
         <Box mb={3} w={[1, 1 / 2, 1 / 3]}>
+          {error && (
+            <Message mb={2} bg="gray">
+              {error}
+            </Message>
+          )}
           <form onSubmit={this.handleSubmit}>
             <Box mb={3}>
               <Label>Username</Label>
@@ -44,8 +54,8 @@ class Login extends Component {
                 onChange={this.handleChange}
               />
             </Box>
-            <Button bg="black" type="submit">
-              Submit
+            <Button bg="black" type="submit" disabled={fetching}>
+              {fetching ? 'Submitting' : 'Submit'}
             </Button>
           </form>
         </Box>

--- a/web/src/containers/Login.js
+++ b/web/src/containers/Login.js
@@ -54,7 +54,7 @@ class Login extends Component {
                 onChange={this.handleChange}
               />
             </Box>
-            <Button bg="black" type="submit" disabled={fetching}>
+            <Button type="submit" disabled={fetching}>
               {fetching ? 'Submitting' : 'Submit'}
             </Button>
           </form>

--- a/web/src/containers/Login.js
+++ b/web/src/containers/Login.js
@@ -1,0 +1,68 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { Box, Button, Code, Heading, Input, Label } from 'rebass';
+import { attemptLogin } from '../actions/auth';
+
+class Login extends Component {
+  state = { username: '', password: '' };
+
+  handleChange = e => {
+    const { name, value } = e.target;
+    this.setState({ [name]: value });
+  };
+
+  handleSubmit = e => {
+    e.preventDefault();
+    const { username, password } = this.state;
+    this.props.attemptLogin(username, password);
+  };
+
+  render() {
+    const { fetching, error, authenticated } = this.props;
+    const { username, password } = this.state;
+
+    return (
+      <Box py={4}>
+        <Heading mb={3}>Please log in.</Heading>
+        <Box mb={3} w={[1, 1 / 2, 1 / 3]}>
+          <form onSubmit={this.handleSubmit}>
+            <Box mb={3}>
+              <Label>Username</Label>
+              <Input
+                name="username"
+                value={username}
+                onChange={this.handleChange}
+              />
+            </Box>
+            <Box mb={3}>
+              <Label>Password</Label>
+              <Input
+                name="password"
+                type="password"
+                value={password}
+                onChange={this.handleChange}
+              />
+            </Box>
+            <Button bg="black" type="submit">
+              Submit
+            </Button>
+          </form>
+        </Box>
+        <Code>{JSON.stringify({ fetching, error, authenticated })}</Code>
+      </Box>
+    );
+  }
+}
+
+Login.propTypes = {
+  authenticated: PropTypes.bool.isRequired,
+  error: PropTypes.string.isRequired,
+  fetching: PropTypes.bool.isRequired,
+  attemptLogin: PropTypes.func.isRequired
+};
+
+const mapStateToProps = ({ auth }) => ({ ...auth });
+const mapDispatchToProps = { attemptLogin };
+
+export default connect(mapStateToProps, mapDispatchToProps)(Login);

--- a/web/src/reducers/auth.js
+++ b/web/src/reducers/auth.js
@@ -1,4 +1,9 @@
-import { LOGIN_REQUEST, LOGIN_SUCCESS, LOGIN_FAILURE } from '../actions/auth';
+import {
+  LOGIN_REQUEST,
+  LOGIN_SUCCESS,
+  LOGIN_FAILURE,
+  LOGOUT_SUCCESS
+} from '../actions/auth';
 
 const initialState = {
   fetching: false,
@@ -14,6 +19,8 @@ const auth = (state = initialState, action) => {
       return { ...state, fetching: false, authenticated: true };
     case LOGIN_FAILURE:
       return { ...state, fetching: false, error: action.error };
+    case LOGOUT_SUCCESS:
+      return { ...initialState };
     default:
       return state;
   }

--- a/web/src/reducers/auth.js
+++ b/web/src/reducers/auth.js
@@ -1,0 +1,22 @@
+import { LOGIN_REQUEST, LOGIN_SUCCESS, LOGIN_FAILURE } from '../actions/auth';
+
+const initialState = {
+  fetching: false,
+  authenticated: false,
+  error: ''
+};
+
+const auth = (state = initialState, action) => {
+  switch (action.type) {
+    case LOGIN_REQUEST:
+      return { ...state, fetching: true, authenticated: false, error: '' };
+    case LOGIN_SUCCESS:
+      return { ...state, fetching: false, authenticated: true };
+    case LOGIN_FAILURE:
+      return { ...state, fetching: false, error: action.error };
+    default:
+      return state;
+  }
+};
+
+export default auth;

--- a/web/src/reducers/auth.test.js
+++ b/web/src/reducers/auth.test.js
@@ -1,0 +1,63 @@
+import auth from './auth';
+import {
+  LOGIN_REQUEST,
+  LOGIN_SUCCESS,
+  LOGIN_FAILURE,
+  LOGOUT_SUCCESS
+} from '../actions/auth';
+
+describe('auth reducer', () => {
+  const initialState = {
+    authenticated: false,
+    error: '',
+    fetching: false
+  };
+
+  it('should handle initial state', () => {
+    expect(auth(undefined, {})).toEqual(initialState);
+  });
+
+  it('should handle LOGIN_REQUEST', () => {
+    expect(auth(initialState, { type: LOGIN_REQUEST })).toEqual({
+      authenticated: false,
+      error: '',
+      fetching: true
+    });
+  });
+
+  it('should handle LOGIN_SUCCESS', () => {
+    expect(auth(initialState, { type: LOGIN_SUCCESS })).toEqual({
+      authenticated: true,
+      error: '',
+      fetching: false
+    });
+  });
+
+  it('should handle LOGIN_FAILURE', () => {
+    expect(auth(initialState, { type: LOGIN_FAILURE, error: 'foo' })).toEqual({
+      authenticated: false,
+      error: 'foo',
+      fetching: false
+    });
+  });
+
+  it('should handle LOGOUT_SUCCESS', () => {
+    expect(auth(initialState, { type: LOGOUT_SUCCESS })).toEqual({
+      authenticated: false,
+      error: '',
+      fetching: false
+    });
+  });
+
+  describe('when user is already logged in', () => {
+    it('should reset auth after LOGOUT_SUCCESS', () => {
+      const state = { authenticated: true };
+
+      expect(auth(state, { type: LOGOUT_SUCCESS })).toEqual({
+        authenticated: false,
+        error: '',
+        fetching: false
+      });
+    });
+  });
+});

--- a/web/src/reducers/index.js
+++ b/web/src/reducers/index.js
@@ -2,9 +2,11 @@ import { routerReducer } from 'react-router-redux';
 import { combineReducers } from 'redux';
 import { reducer as formReducer } from 'redux-form';
 
+import auth from './auth';
 import counter from './counter';
 
 const rootReducer = combineReducers({
+  auth,
   counter,
   router: routerReducer,
   form: formReducer

--- a/web/src/reducers/index.test.js
+++ b/web/src/reducers/index.test.js
@@ -3,6 +3,6 @@ import rootReducer from './index';
 describe('root reducer', () => {
   test('should have proper state slices', () => {
     const stateKeys = Object.keys(rootReducer(undefined, {}));
-    expect(stateKeys).toEqual(['counter', 'router', 'form']);
+    expect(stateKeys).toEqual(['auth', 'counter', 'router', 'form']);
   });
 });


### PR DESCRIPTION
This PR begins work to have users authenticate via our front-end site.

It follows the standard/vanilla redux patterns & organization, and adds `redux-thunk` to handle the async authentication request.

Next up (after this initial chunk is live):

* Adding `ProtectedRoute`(s) that redirect to `Login` if unauthenticated
* Better error handling messaging in UI
* Updating top navbar to have dynamic login / logout links