### PR TITLE
Add OpenAPI spec documentation for existing endpoints

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,7 @@ Describe the pull request here, including any supplemental information needed to
 - [ ] This code has been reviewed by someone other than the original author
 - [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
 - [ ] The change has been documented
+  - [ ] Associated OpenAPI documentation has been updated
 
 ### This feature is done when...
 - [ ] Design has approved the experience

--- a/api/routes/index.js
+++ b/api/routes/index.js
@@ -1,17 +1,17 @@
 const users = require('./users');
 const formLogger = require('./logForm');
-
-const openapi = require('./openAPI');
+const openAPI = require('./openAPI');
 
 module.exports = (
   app,
   usersEndpoint = users,
-  formLoggerEndopint = formLogger
+  formLoggerEndopint = formLogger,
+  openAPIdoc = openAPI
 ) => {
   usersEndpoint(app);
   formLoggerEndopint(app);
 
   app.get('/open-api', (req, res) => {
-    res.send(openapi);
+    res.send(openAPIdoc);
   });
 };

--- a/api/routes/index.js
+++ b/api/routes/index.js
@@ -1,6 +1,8 @@
 const users = require('./users');
 const formLogger = require('./logForm');
 
+const openapi = require('./openAPI');
+
 module.exports = (
   app,
   usersEndpoint = users,
@@ -8,4 +10,8 @@ module.exports = (
 ) => {
   usersEndpoint(app);
   formLoggerEndopint(app);
+
+  app.get('/open-api', (req, res) => {
+    res.send(openapi);
+  });
 };

--- a/api/routes/index.test.js
+++ b/api/routes/index.test.js
@@ -7,10 +7,14 @@ tap.test('endpoint setup', async endpointTest => {
   const app = {
     get: sinon.spy()
   };
+  const res = {
+    send: sinon.spy()
+  };
   const usersEndpoint = sinon.spy();
   const formLoggerEndpoint = sinon.spy();
+  const openAPI = { };
 
-  endpointIndex(app, usersEndpoint, formLoggerEndpoint);
+  endpointIndex(app, usersEndpoint, formLoggerEndpoint, { });
 
   endpointTest.ok(
     usersEndpoint.calledWith(app),
@@ -25,4 +29,10 @@ tap.test('endpoint setup', async endpointTest => {
     app.get.calledWith('/open-api', sinon.match.func),
     'sets up an endpoint to fetch OpenAPI spec'
   );
+
+  const openAPIHandler = app.get.args[0][1];
+
+  openAPIHandler({}, res);
+
+  endpointTest.ok(res.send.calledWith(openAPI));
 });

--- a/api/routes/index.test.js
+++ b/api/routes/index.test.js
@@ -4,7 +4,9 @@ const sinon = require('sinon');
 const endpointIndex = require('./index');
 
 tap.test('endpoint setup', async endpointTest => {
-  const app = {};
+  const app = {
+    get: sinon.spy()
+  };
   const usersEndpoint = sinon.spy();
   const formLoggerEndpoint = sinon.spy();
 
@@ -17,5 +19,10 @@ tap.test('endpoint setup', async endpointTest => {
   endpointTest.ok(
     formLoggerEndpoint.calledWith(app),
     'form logger endpoint is setup with the app'
+  );
+
+  endpointTest.ok(
+    app.get.calledWith('/open-api', sinon.match.func),
+    'sets up an endpoint to fetch OpenAPI spec'
   );
 });

--- a/api/routes/openAPI/auth.js
+++ b/api/routes/openAPI/auth.js
@@ -1,0 +1,51 @@
+module.exports = {
+  '/auth/login': {
+    post: {
+      description: 'Authenticate a user against the local database',
+      parameters: [
+        {
+          name: 'username',
+          in: 'body',
+          required: true
+        },
+        {
+          name: 'password',
+          in: 'body',
+          required: true
+        }
+      ],
+      responses: {
+        200: {
+          description: 'Successful login',
+          headers: {
+            'Set-Cookie': {
+              schema: {
+                type: 'string',
+                example:
+                  'session=session-data; path=/; expires=Sat, 1 Jan 2035 12:00:00 GMT; httponly'
+              }
+            }
+          }
+        },
+        401: {
+          description: 'Unsuccessful login'
+        }
+      }
+    }
+  },
+  '/auth/logout': {
+    get: {
+      200: {
+        description: 'Clears the session cookie',
+        headers: {
+          'Set-Cookie': {
+            schema: {
+              type: 'string',
+              example: 'session=; expires=; httponly'
+            }
+          }
+        }
+      }
+    }
+  }
+};

--- a/api/routes/openAPI/helpers.js
+++ b/api/routes/openAPI/helpers.js
@@ -1,0 +1,54 @@
+module.exports.responses = {
+  unauthed: {
+    401: {
+      description: 'Not logged in'
+    },
+    403: {
+      description: 'Does not have permission to this activity'
+    }
+  }
+};
+
+const jsonResponse = schema => ({
+  'application/json': {
+    schema
+  }
+});
+
+const arrayOf = schema => ({
+  type: 'array',
+  items: schema
+});
+
+module.exports.schema = {
+  jsonResponse,
+  arrayOf,
+
+  errorToken: jsonResponse({
+    type: 'object',
+    properties: {
+      error: {
+        type: 'string',
+        description:
+          'An string token indicating the error, which could be translated into a user-readable string for display by the client'
+      }
+    }
+  })
+};
+
+module.exports.requiresAuth = openAPI => {
+  const authed = { ...openAPI };
+  Object.keys(authed).forEach(route => {
+    Object.keys(authed[route]).forEach(verb => {
+      authed[route][verb].security = ['sessionCookie'];
+
+      const responses = authed[route][verb].responses;
+      authed[route][verb].responses = {
+        ...responses,
+        ...module.exports.responses.unauthed
+      };
+    });
+  });
+
+  return authed;
+};

--- a/api/routes/openAPI/index.js
+++ b/api/routes/openAPI/index.js
@@ -1,0 +1,26 @@
+const pkg = require('../../package.json');
+
+const auth = require('./auth');
+const users = require('../users/openAPI');
+
+module.exports = {
+  openapi: '3.0',
+  info: {
+    title: 'CMS HITECH APD API',
+    description: 'The API for the CMS HITECH APD app.',
+    version: pkg.version
+  },
+  paths: {
+    ...auth,
+    ...users
+  },
+  components: {
+    securitySchemes: {
+      sessionCookie: {
+        type: 'apiKey',
+        in: 'cookie',
+        name: 'session'
+      }
+    }
+  }
+};

--- a/api/routes/users/openAPI.js
+++ b/api/routes/users/openAPI.js
@@ -1,0 +1,87 @@
+const {
+  requiresAuth,
+  schema: { arrayOf, jsonResponse, errorToken }
+} = require('../openAPI/helpers');
+
+const userObjectSchema = {
+  type: 'object',
+  properties: {
+    id: {
+      type: 'number',
+      description: "User's unique ID"
+    },
+    email: {
+      type: 'string',
+      format: 'email',
+      description: "User's email address"
+    }
+  }
+};
+
+const openAPI = {
+  '/users': {
+    get: {
+      description: 'Get a list of all users in the system',
+      responses: {
+        200: {
+          description: 'The list of users known to the system',
+          content: jsonResponse(arrayOf(userObjectSchema))
+        }
+      }
+    },
+    post: {
+      description: 'Add a new user to the system',
+      parameters: [
+        {
+          name: 'email',
+          in: 'body',
+          type: 'string',
+          format: 'email',
+          description: "The new user's email address",
+          required: true
+        },
+        {
+          name: 'password',
+          in: 'body',
+          type: 'string',
+          description: "The new user's password",
+          required: true
+        }
+      ],
+      responses: {
+        200: {
+          description: 'The user was successfully added'
+        },
+        400: {
+          description: 'Invalid user submitted',
+          content: errorToken
+        }
+      }
+    }
+  },
+  '/user/{id}': {
+    get: {
+      description: 'Get a specific user in the system',
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          description: 'The ID of the user to fetch',
+          required: true
+        }
+      ],
+      responses: {
+        200: {
+          description: 'The matching user',
+          content: jsonResponse(userObjectSchema)
+        },
+        404: {
+          description: 'The user ID does not match any known users',
+          content: errorToken
+        }
+      }
+    }
+  }
+};
+
+module.exports = requiresAuth(openAPI);

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,11 @@ about:
 * [our authorization model](api-authorization.md)
 * [how we handle authentication](api-authentication.md)
 
+The API is also documented with [OpenAPI](https://www.openapis.org/).  To see
+the spec document, once the API is running, you can browse to its `/open-api`
+endpoint.  You can also use a hosted version of [Swagger UI](http://petstore.swagger.io/)
+to get a nicer visualization.
+
 ## Testing
 
 We also have [documentation about how to run tests](testing.md).


### PR DESCRIPTION
Adds [OpenAPI specification](https://www.openapis.org/) (formerly called Swagger) documentation for the existing API endpoints, and adds an additional endpoint at `/open-api` that returns the JSON document describing the endpoints.  OpenAPI is a machine-readable description of an API.  This is useful because you can use tools like [Swagger UI](http://petstore.swagger.io/) to build a pretty visualization that developers can use to understand what the API does and how to interact with it.

In a future PR, I would also like to add a step to endpoint testing that verifies that every API endpoint listed in our OpenAPI documentation is exercised during the tests.

I also updated the PR template to include a checkmark for updating OpenAPI documentation as necessary.

Closes #127.

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- ~~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~~
- [x] The change has been documented

### This feature is done when...
- ~~Design has approved the experience~~
- [ ] Product has approved the experience
  - @jeromeleecms @NAretakis: your sign-off on this as an approach would be highly valuable.  Not a code-review per se (though you are welcome!), but just making sure that documenting the API with a standard specification is a good addition for the product
