### PR TITLE
Add state relationship to user model

### DIFF
--- a/api/db/index.js
+++ b/api/db/index.js
@@ -5,6 +5,7 @@ const defaultConfig = require('../knexfile');
 
 const user = require('./user');
 const authorization = require('./authorization');
+const state = require('./state');
 
 const exportedModels = {};
 
@@ -12,7 +13,7 @@ const setup = (
   knex = defaultKnex,
   bookshelf = defaultBookshelf,
   config = defaultConfig,
-  models = [user(), authorization()]
+  models = [user(), authorization(), state()]
 ) => {
   logger.silly(
     `setting up models using [${process.env.NODE_ENV}] configuration`

--- a/api/db/user.js
+++ b/api/db/user.js
@@ -10,6 +10,10 @@ module.exports = (zxcvbn = defaultZxcvbn, bcrypt = defaultBcrypt) => ({
       return this.hasOne('role', 'name', 'auth_role');
     },
 
+    state() {
+      return this.hasOne('state', 'id', 'state_id');
+    },
+
     async activities() {
       logger.silly('getting user activities');
       if (!this.relations.role || !this.relations.role.activities) {

--- a/api/db/user.test.js
+++ b/api/db/user.test.js
@@ -54,6 +54,23 @@ tap.test('user data model', async userModelTests => {
     }
   );
 
+  userModelTests.test(
+    'user model sets up state relationship',
+    async stateTests => {
+      const self = {
+        hasOne: sinon.stub().returns('poptart')
+      };
+
+      const output = user.user.state.bind(self)();
+
+      stateTests.ok(
+        self.hasOne.calledWith('state', 'id', 'state_id'),
+        'sets up the relationship mapping to a state'
+      );
+      stateTests.equal(output, 'poptart', 'returns the expected value');
+    }
+  );
+
   userModelTests.test('validation', async validationTests => {
     const self = {
       where: sandbox.stub(),


### PR DESCRIPTION
Sets up a data relationship between a user and state via Bookshelf relationships.  Also adds the state model to the list of models to be loaded.  😄 

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- ~~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~~
- ~~The change has been documented~~
  - ~~Associated OpenAPI documentation has been updated~~

### This feature is done when...
- ~~Design has approved the experience~~
- ~~Product has approved the experience~~
