### PR TITLE
Role management PUT route

### DIFF
--- a/api/endpoint-tests/roles/get.js
+++ b/api/endpoint-tests/roles/get.js
@@ -1,9 +1,9 @@
 const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
-const getFullPath = require('../utils').getFullPath;
-const login = require('../utils').login;
-const request = require('../utils').request;
+const { db, getFullPath, login, request } = require('../utils');
 
 tap.test('roles endpoint | GET /roles', async getUsersTest => {
+  await db().seed.run();
+
   const url = getFullPath('/roles');
 
   getUsersTest.test('when unauthenticated', async unauthenticatedTest => {

--- a/api/endpoint-tests/roles/put.js
+++ b/api/endpoint-tests/roles/put.js
@@ -1,70 +1,82 @@
 const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
-const {
-  db, request, getFullPath, login
-} = require('../utils');
+const { db, request, getFullPath, login } = require('../utils');
 
 tap.test('roles endpoint | PUT /roles/:roleID', async postRolesTests => {
+  await db().seed.run();
+
   const url = getFullPath('/roles');
 
-  const invalidCases = [{
-    name: 'with no body'
-  }, {
-    name: 'with no activities',
-    body: { name: 'new-role' }
-  }, {
-    name: 'with activities not an array',
-    body: { name: 'new-role', activities: 'wrong' }
-  }, {
-    name: 'with activities where some are not numbers',
-    body: { name: 'new-role', activities: [0, 'wrong', 2] }
-  }, {
-    name: 'with activities that are not valid',
-    body: { name: 'new-role', activities: [1, 2, 9001] }
-  }];
+  const invalidCases = [
+    {
+      name: 'with no body'
+    },
+    {
+      name: 'with no activities',
+      body: { name: 'new-role' }
+    },
+    {
+      name: 'with activities not an array',
+      body: { name: 'new-role', activities: 'wrong' }
+    },
+    {
+      name: 'with activities where some are not numbers',
+      body: { name: 'new-role', activities: [0, 'wrong', 2] }
+    },
+    {
+      name: 'with activities that are not valid',
+      body: { name: 'new-role', activities: [1, 2, 9001] }
+    }
+  ];
 
-  postRolesTests.test('when unauthenticated, invalid ID', async unauthenticatedTests => {
-    [
-      ...invalidCases,
-      {
-        name: 'with a valid body',
-        body: { activities: [1, 2] }
-      }
-    ].forEach(situation => {
-      unauthenticatedTests.test(situation.name, async unauthenticatedTest => {
-        const { response, body } = await request.put(`${url}/9001`, {
-          json: situation.body
+  postRolesTests.test(
+    'when unauthenticated, invalid ID',
+    async unauthenticatedTests => {
+      [
+        ...invalidCases,
+        {
+          name: 'with a valid body',
+          body: { activities: [1, 2] }
+        }
+      ].forEach(situation => {
+        unauthenticatedTests.test(situation.name, async unauthenticatedTest => {
+          const { response, body } = await request.put(`${url}/9001`, {
+            json: situation.body
+          });
+          unauthenticatedTest.equal(
+            response.statusCode,
+            403,
+            'gives a 403 status code'
+          );
+          unauthenticatedTest.notOk(body, 'does not send a body');
         });
-        unauthenticatedTest.equal(
-          response.statusCode,
-          403,
-          'gives a 403 status code'
-        );
-        unauthenticatedTest.notOk(body, 'does not send a body');
       });
-    });
-  });
+    }
+  );
 
-  postRolesTests.test('when unauthenticated, valid ID', async unauthenticatedTests => {
-    [
-      ...invalidCases,
-      {
-        name: 'with a valid body',
-        body: { activities: [1, 2] }
-      }
-    ].forEach(situation => {
-      unauthenticatedTests.test(situation.name, async unauthenticatedTest => {
-        const { response, body } = await request.put(`${url}/1`, {
-          json: situation.body
+  postRolesTests.test(
+    'when unauthenticated, valid ID',
+    async unauthenticatedTests => {
+      [
+        ...invalidCases,
+        {
+          name: 'with a valid body',
+          body: { activities: [1, 2] }
+        }
+      ].forEach(situation => {
+        unauthenticatedTests.test(situation.name, async unauthenticatedTest => {
+          const { response, body } = await request.put(`${url}/1`, {
+            json: situation.body
+          });
+          unauthenticatedTest.equal(
+            response.statusCode,
+            403,
+            'gives a 403 status code'
+          );
+          unauthenticatedTest.notOk(body, 'does not send a body');
         });
-        unauthenticatedTest.equal(
-          response.statusCode,
-          403,
-          'gives a 403 status code'
-        );
-        unauthenticatedTest.notOk(body, 'does not send a body');
       });
-    });
-  });
+    }
+  );
 
   postRolesTests.test('when authenticated', async authenticatedTests => {
     const cookies = await login();
@@ -107,7 +119,11 @@ tap.test('roles endpoint | PUT /roles/:roleID', async postRolesTests => {
         .select('activity_id')
         .map(activity => activity.activity_id);
 
-      validTest.same(activities, [1], 'sets up a mapping between the role and the newly-requested activities');
+      validTest.same(
+        activities,
+        [1],
+        'sets up a mapping between the role and the newly-requested activities'
+      );
     });
   });
 });

--- a/api/endpoint-tests/roles/put.js
+++ b/api/endpoint-tests/roles/put.js
@@ -99,9 +99,8 @@ tap.test('roles endpoint | PUT /roles/:roleID', async postRolesTests => {
         json: { activities: [1] }
       });
 
-      validTest.equal(response.statusCode, 200, 'gives a 200 status code');
-      validTest.ok(body, 'sends a body');
-      validTest.type(body.roleID, 'number', 'sends back a numeric role ID');
+      validTest.equal(response.statusCode, 204, 'gives a 204 status code');
+      validTest.notOk(body, 'does not send a body');
 
       const activities = await db()('auth_role_activity_mapping')
         .where({ role_id: 1 })

--- a/api/endpoint-tests/roles/put.js
+++ b/api/endpoint-tests/roles/put.js
@@ -1,0 +1,114 @@
+const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
+const {
+  db, request, getFullPath, login
+} = require('../utils');
+
+tap.test('roles endpoint | PUT /roles/:roleID', async postRolesTests => {
+  const url = getFullPath('/roles');
+
+  const invalidCases = [{
+    name: 'with no body'
+  }, {
+    name: 'with no activities',
+    body: { name: 'new-role' }
+  }, {
+    name: 'with activities not an array',
+    body: { name: 'new-role', activities: 'wrong' }
+  }, {
+    name: 'with activities where some are not numbers',
+    body: { name: 'new-role', activities: [0, 'wrong', 2] }
+  }, {
+    name: 'with activities that are not valid',
+    body: { name: 'new-role', activities: [1, 2, 9001] }
+  }];
+
+  postRolesTests.test('when unauthenticated, invalid ID', async unauthenticatedTests => {
+    [
+      ...invalidCases,
+      {
+        name: 'with a valid body',
+        body: { activities: [1, 2] }
+      }
+    ].forEach(situation => {
+      unauthenticatedTests.test(situation.name, async unauthenticatedTest => {
+        const { response, body } = await request.put(`${url}/9001`, {
+          json: situation.body
+        });
+        unauthenticatedTest.equal(
+          response.statusCode,
+          403,
+          'gives a 403 status code'
+        );
+        unauthenticatedTest.notOk(body, 'does not send a body');
+      });
+    });
+  });
+
+  postRolesTests.test('when unauthenticated, valid ID', async unauthenticatedTests => {
+    [
+      ...invalidCases,
+      {
+        name: 'with a valid body',
+        body: { activities: [1, 2] }
+      }
+    ].forEach(situation => {
+      unauthenticatedTests.test(situation.name, async unauthenticatedTest => {
+        const { response, body } = await request.put(`${url}/1`, {
+          json: situation.body
+        });
+        unauthenticatedTest.equal(
+          response.statusCode,
+          403,
+          'gives a 403 status code'
+        );
+        unauthenticatedTest.notOk(body, 'does not send a body');
+      });
+    });
+  });
+
+  postRolesTests.test('when authenticated', async authenticatedTests => {
+    const cookies = await login();
+
+    authenticatedTests.test('with an invalid ID', async invalidTest => {
+      const { response, body } = await request.put(`${url}/9001`, {
+        jar: cookies,
+        json: {}
+      });
+      invalidTest.equal(response.statusCode, 404, 'gives a 404 status code');
+      invalidTest.notOk(body, 'does not send a body');
+    });
+
+    invalidCases.forEach(situation => {
+      authenticatedTests.test(situation.name, async invalidTest => {
+        const { response, body } = await request.put(`${url}/1`, {
+          jar: cookies,
+          json: situation.body || true
+        });
+        invalidTest.equal(response.statusCode, 400, 'gives a 400 status code');
+        invalidTest.same(
+          body,
+          { error: 'edit-role-invalid' },
+          'sends a token indicating the failure'
+        );
+      });
+    });
+
+    authenticatedTests.test('with a valid updated role', async validTest => {
+      const { response, body } = await request.put(`${url}/1`, {
+        jar: cookies,
+        json: { activities: [1] }
+      });
+
+      validTest.equal(response.statusCode, 200, 'gives a 200 status code');
+      validTest.ok(body, 'sends a body');
+      validTest.type(body.roleID, 'number', 'sends back a numeric role ID');
+
+      const activities = await db()('auth_role_activity_mapping')
+        .where({ role_id: 1 })
+        .select('activity_id')
+        .map(activity => activity.activity_id);
+
+      validTest.same(activities, [1], 'sets up a mapping between the role and the newly-requested activities');
+    });
+  });
+});

--- a/api/endpoint-tests/users/get.js
+++ b/api/endpoint-tests/users/get.js
@@ -1,9 +1,9 @@
 const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
-const getFullPath = require('../utils').getFullPath;
-const login = require('../utils').login;
-const request = require('../utils').request;
+const { db, getFullPath, login, request } = require('../utils');
 
 tap.test('users endpoint | GET /users', async getUsersTest => {
+  await db().seed.run();
+
   const url = getFullPath('/users');
 
   getUsersTest.test('when unauthenticated', async unauthenticatedTest => {

--- a/api/endpoint-tests/users/post.js
+++ b/api/endpoint-tests/users/post.js
@@ -1,9 +1,9 @@
 const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
-const {
-  db, request, getFullPath, login
-} = require('../utils');
+const { db, request, getFullPath, login } = require('../utils');
 
 tap.test('users endpoint | POST /user', async postUsersTest => {
+  await db().seed.run();
+
   const url = getFullPath('/user');
 
   const invalidCases = [

--- a/api/endpoint-tests/utils.js
+++ b/api/endpoint-tests/utils.js
@@ -22,6 +22,13 @@ const post = async (...args) =>
     });
   });
 
+const put = async (...args) =>
+  new Promise(resolve => {
+    request.put(...args, (err, response, body) => {
+      resolve({ err, response, body });
+    });
+  });
+
 const login = async () => {
   const cookies = request.jar();
 
@@ -53,7 +60,7 @@ const db = () => {
 
 module.exports = {
   db,
-  request: { get, post, jar: request.jar },
+  request: { get, post, put, jar: request.jar },
   getFullPath,
   login
 };

--- a/api/routes/openAPI/index.js
+++ b/api/routes/openAPI/index.js
@@ -2,6 +2,7 @@ const pkg = require('../../package.json');
 
 const auth = require('./auth');
 const users = require('../users/openAPI');
+const roles = require('../roles/openAPI');
 
 module.exports = {
   openapi: '3.0',
@@ -12,7 +13,8 @@ module.exports = {
   },
   paths: {
     ...auth,
-    ...users
+    ...users,
+    ...roles
   },
   components: {
     securitySchemes: {

--- a/api/routes/roles/index.js
+++ b/api/routes/roles/index.js
@@ -1,5 +1,7 @@
 const get = require('./get');
+const put = require('./put');
 
-module.exports = (app, getEndpoint = get) => {
+module.exports = (app, getEndpoint = get, postEndpoint, putEndpoint = put) => {
   getEndpoint(app);
+  putEndpoint(app);
 };

--- a/api/routes/roles/index.test.js
+++ b/api/routes/roles/index.test.js
@@ -19,8 +19,8 @@ tap.test('roles endpoint setup', async endpointTest => {
   //   postEndpoint.calledWith(app),
   //   'users POST endpoint is setup with the app'
   // );
-  // endpointTest.ok(
-  //   putEndpoint.calledWith(app),
-  //   'users PUT endpoint is setup with the app'
-  // );
+  endpointTest.ok(
+    putEndpoint.calledWith(app),
+    'users PUT endpoint is setup with the app'
+  );
 });

--- a/api/routes/roles/openAPI.js
+++ b/api/routes/roles/openAPI.js
@@ -35,24 +35,39 @@ const openAPI = {
   },
   '/roles/{id}': {
     put: {
-      description: 'Update an existing role in the system',
+      description: 'Change which activities an existing role is associated with',
       parameters: [{
         name: 'id',
         in: 'path',
         description: 'The ID of the role to update',
         required: true
-      }, {
-        name: 'activities',
-        in: 'body',
-        description: 'Array of activity IDs. IDs must be numeric, and must be IDs of existing activities',
-        required: 'true'
       }],
+      requestBody: {
+        description: 'The new values for the role',
+        required: true,
+        content: jsonResponse({
+          type: 'object',
+          properties: {
+            activities: {
+              description: 'List of activities to associate with this role; this list is definitive and after this operation, only the activities in this list will be associated with the role',
+              ...arrayOf({
+                type: 'number',
+                description: 'An activity ID'
+              })
+            }
+          }
+        })
+      },
       responses: {
         204: {
           description: 'The update was successful',
         },
+        400: {
+          description: 'The body of the request is invalid: there are no activities defined, some activities are not numeric, or some activities do not exist',
+          content: errorToken
+        },
         404: {
-          description: 'The user ID does not match any known users',
+          description: 'The role ID does not match any known roles',
           content: errorToken
         }
       }

--- a/api/routes/roles/openAPI.js
+++ b/api/routes/roles/openAPI.js
@@ -1,0 +1,63 @@
+const {
+  requiresAuth,
+  schema: { arrayOf, jsonResponse, errorToken }
+} = require('../openAPI/helpers');
+
+const roleObjectSchema = {
+  type: 'object',
+  properties: {
+    id: {
+      type: 'number',
+      description: 'Role ID'
+    },
+    name: {
+      type: 'string',
+      description: 'Role name'
+    },
+    activities: arrayOf({
+      type: 'string',
+      description: 'Activity name'
+    })
+  }
+};
+
+const openAPI = {
+  '/roles': {
+    get: {
+      description: 'Get a list of all roles in the system',
+      responses: {
+        200: {
+          description: 'The list of roles known to the system',
+          content: jsonResponse(arrayOf(roleObjectSchema))
+        }
+      }
+    }
+  },
+  '/roles/{id}': {
+    put: {
+      description: 'Update an existing role in the system',
+      parameters: [{
+        name: 'id',
+        in: 'path',
+        description: 'The ID of the role to update',
+        required: true
+      }, {
+        name: 'activities',
+        in: 'body',
+        description: 'Array of activity IDs. IDs must be numeric, and must be IDs of existing activities',
+        required: 'true'
+      }],
+      responses: {
+        204: {
+          description: 'The update was successful',
+        },
+        404: {
+          description: 'The user ID does not match any known users',
+          content: errorToken
+        }
+      }
+    }
+  }
+};
+
+module.exports = requiresAuth(openAPI);

--- a/api/routes/roles/put.js
+++ b/api/routes/roles/put.js
@@ -55,7 +55,6 @@ module.exports = (
     if (!role) {
       return res
         .status(404)
-        .send({ error: `No such role ID ${req.params.id}` })
         .end();
     }
 
@@ -65,12 +64,13 @@ module.exports = (
     } catch (e) {
       return res
         .status(400)
-        .send({ error: e.message })
+        .send({ error: 'edit-role-invalid' })
         .end();
     }
 
     try {
       role.activities().detach(await role.getActivities());
+      await role.save();
       role.activities().attach(roleMeta.activities);
       await role.save();
       return res.send({ roleID: role.get('id') });

--- a/api/routes/roles/put.js
+++ b/api/routes/roles/put.js
@@ -69,7 +69,7 @@ module.exports = (
     }
 
     try {
-      role.activities().detach(await role.getActivities());
+      role.activities().detach();
       await role.save();
       role.activities().attach(roleMeta.activities);
       await role.save();

--- a/api/routes/roles/put.js
+++ b/api/routes/roles/put.js
@@ -50,7 +50,7 @@ module.exports = (
   RoleModel = defaultRoleModel,
   ActivityModel = defaultActivityModel
 ) => {
-  app.put('/roles/:id', can('create-roles'), async (req, res) => {
+  app.put('/roles/:id', can('edit-roles'), async (req, res) => {
     const role = await RoleModel.where({ id: req.params.id }).fetch();
     if (!role) {
       return res
@@ -70,7 +70,7 @@ module.exports = (
     }
 
     try {
-      role.activities().detach(role.getActivities());
+      role.activities().detach(await role.getActivities());
       role.activities().attach(roleMeta.activities);
       await role.save();
       return res.send({ roleID: role.get('id') });

--- a/api/routes/roles/put.js
+++ b/api/routes/roles/put.js
@@ -1,8 +1,81 @@
 const defaultRoleModel = require('../../db').models.role;
+const defaultActivityModel = require('../../db').models.activity;
 const can = require('../../auth/middleware').can;
 
-module.exports = (app, RoleModel = defaultRoleModel) => {
-  app.put('/roles', can('edit-roles'), async (req, res) => {
-    res.status(501).end();
+const validateRole = async (role, RoleModel, ActivityModel) => {
+  if (RoleModel) {
+    if (!role.name) {
+      throw new Error('Role must have a name');
+    }
+    if (await RoleModel.where({ name: role.name }).fetch()) {
+      throw new Error(`Role name "${role.name}" already exists`);
+    }
+  }
+  if (ActivityModel) {
+    if (!Array.isArray(role.activities)) {
+      throw new Error('Role must have a list of activities');
+    }
+    if (role.activities.filter(id => typeof id !== 'number').length > 0) {
+      throw new Error('Role activites must be numbers');
+    }
+
+    const validActivities = await ActivityModel.where(
+      'id',
+      'in',
+      role.activities
+    ).fetchAll({ columns: ['id'] });
+    const validIDs = validActivities.map(activity => activity.get('id'));
+    const invalidIDs = role.activities.filter(
+      roleID => !validIDs.includes(roleID)
+    );
+
+    if (invalidIDs.length) {
+      throw new Error(
+        `Activity IDs ${JSON.stringify(invalidIDs).replace(
+          /\[(.+)\]/,
+          '$1'
+        )} are invalid`
+      );
+    }
+  }
+
+  return {
+    name: role.name,
+    activities: role.activities.filter(id => !Number.isNaN(Number(id)))
+  };
+};
+
+module.exports = (
+  app,
+  RoleModel = defaultRoleModel,
+  ActivityModel = defaultActivityModel
+) => {
+  app.put('/roles/:id', can('create-roles'), async (req, res) => {
+    const role = await RoleModel.where({ id: req.params.id }).fetch();
+    if (!role) {
+      return res
+        .status(404)
+        .send({ error: `No such role ID ${req.params.id}` })
+        .end();
+    }
+
+    let roleMeta;
+    try {
+      roleMeta = await validateRole(req.body, null, ActivityModel);
+    } catch (e) {
+      return res
+        .status(400)
+        .send({ error: e.message })
+        .end();
+    }
+
+    try {
+      role.activities().detach(role.getActivities());
+      role.activities().attach(roleMeta.activities);
+      await role.save();
+      return res.send({ roleID: role.get('id') });
+    } catch (e) {
+      return res.status(500).end();
+    }
   });
 };

--- a/api/routes/roles/put.js
+++ b/api/routes/roles/put.js
@@ -73,7 +73,7 @@ module.exports = (
       await role.save();
       role.activities().attach(roleMeta.activities);
       await role.save();
-      return res.send({ roleID: role.get('id') });
+      return res.status(204);
     } catch (e) {
       return res.status(500).end();
     }

--- a/api/routes/roles/put.js
+++ b/api/routes/roles/put.js
@@ -1,0 +1,8 @@
+const defaultRoleModel = require('../../db').models.role;
+const can = require('../../auth/middleware').can;
+
+module.exports = (app, RoleModel = defaultRoleModel) => {
+  app.put('/roles', can('edit-roles'), async (req, res) => {
+    res.status(501).end();
+  });
+};

--- a/api/routes/roles/put.js
+++ b/api/routes/roles/put.js
@@ -73,7 +73,7 @@ module.exports = (
       await role.save();
       role.activities().attach(roleMeta.activities);
       await role.save();
-      return res.status(204);
+      return res.status(204).end();
     } catch (e) {
       return res.status(500).end();
     }

--- a/api/routes/roles/put.test.js
+++ b/api/routes/roles/put.test.js
@@ -1,0 +1,37 @@
+const tap = require('tap');
+const sinon = require('sinon');
+
+const canMiddleware = require('../../auth/middleware').can('edit-roles');
+const putEndpoint = require('./put');
+
+tap.test('roles PUT endpoint', async endpointTest => {
+  const sandbox = sinon.createSandbox();
+  const app = {
+    put: sandbox.stub()
+  };
+  const RoleModel = {
+    fetchAll: sandbox.stub()
+  };
+  const res = {
+    status: sandbox.stub(),
+    send: sandbox.stub(),
+    end: sandbox.stub()
+  };
+
+  endpointTest.beforeEach(async () => {
+    sandbox.reset();
+
+    res.status.returns(res);
+    res.send.returns(res);
+    res.end.returns(res);
+  });
+
+  endpointTest.test('setup', async setupTest => {
+    putEndpoint(app, RoleModel);
+
+    setupTest.ok(
+      app.put.calledWith('/roles', canMiddleware, sinon.match.func),
+      'roles PUT endpoint is registered'
+    );
+  });
+});

--- a/api/routes/roles/put.test.js
+++ b/api/routes/roles/put.test.js
@@ -57,7 +57,7 @@ tap.test('roles POST endpoint', async endpointTest => {
       await handler(req, res);
 
       notFoundTest.ok(res.status.calledWith(404), 'HTTP status set to 404');
-      notFoundTest.ok(res.send.calledWith({ error: sinon.match.string }), 'sends back an error string');
+      notFoundTest.ok(res.send.notCalled, 'no body is sent');
       notFoundTest.ok(res.end.calledOnce, 'response is terminated');
     });
 

--- a/api/routes/roles/put.test.js
+++ b/api/routes/roles/put.test.js
@@ -241,6 +241,7 @@ tap.test('roles POST endpoint', async endpointTest => {
         save.calledAfter(attach),
         'the model is saved after new activities are attached'
       );
+      saveTest.ok(res.status.calledWith(204), 'HTTP status set to 204');
     });
   });
 });

--- a/api/routes/roles/put.test.js
+++ b/api/routes/roles/put.test.js
@@ -4,13 +4,19 @@ const sinon = require('sinon');
 const canMiddleware = require('../../auth/middleware').can('edit-roles');
 const putEndpoint = require('./put');
 
-tap.test('roles PUT endpoint', async endpointTest => {
+tap.test('roles POST endpoint', async endpointTest => {
   const sandbox = sinon.createSandbox();
   const app = {
     put: sandbox.stub()
   };
   const RoleModel = {
-    fetchAll: sandbox.stub()
+    fetch: sandbox.stub(),
+    forge: sandbox.stub(),
+    where: sandbox.stub()
+  };
+  const ActivityModel = {
+    fetchAll: sandbox.stub(),
+    where: sandbox.stub()
   };
   const res = {
     status: sandbox.stub(),
@@ -27,11 +33,210 @@ tap.test('roles PUT endpoint', async endpointTest => {
   });
 
   endpointTest.test('setup', async setupTest => {
-    putEndpoint(app, RoleModel);
+    putEndpoint(app, RoleModel, ActivityModel);
 
     setupTest.ok(
-      app.put.calledWith('/roles', canMiddleware, sinon.match.func),
+      app.put.calledWith('/roles/:id', canMiddleware, sinon.match.func),
       'roles PUT endpoint is registered'
     );
+  });
+
+  endpointTest.test('edit role handler', async handlerTest => {
+    let handler;
+    handlerTest.beforeEach(done => {
+      putEndpoint(app, RoleModel, ActivityModel);
+      handler = app.put.args.find(args => args[0] === '/roles/:id')[2];
+      done();
+    });
+
+    handlerTest.test('sends a not found error if requesting to edit a role that does not exist', async notFoundTest => {
+      const req = { params: { id: 1 }, body: { activities: [1, 2, 3] } };
+      RoleModel.where.withArgs({ id: 1 }).returns({ fetch: RoleModel.fetch });
+      RoleModel.fetch.resolves(null);
+
+      await handler(req, res);
+
+      notFoundTest.ok(res.status.calledWith(404), 'HTTP status set to 404');
+      notFoundTest.ok(res.send.calledWith({ error: sinon.match.string }), 'sends back an error string');
+      notFoundTest.ok(res.end.calledOnce, 'response is terminated');
+    });
+
+    handlerTest.test(
+      'rejects invalid role objects...',
+      async validationTest => {
+        validationTest.beforeEach(async () => {
+          const fetch = sinon.stub.resolves(true);
+          RoleModel.where.withArgs({ id: 1 }).returns({ fetch });
+        });
+
+        validationTest.test(
+          'if the role does not have any activities',
+          async invalidTest => {
+            const req = { params: { id: 1 }, body: { } };
+            RoleModel.where
+              .withArgs({ name: 'bob' })
+              .returns({ fetch: RoleModel.fetch });
+            RoleModel.fetch.resolves(null);
+
+            await handler(req, res);
+
+            invalidTest.ok(
+              res.send.calledWith({ error: sinon.match.string }),
+              'sends back an error string'
+            );
+            invalidTest.ok(
+              res.status.calledWith(400),
+              'HTTP status set to 400'
+            );
+            invalidTest.ok(res.end.calledOnce, 'response is terminated');
+          }
+        );
+
+        validationTest.test(
+          'if the role has non-numeric activities',
+          async invalidTest => {
+            const req = { params: { id: 1 }, body: { activities: [1, 'one'] } };
+            RoleModel.where
+              .withArgs({ name: 'bob' })
+              .returns({ fetch: RoleModel.fetch });
+            RoleModel.fetch.resolves(null);
+
+            await handler(req, res);
+
+            invalidTest.ok(
+              res.send.calledWith({ error: sinon.match.string }),
+              'sends back an error string'
+            );
+            invalidTest.ok(
+              res.status.calledWith(400),
+              'HTTP status set to 400'
+            );
+            invalidTest.ok(res.end.calledOnce, 'response is terminated');
+          }
+        );
+
+        validationTest.test(
+          'if the role has activity IDs that do not match any activities',
+          async invalidTest => {
+            const req = { params: { id: 1 }, body: { activities: [1, 2, 3] } };
+            RoleModel.where
+              .withArgs({ name: 'bob' })
+              .returns({ fetch: RoleModel.fetch });
+            RoleModel.fetch.resolves(null);
+            ActivityModel.where
+              .withArgs('id', 'in', sinon.match.array)
+              .returns({ fetchAll: ActivityModel.fetchAll });
+
+            // This fetchAll returns the activity IDs that ARE KNOWN to the
+            // system, so we trigger this invalidation route by leaving out
+            // one or more of the activity IDs from the test data
+            ActivityModel.fetchAll.resolves([
+              { get: sinon.stub().returns(1) },
+              { get: sinon.stub().returns(2) }
+            ]);
+
+            await handler(req, res);
+
+            invalidTest.ok(
+              res.send.calledWith({ error: sinon.match.string }),
+              'sends back an error string'
+            );
+            invalidTest.ok(
+              res.status.calledWith(400),
+              'HTTP status set to 400'
+            );
+            invalidTest.ok(res.end.calledOnce, 'response is terminated');
+          }
+        );
+      }
+    );
+
+    handlerTest.test(
+      'sends a server error if anything goes wrong',
+      async saveTest => {
+        const req = { params: { id: 1 }, body: { name: 'bob', activities: [1, 2] } };
+        const save = sinon.stub().rejects();
+        const attach = sinon.stub();
+        const detach = sinon.stub();
+        const fetch = sinon.stub;
+        RoleModel.where.withArgs({ id: 1 }).returns({ fetch });
+        RoleModel.where
+          .withArgs({ name: 'bob' })
+          .returns({ fetch: RoleModel.fetch });
+        RoleModel.fetch.resolves(null);
+        ActivityModel.where
+          .withArgs('id', 'in', sinon.match.array)
+          .returns({ fetchAll: ActivityModel.fetchAll });
+        ActivityModel.fetchAll.resolves([
+          { get: sinon.stub().returns(1) },
+          { get: sinon.stub().returns(2) }
+        ]);
+        fetch.resolves({
+          save,
+          activities: () => ({ attach, detach }),
+          get: sinon
+            .stub()
+            .withArgs('id')
+            .returns('bob-id')
+        });
+
+        await handler(req, res);
+
+        saveTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
+      }
+    );
+
+    handlerTest.test('saves a valid role object', async saveTest => {
+      const req = { params: { id: 1 }, body: { name: 'bob', activities: [1, 2] } };
+      const save = sinon.stub().resolves();
+      const attach = sinon.stub();
+      const detach = sinon.stub();
+      const fetch = sinon.stub();
+      RoleModel.where.withArgs({ id: 1 }).returns({ fetch });
+      RoleModel.where
+        .withArgs({ name: 'bob' })
+        .returns({ fetch: RoleModel.fetch });
+      RoleModel.fetch.resolves(null);
+      ActivityModel.where
+        .withArgs('id', 'in', sinon.match.array)
+        .returns({ fetchAll: ActivityModel.fetchAll });
+      ActivityModel.fetchAll.resolves([
+        { get: sinon.stub().returns(1) },
+        { get: sinon.stub().returns(2) }
+      ]);
+      fetch.resolves({
+        save,
+        activities: () => ({ attach, detach }),
+        getActivities: async () => ['activity model 1', 'activity model 2'],
+        get: sinon
+          .stub()
+          .withArgs('id')
+          .returns('bob-id')
+      });
+
+      await handler(req, res);
+      saveTest.ok(true);
+
+      saveTest.ok(
+        detach.calledBefore(attach),
+        'activities are detached before new activities are added'
+      );
+      saveTest.ok(
+        detach.calledWith(sinon.match.array.deepEquals(['activity model 1', 'activity model 2'])),
+        'the existing activities are removed'
+      );
+      saveTest.ok(
+        attach.calledWith(sinon.match.array.deepEquals([1, 2])),
+        'the role is associated with new activities'
+      );
+      saveTest.ok(
+        save.calledAfter(attach),
+        'the model is saved after activities are attached'
+      );
+      saveTest.ok(
+        res.send.calledWith({ roleID: 'bob-id' }),
+        'sends back the role ID from the database'
+      );
+    });
   });
 });

--- a/api/routes/roles/put.test.js
+++ b/api/routes/roles/put.test.js
@@ -222,8 +222,16 @@ tap.test('roles POST endpoint', async endpointTest => {
         'activities are detached before new activities are added'
       );
       saveTest.ok(
-        detach.calledWith(sinon.match.array.deepEquals(['activity model 1', 'activity model 2'])),
-        'the existing activities are removed'
+        detach.calledWithExactly(),
+        'all existing related activities are removed'
+      );
+      saveTest.ok(
+        save.calledAfter(detach),
+        'the model is saved after old activities are detached'
+      );
+      saveTest.ok(
+        save.calledBefore(attach),
+        'the model is saved before new activities are attached'
       );
       saveTest.ok(
         attach.calledWith(sinon.match.array.deepEquals([1, 2])),
@@ -231,11 +239,7 @@ tap.test('roles POST endpoint', async endpointTest => {
       );
       saveTest.ok(
         save.calledAfter(attach),
-        'the model is saved after activities are attached'
-      );
-      saveTest.ok(
-        res.send.calledWith({ roleID: 'bob-id' }),
-        'sends back the role ID from the database'
+        'the model is saved after new activities are attached'
       );
     });
   });

--- a/api/routes/roles/put.test.js
+++ b/api/routes/roles/put.test.js
@@ -242,6 +242,7 @@ tap.test('roles POST endpoint', async endpointTest => {
         'the model is saved after new activities are attached'
       );
       saveTest.ok(res.status.calledWith(204), 'HTTP status set to 204');
+      saveTest.ok(res.end.calledOnce, 'response is terminated');
     });
   });
 });


### PR DESCRIPTION
Adds an API route for updating an existing role.  The route is at `/roles/:roleID` and it expects a JSON object body that looks like this:

```json
{
  "activities": [ 0, 1, 2 ]
}
```

...where the values of the `activities` array must be numeric and must correspond to IDs of activities known to the system.  Will return a 400 if the body is invalid, 404 if the role ID from the route is not found, or 204 if the role is updated.

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- ~~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~~
- [x] The change has been documented
  - [x] Associated OpenAPI documentation has been updated

### This feature is done when...
- ~~Design has approved the experience~~
- ~~Product has approved the experience~~
