### PR TITLE
Refactor endpoint test request util

### DIFF
--- a/api/endpoint-tests/utils.js
+++ b/api/endpoint-tests/utils.js
@@ -8,38 +8,18 @@ const getFullPath = endpointPath =>
     process.env.PORT ||
     8000}${endpointPath}`;
 
-const del = async (...args) =>
+const execRequest = async (method, ...args) =>
   new Promise(resolve => {
-    request.delete(...args, (err, response, body) => {
+    request[method](...args, (err, response, body) => {
       resolve({ err, response, body });
     });
   });
-
-const get = async (...args) =>
-  new Promise(resolve => {
-    request.get(...args, (err, response, body) => {
-      resolve({ err, response, body });
-    });
-  });
-
-const post = async (...args) =>
-  new Promise(resolve => {
-    request.post(...args, (err, response, body) => {
-      resolve({ err, response, body });
-    });
-  });
-
-const put = async (...args) =>
-  new Promise(resolve => {
-    request.put(...args, (err, response, body) => {
-      resolve({ err, response, body });
-    });
-  });
+const requestFor = method => (...args) => execRequest(method, ...args);
 
 const login = async () => {
   const cookies = request.jar();
 
-  const { response } = await post(getFullPath('/auth/login'), {
+  const { response } = await execRequest('post', getFullPath('/auth/login'), {
     jar: cookies,
     json: { username: 'em@il.com', password: 'password' }
   });
@@ -67,7 +47,13 @@ const db = () => {
 
 module.exports = {
   db,
-  request: { delete: del, get, post, put, jar: request.jar },
+  request: {
+    delete: requestFor('delete'),
+    get: requestFor('get'),
+    post: requestFor('post'),
+    put: requestFor('put'),
+    jar: request.jar
+  },
   getFullPath,
   login
 };


### PR DESCRIPTION
Simplify the wrapper code around `request` for endpoint tests.  In some future state, this may enable us to compute a kind of "endpoint coverage" metric, so we'll know which endpoints aren't being tested.

### This pull request is ready to merge when...
- ~~Tests have been updated (and all tests are passing)~~
- [ ] This code has been reviewed by someone other than the original author
- ~~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~~
- ~~The change has been documented~~
  - Associated OpenAPI documentation has been updated~~

### This feature is done when...
- ~~Design has approved the experience~~
- ~~Product has approved the experience~~
