### PR TITLE
Update CORS

### DIFF
--- a/api/endpoint-tests/auth/login.js
+++ b/api/endpoint-tests/auth/login.js
@@ -9,6 +9,18 @@ tap.test('login endpoint | /auth/login', async loginTest => {
     invalidTest.equal(response.statusCode, 400, 'gives a 400 status code');
   });
 
+  loginTest.test('proper response headers', async headerTest => {
+    const { response } = await request.post(url);
+    const { headers } = response;
+
+    headerTest.equal(headers.vary, 'Origin', 'vary origin');
+    headerTest.equal(
+      headers['access-control-allow-credentials'],
+      'true',
+      'allow credentials'
+    );
+  });
+
   const invalidCases = [
     {
       title: 'with a post body, but no username or password',

--- a/api/main.js
+++ b/api/main.js
@@ -10,7 +10,7 @@ const routes = require('./routes');
 const server = express();
 
 server.use(express.urlencoded({ extended: true }));
-server.use(cors());
+server.use(cors({ credentials: true, origin: true }));
 server.use(bodyParser.json());
 
 auth.setup(server);

--- a/web/src/actions/auth.js
+++ b/web/src/actions/auth.js
@@ -1,5 +1,6 @@
-import axios from 'axios';
+import axiosClient from 'axios';
 
+const axios = axiosClient.create({ withCredentials: true });
 const API_URL = process.env.API_URL || 'http://localhost:8000';
 
 export const LOGIN_REQUEST = 'LOGIN_REQUEST';

--- a/web/src/actions/auth.js
+++ b/web/src/actions/auth.js
@@ -1,6 +1,5 @@
-import axiosClient from 'axios';
+import axios from '../util/api';
 
-const axios = axiosClient.create({ withCredentials: true });
 const API_URL = process.env.API_URL || 'http://localhost:8000';
 
 export const LOGIN_REQUEST = 'LOGIN_REQUEST';

--- a/web/src/actions/auth.test.js
+++ b/web/src/actions/auth.test.js
@@ -1,9 +1,9 @@
-import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import * as actions from './auth';
+import axios from '../util/api';
 
 const mockStore = configureStore([thunk]);
 const fetchMock = new MockAdapter(axios);

--- a/web/src/util/api.js
+++ b/web/src/util/api.js
@@ -1,0 +1,5 @@
+import axiosClient from 'axios';
+
+const axios = axiosClient.create({ withCredentials: true });
+
+export default axios;


### PR DESCRIPTION
* sets origin to reflect the request origin
* now passes the `Access-Control-Allow-Credentials` header

on the front-end, we now have to explicitly set the `withCredentials` param to `true` for all axios requests. I created an axios instance that does this in `./util/api` (i wasn't sure where to put this)

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [x] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [x] The change has been documented