### PR TITLE
Fix database seed bug

### DIFF
--- a/api/seeds/01-roles-and-activities.js
+++ b/api/seeds/01-roles-and-activities.js
@@ -1,37 +1,60 @@
-const setupActivities = async activitiesTable => {
-  await activitiesTable.insert({ id: 1, name: 'view-all-apds' });
-  await activitiesTable.insert({ id: 2, name: 'comment-on-apd' });
-  await activitiesTable.insert({ id: 3, name: 'send-apd-to-state' });
-  await activitiesTable.insert({ id: 4, name: 'view-own-apds' });
-  await activitiesTable.insert({ id: 5, name: 'create-apd' });
+const activities = {
+  'view-roles': false,
+  'create-roles': false,
+  'edit-roles': false
 };
 
-const setupRoles = async rolesTable => {
-  await rolesTable.insert({ id: 1, name: 'admin' });
-  await rolesTable.insert({ id: 2, name: 'cms-reviewer' });
-  await rolesTable.insert({ id: 3, name: 'state-submitter' });
+const roles = {
+  admin: false,
+  'cms-reviewer': false,
+  'state-submitter': false
 };
 
-const setupMappings = async mappingTable => {
-  // Admins
-  await mappingTable.insert({ role_id: 1, activity_id: 1 });
-  await mappingTable.insert({ role_id: 1, activity_id: 2 });
-  await mappingTable.insert({ role_id: 1, activity_id: 3 });
-  await mappingTable.insert({ role_id: 1, activity_id: 4 });
-  await mappingTable.insert({ role_id: 1, activity_id: 5 });
+const roleToActivityMappings = {
+  admin: [
+    'view-roles',
+    'create-roles',
+    'edit-roles'
+  ],
+  'cms-reviewer': [],
+  'state-submitter': []
+};
 
-  // CMS reviewers
-  await mappingTable.insert({ role_id: 2, activity_id: 1 });
-  await mappingTable.insert({ role_id: 2, activity_id: 2 });
-  await mappingTable.insert({ role_id: 2, activity_id: 3 });
+// Take the knex object and the table name as arguments, instead of just
+// the knex table object.  The reason is that if you have an insert on
+// the knex table object and then try to do an insert, under the hood it
+// attempts the insert again, which is bad of course, but it also causes
+// a key constraint error.
+const insertAndGetIDs = async (knex, tableName, values) => {
+  const insert = Object.keys(values).map(name => ({ name }));
+  await knex(tableName).insert(insert);
+  const asInserted = await knex(tableName).select('*');
 
-  // State submitters
-  await mappingTable.insert({ role_id: 3, activity_id: 4 });
-  await mappingTable.insert({ role_id: 3, activity_id: 5 });
+  const idMapping = { };
+  asInserted.forEach(as => {
+    idMapping[as.name] = as.id;
+  });
+  return idMapping;
+};
+
+const setupMappings = async (knex, tableName, roleIDs, activityIDs, mappings) => {
+  const table = knex(tableName);
+
+  await Promise.all(Object.keys(mappings).map(async role => {
+    const roleID = roleIDs[role];
+    for (let i = 0; i < mappings[role].length; i += 1) {
+      const activityID = activityIDs[mappings[role][i]];
+
+      // We actually need to block here, otherwise weird reference stuff happens
+      // and we just map the role to a single activity multiple times.
+      // eslint-disable-next-line no-await-in-loop
+      await table.insert({ role_id: roleID, activity_id: activityID });
+    }
+  }));
 };
 
 exports.seed = async knex => {
-  await setupActivities(knex('auth_activities'));
-  await setupRoles(knex('auth_roles'));
-  await setupMappings(knex('auth_role_activity_mapping'));
+  const activityIDs = await insertAndGetIDs(knex, 'auth_activities', activities);
+  const roleIDs = await insertAndGetIDs(knex, 'auth_roles', roles);
+  await setupMappings(knex, 'auth_role_activity_mapping', roleIDs, activityIDs, roleToActivityMappings);
 };


### PR DESCRIPTION
The database was being seeded with activities and roles using known IDs.  The reason for that is so we could easily map the activities into roles.  The *problem* is that the ID is an autoincremented field, but when you set the ID yourself, the database does not set the "next autoincrement value" accordingly.  What that means in practice is if you try to insert another row without specifying an ID and the next autoincremented ID happens to be one of the manually set IDs, it will reject the insert.

So instead of setting the IDs manually, this PR allows them to be set by the database.  It then queries the database to find out what the IDs are, and uses that to setup the roles/activities mappings.

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [x] The change has been documented

### This feature is done when...
- ~~Design has approved the experience~~
- ~~Product has approved the experience~~
