### PR TITLE
Fix UX deploy

### DIFF
--- a/bin/deploy-ux-testing.sh
+++ b/bin/deploy-ux-testing.sh
@@ -46,7 +46,7 @@ if [[ $route =~ .+\ hitech-api-ux.app.cloud.gov ]]
 then
   # ...delete the database and add a new one.  This
   # guarantees us a fresh database for each deploy.
-  cf delete-service cms-db
+  cf delete-service cms-db -f
   cf create-service aws-rds shared-psql cms-db
   cf bind-service hitech-apd-api cms-db
 fi


### PR DESCRIPTION
The UX deploy was hanging on the step to delete the database because it wanted a confirmation.  When it didn't get one, it attempted to proceed to create a new database with the same name, but there was a collision so it would fail.

### This pull request is ready to merge when...
- ~~Tests have been updated (and all tests are passing)~~
- [x] This code has been reviewed by someone other than the original author
- ~~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~~
- ~~The change has been documented~~
  - ~~Associated OpenAPI documentation has been updated~~

### This feature is done when...
- ~~Design has approved the experience~~
- ~~Product has approved the experience~~
