### PR TITLE
Standardize some endpoint tests

### DIFF
--- a/api/endpoint-tests/activities/get.js
+++ b/api/endpoint-tests/activities/get.js
@@ -1,18 +1,17 @@
 const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
-const { getFullPath, login, request } = require('../utils');
+const {
+  getFullPath,
+  login,
+  request,
+  unauthenticatedTest,
+  unauthorizedTest
+} = require('../utils');
 
 tap.test('activities endpoint | GET /activities', async getUsersTest => {
   const url = getFullPath('/activities');
 
-  getUsersTest.test('when unauthenticated', async unauthenticatedTest => {
-    const { response, body } = await request.get(url);
-    unauthenticatedTest.equal(
-      response.statusCode,
-      403,
-      'gives a 403 status code'
-    );
-    unauthenticatedTest.notOk(body, 'does not send a body');
-  });
+  unauthenticatedTest('get', url, getUsersTest);
+  unauthorizedTest('get', url, getUsersTest);
 
   getUsersTest.test('when authenticated', async validTest => {
     const cookies = await login();

--- a/api/endpoint-tests/roles/delete.js
+++ b/api/endpoint-tests/roles/delete.js
@@ -1,24 +1,20 @@
 const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
-const { db, request, getFullPath, login } = require('../utils');
+const {
+  db,
+  request,
+  getFullPath,
+  login,
+  unauthenticatedTest,
+  unauthorizedTest
+} = require('../utils');
 
 tap.test('roles endpoint | DELETE /roles/:roleID', async deleteRolesTests => {
   await db().seed.run();
 
   const url = getFullPath('/roles');
 
-  deleteRolesTests.test('when unauthenticated', async unauthenticatedTests => {
-    unauthenticatedTests.test('with invalid role ID', async invalidTest => {
-      const { response, body } = await request.delete(`${url}/9001`);
-      invalidTest.equal(response.statusCode, 403, 'gives a 403 status code');
-      invalidTest.notOk(body, 'does not send a body');
-    });
-
-    unauthenticatedTests.test('with valid role ID', async invalidTest => {
-      const { response, body } = await request.delete(`${url}/1`);
-      invalidTest.equal(response.statusCode, 403, 'gives a 403 status code');
-      invalidTest.notOk(body, 'does not send a body');
-    });
-  });
+  unauthenticatedTest('delete', `${url}/1001`, deleteRolesTests);
+  unauthorizedTest('delete', `${url}/1001`, deleteRolesTests);
 
   deleteRolesTests.test('when authenticated', async authenticatedTests => {
     const cookies = await login();

--- a/api/endpoint-tests/roles/get.js
+++ b/api/endpoint-tests/roles/get.js
@@ -1,20 +1,20 @@
 const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
-const { db, getFullPath, login, request } = require('../utils');
+const {
+  db,
+  getFullPath,
+  login,
+  request,
+  unauthenticatedTest,
+  unauthorizedTest
+} = require('../utils');
 
 tap.test('roles endpoint | GET /roles', async getUsersTest => {
   await db().seed.run();
 
   const url = getFullPath('/roles');
 
-  getUsersTest.test('when unauthenticated', async unauthenticatedTest => {
-    const { response, body } = await request.get(url);
-    unauthenticatedTest.equal(
-      response.statusCode,
-      403,
-      'gives a 403 status code'
-    );
-    unauthenticatedTest.notOk(body, 'does not send a body');
-  });
+  unauthenticatedTest('get', url, getUsersTest);
+  unauthorizedTest('get', url, getUsersTest);
 
   getUsersTest.test('when authenticated', async validTest => {
     const cookies = await login();

--- a/api/endpoint-tests/roles/post.js
+++ b/api/endpoint-tests/roles/post.js
@@ -1,5 +1,12 @@
 const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
-const { db, request, getFullPath, login } = require('../utils');
+const {
+  db,
+  request,
+  getFullPath,
+  login,
+  unauthenticatedTest,
+  unauthorizedTest
+} = require('../utils');
 
 tap.test('roles endpoint | POST /roles', async postRolesTests => {
   await db().seed.run();
@@ -36,27 +43,8 @@ tap.test('roles endpoint | POST /roles', async postRolesTests => {
     }
   ];
 
-  postRolesTests.test('when unauthenticated', async unauthenticatedTests => {
-    [
-      ...invalidCases,
-      {
-        name: 'with a valid body',
-        body: { name: 'new-role', activities: [1, 2] }
-      }
-    ].forEach(situation => {
-      unauthenticatedTests.test(situation.name, async unauthenticatedTest => {
-        const { response, body } = await request.post(url, {
-          json: situation.body
-        });
-        unauthenticatedTest.equal(
-          response.statusCode,
-          403,
-          'gives a 403 status code'
-        );
-        unauthenticatedTest.notOk(body, 'does not send a body');
-      });
-    });
-  });
+  unauthenticatedTest('post', url, postRolesTests);
+  unauthorizedTest('post', url, postRolesTests);
 
   postRolesTests.test('when authenticated', async authenticatedTests => {
     const cookies = await login();

--- a/api/endpoint-tests/roles/put.js
+++ b/api/endpoint-tests/roles/put.js
@@ -1,5 +1,12 @@
 const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
-const { db, request, getFullPath, login } = require('../utils');
+const {
+  db,
+  request,
+  getFullPath,
+  login,
+  unauthenticatedTest,
+  unauthorizedTest
+} = require('../utils');
 
 tap.test('roles endpoint | PUT /roles/:roleID', async putRolesTests => {
   await db().seed.run();
@@ -28,55 +35,8 @@ tap.test('roles endpoint | PUT /roles/:roleID', async putRolesTests => {
     }
   ];
 
-  putRolesTests.test(
-    'when unauthenticated, invalid ID',
-    async unauthenticatedTests => {
-      [
-        ...invalidCases,
-        {
-          name: 'with a valid body',
-          body: { activities: [1, 2] }
-        }
-      ].forEach(situation => {
-        unauthenticatedTests.test(situation.name, async unauthenticatedTest => {
-          const { response, body } = await request.put(`${url}/9001`, {
-            json: situation.body
-          });
-          unauthenticatedTest.equal(
-            response.statusCode,
-            403,
-            'gives a 403 status code'
-          );
-          unauthenticatedTest.notOk(body, 'does not send a body');
-        });
-      });
-    }
-  );
-
-  putRolesTests.test(
-    'when unauthenticated, valid ID',
-    async unauthenticatedTests => {
-      [
-        ...invalidCases,
-        {
-          name: 'with a valid body',
-          body: { activities: [1, 2] }
-        }
-      ].forEach(situation => {
-        unauthenticatedTests.test(situation.name, async unauthenticatedTest => {
-          const { response, body } = await request.put(`${url}/1001`, {
-            json: situation.body
-          });
-          unauthenticatedTest.equal(
-            response.statusCode,
-            403,
-            'gives a 403 status code'
-          );
-          unauthenticatedTest.notOk(body, 'does not send a body');
-        });
-      });
-    }
-  );
+  unauthenticatedTest('put', `${url}/1001`, putRolesTests);
+  unauthorizedTest('put', `${url}/1001`, putRolesTests);
 
   putRolesTests.test('when authenticated', async authenticatedTests => {
     const cookies = await login();

--- a/api/endpoint-tests/states/get.js
+++ b/api/endpoint-tests/states/get.js
@@ -1,18 +1,20 @@
 const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
-const { db, getFullPath, login, request } = require('../utils');
+const {
+  db,
+  getFullPath,
+  login,
+  request,
+  unauthenticatedTest,
+  unauthorizedTest
+} = require('../utils');
 
-tap.test('states endpoint | GET /states', async getUserStateProgramTest => {
+tap.test('states endpoint | GET /states', async getUserStateTest => {
   const url = getFullPath('/states');
   await db().seed.run();
 
-  getUserStateProgramTest.test('when unauthenticated', async invalidTest => {
-    const { response, body } = await request.get(url);
+  unauthenticatedTest('get', url, getUserStateTest);
 
-    invalidTest.equal(response.statusCode, 403, 'gives a 403 status code');
-    invalidTest.notOk(body, 'does not send a body');
-  });
-
-  getUserStateProgramTest.test(
+  getUserStateTest.test(
     'when authenticated as a user without an associated state',
     async invalidTest => {
       const cookies = await login();
@@ -26,7 +28,7 @@ tap.test('states endpoint | GET /states', async getUserStateProgramTest => {
     }
   );
 
-  getUserStateProgramTest.test(
+  getUserStateTest.test(
     'when authenticated as a user with an associated state',
     async validTest => {
       const cookies = await login('user2@email', 'something');
@@ -62,32 +64,14 @@ tap.test('states endpoint | GET /states', async getUserStateProgramTest => {
   );
 });
 
-tap.test('states/:id endpoint | GET /states/:id', async getStateProgramTest => {
+tap.test('states/:id endpoint | GET /states/:id', async getStateTest => {
   const url = getFullPath('/states/mn');
   await db().seed.run();
 
-  getStateProgramTest.test('when unauthenticated', async invalidTest => {
-    const { response, body } = await request.get(url);
+  unauthenticatedTest('get', url, getStateTest);
+  unauthorizedTest('get', url, getStateTest);
 
-    invalidTest.equal(response.statusCode, 403, 'gives a 403 status code');
-    invalidTest.notOk(body, 'does not send a body');
-  });
-
-  getStateProgramTest.test(
-    'when authenticated as a user without permission',
-    async invalidTest => {
-      const cookies = await login('user2@email', 'something');
-      const { response, body } = await request.get(url, {
-        jar: cookies,
-        json: true
-      });
-
-      invalidTest.equal(response.statusCode, 401, 'gives a 401 status code');
-      invalidTest.notOk(body, 'does not send a body');
-    }
-  );
-
-  getStateProgramTest.test(
+  getStateTest.test(
     'when authenticated as a user with permission',
     async authenticatedTest => {
       const cookies = await login();

--- a/api/endpoint-tests/users/get.js
+++ b/api/endpoint-tests/users/get.js
@@ -37,43 +37,7 @@ tap.test('users endpoint | GET /users/:userID', async getUserTest => {
   unauthenticatedTest('get', `${url}/some-id`, getUserTest);
   unauthorizedTest('get', `${url}/some-id`, getUserTest);
 
-  getUserTest.test('when unauthenticated', async unauthenticatedTests => {
-    [
-      { name: 'when requesting an invalid user ID', id: 'random-id' },
-      { name: 'when requesting a non-existing user ID', id: 500 },
-      { name: 'when requesting a valid user ID', id: 57 }
-    ].forEach(situation => {
-      unauthenticatedTests.test(situation.name, async unauthentedTest => {
-        const { response, body } = await request.get(`${url}/${situation.id}`);
-        unauthentedTest.equal(
-          response.statusCode,
-          403,
-          'gives a 403 status code'
-        );
-        unauthentedTest.notOk(body, 'does not send a body');
-      });
-    });
-  });
-
   getUserTest.test('when authenticated', async authenticatedTests => {
-    authenticatedTests.test(
-      'when requesting an invalid user ID',
-      async invalidTest => {
-        const cookies = await login();
-        const { response, body } = await request.get(`${url}/random-id`, {
-          jar: cookies,
-          json: true
-        });
-
-        invalidTest.equal(response.statusCode, 400, 'gives a 400 status code');
-        invalidTest.same(
-          body,
-          { error: 'get-user-invalid' },
-          'sends a token indicating the failure'
-        );
-      }
-    );
-
     authenticatedTests.test(
       'when requesting a non-existant user ID',
       async invalidTest => {

--- a/api/endpoint-tests/users/get.js
+++ b/api/endpoint-tests/users/get.js
@@ -1,20 +1,20 @@
 const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
-const { db, getFullPath, login, request } = require('../utils');
+const {
+  db,
+  getFullPath,
+  login,
+  request,
+  unauthenticatedTest,
+  unauthorizedTest
+} = require('../utils');
 
 const url = getFullPath('/users');
 
 tap.test('users endpoint | GET /users', async getUsersTest => {
   await db().seed.run();
 
-  getUsersTest.test('when unauthenticated', async unauthenticatedTest => {
-    const { response, body } = await request.get(url);
-    unauthenticatedTest.equal(
-      response.statusCode,
-      403,
-      'gives a 403 status code'
-    );
-    unauthenticatedTest.notOk(body, 'does not send a body');
-  });
+  unauthenticatedTest('get', url, getUsersTest);
+  unauthorizedTest('get', url, getUsersTest);
 
   getUsersTest.test('when authenticated', async validTest => {
     const cookies = await login();
@@ -33,6 +33,9 @@ tap.test('users endpoint | GET /users', async getUsersTest => {
 
 tap.test('users endpoint | GET /users/:userID', async getUserTest => {
   await db().seed.run();
+
+  unauthenticatedTest('get', `${url}/some-id`, getUserTest);
+  unauthorizedTest('get', `${url}/some-id`, getUserTest);
 
   getUserTest.test('when unauthenticated', async unauthenticatedTests => {
     [

--- a/api/endpoint-tests/users/put.js
+++ b/api/endpoint-tests/users/put.js
@@ -1,59 +1,20 @@
 const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
-const { db, request, getFullPath, login } = require('../utils');
+const {
+  db,
+  request,
+  getFullPath,
+  login,
+  unauthenticatedTest,
+  unauthorizedTest
+} = require('../utils');
 
 tap.test('users endpoint | PUT /users/:userID', async putUsersTests => {
   await db().seed.run();
 
   const url = getFullPath('/users');
 
-  const invalidCases = [
-    {
-      name: 'with email that already exists',
-      body: { email: 'user2@email' }
-    },
-    {
-      name: 'with simple password',
-      body: { password: 'password' }
-    }
-  ];
-
-  putUsersTests.test(
-    'when unauthenticated, invalid ID',
-    async unauthenticatedTests => {
-      invalidCases.forEach(situation => {
-        unauthenticatedTests.test(situation.name, async unauthenticatedTest => {
-          const { response, body } = await request.put(`${url}/9001`, {
-            json: situation.body
-          });
-          unauthenticatedTest.equal(
-            response.statusCode,
-            403,
-            'gives a 403 status code'
-          );
-          unauthenticatedTest.notOk(body, 'does not send a body');
-        });
-      });
-    }
-  );
-
-  putUsersTests.test(
-    'when unauthenticated, valid ID',
-    async unauthenticatedTests => {
-      invalidCases.forEach(situation => {
-        unauthenticatedTests.test(situation.name, async unauthenticatedTest => {
-          const { response, body } = await request.put(`${url}/57`, {
-            json: situation.body
-          });
-          unauthenticatedTest.equal(
-            response.statusCode,
-            403,
-            'gives a 403 status code'
-          );
-          unauthenticatedTest.notOk(body, 'does not send a body');
-        });
-      });
-    }
-  );
+  unauthenticatedTest('put', `${url}/1001`, putUsersTests);
+  unauthorizedTest('put', `${url}/1001`, putUsersTests);
 
   putUsersTests.test('when authenticated', async authenticatedTests => {
     const cookies = await login();

--- a/api/endpoint-tests/utils.js
+++ b/api/endpoint-tests/utils.js
@@ -41,7 +41,7 @@ const unauthenticatedTest = (method, url, test) => {
 
 const unauthorizedTest = (method, url, test) => {
   test.test('with unauthorized', async invalidTest => {
-    const jar = await login('user2@email', 'something'); // this user has no permissions
+    const jar = await login('no-permissions', 'password'); // this user has no permissions
     const { response: { statusCode }, body } = await requestFor(method)(url, {
       jar
     });

--- a/api/routes/openAPI/auth.js
+++ b/api/routes/openAPI/auth.js
@@ -27,6 +27,9 @@ module.exports = {
             }
           }
         },
+        400: {
+          description: 'Missing username or password'
+        },
         401: {
           description: 'Unsuccessful login'
         }
@@ -35,13 +38,16 @@ module.exports = {
   },
   '/auth/logout': {
     get: {
-      200: {
-        description: 'Clears the session cookie',
-        headers: {
-          'Set-Cookie': {
-            schema: {
-              type: 'string',
-              example: 'session=; expires=; httponly'
+      description: 'Logs the user out by invalidating the session cookie',
+      responses: {
+        200: {
+          description: 'Clears the session cookie',
+          headers: {
+            'Set-Cookie': {
+              schema: {
+                type: 'string',
+                example: 'session=; expires=; httponly'
+              }
             }
           }
         }

--- a/api/routes/users/get.js
+++ b/api/routes/users/get.js
@@ -18,30 +18,22 @@ const allUsersHandler = async (req, res, UserModel) => {
 
 const oneUserHandler = async (req, res, UserModel) => {
   logger.silly(req, 'handling GET /users/:id route');
-  if (req.params.id && !Number.isNaN(Number(req.params.id))) {
-    logger.silly(req, 'got a request for a single user', req.params.id);
-    try {
-      const user = await UserModel.where({ id: Number(req.params.id) }).fetch({
-        columns: ['id', 'email', 'name', 'position', 'phone', 'state']
-      });
-      if (user) {
-        const userObj = JSON.parse(JSON.stringify(user));
-        logger.silly(req, 'sending user', userObj);
-        res.send(userObj);
-      } else {
-        logger.verbose(req, `no user found [${req.params.id}]`);
-        res.status(404).end();
-      }
-    } catch (e) {
-      logger.error(req, e);
-      res.status(500).end();
+  logger.silly(req, 'got a request for a single user', req.params.id);
+  try {
+    const user = await UserModel.where({ id: Number(req.params.id) }).fetch({
+      columns: ['id', 'email', 'name', 'position', 'phone', 'state']
+    });
+    if (user) {
+      const userObj = JSON.parse(JSON.stringify(user));
+      logger.silly(req, 'sending user', userObj);
+      res.send(userObj);
+    } else {
+      logger.verbose(req, `no user found [${req.params.id}]`);
+      res.status(404).end();
     }
-  } else {
-    logger.verbose(req, `invalid request: [${req.params.id}]`);
-    res
-      .status(400)
-      .send({ error: 'get-user-invalid' })
-      .end();
+  } catch (e) {
+    logger.error(req, e);
+    res.status(500).end();
   }
 };
 

--- a/api/routes/users/get.test.js
+++ b/api/routes/users/get.test.js
@@ -114,31 +114,6 @@ tap.test('user GET endpoint', async endpointTest => {
       done();
     });
 
-    handlerTest.test('rejects invalid requests', async invalidTests => {
-      const invalidCases = [
-        {
-          title: 'no user ID',
-          params: {}
-        },
-        {
-          title: 'non-numeric ID',
-          params: { id: 'letters' }
-        }
-      ];
-
-      invalidCases.forEach(invalidCase => {
-        invalidTests.test(invalidCase.title, async invalidTest => {
-          handler({ params: invalidCase.params }, res);
-          invalidTest.ok(res.status.calledWith(400), 'HTTP status set to 400');
-          invalidTest.ok(
-            res.send.calledWith({ error: 'get-user-invalid' }),
-            'sets an error message'
-          );
-          invalidTest.ok(res.end.called, 'response is terminated');
-        });
-      });
-    });
-
     handlerTest.test(
       'sends a server error code if there is a database error',
       async invalidTest => {

--- a/api/routes/users/openAPI.js
+++ b/api/routes/users/openAPI.js
@@ -127,8 +127,9 @@ const openAPI = {
         })
       },
       responses: {
-        204: {
-          description: 'The update was successful'
+        200: {
+          description: 'The update was successful',
+          content: jsonResponse(arrayOf(userObjectSchema))
         },
         400: {
           description:

--- a/api/seeds/test/users.js
+++ b/api/seeds/test/users.js
@@ -14,6 +14,11 @@ exports.seed = async knex => {
       email: 'user2@email',
       password: bcrypt.hashSync('something'),
       state_id: 'mn'
+    },
+    {
+      id: 1000,
+      email: 'no-permissions',
+      password: bcrypt.hashSync('password')
     }
   ]);
 };


### PR DESCRIPTION
Almost all of our endpoints have identical tests for unauthenticated cases, and no tests for unauthorized cases.  This PR creates a pair of generic methods to do those tests for every endpoint which simultaneously increases our endpoint coverage and reduces the amount of code we have to support.

The PR also fixes some of the OpenAPI documentation that was outdated, which was revealed after #272 was merged.  :tada:

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- ~~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~~
- [x] The change has been documented
  - [x] Associated OpenAPI documentation has been updated

### This feature is done when...
- ~~Design has approved the experience~~
- ~~Product has approved the experience~~
