### PR TITLE
add review, success (static) pages

### DIFF
--- a/web/src/components/App.js
+++ b/web/src/components/App.js
@@ -5,6 +5,7 @@ import { Container, Provider } from 'rebass';
 import Demo from './Demo';
 import DevProvider from './DevProvider';
 import NoMatch from './NoMatch';
+import SubmissionSuccess from './SubmissionSuccess';
 import ActivitiesStart from '../containers/ActivitiesStart';
 import ActivitiesList from '../containers/ActivitiesList';
 import ActivityApproach from '../containers/ActivityApproach';
@@ -13,6 +14,7 @@ import ActivityOverview from '../containers/ActivityOverview';
 import ApdOverview from '../containers/ApdOverview';
 import Login from '../containers/Login';
 import PrivateRoute from '../containers/PrivateRoute';
+import ReviewAndSubmit from '../containers/ReviewAndSubmit';
 import StateContacts from '../containers/StateContacts';
 import StateStart from '../containers/StateStart';
 import StatePersonnel from '../containers/StatePersonnel';
@@ -40,12 +42,23 @@ const App = () => (
         <PrivateRoute path="/activity-overview" component={ActivityOverview} />
         <PrivateRoute path="/activity-schedule" component={ActivitySchedule} />
         <PrivateRoute path="/apd-overview" component={ApdOverview} />
-        <PrivateRoute path="/expenses-start" component={ActivityExpensesStart} />
+        <PrivateRoute
+          path="/expenses-start"
+          component={ActivityExpensesStart}
+        />
         <PrivateRoute path="/expenses-list" component={ActivityExpensesList} />
-        <PrivateRoute path="/expenses-details" component={ActivityExpensesDetails} />
+        <PrivateRoute
+          path="/expenses-details"
+          component={ActivityExpensesDetails}
+        />
+        <PrivateRoute path="/review-and-submit" component={ReviewAndSubmit} />
         <PrivateRoute path="/state-contacts" component={StateContacts} />
         <PrivateRoute path="/state-personnel" component={StatePersonnel} />
         <PrivateRoute path="/state-start" component={StateStart} />
+        <PrivateRoute
+          path="/submission-success"
+          component={SubmissionSuccess}
+        />
 
         <Route component={NoMatch} />
       </Switch>

--- a/web/src/components/SubmissionSuccess.js
+++ b/web/src/components/SubmissionSuccess.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Box, Heading, Text } from 'rebass';
+
+const SubmissionSuccess = () => (
+  <Box py={4}>
+    <Heading mb={3}>Thanks! We’ve received your request.</Heading>
+    <Text mb={2}>
+      Some sort of confirmation number or note about checking email etc.
+    </Text>
+    <Text mb={2}>
+      A sentence about how long it usually takes to receive a response.
+    </Text>
+    <Text mb={2}>A sentence about what to do if you have questions.</Text>
+  </Box>
+);
+
+export default SubmissionSuccess;

--- a/web/src/components/__snapshots__/App.test.js.snap
+++ b/web/src/components/__snapshots__/App.test.js.snap
@@ -72,6 +72,10 @@ ShallowWrapper {
             />
             <Connect(PrivateRoute)
               component={[Function]}
+              path="/review-and-submit"
+            />
+            <Connect(PrivateRoute)
+              component={[Function]}
               path="/state-contacts"
             />
             <Connect(PrivateRoute)
@@ -81,6 +85,10 @@ ShallowWrapper {
             <Connect(PrivateRoute)
               component={[Function]}
               path="/state-start"
+            />
+            <Connect(PrivateRoute)
+              component={[Function]}
+              path="/submission-success"
             />
             <Route
               component={[Function]}
@@ -157,6 +165,10 @@ ShallowWrapper {
             />
             <Connect(PrivateRoute)
               component={[Function]}
+              path="/review-and-submit"
+            />
+            <Connect(PrivateRoute)
+              component={[Function]}
               path="/state-contacts"
             />
             <Connect(PrivateRoute)
@@ -166,6 +178,10 @@ ShallowWrapper {
             <Connect(PrivateRoute)
               component={[Function]}
               path="/state-start"
+            />
+            <Connect(PrivateRoute)
+              component={[Function]}
+              path="/submission-success"
             />
             <Route
               component={[Function]}
@@ -230,6 +246,10 @@ ShallowWrapper {
               />,
               <Connect(PrivateRoute)
                 component={[Function]}
+                path="/review-and-submit"
+              />,
+              <Connect(PrivateRoute)
+                component={[Function]}
                 path="/state-contacts"
               />,
               <Connect(PrivateRoute)
@@ -239,6 +259,10 @@ ShallowWrapper {
               <Connect(PrivateRoute)
                 component={[Function]}
                 path="/state-start"
+              />,
+              <Connect(PrivateRoute)
+                component={[Function]}
+                path="/submission-success"
               />,
               <Route
                 component={[Function]}
@@ -398,6 +422,18 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "component": [Function],
+                "path": "/review-and-submit",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "component": [Function],
                 "path": "/state-contacts",
               },
               "ref": null,
@@ -423,6 +459,18 @@ ShallowWrapper {
               "props": Object {
                 "component": [Function],
                 "path": "/state-start",
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "component": [Function],
+                "path": "/submission-success",
               },
               "ref": null,
               "rendered": null,
@@ -508,6 +556,10 @@ ShallowWrapper {
               />
               <Connect(PrivateRoute)
                 component={[Function]}
+                path="/review-and-submit"
+              />
+              <Connect(PrivateRoute)
+                component={[Function]}
                 path="/state-contacts"
               />
               <Connect(PrivateRoute)
@@ -517,6 +569,10 @@ ShallowWrapper {
               <Connect(PrivateRoute)
                 component={[Function]}
                 path="/state-start"
+              />
+              <Connect(PrivateRoute)
+                component={[Function]}
+                path="/submission-success"
               />
               <Route
                 component={[Function]}
@@ -593,6 +649,10 @@ ShallowWrapper {
               />
               <Connect(PrivateRoute)
                 component={[Function]}
+                path="/review-and-submit"
+              />
+              <Connect(PrivateRoute)
+                component={[Function]}
                 path="/state-contacts"
               />
               <Connect(PrivateRoute)
@@ -602,6 +662,10 @@ ShallowWrapper {
               <Connect(PrivateRoute)
                 component={[Function]}
                 path="/state-start"
+              />
+              <Connect(PrivateRoute)
+                component={[Function]}
+                path="/submission-success"
               />
               <Route
                 component={[Function]}
@@ -666,6 +730,10 @@ ShallowWrapper {
                 />,
                 <Connect(PrivateRoute)
                   component={[Function]}
+                  path="/review-and-submit"
+                />,
+                <Connect(PrivateRoute)
+                  component={[Function]}
                   path="/state-contacts"
                 />,
                 <Connect(PrivateRoute)
@@ -675,6 +743,10 @@ ShallowWrapper {
                 <Connect(PrivateRoute)
                   component={[Function]}
                   path="/state-start"
+                />,
+                <Connect(PrivateRoute)
+                  component={[Function]}
+                  path="/submission-success"
                 />,
                 <Route
                   component={[Function]}
@@ -834,6 +906,18 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "component": [Function],
+                  "path": "/review-and-submit",
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "component": [Function],
                   "path": "/state-contacts",
                 },
                 "ref": null,
@@ -859,6 +943,18 @@ ShallowWrapper {
                 "props": Object {
                   "component": [Function],
                   "path": "/state-start",
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "component": [Function],
+                  "path": "/submission-success",
                 },
                 "ref": null,
                 "rendered": null,

--- a/web/src/containers/ReviewAndSubmit.js
+++ b/web/src/containers/ReviewAndSubmit.js
@@ -1,0 +1,81 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import { push } from 'react-router-redux';
+import { Box, Button, ButtonOutline, Heading, Text } from 'rebass';
+import { bindActionCreators } from 'redux';
+
+const Section = ({ title }) => (
+  <tbody>
+    <tr>
+      <td colSpan="4">{title}</td>
+    </tr>
+    <tr>
+      <td>2019</td>
+      <td />
+      <td />
+      <td />
+    </tr>
+    <tr>
+      <td>2020</td>
+      <td />
+      <td />
+      <td />
+    </tr>
+  </tbody>
+);
+
+Section.propTypes = {
+  title: PropTypes.string.isRequired
+};
+
+const ReviewAndSubmit = ({ goTo }) => (
+  <Box py={4}>
+    <Heading mb={1}>Here’s a quick summary of the numbers</Heading>
+    <Text mb={4}>
+      This table outlines the total requested amount for 2019–2020 with the cost
+      broken down by funding stream.
+    </Text>
+    <Box mb={3}>
+      <table className="table table-bordered">
+        <thead>
+          <tr>
+            <th>Activities</th>
+            <th>Federal Share</th>
+            <th>State Share</th>
+            <th>Total</th>
+          </tr>
+        </thead>
+        <Section title="Health Information Technology for Economic and Clinical Health (HITECH)" />
+        <Section title="Maintenance Management Information System (MMIS)" />
+        <Section title="Health Information Exchange (HIE)" />
+        <tbody>
+          <tr>
+            <td>Grand Total</td>
+            <td />
+            <td />
+            <td />
+          </tr>
+        </tbody>
+      </table>
+    </Box>
+    <Box mb={4}>
+      <ButtonOutline mr={2}>Download PDF</ButtonOutline>
+      <ButtonOutline>Print</ButtonOutline>
+    </Box>
+    <Text mb={3}>
+      By clicking Submit, you agree that your funding request fulfills our{' '}
+      <a href="#!">standards and requirements</a>.
+    </Text>
+    <Button onClick={() => goTo('/submission-success')}>Submit</Button>
+  </Box>
+);
+
+ReviewAndSubmit.propTypes = {
+  goTo: PropTypes.func.isRequired
+};
+
+const mapDispatchToProps = dispatch =>
+  bindActionCreators({ goTo: path => push(path) }, dispatch);
+
+export default connect(null, mapDispatchToProps)(ReviewAndSubmit);

--- a/web/src/styles/base.js
+++ b/web/src/styles/base.js
@@ -96,6 +96,39 @@ injectGlobal`
     cursor: pointer;
   }
 
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
+    max-width: 100%;
+    width: 100%;
+  }
+
+  th,
+  td {
+    padding: 0.5rem 1rem;
+    line-height: inherit;
+  }
+
+  th {
+    text-align: left;
+    font-weight: bold;
+    vertical-align: bottom;
+  }
+
+  td {
+    vertical-align: top;
+  }
+
+  .table th,
+  .table td {
+    border-top: 1px solid #e7e7e7;
+  }
+
+  .table-bordered td,
+  .table-bordered th {
+    border: 1px solid #e7e7e7;
+  }
+
   .sr-only {
     border: 0;
     clip: rect(0 0 0 0);


### PR DESCRIPTION
This adds two static pages based on the content exploration doc -- a "number/table summary review" page and a "submission received" page

Other bits:
* Adds basic table reset styles and two optional table classes to add additional styles (i.e., adding a light border around cells)

Preview:
![preview](https://user-images.githubusercontent.com/1060893/36436897-90c68d42-1633-11e8-97fa-0236112cc926.png)

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This feature is done when...
- [ ] Design has approved the experience
- [ ] Product has approved the experience
