### PR TITLE
Add authorization to API calls for viewing and creating users

### DIFF
--- a/api/endpoint-tests/roles/get.js
+++ b/api/endpoint-tests/roles/get.js
@@ -29,7 +29,7 @@ tap.test('roles endpoint | GET /roles', async getUsersTest => {
       [{
         name: 'admin',
         id: 1,
-        activities: ['view-roles', 'create-roles', 'edit-roles']
+        activities: ['view-roles', 'create-roles', 'edit-roles', 'view-users', 'add-users']
       }, {
         name: 'cms-reviewer',
         id: 2,

--- a/api/endpoint-tests/roles/get.js
+++ b/api/endpoint-tests/roles/get.js
@@ -26,19 +26,29 @@ tap.test('roles endpoint | GET /roles', async getUsersTest => {
     validTest.equal(response.statusCode, 200, 'gives a 200 status code');
     validTest.same(
       body,
-      [{
-        name: 'admin',
-        id: 1,
-        activities: ['view-roles', 'create-roles', 'edit-roles', 'view-users', 'add-users']
-      }, {
-        name: 'cms-reviewer',
-        id: 2,
-        activities: ['edit-roles']
-      }, {
-        name: 'state-submitter',
-        id: 3,
-        activities: []
-      }],
+      [
+        {
+          name: 'admin',
+          id: 1,
+          activities: [
+            'view-roles',
+            'create-roles',
+            'edit-roles',
+            'view-users',
+            'add-users'
+          ]
+        },
+        {
+          name: 'cms-reviewer',
+          id: 2,
+          activities: ['edit-roles']
+        },
+        {
+          name: 'state-submitter',
+          id: 3,
+          activities: []
+        }
+      ],
       'returns an array of known roles'
     );
   });

--- a/api/routes/users/get.js
+++ b/api/routes/users/get.js
@@ -1,5 +1,5 @@
 const defaultUserModel = require('../../db').models.user;
-const loggedIn = require('../../auth/middleware').loggedIn;
+const can = require('../../auth/middleware').can;
 
 const allUsersHandler = async (req, res, UserModel) => {
   try {
@@ -33,10 +33,10 @@ const oneUserHandler = async (req, res, UserModel) => {
 };
 
 module.exports = (app, UserModel = defaultUserModel) => {
-  app.get('/users', loggedIn, (req, res) =>
+  app.get('/users', can('view-users'), (req, res) =>
     allUsersHandler(req, res, UserModel)
   );
-  app.get('/user/:id', loggedIn, (req, res) =>
+  app.get('/user/:id', can('view-users'), (req, res) =>
     oneUserHandler(req, res, UserModel)
   );
 };

--- a/api/routes/users/get.test.js
+++ b/api/routes/users/get.test.js
@@ -1,7 +1,7 @@
 const tap = require('tap');
 const sinon = require('sinon');
 
-const loggedInMiddleware = require('../../auth/middleware').loggedIn;
+const canMiddleware = require('../../auth/middleware').can('view-users');
 const getEndpoint = require('./get');
 
 tap.test('user GET endpoint', async endpointTest => {
@@ -36,11 +36,11 @@ tap.test('user GET endpoint', async endpointTest => {
     getEndpoint(app, UserModel);
 
     setupTest.ok(
-      app.get.calledWith('/user/:id', loggedInMiddleware, sinon.match.func),
+      app.get.calledWith('/user/:id', canMiddleware, sinon.match.func),
       'single user GET endpoint is registered'
     );
     setupTest.ok(
-      app.get.calledWith('/users', loggedInMiddleware, sinon.match.func),
+      app.get.calledWith('/users', canMiddleware, sinon.match.func),
       'all users GET endpoint is registered'
     );
   });

--- a/api/routes/users/post.js
+++ b/api/routes/users/post.js
@@ -1,6 +1,6 @@
 const bcrypt = require('bcryptjs');
 const defaultUserModel = require('../../db').models.user;
-const loggedIn = require('../../auth/middleware').loggedIn;
+const can = require('../../auth/middleware').can;
 
 const userIsNew = async (email, UserModel) => {
   const user = await UserModel.where({ email }).fetch();
@@ -18,7 +18,7 @@ const insert = async (email, password, UserModel) => {
 };
 
 module.exports = (app, UserModel = defaultUserModel) => {
-  app.post('/user', loggedIn, async (req, res) => {
+  app.post('/user', can('add-users'), async (req, res) => {
     if (req.body.email && req.body.password) {
       try {
         if (await userIsNew(req.body.email, UserModel)) {

--- a/api/routes/users/post.test.js
+++ b/api/routes/users/post.test.js
@@ -1,7 +1,7 @@
 const tap = require('tap');
 const sinon = require('sinon');
 
-const loggedInMiddleware = require('../../auth/middleware').loggedIn;
+const canMiddleware = require('../../auth/middleware').can('add-users');
 const postEndpoint = require('./post');
 
 tap.test('user POST endpoint', async endpointTest => {
@@ -38,7 +38,7 @@ tap.test('user POST endpoint', async endpointTest => {
     postEndpoint(app, UserModel);
 
     setupTest.ok(
-      app.post.calledWith('/user', loggedInMiddleware, sinon.match.func),
+      app.post.calledWith('/user', canMiddleware, sinon.match.func),
       'user POST endpoint is registered'
     );
   });

--- a/api/seeds/01-roles-and-activities.js
+++ b/api/seeds/01-roles-and-activities.js
@@ -34,31 +34,49 @@ const insertAndGetIDs = async (knex, tableName, values) => {
   await knex(tableName).insert(insert);
   const asInserted = await knex(tableName).select('*');
 
-  const idMapping = { };
+  const idMapping = {};
   asInserted.forEach(as => {
     idMapping[as.name] = as.id;
   });
   return idMapping;
 };
 
-const setupMappings = async (knex, tableName, roleIDs, activityIDs, mappings) => {
+const setupMappings = async (
+  knex,
+  tableName,
+  roleIDs,
+  activityIDs,
+  mappings
+) => {
   const table = knex(tableName);
 
-  await Promise.all(Object.keys(mappings).map(async role => {
-    const roleID = roleIDs[role];
-    for (let i = 0; i < mappings[role].length; i += 1) {
-      const activityID = activityIDs[mappings[role][i]];
+  await Promise.all(
+    Object.keys(mappings).map(async role => {
+      const roleID = roleIDs[role];
+      for (let i = 0; i < mappings[role].length; i += 1) {
+        const activityID = activityIDs[mappings[role][i]];
 
-      // We actually need to block here, otherwise weird reference stuff happens
-      // and we just map the role to a single activity multiple times.
-      // eslint-disable-next-line no-await-in-loop
-      await table.insert({ role_id: roleID, activity_id: activityID });
-    }
-  }));
+        // We actually need to block here, otherwise weird reference stuff happens
+        // and we just map the role to a single activity multiple times.
+        // eslint-disable-next-line no-await-in-loop
+        await table.insert({ role_id: roleID, activity_id: activityID });
+      }
+    })
+  );
 };
 
 exports.seed = async knex => {
-  const activityIDs = await insertAndGetIDs(knex, 'auth_activities', activities);
+  const activityIDs = await insertAndGetIDs(
+    knex,
+    'auth_activities',
+    activities
+  );
   const roleIDs = await insertAndGetIDs(knex, 'auth_roles', roles);
-  await setupMappings(knex, 'auth_role_activity_mapping', roleIDs, activityIDs, roleToActivityMappings);
+  await setupMappings(
+    knex,
+    'auth_role_activity_mapping',
+    roleIDs,
+    activityIDs,
+    roleToActivityMappings
+  );
 };

--- a/api/seeds/01-roles-and-activities.js
+++ b/api/seeds/01-roles-and-activities.js
@@ -1,4 +1,6 @@
 const activities = {
+  'view-users': false,
+  'add-users': false,
   'view-roles': false,
   'create-roles': false,
   'edit-roles': false
@@ -12,6 +14,8 @@ const roles = {
 
 const roleToActivityMappings = {
   admin: [
+    'view-users',
+    'add-users',
     'view-roles',
     'create-roles',
     'edit-roles'

--- a/api/seeds/test/roles.js
+++ b/api/seeds/test/roles.js
@@ -8,6 +8,8 @@ exports.seed = async knex => {
   await knex('auth_activities').insert({ id: 1, name: 'view-roles' });
   await knex('auth_activities').insert({ id: 2, name: 'create-roles' });
   await knex('auth_activities').insert({ id: 3, name: 'edit-roles' });
+  await knex('auth_activities').insert({ id: 4, name: 'view-users' });
+  await knex('auth_activities').insert({ id: 5, name: 'add-users' });
 
   await knex('auth_roles').insert({ id: 1, name: 'admin' });
   await knex('auth_roles').insert({ id: 2, name: 'cms-reviewer' });
@@ -16,5 +18,7 @@ exports.seed = async knex => {
   await knex('auth_role_activity_mapping').insert({ role_id: 1, activity_id: 1 });
   await knex('auth_role_activity_mapping').insert({ role_id: 1, activity_id: 2 });
   await knex('auth_role_activity_mapping').insert({ role_id: 1, activity_id: 3 });
+  await knex('auth_role_activity_mapping').insert({ role_id: 1, activity_id: 4 });
+  await knex('auth_role_activity_mapping').insert({ role_id: 1, activity_id: 5 });
   await knex('auth_role_activity_mapping').insert({ role_id: 2, activity_id: 3 });
 };

--- a/api/seeds/test/roles.js
+++ b/api/seeds/test/roles.js
@@ -15,10 +15,28 @@ exports.seed = async knex => {
   await knex('auth_roles').insert({ id: 2, name: 'cms-reviewer' });
   await knex('auth_roles').insert({ id: 3, name: 'state-submitter' });
 
-  await knex('auth_role_activity_mapping').insert({ role_id: 1, activity_id: 1 });
-  await knex('auth_role_activity_mapping').insert({ role_id: 1, activity_id: 2 });
-  await knex('auth_role_activity_mapping').insert({ role_id: 1, activity_id: 3 });
-  await knex('auth_role_activity_mapping').insert({ role_id: 1, activity_id: 4 });
-  await knex('auth_role_activity_mapping').insert({ role_id: 1, activity_id: 5 });
-  await knex('auth_role_activity_mapping').insert({ role_id: 2, activity_id: 3 });
+  await knex('auth_role_activity_mapping').insert({
+    role_id: 1,
+    activity_id: 1
+  });
+  await knex('auth_role_activity_mapping').insert({
+    role_id: 1,
+    activity_id: 2
+  });
+  await knex('auth_role_activity_mapping').insert({
+    role_id: 1,
+    activity_id: 3
+  });
+  await knex('auth_role_activity_mapping').insert({
+    role_id: 1,
+    activity_id: 4
+  });
+  await knex('auth_role_activity_mapping').insert({
+    role_id: 1,
+    activity_id: 5
+  });
+  await knex('auth_role_activity_mapping').insert({
+    role_id: 2,
+    activity_id: 3
+  });
 };


### PR DESCRIPTION
Previously, any logged in user could view a list of all users and could create new users.  Not ideal.  😄 

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- ~~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~~
- [x] The change has been documented (N/A)
  - [x] Associated OpenAPI documentation has been updated (N/A)

### This feature is done when...
- ~~Design has approved the experience~~
- ~~Product has approved the experience~~
