### PR TITLE
De-duplicate role validation code

### DIFF
--- a/api/routes/roles/post.js
+++ b/api/routes/roles/post.js
@@ -3,47 +3,7 @@ const defaultRoleModel = require('../../db').models.role;
 const defaultActivityModel = require('../../db').models.activity;
 const can = require('../../auth/middleware').can;
 
-const validateRole = async (role, RoleModel, ActivityModel) => {
-  if (!role) {
-    throw new Error('Role must be specified');
-  }
-  if (!role.name) {
-    throw new Error('Role must have a name');
-  }
-  if (await RoleModel.where({ name: role.name }).fetch()) {
-    throw new Error(`Role name "${role.name}" already exists`);
-  }
-  if (!Array.isArray(role.activities)) {
-    throw new Error('Role must have a list of activities');
-  }
-  if (role.activities.filter(id => typeof id !== 'number').length > 0) {
-    throw new Error('Role activites must be numbers');
-  }
-
-  const validActivities = await ActivityModel.where(
-    'id',
-    'in',
-    role.activities
-  ).fetchAll({ columns: ['id'] });
-  const validIDs = validActivities.map(activity => activity.get('id'));
-  const invalidIDs = role.activities.filter(
-    roleID => !validIDs.includes(roleID)
-  );
-
-  if (invalidIDs.length) {
-    throw new Error(
-      `Activity IDs ${JSON.stringify(invalidIDs).replace(
-        /\[(.+)\]/,
-        '$1'
-      )} are invalid`
-    );
-  }
-
-  return {
-    name: role.name,
-    activities: role.activities
-  };
-};
+const validateRole = require('./validator');
 
 module.exports = (
   app,

--- a/api/routes/roles/post.test.js
+++ b/api/routes/roles/post.test.js
@@ -52,6 +52,19 @@ tap.test('roles POST endpoint', async endpointTest => {
     handlerTest.test(
       'rejects invalid role objects...',
       async validationTest => {
+        validationTest.test('if no role is sent', async invalidTest => {
+          const req = {};
+
+          await handler(req, res);
+
+          invalidTest.ok(
+            res.send.calledWith({ error: sinon.match.string }),
+            'sends back an error string'
+          );
+          invalidTest.ok(res.status.calledWith(400), 'HTTP status set to 400');
+          invalidTest.ok(res.end.calledOnce, 'response is terminated');
+        });
+
         validationTest.test(
           'if the role does not have a name',
           async invalidTest => {

--- a/api/routes/roles/put.js
+++ b/api/routes/roles/put.js
@@ -3,48 +3,7 @@ const defaultRoleModel = require('../../db').models.role;
 const defaultActivityModel = require('../../db').models.activity;
 const can = require('../../auth/middleware').can;
 
-const validateRole = async (role, RoleModel, ActivityModel) => {
-  if (RoleModel) {
-    if (!role.name) {
-      throw new Error('Role must have a name');
-    }
-    if (await RoleModel.where({ name: role.name }).fetch()) {
-      throw new Error(`Role name "${role.name}" already exists`);
-    }
-  }
-  if (ActivityModel) {
-    if (!Array.isArray(role.activities)) {
-      throw new Error('Role must have a list of activities');
-    }
-    if (role.activities.filter(id => typeof id !== 'number').length > 0) {
-      throw new Error('Role activites must be numbers');
-    }
-
-    const validActivities = await ActivityModel.where(
-      'id',
-      'in',
-      role.activities
-    ).fetchAll({ columns: ['id'] });
-    const validIDs = validActivities.map(activity => activity.get('id'));
-    const invalidIDs = role.activities.filter(
-      roleID => !validIDs.includes(roleID)
-    );
-
-    if (invalidIDs.length) {
-      throw new Error(
-        `Activity IDs ${JSON.stringify(invalidIDs).replace(
-          /\[(.+)\]/,
-          '$1'
-        )} are invalid`
-      );
-    }
-  }
-
-  return {
-    name: role.name,
-    activities: role.activities.filter(id => !Number.isNaN(Number(id)))
-  };
-};
+const validateRole = require('./validator');
 
 module.exports = (
   app,

--- a/api/routes/roles/validator.js
+++ b/api/routes/roles/validator.js
@@ -1,0 +1,44 @@
+const validateRole = async (role, RoleModel, ActivityModel) => {
+  if (RoleModel) {
+    if (!role.name) {
+      throw new Error('Role must have a name');
+    }
+    if (await RoleModel.where({ name: role.name }).fetch()) {
+      throw new Error(`Role name "${role.name}" already exists`);
+    }
+  }
+  if (ActivityModel) {
+    if (!Array.isArray(role.activities)) {
+      throw new Error('Role must have a list of activities');
+    }
+    if (role.activities.filter(id => typeof id !== 'number').length > 0) {
+      throw new Error('Role activites must be numbers');
+    }
+
+    const validActivities = await ActivityModel.where(
+      'id',
+      'in',
+      role.activities
+    ).fetchAll({ columns: ['id'] });
+    const validIDs = validActivities.map(activity => activity.get('id'));
+    const invalidIDs = role.activities.filter(
+      roleID => !validIDs.includes(roleID)
+    );
+
+    if (invalidIDs.length) {
+      throw new Error(
+        `Activity IDs ${JSON.stringify(invalidIDs).replace(
+          /\[(.+)\]/,
+          '$1'
+        )} are invalid`
+      );
+    }
+  }
+
+  return {
+    name: role.name,
+    activities: role.activities.filter(id => !Number.isNaN(Number(id)))
+  };
+};
+
+module.exports = validateRole;


### PR DESCRIPTION
Role validation code existed in both the `POST` and `PUT` endpoint handlers.  This PR splits it into a separate module that they both share.  Perhaps a small step in the direction of moving validation into the models?

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- ~~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~~
- ~~The change has been documented~~
  - ~~Associated OpenAPI documentation has been updated~~

### This feature is done when...
- ~~Design has approved the experience~~
- ~~Product has approved the experience~~
