### PR TITLE
Some more data modeling around APD activities

### DIFF
--- a/api/db/activity.js
+++ b/api/db/activity.js
@@ -1,9 +1,33 @@
 module.exports = () => ({
-  activity: {
+  apdActivity: {
     tableName: 'activities',
 
     apd() {
       return this.hasOne('apd', 'id', 'apd_id');
+    },
+
+    goals() {
+      return this.hasMany('apdActivityGoal');
+    }
+  },
+
+  apdActivityGoal: {
+    tableName: 'activity_goals',
+
+    activity() {
+      return this.belongsTo('apdActivity');
+    },
+
+    objectives() {
+      return this.hasMany('apdActivityGoalObjective');
+    }
+  },
+
+  apdActivityGoalObjective: {
+    tableName: 'activity_goal_objectives',
+
+    goal() {
+      return this.belongsTo('apdActivityGoal');
     }
   }
 });

--- a/api/db/activity.test.js
+++ b/api/db/activity.test.js
@@ -7,14 +7,42 @@ tap.test('activity data model', async activityModelTests => {
   activityModelTests.test('setup', async setupTests => {
     setupTests.match(
       activity,
-      { activity: { tableName: 'activities' } },
+      {
+        apdActivity: { tableName: 'activities' },
+        apdActivityGoal: { tableName: 'activity_goals' },
+        apdActivityGoalObjective: { tableName: 'activity_goal_objectives' }
+      },
       'get the expected model definitions'
     );
 
     setupTests.type(
-      activity.activity.apd,
+      activity.apdActivity.apd,
       'function',
       'creates a apd relationship for the activity model'
+    );
+
+    setupTests.type(
+      activity.apdActivity.goals,
+      'function',
+      'creates a goals relationship for the activity model'
+    );
+
+    setupTests.type(
+      activity.apdActivityGoal.activity,
+      'function',
+      'creates a activity relationship for the goal model'
+    );
+
+    setupTests.type(
+      activity.apdActivityGoal.objectives,
+      'function',
+      'creates a objectives relationship for the goal model'
+    );
+
+    setupTests.type(
+      activity.apdActivityGoalObjective.goal,
+      'function',
+      'creates a goal relationship for the objective model'
     );
   });
 
@@ -25,13 +53,81 @@ tap.test('activity data model', async activityModelTests => {
         hasOne: sinon.stub().returns('baz')
       };
 
-      const output = activity.activity.apd.bind(self)();
+      const output = activity.apdActivity.apd.bind(self)();
 
       apdTests.ok(
         self.hasOne.calledWith('apd', 'id', 'apd_id'),
         'sets up the relationship mapping to a apd'
       );
       apdTests.equal(output, 'baz', 'returns the expected value');
+    }
+  );
+
+  activityModelTests.test(
+    'activity model sets up goals relationship',
+    async apdTests => {
+      const self = {
+        hasMany: sinon.stub().returns('bag')
+      };
+
+      const output = activity.apdActivity.goals.bind(self)();
+
+      apdTests.ok(
+        self.hasMany.calledWith('apdActivityGoal'),
+        'sets up the relationship mapping to goal'
+      );
+      apdTests.equal(output, 'bag', 'returns the expected value');
+    }
+  );
+
+  activityModelTests.test(
+    'activity model sets up goals relationship',
+    async apdTests => {
+      const self = {
+        belongsTo: sinon.stub().returns('frood')
+      };
+
+      const output = activity.apdActivityGoal.activity.bind(self)();
+
+      apdTests.ok(
+        self.belongsTo.calledWith('apdActivity'),
+        'sets up the relationship mapping to activity'
+      );
+      apdTests.equal(output, 'frood', 'returns the expected value');
+    }
+  );
+
+  activityModelTests.test(
+    'goal model sets up objectives relationship',
+    async apdTests => {
+      const self = {
+        hasMany: sinon.stub().returns('flippity')
+      };
+
+      const output = activity.apdActivityGoal.objectives.bind(self)();
+
+      apdTests.ok(
+        self.hasMany.calledWith('apdActivityGoalObjective'),
+        'sets up the relationship mapping to objectives'
+      );
+      apdTests.equal(output, 'flippity', 'returns the expected value');
+    }
+  );
+
+  activityModelTests.test(
+    'objective model sets up goal relationship',
+    async apdTests => {
+      const self = {
+        belongsTo: sinon.stub().returns('floppity')
+      };
+
+      const output = activity.apdActivityGoalObjective.goal.bind(self)();
+
+      apdTests.ok(
+        self.belongsTo.calledWith('apdActivityGoal'),
+        'sets up the relationship mapping to goal'
+      );
+      apdTests.equal(output, 'floppity', 'returns the expected value');
     }
   );
 });

--- a/api/db/apd.js
+++ b/api/db/apd.js
@@ -2,6 +2,10 @@ module.exports = () => ({
   apd: {
     tableName: 'apds',
 
+    activities() {
+      return this.hasMany('apdActivity');
+    },
+
     state() {
       return this.belongsTo('state');
     }

--- a/api/db/apd.test.js
+++ b/api/db/apd.test.js
@@ -12,11 +12,34 @@ tap.test('apd data model', async apdModelTests => {
     );
 
     setupTests.type(
+      apd.apd.activities,
+      'function',
+      'creates an activities relationship for the apd model'
+    );
+
+    setupTests.type(
       apd.apd.state,
       'function',
       'creates a state relationship for the apd model'
     );
   });
+
+  apdModelTests.test(
+    'apd model sets up activities relationship',
+    async activitiesTests => {
+      const self = {
+        hasMany: sinon.stub().returns('florp')
+      };
+
+      const output = apd.apd.activities.bind(self)();
+
+      activitiesTests.ok(
+        self.hasMany.calledWith('apdActivity'),
+        'sets up the relationship mapping to activities'
+      );
+      activitiesTests.equal(output, 'florp', 'returns the expected value');
+    }
+  );
 
   apdModelTests.test(
     'apd model sets up state relationship',

--- a/api/db/index.js
+++ b/api/db/index.js
@@ -7,6 +7,7 @@ const user = require('./user');
 const authorization = require('./authorization');
 const state = require('./state');
 const apd = require('./apd');
+const apdActivity = require('./activity');
 
 const exportedModels = {};
 
@@ -14,7 +15,7 @@ const setup = (
   knex = defaultKnex,
   bookshelf = defaultBookshelf,
   config = defaultConfig,
-  models = [user(), authorization(), state(), apd()]
+  models = [user(), authorization(), state(), apd(), apdActivity()]
 ) => {
   logger.silly(
     `setting up models using [${process.env.NODE_ENV}] configuration`

--- a/api/migrations/20180313090604_add-activity-goals-and-objectives.js
+++ b/api/migrations/20180313090604_add-activity-goals-and-objectives.js
@@ -1,0 +1,22 @@
+exports.up = async knex => {
+  await knex.schema.createTable('activity_goals', table => {
+    table.increments('id');
+    table.text('description');
+
+    table.integer('activity_id');
+    table.foreign('activity_id').references('activities.id');
+  });
+
+  await knex.schema.createTable('activity_goal_objectives', table => {
+    table.increments('id');
+    table.text('description');
+
+    table.integer('activity_goal_id');
+    table.foreign('activity_goal_id').references('activity_goals.id');
+  });
+};
+
+exports.down = async knex => {
+  await knex.schema.dropTable('activity_goal_objectives');
+  await knex.schema.dropTable('activity_goals');
+};

--- a/api/routes/apds/get.js
+++ b/api/routes/apds/get.js
@@ -17,7 +17,9 @@ module.exports = (app, ApdModel = defaultApdModel) => {
       }
 
       const whereCondits = { state_id: stateId };
-      const apds = (await ApdModel.where(whereCondits).fetchAll()).toJSON();
+      const apds = (await ApdModel.where(whereCondits).fetchAll({
+        withRelated: ['activities.goals.objectives']
+      })).toJSON();
 
       logger.silly(req, `got apds:`);
       logger.silly(req, apds);

--- a/api/routes/apds/get.test.js
+++ b/api/routes/apds/get.test.js
@@ -80,6 +80,12 @@ tap.test('apds GET endpoint', async endpointTest => {
 
       validTest.ok(res.status.notCalled, 'HTTP status not explicitly set');
       validTest.ok(
+        ApdModel.fetchAll.calledWith({
+          withRelated: ['activities.goals.objectives']
+        }),
+        'fetches related activities, goals, and objectives'
+      );
+      validTest.ok(
         res.send.calledWith(['a', 'b', 'c']),
         'program info is sent back'
       );

--- a/api/routes/apds/openAPI.js
+++ b/api/routes/apds/openAPI.js
@@ -29,7 +29,50 @@ const apdObjectSchema = {
     approved_at: {
       type: 'dateTime',
       description: 'Approval date'
-    }
+    },
+    activities: arrayOf({
+      type: 'object',
+      properties: {
+        id: {
+          type: 'number',
+          description: 'Activity ID'
+        },
+        name: {
+          type: 'string',
+          description: 'Short name for the activity'
+        },
+        description: {
+          type: 'string',
+          description: 'A description of this activity'
+        },
+        goals: arrayOf({
+          type: 'object',
+          properties: {
+            id: {
+              type: 'number',
+              description: 'Goal ID'
+            },
+            description: {
+              type: 'string',
+              description: 'A description of this goal'
+            },
+            objectives: arrayOf({
+              type: 'object',
+              properties: {
+                id: {
+                  type: 'number',
+                  description: 'Objective ID'
+                },
+                description: {
+                  type: 'string',
+                  description: 'A description of this objective'
+                }
+              }
+            })
+          }
+        })
+      }
+    })
   }
 };
 

--- a/api/seeds/shared/delete-everything.js
+++ b/api/seeds/shared/delete-everything.js
@@ -8,6 +8,12 @@ exports.seed = async knex => {
   await knex('auth_roles').del();
   await knex('auth_activities').del();
 
+  // have cascading foreign key relationships, so make sure we
+  // delete them in the right order
+  await knex('activity_goal_objectives').del();
+  await knex('activity_goals').del();
+  await knex('activities').del();
+
   await knex('apds').del();
   await knex('states').del();
 };


### PR DESCRIPTION
Adds activity goals and objectives tables and data models, and hooks up the relationships.  Updates the `/apds` GET route to fetch the related data and return it all at once.

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- ~~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~~
- [x] The change has been documented
  - [x] Associated OpenAPI documentation has been updated

### This feature is done when...
- ~~Design has approved the experience~~
- ~~Product has approved the experience~~
