### PR TITLE
Role management DELETE endpoint

### DIFF
--- a/api/auth/serialization.js
+++ b/api/auth/serialization.js
@@ -19,6 +19,7 @@ module.exports.deserializeUser = async (
       done(null, {
         username: user.get('email'),
         id: user.get('id'),
+        role: user.get('auth_role'),
         activities: await user.activities()
       });
     } else {

--- a/api/auth/serialization.test.js
+++ b/api/auth/serialization.test.js
@@ -66,6 +66,7 @@ tap.test('passport serialization', async serializationTest => {
           doneCallback.calledWith(null, {
             username: 'test-email',
             id: 'test-id',
+            role: undefined,
             activities: sinon.match.array.deepEquals([])
           }),
           'deserializes the user ID to an object'
@@ -75,6 +76,7 @@ tap.test('passport serialization', async serializationTest => {
       validTest.test('with a role', async adminRoleTest => {
         get.withArgs('email').returns('test-email');
         get.withArgs('id').returns('test-id');
+        get.withArgs('auth_role').returns('test-role');
         activities.resolves(['activity 1', 'activity 2']);
         userModel.fetch.resolves({ get, activities });
 
@@ -84,6 +86,7 @@ tap.test('passport serialization', async serializationTest => {
           doneCallback.calledWith(null, {
             username: 'test-email',
             id: 'test-id',
+            role: 'test-role',
             activities: sinon.match.array.deepEquals([
               'activity 1',
               'activity 2'

--- a/api/endpoint-tests/roles/delete.js
+++ b/api/endpoint-tests/roles/delete.js
@@ -1,0 +1,66 @@
+const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
+const { db, request, getFullPath, login } = require('../utils');
+
+tap.test('roles endpoint | DELETE /roles/:roleID', async deleteRolesTests => {
+  await db().seed.run();
+
+  const url = getFullPath('/roles');
+
+  deleteRolesTests.test('when unauthenticated', async unauthenticatedTests => {
+    unauthenticatedTests.test('with invalid ID', async invalidTest => {
+      const { response, body } = await request.delete(`${url}/9001`);
+      invalidTest.equal(
+        response.statusCode,
+        403,
+        'gives a 403 status code'
+      );
+      invalidTest.notOk(body, 'does not send a body');
+    });
+
+    unauthenticatedTests.test('with invalid ID', async invalidTest => {
+      const { response, body } = await request.delete(`${url}/1`);
+      invalidTest.equal(
+        response.statusCode,
+        403,
+        'gives a 403 status code'
+      );
+      invalidTest.notOk(body, 'does not send a body');
+    });
+  });
+
+  deleteRolesTests.test('when authenticated', async authenticatedTests => {
+    const cookies = await login();
+
+    authenticatedTests.test('with an invalid ID', async invalidTest => {
+      const { response, body } = await request.delete(`${url}/9001`, { jar: cookies });
+      invalidTest.equal(response.statusCode, 404, 'gives a 404 status code');
+      invalidTest.notOk(body, 'does not send a body');
+    });
+
+    authenticatedTests.test('with an ID for a role that the user belongs to', async invalidTest => {
+      const { response, body } = await request.delete(`${url}/1`, { jar: cookies });
+      invalidTest.equal(response.statusCode, 401, 'gives a 401 status code');
+      invalidTest.notOk(body, 'does not send a body');
+    });
+
+    authenticatedTests.test('with a valid role ID that the user does not belong to', async validTest => {
+      const { response, body } = await request.delete(`${url}/2`, { jar: cookies });
+
+      validTest.equal(response.statusCode, 204, 'gives a 204 status code');
+      validTest.notOk(body, 'does not send a body');
+
+      const role = await db()('auth_roles').where({ id: 2 }).first();
+      const mappings = await db()('auth_role_activity_mapping')
+        .where({ role_id: 2 })
+        .select('*');
+
+      validTest.notOk(role, 'deletes the role from the database');
+
+      validTest.same(
+        mappings,
+        [],
+        'deletes mappings between the role and all activities in the database'
+      );
+    });
+  });
+});

--- a/api/endpoint-tests/roles/delete.js
+++ b/api/endpoint-tests/roles/delete.js
@@ -9,21 +9,13 @@ tap.test('roles endpoint | DELETE /roles/:roleID', async deleteRolesTests => {
   deleteRolesTests.test('when unauthenticated', async unauthenticatedTests => {
     unauthenticatedTests.test('with invalid ID', async invalidTest => {
       const { response, body } = await request.delete(`${url}/9001`);
-      invalidTest.equal(
-        response.statusCode,
-        403,
-        'gives a 403 status code'
-      );
+      invalidTest.equal(response.statusCode, 403, 'gives a 403 status code');
       invalidTest.notOk(body, 'does not send a body');
     });
 
     unauthenticatedTests.test('with invalid ID', async invalidTest => {
       const { response, body } = await request.delete(`${url}/1`);
-      invalidTest.equal(
-        response.statusCode,
-        403,
-        'gives a 403 status code'
-      );
+      invalidTest.equal(response.statusCode, 403, 'gives a 403 status code');
       invalidTest.notOk(body, 'does not send a body');
     });
   });
@@ -32,35 +24,49 @@ tap.test('roles endpoint | DELETE /roles/:roleID', async deleteRolesTests => {
     const cookies = await login();
 
     authenticatedTests.test('with an invalid ID', async invalidTest => {
-      const { response, body } = await request.delete(`${url}/9001`, { jar: cookies });
+      const { response, body } = await request.delete(`${url}/9001`, {
+        jar: cookies
+      });
       invalidTest.equal(response.statusCode, 404, 'gives a 404 status code');
       invalidTest.notOk(body, 'does not send a body');
     });
 
-    authenticatedTests.test('with an ID for a role that the user belongs to', async invalidTest => {
-      const { response, body } = await request.delete(`${url}/1`, { jar: cookies });
-      invalidTest.equal(response.statusCode, 401, 'gives a 401 status code');
-      invalidTest.notOk(body, 'does not send a body');
-    });
+    authenticatedTests.test(
+      'with an ID for a role that the user belongs to',
+      async invalidTest => {
+        const { response, body } = await request.delete(`${url}/1`, {
+          jar: cookies
+        });
+        invalidTest.equal(response.statusCode, 401, 'gives a 401 status code');
+        invalidTest.notOk(body, 'does not send a body');
+      }
+    );
 
-    authenticatedTests.test('with a valid role ID that the user does not belong to', async validTest => {
-      const { response, body } = await request.delete(`${url}/2`, { jar: cookies });
+    authenticatedTests.test(
+      'with a valid role ID that the user does not belong to',
+      async validTest => {
+        const { response, body } = await request.delete(`${url}/2`, {
+          jar: cookies
+        });
 
-      validTest.equal(response.statusCode, 204, 'gives a 204 status code');
-      validTest.notOk(body, 'does not send a body');
+        validTest.equal(response.statusCode, 204, 'gives a 204 status code');
+        validTest.notOk(body, 'does not send a body');
 
-      const role = await db()('auth_roles').where({ id: 2 }).first();
-      const mappings = await db()('auth_role_activity_mapping')
-        .where({ role_id: 2 })
-        .select('*');
+        const role = await db()('auth_roles')
+          .where({ id: 2 })
+          .first();
+        const mappings = await db()('auth_role_activity_mapping')
+          .where({ role_id: 2 })
+          .select('*');
 
-      validTest.notOk(role, 'deletes the role from the database');
+        validTest.notOk(role, 'deletes the role from the database');
 
-      validTest.same(
-        mappings,
-        [],
-        'deletes mappings between the role and all activities in the database'
-      );
-    });
+        validTest.same(
+          mappings,
+          [],
+          'deletes mappings between the role and all activities in the database'
+        );
+      }
+    );
   });
 });

--- a/api/endpoint-tests/roles/delete.js
+++ b/api/endpoint-tests/roles/delete.js
@@ -7,13 +7,13 @@ tap.test('roles endpoint | DELETE /roles/:roleID', async deleteRolesTests => {
   const url = getFullPath('/roles');
 
   deleteRolesTests.test('when unauthenticated', async unauthenticatedTests => {
-    unauthenticatedTests.test('with invalid ID', async invalidTest => {
+    unauthenticatedTests.test('with invalid role ID', async invalidTest => {
       const { response, body } = await request.delete(`${url}/9001`);
       invalidTest.equal(response.statusCode, 403, 'gives a 403 status code');
       invalidTest.notOk(body, 'does not send a body');
     });
 
-    unauthenticatedTests.test('with invalid ID', async invalidTest => {
+    unauthenticatedTests.test('with valid role ID', async invalidTest => {
       const { response, body } = await request.delete(`${url}/1`);
       invalidTest.equal(response.statusCode, 403, 'gives a 403 status code');
       invalidTest.notOk(body, 'does not send a body');
@@ -23,7 +23,7 @@ tap.test('roles endpoint | DELETE /roles/:roleID', async deleteRolesTests => {
   deleteRolesTests.test('when authenticated', async authenticatedTests => {
     const cookies = await login();
 
-    authenticatedTests.test('with an invalid ID', async invalidTest => {
+    authenticatedTests.test('with an invalid role ID', async invalidTest => {
       const { response, body } = await request.delete(`${url}/9001`, {
         jar: cookies
       });
@@ -32,7 +32,7 @@ tap.test('roles endpoint | DELETE /roles/:roleID', async deleteRolesTests => {
     });
 
     authenticatedTests.test(
-      'with an ID for a role that the user belongs to',
+      'deleting the role that the user belongs to',
       async invalidTest => {
         const { response, body } = await request.delete(`${url}/1`, {
           jar: cookies
@@ -43,7 +43,7 @@ tap.test('roles endpoint | DELETE /roles/:roleID', async deleteRolesTests => {
     );
 
     authenticatedTests.test(
-      'with a valid role ID that the user does not belong to',
+      'deleting a role that the user does not belong to',
       async validTest => {
         const { response, body } = await request.delete(`${url}/2`, {
           jar: cookies

--- a/api/endpoint-tests/roles/get.js
+++ b/api/endpoint-tests/roles/get.js
@@ -23,6 +23,8 @@ tap.test('roles endpoint | GET /roles', async getUsersTest => {
       json: true
     });
 
+    body.forEach(role => role.activities.sort());
+
     validTest.equal(response.statusCode, 200, 'gives a 200 status code');
     validTest.same(
       body,
@@ -31,11 +33,12 @@ tap.test('roles endpoint | GET /roles', async getUsersTest => {
           name: 'admin',
           id: 1,
           activities: [
-            'view-roles',
+            'add-users',
             'create-roles',
+            'delete-roles',
             'edit-roles',
-            'view-users',
-            'add-users'
+            'view-roles',
+            'view-users'
           ]
         },
         {

--- a/api/endpoint-tests/utils.js
+++ b/api/endpoint-tests/utils.js
@@ -8,6 +8,13 @@ const getFullPath = endpointPath =>
     process.env.PORT ||
     8000}${endpointPath}`;
 
+const del = async (...args) =>
+  new Promise(resolve => {
+    request.delete(...args, (err, response, body) => {
+      resolve({ err, response, body });
+    });
+  });
+
 const get = async (...args) =>
   new Promise(resolve => {
     request.get(...args, (err, response, body) => {
@@ -60,7 +67,7 @@ const db = () => {
 
 module.exports = {
   db,
-  request: { get, post, put, jar: request.jar },
+  request: { delete: del, get, post, put, jar: request.jar },
   getFullPath,
   login
 };

--- a/api/routes/roles/delete.js
+++ b/api/routes/roles/delete.js
@@ -1,0 +1,32 @@
+const defaultRoleModel = require('../../db').models.role;
+const can = require('../../auth/middleware').can;
+
+module.exports = (
+  app,
+  RoleModel = defaultRoleModel
+) => {
+  app.delete('/roles/:id', can('delete-roles'), async (req, res) => {
+    const targetRole = await RoleModel.where({ id: req.params.id }).fetch();
+    if (!targetRole) {
+      return res
+        .status(404)
+        .end();
+    }
+
+    const userRole = await RoleModel.where({ name: req.user.role }).fetch();
+    if (userRole.get('id') === targetRole.get('id')) {
+      return res
+        .status(401)
+        .end();
+    }
+
+    try {
+      targetRole.activities().detach();
+      await targetRole.save();
+      await targetRole.destroy();
+      return res.status(204).end();
+    } catch (e) {
+      return res.status(500).end();
+    }
+  });
+};

--- a/api/routes/roles/delete.js
+++ b/api/routes/roles/delete.js
@@ -1,23 +1,16 @@
 const defaultRoleModel = require('../../db').models.role;
 const can = require('../../auth/middleware').can;
 
-module.exports = (
-  app,
-  RoleModel = defaultRoleModel
-) => {
+module.exports = (app, RoleModel = defaultRoleModel) => {
   app.delete('/roles/:id', can('delete-roles'), async (req, res) => {
     const targetRole = await RoleModel.where({ id: req.params.id }).fetch();
     if (!targetRole) {
-      return res
-        .status(404)
-        .end();
+      return res.status(404).end();
     }
 
     const userRole = await RoleModel.where({ name: req.user.role }).fetch();
     if (userRole.get('id') === targetRole.get('id')) {
-      return res
-        .status(401)
-        .end();
+      return res.status(401).end();
     }
 
     try {

--- a/api/routes/roles/delete.test.js
+++ b/api/routes/roles/delete.test.js
@@ -1,0 +1,105 @@
+const tap = require('tap');
+const sinon = require('sinon');
+
+const canMiddleware = require('../../auth/middleware').can('delete-roles');
+const deleteEndpoint = require('./delete');
+
+tap.test('roles DELETE endpoint', async endpointTest => {
+  const sandbox = sinon.createSandbox();
+  const app = {
+    delete: sandbox.stub()
+  };
+  const RoleModel = {
+    fetch: sandbox.stub(),
+    where: sandbox.stub()
+  };
+  const res = {
+    status: sandbox.stub(),
+    send: sandbox.stub(),
+    end: sandbox.stub()
+  };
+
+  endpointTest.beforeEach(async () => {
+    sandbox.reset();
+
+    res.status.returns(res);
+    res.send.returns(res);
+    res.end.returns(res);
+  });
+
+  endpointTest.test('setup', async setupTest => {
+    deleteEndpoint(app, RoleModel);
+
+    setupTest.ok(
+      app.delete.calledWith('/roles/:id', canMiddleware, sinon.match.func),
+      'roles DELETE endpoint is registered'
+    );
+  });
+
+  endpointTest.test('delete role handler', async handlerTest => {
+    let handler;
+    handlerTest.beforeEach(done => {
+      deleteEndpoint(app, RoleModel);
+      handler = app.delete.args.find(args => args[0] === '/roles/:id')[2];
+      done();
+    });
+
+    handlerTest.test('sends a not found error if requesting to delete a role that does not exist', async notFoundTest => {
+      const req = { user: { role: 'user-role' }, params: { id: 1 } };
+      RoleModel.where.withArgs({ id: 1 }).returns({ fetch: RoleModel.fetch });
+      RoleModel.fetch.resolves(null);
+
+      await handler(req, res);
+
+      notFoundTest.ok(res.status.calledWith(404), 'HTTP status set to 404');
+      notFoundTest.ok(res.send.notCalled, 'no body is sent');
+      notFoundTest.ok(res.end.calledOnce, 'response is terminated');
+    });
+
+    handlerTest.test('sends an unauthorized error if requesting to delete a role that the user belongs to', async unauthorizedTest => {
+      const req = { user: { role: 'user-role' }, params: { id: 1 } };
+      const get = sinon.stub().withArgs('id').returns('role-id');
+      RoleModel.where.withArgs({ id: 1 }).returns({ fetch: RoleModel.fetch });
+      RoleModel.where.withArgs({ name: 'user-role' }).returns({ fetch: RoleModel.fetch });
+      RoleModel.fetch.resolves({ get });
+
+      await handler(req, res);
+
+      unauthorizedTest.ok(res.status.calledWith(401), 'HTTP status set to 401');
+      unauthorizedTest.ok(res.send.notCalled, 'no body is sent');
+      unauthorizedTest.ok(res.end.calledOnce, 'response is terminated');
+    });
+
+    handlerTest.test(
+      'sends a server error if anything goes wrong',
+      async saveTest => {
+        const req = { user: { role: 'user-role' }, params: { id: 1 } };
+        const get1 = sinon.stub().withArgs('id').returns('role-id-1');
+        const get2 = sinon.stub().withArgs('id').returns('role-id-2');
+        const destroy = sinon.stub().rejects();
+        RoleModel.where.withArgs({ id: 1 }).returns({ fetch: sinon.stub().resolves({ destroy, get: get1 }) });
+        RoleModel.where.withArgs({ name: 'user-role' }).returns({ fetch: sinon.stub().resolves({ get: get2 }) });
+
+        await handler(req, res);
+
+        saveTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
+      }
+    );
+
+    handlerTest.test('deletes a role', async saveTest => {
+      const req = { user: { role: 'user-role' }, params: { id: 1 } };
+      const get1 = sinon.stub().withArgs('id').returns('role-id-1');
+      const get2 = sinon.stub().withArgs('id').returns('role-id-2');
+      const destroy = sinon.stub().resolves();
+      RoleModel.where.withArgs({ id: 1 }).returns({ fetch: sinon.stub().resolves({ destroy, get: get1 }) });
+      RoleModel.where.withArgs({ name: 'user-role' }).returns({ fetch: sinon.stub().resolves({ get: get2 }) });
+
+      await handler(req, res);
+      saveTest.ok(true);
+
+      saveTest.ok(destroy.calledOnce, 'model is destroyed');
+      saveTest.ok(res.status.calledWith(204), 'HTTP status set to 204');
+      saveTest.ok(res.end.calledOnce, 'response is terminated');
+    });
+  });
+});

--- a/api/routes/roles/delete.test.js
+++ b/api/routes/roles/delete.test.js
@@ -44,44 +44,63 @@ tap.test('roles DELETE endpoint', async endpointTest => {
       done();
     });
 
-    handlerTest.test('sends a not found error if requesting to delete a role that does not exist', async notFoundTest => {
-      const req = { user: { role: 'user-role' }, params: { id: 1 } };
-      RoleModel.where.withArgs({ id: 1 }).returns({ fetch: RoleModel.fetch });
-      RoleModel.fetch.resolves(null);
+    handlerTest.test(
+      'sends a not found error if requesting to delete a role that does not exist',
+      async notFoundTest => {
+        const req = { user: { role: 'user-role' }, params: { id: 1 } };
+        RoleModel.where.withArgs({ id: 1 }).returns({ fetch: RoleModel.fetch });
+        RoleModel.fetch.resolves(null);
 
-      await handler(req, res);
+        await handler(req, res);
 
-      notFoundTest.ok(res.status.calledWith(404), 'HTTP status set to 404');
-      notFoundTest.ok(res.send.notCalled, 'no body is sent');
-      notFoundTest.ok(res.end.calledOnce, 'response is terminated');
-    });
+        notFoundTest.ok(res.status.calledWith(404), 'HTTP status set to 404');
+        notFoundTest.ok(res.send.notCalled, 'no body is sent');
+        notFoundTest.ok(res.end.calledOnce, 'response is terminated');
+      }
+    );
 
-    handlerTest.test('sends an unauthorized error if requesting to delete a role that the user belongs to', async unauthorizedTest => {
-      const req = { user: { role: 'user-role' }, params: { id: 1 } };
-      const get = sinon.stub().withArgs('id').returns('role-id');
-      RoleModel.where.withArgs({ id: 1 }).returns({ fetch: RoleModel.fetch });
-      RoleModel.where.withArgs({ name: 'user-role' }).returns({ fetch: RoleModel.fetch });
-      RoleModel.fetch.resolves({ get });
+    handlerTest.test(
+      'sends an unauthorized error if requesting to delete a role that the user belongs to',
+      async unauthorizedTest => {
+        const req = { user: { role: 'user-role' }, params: { id: 1 } };
+        const get = sinon
+          .stub()
+          .withArgs('id')
+          .returns('role-id');
+        RoleModel.where.withArgs({ id: 1 }).returns({ fetch: RoleModel.fetch });
+        RoleModel.where
+          .withArgs({ name: 'user-role' })
+          .returns({ fetch: RoleModel.fetch });
+        RoleModel.fetch.resolves({ get });
 
-      await handler(req, res);
+        await handler(req, res);
 
-      unauthorizedTest.ok(res.status.calledWith(401), 'HTTP status set to 401');
-      unauthorizedTest.ok(res.send.notCalled, 'no body is sent');
-      unauthorizedTest.ok(res.end.calledOnce, 'response is terminated');
-    });
+        unauthorizedTest.ok(
+          res.status.calledWith(401),
+          'HTTP status set to 401'
+        );
+        unauthorizedTest.ok(res.send.notCalled, 'no body is sent');
+        unauthorizedTest.ok(res.end.calledOnce, 'response is terminated');
+      }
+    );
 
     handlerTest.test(
       'sends a server error if anything goes wrong',
       async saveTest => {
         const req = { user: { role: 'user-role' }, params: { id: 1 } };
-        const get = sinon.stub().withArgs('id').returns('role-id-2');
+        const get = sinon
+          .stub()
+          .withArgs('id')
+          .returns('role-id-2');
         const fetch = sinon.stub();
         const destroy = sinon.stub().resolves();
         const save = sinon.stub().rejects();
         const detach = sinon.stub();
 
         RoleModel.where.withArgs({ id: 1 }).returns({ fetch });
-        RoleModel.where.withArgs({ name: 'user-role' }).returns({ fetch: sinon.stub().resolves({ get }) });
+        RoleModel.where
+          .withArgs({ name: 'user-role' })
+          .returns({ fetch: sinon.stub().resolves({ get }) });
 
         fetch.resolves({
           save,
@@ -101,14 +120,19 @@ tap.test('roles DELETE endpoint', async endpointTest => {
 
     handlerTest.test('deletes a role', async saveTest => {
       const req = { user: { role: 'user-role' }, params: { id: 1 } };
-      const get = sinon.stub().withArgs('id').returns('role-id-2');
+      const get = sinon
+        .stub()
+        .withArgs('id')
+        .returns('role-id-2');
       const fetch = sinon.stub();
       const destroy = sinon.stub().resolves();
       const save = sinon.stub().resolves();
       const detach = sinon.stub();
 
       RoleModel.where.withArgs({ id: 1 }).returns({ fetch });
-      RoleModel.where.withArgs({ name: 'user-role' }).returns({ fetch: sinon.stub().resolves({ get }) });
+      RoleModel.where
+        .withArgs({ name: 'user-role' })
+        .returns({ fetch: sinon.stub().resolves({ get }) });
 
       fetch.resolves({
         save,
@@ -122,9 +146,18 @@ tap.test('roles DELETE endpoint', async endpointTest => {
 
       await handler(req, res);
 
-      saveTest.ok(detach.calledWithExactly(), 'activity associations are removed');
-      saveTest.ok(save.calledAfter(detach), 'model is saved after activities are disassociated');
-      saveTest.ok(destroy.calledAfter(save), 'model is destroyed after saving disassociation');
+      saveTest.ok(
+        detach.calledWithExactly(),
+        'activity associations are removed'
+      );
+      saveTest.ok(
+        save.calledAfter(detach),
+        'model is saved after activities are disassociated'
+      );
+      saveTest.ok(
+        destroy.calledAfter(save),
+        'model is destroyed after saving disassociation'
+      );
       saveTest.ok(res.status.calledWith(204), 'HTTP status set to 204');
       saveTest.ok(res.end.calledOnce, 'response is terminated');
     });

--- a/api/routes/roles/index.js
+++ b/api/routes/roles/index.js
@@ -1,7 +1,9 @@
+const del = require('./delete');
 const get = require('./get');
 const put = require('./put');
 
-module.exports = (app, getEndpoint = get, postEndpoint, putEndpoint = put) => {
+module.exports = (app, deleteEndpoint = del, getEndpoint = get, postEndpoint, putEndpoint = put) => {
+  deleteEndpoint(app);
   getEndpoint(app);
   putEndpoint(app);
 };

--- a/api/routes/roles/index.js
+++ b/api/routes/roles/index.js
@@ -2,7 +2,13 @@ const del = require('./delete');
 const get = require('./get');
 const put = require('./put');
 
-module.exports = (app, deleteEndpoint = del, getEndpoint = get, postEndpoint, putEndpoint = put) => {
+module.exports = (
+  app,
+  deleteEndpoint = del,
+  getEndpoint = get,
+  postEndpoint,
+  putEndpoint = put
+) => {
   deleteEndpoint(app);
   getEndpoint(app);
   putEndpoint(app);

--- a/api/routes/roles/index.test.js
+++ b/api/routes/roles/index.test.js
@@ -5,12 +5,17 @@ const rolesIndex = require('./index');
 
 tap.test('roles endpoint setup', async endpointTest => {
   const app = {};
+  const delEndpoint = sinon.spy();
   const getEndpoint = sinon.spy();
   const postEndpoint = sinon.spy();
   const putEndpoint = sinon.spy();
 
-  rolesIndex(app, getEndpoint, postEndpoint, putEndpoint);
+  rolesIndex(app, delEndpoint, getEndpoint, postEndpoint, putEndpoint);
 
+  endpointTest.ok(
+    delEndpoint.calledWith(app),
+    'users DELETE endpoint is setup with the app'
+  );
   endpointTest.ok(
     getEndpoint.calledWith(app),
     'users GET endpoint is setup with the app'

--- a/api/routes/roles/openAPI.js
+++ b/api/routes/roles/openAPI.js
@@ -67,8 +67,24 @@ const openAPI = {
           content: errorToken
         },
         404: {
-          description: 'The role ID does not match any known roles',
-          content: errorToken
+          description: 'The role ID does not match any known roles'
+        }
+      }
+    },
+    delete: {
+      description: 'Remove the associations between a role and activities, and delete the role',
+      parameters: [{
+        name: 'id',
+        in: 'path',
+        description: 'The ID of the role to delete',
+        required: true
+      }],
+      responses: {
+        204: {
+          description: 'The role was deleted successfully'
+        },
+        404: {
+          description: 'The role ID does not match any known roles'
         }
       }
     }

--- a/api/routes/roles/openAPI.js
+++ b/api/routes/roles/openAPI.js
@@ -35,13 +35,16 @@ const openAPI = {
   },
   '/roles/{id}': {
     put: {
-      description: 'Change which activities an existing role is associated with',
-      parameters: [{
-        name: 'id',
-        in: 'path',
-        description: 'The ID of the role to update',
-        required: true
-      }],
+      description:
+        'Change which activities an existing role is associated with',
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          description: 'The ID of the role to update',
+          required: true
+        }
+      ],
       requestBody: {
         description: 'The new values for the role',
         required: true,
@@ -49,7 +52,8 @@ const openAPI = {
           type: 'object',
           properties: {
             activities: {
-              description: 'List of activities to associate with this role; this list is definitive and after this operation, only the activities in this list will be associated with the role',
+              description:
+                'List of activities to associate with this role; this list is definitive and after this operation, only the activities in this list will be associated with the role',
               ...arrayOf({
                 type: 'number',
                 description: 'An activity ID'
@@ -60,10 +64,11 @@ const openAPI = {
       },
       responses: {
         204: {
-          description: 'The update was successful',
+          description: 'The update was successful'
         },
         400: {
-          description: 'The body of the request is invalid: there are no activities defined, some activities are not numeric, or some activities do not exist',
+          description:
+            'The body of the request is invalid: there are no activities defined, some activities are not numeric, or some activities do not exist',
           content: errorToken
         },
         404: {
@@ -72,13 +77,16 @@ const openAPI = {
       }
     },
     delete: {
-      description: 'Remove the associations between a role and activities, and delete the role',
-      parameters: [{
-        name: 'id',
-        in: 'path',
-        description: 'The ID of the role to delete',
-        required: true
-      }],
+      description:
+        'Remove the associations between a role and activities, and delete the role',
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          description: 'The ID of the role to delete',
+          required: true
+        }
+      ],
       responses: {
         204: {
           description: 'The role was deleted successfully'

--- a/api/seeds/01-roles-and-activities.js
+++ b/api/seeds/01-roles-and-activities.js
@@ -3,7 +3,8 @@ const activities = {
   'add-users': false,
   'view-roles': false,
   'create-roles': false,
-  'edit-roles': false
+  'edit-roles': false,
+  'delete-roles': false
 };
 
 const roles = {
@@ -18,7 +19,8 @@ const roleToActivityMappings = {
     'add-users',
     'view-roles',
     'create-roles',
-    'edit-roles'
+    'edit-roles',
+    'delete-roles'
   ],
   'cms-reviewer': [],
   'state-submitter': []

--- a/api/seeds/test/roles.js
+++ b/api/seeds/test/roles.js
@@ -8,8 +8,9 @@ exports.seed = async knex => {
   await knex('auth_activities').insert({ id: 1, name: 'view-roles' });
   await knex('auth_activities').insert({ id: 2, name: 'create-roles' });
   await knex('auth_activities').insert({ id: 3, name: 'edit-roles' });
-  await knex('auth_activities').insert({ id: 4, name: 'view-users' });
-  await knex('auth_activities').insert({ id: 5, name: 'add-users' });
+  await knex('auth_activities').insert({ id: 4, name: 'delete-roles' });
+  await knex('auth_activities').insert({ id: 5, name: 'view-users' });
+  await knex('auth_activities').insert({ id: 6, name: 'add-users' });
 
   await knex('auth_roles').insert({ id: 1, name: 'admin' });
   await knex('auth_roles').insert({ id: 2, name: 'cms-reviewer' });
@@ -34,6 +35,10 @@ exports.seed = async knex => {
   await knex('auth_role_activity_mapping').insert({
     role_id: 1,
     activity_id: 5
+  });
+  await knex('auth_role_activity_mapping').insert({
+    role_id: 1,
+    activity_id: 6
   });
   await knex('auth_role_activity_mapping').insert({
     role_id: 2,


### PR DESCRIPTION
Delete roles.  Sorry for the flood of these, @brendansudol.  They happen to all be pretty similar, which means I've been able to churn them out pretty fast.  There's really just one left (`PUT /users/:id`) which will give us all the user/role management API functionality we should need for a while.

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- ~~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~~
- [x] The change has been documented
  - [x] Associated OpenAPI documentation has been updated

### This feature is done when...
- ~~Design has approved the experience~~
- ~~Product has approved the experience~~
