### PR TITLE
Fix user deserialization bug

### DIFF
--- a/api/auth/serialization.js
+++ b/api/auth/serialization.js
@@ -15,11 +15,15 @@ module.exports.deserializeUser = async (
 ) => {
   try {
     const user = await userModel.where({ id: userID }).fetch();
-    done(null, {
-      username: user.get('email'),
-      id: user.get('id'),
-      activities: await user.activities()
-    });
+    if (user) {
+      done(null, {
+        username: user.get('email'),
+        id: user.get('id'),
+        activities: await user.activities()
+      });
+    } else {
+      done(null, null);
+    }
   } catch (e) {
     done('Could not deserialize user');
   }

--- a/api/auth/serialization.test.js
+++ b/api/auth/serialization.test.js
@@ -32,6 +32,17 @@ tap.test('passport serialization', async serializationTest => {
   serializationTest.test('deserialize a user', async deserializeTest => {
     const userID = 'the-user-id';
 
+    deserializeTest.test('when there is a database problem', async invalidTest => {
+      userModel.fetch.rejects();
+
+      await serialization.deserializeUser(userID, doneCallback, userModel);
+      invalidTest.ok(
+        doneCallback.calledWith(sinon.match.string),
+        'calls back with an error'
+      );
+    });
+
+
     deserializeTest.test('that is not in the database', async invalidTest => {
       userModel.fetch.resolves(null);
 

--- a/api/auth/serialization.test.js
+++ b/api/auth/serialization.test.js
@@ -37,8 +37,8 @@ tap.test('passport serialization', async serializationTest => {
 
       await serialization.deserializeUser(userID, doneCallback, userModel);
       invalidTest.ok(
-        doneCallback.calledWith(sinon.match.string),
-        'calls back with an error'
+        doneCallback.calledWith(null, null),
+        'deserializes to a null user'
       );
     });
 


### PR DESCRIPTION
When a session cookie arrives at the API and it decrypts successfully, if it refers to a user ID that does not exist in the database, deserialization would fail.  When deserialization failed, the session cookie would not be unset or modified, meaning subsequent requests to the API would continue to fail.  Even logging out failed.

To fix that, deserializing a user from a nonexistent user ID will instead result in a null user, which indicates to the rest of the system that they are not logged in and have no permissions.

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [x] The change has been documented

### This feature is done when...
- ~~Design has approved the experience~~
- ~~Product has approved the experience~~
