### PR TITLE
Role management GET route

### DIFF
--- a/api/_setup.test.js
+++ b/api/_setup.test.js
@@ -21,6 +21,10 @@ require('./auth/serialization');
 require('./auth/session');
 
 require('./routes');
+require('./routes/roles');
+require('./routes/roles/get');
+require('./routes/roles/post');
+require('./routes/roles/put');
 require('./routes/users');
 require('./routes/users/get');
 require('./routes/users/post');

--- a/api/auth/middleware.js
+++ b/api/auth/middleware.js
@@ -1,3 +1,5 @@
+const canCache = { };
+
 module.exports.loggedIn = (req, res, next) => {
   if (req.user) {
     next();
@@ -6,14 +8,19 @@ module.exports.loggedIn = (req, res, next) => {
   }
 };
 
-module.exports.can = activity => (req, res, next) => {
-  // First check if they're logged in
-  module.exports.loggedIn(req, res, () => {
-    // Then check if they have the activity
-    if (req.user.activities.includes(activity)) {
-      next();
-    } else {
-      res.status(401).end();
-    }
-  });
+module.exports.can = activity => {
+  if (!canCache[activity]) {
+    canCache[activity] = (req, res, next) => {
+      // First check if they're logged in
+      module.exports.loggedIn(req, res, () => {
+        // Then check if they have the activity
+        if (req.user.activities.includes(activity)) {
+          next();
+        } else {
+          res.status(401).end();
+        }
+      });
+    };
+  }
+  return canCache[activity];
 };

--- a/api/db/authorization.js
+++ b/api/db/authorization.js
@@ -20,6 +20,14 @@ module.exports = {
         'role_id',
         'activity_id'
       );
+    },
+
+    async getActivities() {
+      if (!this.relations.activities) {
+        await this.load('activities');
+      }
+
+      return this.related('activities').pluck('name');
     }
   }
 };

--- a/api/db/authorization.test.js
+++ b/api/db/authorization.test.js
@@ -72,4 +72,61 @@ tap.test('authorization data models', async authModelTests => {
       activityTests.equal(output, 'frootloop', 'returns the expected value');
     }
   );
+
+  authModelTests.test('activities getter helper method', async getActivitesTests => {
+    const sandbox = sinon.createSandbox();
+    const self = {
+      load: sandbox.stub(),
+      related: sandbox.stub(),
+      relations: { activities: false }
+    };
+    const pluck = sandbox.stub();
+    const getActivities = authorization.role.getActivities.bind(self);
+
+    getActivitesTests.beforeEach(done => {
+      sandbox.reset();
+
+      self.load.resolves();
+      self.related.withArgs('activities').returns({ pluck });
+      pluck.withArgs('name').returns(['one', 'two', 'three']);
+
+      done();
+    });
+
+    getActivitesTests.test(
+      'resolves a list of activites when the role relationship is already loaded',
+      async alreadyLoadedTests => {
+        self.relations.activities = true;
+        const list = await getActivities();
+
+        alreadyLoadedTests.ok(
+          self.load.notCalled,
+          'the model load method is not called'
+        );
+        alreadyLoadedTests.same(
+          list,
+          ['one', 'two', 'three'],
+          'returns the list of activities'
+        );
+      }
+    );
+
+    getActivitesTests.test(
+      'resolves a list of activites when the role relationship is not already loaded',
+      async notAlreadyLoadedTests => {
+        self.relations.activities = false;
+        const list = await getActivities();
+
+        notAlreadyLoadedTests.ok(
+          self.load.calledOnce,
+          'the model load method is called'
+        );
+        notAlreadyLoadedTests.same(
+          list,
+          ['one', 'two', 'three'],
+          'returns the list of activities'
+        );
+      }
+    );
+  });
 });

--- a/api/docker-compose.endpoint-tests.yml
+++ b/api/docker-compose.endpoint-tests.yml
@@ -40,6 +40,7 @@ services:
     depends_on:
       - db
       - api-for-testing
+      - api-migration
     environment:
       - NODE_ENV=test
     volumes:

--- a/api/endpoint-tests/roles/get.js
+++ b/api/endpoint-tests/roles/get.js
@@ -1,0 +1,45 @@
+const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
+const getFullPath = require('../utils').getFullPath;
+const login = require('../utils').login;
+const request = require('../utils').request;
+
+tap.test('roles endpoint | GET /roles', async getUsersTest => {
+  const url = getFullPath('/roles');
+
+  getUsersTest.test('when unauthenticated', async unauthenticatedTest => {
+    const { response, body } = await request.get(url);
+    unauthenticatedTest.equal(
+      response.statusCode,
+      403,
+      'gives a 403 status code'
+    );
+    unauthenticatedTest.notOk(body, 'does not send a body');
+  });
+
+  getUsersTest.test('when authenticated', async validTest => {
+    const cookies = await login();
+    const { response, body } = await request.get(url, {
+      jar: cookies,
+      json: true
+    });
+
+    validTest.equal(response.statusCode, 200, 'gives a 200 status code');
+    validTest.same(
+      body,
+      [{
+        name: 'admin',
+        id: 1,
+        activities: ['view-roles', 'create-roles', 'edit-roles']
+      }, {
+        name: 'cms-reviewer',
+        id: 2,
+        activities: ['edit-roles']
+      }, {
+        name: 'state-submitter',
+        id: 3,
+        activities: []
+      }],
+      'returns an array of known roles'
+    );
+  });
+});

--- a/api/routes/index.js
+++ b/api/routes/index.js
@@ -1,11 +1,14 @@
+const roles = require('./roles');
 const users = require('./users');
 const formLogger = require('./logForm');
 
 module.exports = (
   app,
+  rolesEndpoint = roles,
   usersEndpoint = users,
   formLoggerEndopint = formLogger
 ) => {
+  rolesEndpoint(app);
   usersEndpoint(app);
   formLoggerEndopint(app);
 };

--- a/api/routes/index.test.js
+++ b/api/routes/index.test.js
@@ -5,11 +5,16 @@ const endpointIndex = require('./index');
 
 tap.test('endpoint setup', async endpointTest => {
   const app = {};
+  const rolesEndpoint = sinon.spy();
   const usersEndpoint = sinon.spy();
   const formLoggerEndpoint = sinon.spy();
 
-  endpointIndex(app, usersEndpoint, formLoggerEndpoint);
+  endpointIndex(app, rolesEndpoint, usersEndpoint, formLoggerEndpoint);
 
+  endpointTest.ok(
+    rolesEndpoint.calledWith(app),
+    'roles endpoint is setup with the app'
+  );
   endpointTest.ok(
     usersEndpoint.calledWith(app),
     'users endpoint is setup with the app'

--- a/api/routes/roles/get.js
+++ b/api/routes/roles/get.js
@@ -1,0 +1,18 @@
+const defaultRoleModel = require('../../db').models.role;
+const can = require('../../auth/middleware').can;
+
+module.exports = (app, RoleModel = defaultRoleModel) => {
+  app.get('/roles', can('view-roles'), async (req, res) => {
+    try {
+      const roles = await RoleModel.fetchAll({ columns: ['id', 'name'] });
+      const sendRoles = await Promise.all(roles.map(async role => ({
+        id: role.get('id'),
+        name: role.get('name'),
+        activities: await role.getActivities()
+      })));
+      res.send(sendRoles);
+    } catch (e) {
+      res.status(500).end();
+    }
+  });
+};

--- a/api/routes/roles/get.test.js
+++ b/api/routes/roles/get.test.js
@@ -1,6 +1,7 @@
 const tap = require('tap');
 const sinon = require('sinon');
 
+const canMiddleware = require('../../auth/middleware').can('view-roles');
 const getEndpoint = require('./get');
 
 tap.only('roles GET endpoint', async endpointTest => {
@@ -29,7 +30,7 @@ tap.only('roles GET endpoint', async endpointTest => {
     getEndpoint(app, RoleModel);
 
     setupTest.ok(
-      app.get.calledWith('/roles', sinon.match.func, sinon.match.func),
+      app.get.calledWith('/roles', canMiddleware, sinon.match.func),
       'roles GET endpoint is registered'
     );
   });

--- a/api/routes/roles/get.test.js
+++ b/api/routes/roles/get.test.js
@@ -4,7 +4,7 @@ const sinon = require('sinon');
 const canMiddleware = require('../../auth/middleware').can('view-roles');
 const getEndpoint = require('./get');
 
-tap.only('roles GET endpoint', async endpointTest => {
+tap.test('roles GET endpoint', async endpointTest => {
   const sandbox = sinon.createSandbox();
   const app = {
     get: sandbox.stub()

--- a/api/routes/roles/get.test.js
+++ b/api/routes/roles/get.test.js
@@ -1,0 +1,93 @@
+const tap = require('tap');
+const sinon = require('sinon');
+
+const getEndpoint = require('./get');
+
+tap.only('roles GET endpoint', async endpointTest => {
+  const sandbox = sinon.createSandbox();
+  const app = {
+    get: sandbox.stub()
+  };
+  const RoleModel = {
+    fetchAll: sandbox.stub()
+  };
+  const res = {
+    status: sandbox.stub(),
+    send: sandbox.stub(),
+    end: sandbox.stub()
+  };
+
+  endpointTest.beforeEach(async () => {
+    sandbox.reset();
+
+    res.status.returns(res);
+    res.send.returns(res);
+    res.end.returns(res);
+  });
+
+  endpointTest.test('setup', async setupTest => {
+    getEndpoint(app, RoleModel);
+
+    setupTest.ok(
+      app.get.calledWith('/roles', sinon.match.func, sinon.match.func),
+      'roles GET endpoint is registered'
+    );
+  });
+
+  endpointTest.test('get roles handler', async handlerTest => {
+    let handler;
+    handlerTest.beforeEach(done => {
+      getEndpoint(app, RoleModel);
+      handler = app.get.args.find(args => args[0] === '/roles')[2];
+      done();
+    });
+
+    handlerTest.test(
+      'sends a server error code if there is a database error',
+      async invalidTest => {
+        RoleModel.fetchAll.rejects();
+
+        await handler({}, res);
+
+        invalidTest.ok(
+          RoleModel.fetchAll.calledWith({
+            columns: sinon.match.array.deepEquals(['id', 'name'])
+          }),
+          'selects only role ID and name'
+        );
+        invalidTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
+        invalidTest.ok(res.send.notCalled, 'no body is sent');
+        invalidTest.ok(res.end.called, 'response is terminated');
+      }
+    );
+
+    handlerTest.test('sends back a list of roles', async validTest => {
+      const get = sinon.stub();
+      get.withArgs('id').returns(1);
+      get.withArgs('name').returns('hi');
+
+      const getActivities = sinon.stub().resolves(['activity1.1', 'activity1.2']);
+
+      const roles = [
+        { get, getActivities }
+      ];
+      RoleModel.fetchAll.resolves(roles);
+
+      await handler({}, res);
+
+      validTest.ok(
+        RoleModel.fetchAll.calledWith({
+          columns: sinon.match.array.deepEquals(['id', 'name'])
+        }),
+        'selects only role ID and name'
+      );
+      validTest.ok(res.status.notCalled, 'HTTP status is not explicitly set');
+      validTest.ok(
+        res.send.calledWith([
+          { id: 1, name: 'hi', activities: ['activity1.1', 'activity1.2'] }
+        ]),
+        'body is set to the list of roles'
+      );
+    });
+  });
+});

--- a/api/routes/roles/index.js
+++ b/api/routes/roles/index.js
@@ -1,9 +1,5 @@
-const post = require('./post');
 const get = require('./get');
-const put = require('./put');
 
-module.exports = (app, getEndpoint = get, postEndpoint = post, putEndpoint = put) => {
+module.exports = (app, getEndpoint = get) => {
   getEndpoint(app);
-  // postEndpoint(app);
-  // putEndpoint(app);
 };

--- a/api/routes/roles/index.js
+++ b/api/routes/roles/index.js
@@ -1,0 +1,9 @@
+const post = require('./post');
+const get = require('./get');
+const put = require('./put');
+
+module.exports = (app, getEndpoint = get, postEndpoint = post, putEndpoint = put) => {
+  getEndpoint(app);
+  // postEndpoint(app);
+  // putEndpoint(app);
+};

--- a/api/routes/roles/index.test.js
+++ b/api/routes/roles/index.test.js
@@ -15,12 +15,12 @@ tap.test('roles endpoint setup', async endpointTest => {
     getEndpoint.calledWith(app),
     'users GET endpoint is setup with the app'
   );
-  endpointTest.ok(
-    postEndpoint.calledWith(app),
-    'users POST endpoint is setup with the app'
-  );
-  endpointTest.ok(
-    putEndpoint.calledWith(app),
-    'users PUT endpoint is setup with the app'
-  );
+  // endpointTest.ok(
+  //   postEndpoint.calledWith(app),
+  //   'users POST endpoint is setup with the app'
+  // );
+  // endpointTest.ok(
+  //   putEndpoint.calledWith(app),
+  //   'users PUT endpoint is setup with the app'
+  // );
 });

--- a/api/routes/roles/index.test.js
+++ b/api/routes/roles/index.test.js
@@ -1,0 +1,26 @@
+const tap = require('tap');
+const sinon = require('sinon');
+
+const rolesIndex = require('./index');
+
+tap.test('roles endpoint setup', async endpointTest => {
+  const app = {};
+  const getEndpoint = sinon.spy();
+  const postEndpoint = sinon.spy();
+  const putEndpoint = sinon.spy();
+
+  rolesIndex(app, getEndpoint, postEndpoint, putEndpoint);
+
+  endpointTest.ok(
+    getEndpoint.calledWith(app),
+    'users GET endpoint is setup with the app'
+  );
+  endpointTest.ok(
+    postEndpoint.calledWith(app),
+    'users POST endpoint is setup with the app'
+  );
+  endpointTest.ok(
+    putEndpoint.calledWith(app),
+    'users PUT endpoint is setup with the app'
+  );
+});

--- a/api/seeds/01-roles-and-activities.js
+++ b/api/seeds/01-roles-and-activities.js
@@ -4,6 +4,9 @@ const setupActivities = async activitiesTable => {
   await activitiesTable.insert({ id: 3, name: 'send-apd-to-state' });
   await activitiesTable.insert({ id: 4, name: 'view-own-apds' });
   await activitiesTable.insert({ id: 5, name: 'create-apd' });
+  await activitiesTable.insert({ id: 6, name: 'view-roles' });
+  await activitiesTable.insert({ id: 7, name: 'create-roles' });
+  await activitiesTable.insert({ id: 8, name: 'edit-roles' });
 };
 
 const setupRoles = async rolesTable => {
@@ -19,6 +22,9 @@ const setupMappings = async mappingTable => {
   await mappingTable.insert({ role_id: 1, activity_id: 3 });
   await mappingTable.insert({ role_id: 1, activity_id: 4 });
   await mappingTable.insert({ role_id: 1, activity_id: 5 });
+  await mappingTable.insert({ role_id: 1, activity_id: 6 });
+  await mappingTable.insert({ role_id: 1, activity_id: 7 });
+  await mappingTable.insert({ role_id: 1, activity_id: 8 });
 
   // CMS reviewers
   await mappingTable.insert({ role_id: 2, activity_id: 1 });

--- a/api/seeds/10-test.js
+++ b/api/seeds/10-test.js
@@ -1,3 +1,4 @@
+const roles = require('./test/roles');
 const users = require('./test/users');
 
 exports.seed = async knex => {
@@ -7,5 +8,6 @@ exports.seed = async knex => {
   }
 
   // Call specific seeds from here.
+  await roles.seed(knex);
   await users.seed(knex);
 };

--- a/api/seeds/test/roles.js
+++ b/api/seeds/test/roles.js
@@ -1,0 +1,20 @@
+exports.seed = async knex => {
+  // For testing, throw out the standard stuff and put in our
+  // hard-coded stuff so we know what IDs to expect.
+  await knex('auth_role_activity_mapping').del();
+  await knex('auth_roles').del();
+  await knex('auth_activities').del();
+
+  await knex('auth_activities').insert({ id: 1, name: 'view-roles' });
+  await knex('auth_activities').insert({ id: 2, name: 'create-roles' });
+  await knex('auth_activities').insert({ id: 3, name: 'edit-roles' });
+
+  await knex('auth_roles').insert({ id: 1, name: 'admin' });
+  await knex('auth_roles').insert({ id: 2, name: 'cms-reviewer' });
+  await knex('auth_roles').insert({ id: 3, name: 'state-submitter' });
+
+  await knex('auth_role_activity_mapping').insert({ role_id: 1, activity_id: 1 });
+  await knex('auth_role_activity_mapping').insert({ role_id: 1, activity_id: 2 });
+  await knex('auth_role_activity_mapping').insert({ role_id: 1, activity_id: 3 });
+  await knex('auth_role_activity_mapping').insert({ role_id: 2, activity_id: 3 });
+};


### PR DESCRIPTION
Adds a route for getting a list of roles.  By navigating to `https://{api-url}/roles`, you can get a list of roles in JSON format.  For each role, it returns its internal ID, its name, and a list of activities (by name) that are currently associated with that role.  It looks like this:

```json
[{
  "id": 33,
  "name": "admin",
  "activities": [
    "view-roles",
    "create-roles",
    "edit-roles"]
}, {
  "id": 34,
  "name": "cms-reviewer",
  "activities": []
}, {
  "id": 35,
  "name": "state-submitter",
  "activities": []
}]
```

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author

### This feature is done when...
- ~~Design has approved the experience~~
- [ ] Product has approved the experience (cc: @jeromeleecms @NAretakis for approval)
