### PR TITLE
Add protected routes

### DIFF
--- a/web/.eslintrc.json
+++ b/web/.eslintrc.json
@@ -4,6 +4,7 @@
   "rules": {
     "arrow-parens": ["error", "as-needed"],
     "comma-dangle": [1, "never"],
+    "no-confusing-arrow": 0,
 
     "jsx-a11y/anchor-is-valid": [
       2,

--- a/web/src/components/App.js
+++ b/web/src/components/App.js
@@ -12,6 +12,7 @@ import ActivityGoals from '../containers/ActivityGoals';
 import ActivityOverview from '../containers/ActivityOverview';
 import ApdOverview from '../containers/ApdOverview';
 import Login from '../containers/Login';
+import PrivateRoute from '../containers/PrivateRoute';
 import StateContacts from '../containers/StateContacts';
 import StateStart from '../containers/StateStart';
 import StatePersonnel from '../containers/StatePersonnel';
@@ -29,16 +30,16 @@ const App = () => (
         <Route exact path="/" component={Demo} />
         <Route path="/login" component={Login} />
 
-        <Route path="/activities-list" component={ActivitiesList} />
-        <Route path="/activities-start" component={ActivitiesStart} />
-        <Route path="/activity-approach" component={ActivityApproach} />
-        <Route path="/activity-goals" component={ActivityGoals} />
-        <Route path="/activity-overview" component={ActivityOverview} />
-        <Route path="/activity-schedule" component={ActivitySchedule} />
-        <Route path="/apd-overview" component={ApdOverview} />
-        <Route path="/state-contacts" component={StateContacts} />
-        <Route path="/state-personnel" component={StatePersonnel} />
-        <Route path="/state-start" component={StateStart} />
+        <PrivateRoute path="/activities-list" component={ActivitiesList} />
+        <PrivateRoute path="/activities-start" component={ActivitiesStart} />
+        <PrivateRoute path="/activity-approach" component={ActivityApproach} />
+        <PrivateRoute path="/activity-goals" component={ActivityGoals} />
+        <PrivateRoute path="/activity-overview" component={ActivityOverview} />
+        <PrivateRoute path="/activity-schedule" component={ActivitySchedule} />
+        <PrivateRoute path="/apd-overview" component={ApdOverview} />
+        <PrivateRoute path="/state-contacts" component={StateContacts} />
+        <PrivateRoute path="/state-personnel" component={StatePersonnel} />
+        <PrivateRoute path="/state-start" component={StateStart} />
 
         <Route component={NoMatch} />
       </Switch>

--- a/web/src/components/__snapshots__/App.test.js.snap
+++ b/web/src/components/__snapshots__/App.test.js.snap
@@ -30,43 +30,43 @@ ShallowWrapper {
               component={[Function]}
               path="/login"
             />
-            <Route
+            <Connect(PrivateRoute)
               component={[Function]}
               path="/activities-list"
             />
-            <Route
+            <Connect(PrivateRoute)
               component={[Function]}
               path="/activities-start"
             />
-            <Route
+            <Connect(PrivateRoute)
               component={[Function]}
               path="/activity-approach"
             />
-            <Route
+            <Connect(PrivateRoute)
               component={[Function]}
               path="/activity-goals"
             />
-            <Route
+            <Connect(PrivateRoute)
               component={[Function]}
               path="/activity-overview"
             />
-            <Route
+            <Connect(PrivateRoute)
               component={[Function]}
               path="/activity-schedule"
             />
-            <Route
+            <Connect(PrivateRoute)
               component={[Function]}
               path="/apd-overview"
             />
-            <Route
+            <Connect(PrivateRoute)
               component={[Function]}
               path="/state-contacts"
             />
-            <Route
+            <Connect(PrivateRoute)
               component={[Function]}
               path="/state-personnel"
             />
-            <Route
+            <Connect(PrivateRoute)
               component={[Function]}
               path="/state-start"
             />
@@ -103,43 +103,43 @@ ShallowWrapper {
               component={[Function]}
               path="/login"
             />
-            <Route
+            <Connect(PrivateRoute)
               component={[Function]}
               path="/activities-list"
             />
-            <Route
+            <Connect(PrivateRoute)
               component={[Function]}
               path="/activities-start"
             />
-            <Route
+            <Connect(PrivateRoute)
               component={[Function]}
               path="/activity-approach"
             />
-            <Route
+            <Connect(PrivateRoute)
               component={[Function]}
               path="/activity-goals"
             />
-            <Route
+            <Connect(PrivateRoute)
               component={[Function]}
               path="/activity-overview"
             />
-            <Route
+            <Connect(PrivateRoute)
               component={[Function]}
               path="/activity-schedule"
             />
-            <Route
+            <Connect(PrivateRoute)
               component={[Function]}
               path="/apd-overview"
             />
-            <Route
+            <Connect(PrivateRoute)
               component={[Function]}
               path="/state-contacts"
             />
-            <Route
+            <Connect(PrivateRoute)
               component={[Function]}
               path="/state-personnel"
             />
-            <Route
+            <Connect(PrivateRoute)
               component={[Function]}
               path="/state-start"
             />
@@ -164,43 +164,43 @@ ShallowWrapper {
                 component={[Function]}
                 path="/login"
               />,
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/activities-list"
               />,
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/activities-start"
               />,
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/activity-approach"
               />,
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/activity-goals"
               />,
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/activity-overview"
               />,
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/activity-schedule"
               />,
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/apd-overview"
               />,
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/state-contacts"
               />,
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/state-personnel"
               />,
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/state-start"
               />,
@@ -394,43 +394,43 @@ ShallowWrapper {
                 component={[Function]}
                 path="/login"
               />
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/activities-list"
               />
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/activities-start"
               />
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/activity-approach"
               />
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/activity-goals"
               />
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/activity-overview"
               />
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/activity-schedule"
               />
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/apd-overview"
               />
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/state-contacts"
               />
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/state-personnel"
               />
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/state-start"
               />
@@ -467,43 +467,43 @@ ShallowWrapper {
                 component={[Function]}
                 path="/login"
               />
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/activities-list"
               />
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/activities-start"
               />
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/activity-approach"
               />
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/activity-goals"
               />
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/activity-overview"
               />
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/activity-schedule"
               />
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/apd-overview"
               />
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/state-contacts"
               />
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/state-personnel"
               />
-              <Route
+              <Connect(PrivateRoute)
                 component={[Function]}
                 path="/state-start"
               />
@@ -528,43 +528,43 @@ ShallowWrapper {
                   component={[Function]}
                   path="/login"
                 />,
-                <Route
+                <Connect(PrivateRoute)
                   component={[Function]}
                   path="/activities-list"
                 />,
-                <Route
+                <Connect(PrivateRoute)
                   component={[Function]}
                   path="/activities-start"
                 />,
-                <Route
+                <Connect(PrivateRoute)
                   component={[Function]}
                   path="/activity-approach"
                 />,
-                <Route
+                <Connect(PrivateRoute)
                   component={[Function]}
                   path="/activity-goals"
                 />,
-                <Route
+                <Connect(PrivateRoute)
                   component={[Function]}
                   path="/activity-overview"
                 />,
-                <Route
+                <Connect(PrivateRoute)
                   component={[Function]}
                   path="/activity-schedule"
                 />,
-                <Route
+                <Connect(PrivateRoute)
                   component={[Function]}
                   path="/apd-overview"
                 />,
-                <Route
+                <Connect(PrivateRoute)
                   component={[Function]}
                   path="/state-contacts"
                 />,
-                <Route
+                <Connect(PrivateRoute)
                   component={[Function]}
                   path="/state-personnel"
                 />,
-                <Route
+                <Connect(PrivateRoute)
                   component={[Function]}
                   path="/state-start"
                 />,

--- a/web/src/containers/Login.js
+++ b/web/src/containers/Login.js
@@ -21,11 +21,12 @@ class Login extends Component {
   };
 
   render() {
-    const { fetching, error, authenticated } = this.props;
+    const { authenticated, error, fetching, location } = this.props;
+    const { from } = location.state || { from: { pathname: '/' } };
     const { username, password } = this.state;
 
     if (authenticated) {
-      return <Redirect to="/" />;
+      return <Redirect to={from} />;
     }
 
     return (
@@ -66,10 +67,11 @@ class Login extends Component {
 }
 
 Login.propTypes = {
+  attemptLogin: PropTypes.func.isRequired,
   authenticated: PropTypes.bool.isRequired,
   error: PropTypes.string.isRequired,
   fetching: PropTypes.bool.isRequired,
-  attemptLogin: PropTypes.func.isRequired
+  location: PropTypes.object.isRequired
 };
 
 const mapStateToProps = ({ auth: { authenticated, error, fetching } }) => ({

--- a/web/src/containers/PrivateRoute.js
+++ b/web/src/containers/PrivateRoute.js
@@ -1,0 +1,32 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Route, Redirect } from 'react-router-dom';
+import { connect } from 'react-redux';
+
+const PrivateRoute = ({ authenticated, component: Component, ...rest }) => (
+  <Route
+    {...rest}
+    render={props =>
+      authenticated ? (
+        <Component {...props} />
+      ) : (
+        <Redirect
+          to={{
+            pathname: '/login',
+            state: { from: props.location }
+          }}
+        />
+      )
+    }
+  />
+);
+
+PrivateRoute.propTypes = {
+  authenticated: PropTypes.bool.isRequired,
+  component: PropTypes.func.isRequired,
+  location: PropTypes.object.isRequired
+};
+
+const mapStateToProps = ({ auth: { authenticated } }) => ({ authenticated });
+
+export default connect(mapStateToProps)(PrivateRoute);


### PR DESCRIPTION
This PR adds protected routes to the front-end. If a user tries to go to a "protected" page and they have not authenticated, it redirects to login page and upon successful login takes you back to that page.

In time, we may want to add some custom messaging when this happens (i.e., "You need to log in to see that page...") 

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [x] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [x] The change has been documented

### This feature is done when...
- [ ] Product has approved the experience
