### PR TITLE
Add API endpoints to create APD activities, goals, and objectives

### DIFF
--- a/api/db/activity.js
+++ b/api/db/activity.js
@@ -8,6 +8,15 @@ module.exports = () => ({
 
     goals() {
       return this.hasMany('apdActivityGoal');
+    },
+
+    toJSON() {
+      return {
+        id: this.get('id'),
+        name: this.get('name'),
+        description: this.get('description'),
+        goals: this.related('goals')
+      };
     }
   },
 
@@ -20,6 +29,13 @@ module.exports = () => ({
 
     objectives() {
       return this.hasMany('apdActivityGoalObjective');
+    },
+
+    toJSON() {
+      return {
+        description: this.get('description'),
+        objectives: this.related('objectives')
+      };
     }
   },
 
@@ -28,6 +44,10 @@ module.exports = () => ({
 
     goal() {
       return this.belongsTo('apdActivityGoal');
+    },
+
+    toJSON() {
+      return this.get('description');
     }
   }
 });

--- a/api/db/activity.js
+++ b/api/db/activity.js
@@ -3,7 +3,7 @@ module.exports = () => ({
     tableName: 'activities',
 
     apd() {
-      return this.hasOne('apd', 'id', 'apd_id');
+      return this.belongsTo('apd');
     },
 
     goals() {

--- a/api/db/activity.test.js
+++ b/api/db/activity.test.js
@@ -98,6 +98,35 @@ tap.test('activity data model', async activityModelTests => {
   );
 
   activityModelTests.test(
+    'activity model overrides toJSON method',
+    async apdTests => {
+      const self = {
+        get: sinon.stub(),
+        related: sinon
+          .stub()
+          .withArgs('goals')
+          .returns('goooooaaaaals')
+      };
+      self.get.withArgs('id').returns('eye-dee');
+      self.get.withArgs('name').returns('Jerome Lee');
+      self.get.withArgs('description').returns('cool CMS person');
+
+      const output = activity.apdActivity.toJSON.bind(self)();
+
+      apdTests.match(
+        output,
+        {
+          id: 'eye-dee',
+          name: 'Jerome Lee',
+          description: 'cool CMS person',
+          goals: 'goooooaaaaals'
+        },
+        'gives us back the right JSON-ified object'
+      );
+    }
+  );
+
+  activityModelTests.test(
     'goal model sets up objectives relationship',
     async apdTests => {
       const self = {
@@ -115,6 +144,33 @@ tap.test('activity data model', async activityModelTests => {
   );
 
   activityModelTests.test(
+    'activity goal model overrides toJSON method',
+    async apdTests => {
+      const self = {
+        get: sinon
+          .stub()
+          .withArgs('description')
+          .returns('to eat a whole bucket of ice cream in one sitting'),
+        related: sinon
+          .stub()
+          .withArgs('objectives')
+          .returns('twenty-seven')
+      };
+
+      const output = activity.apdActivityGoal.toJSON.bind(self)();
+
+      apdTests.match(
+        output,
+        {
+          description: 'to eat a whole bucket of ice cream in one sitting',
+          objectives: 'twenty-seven'
+        },
+        'gives us back the right JSON-ified object'
+      );
+    }
+  );
+
+  activityModelTests.test(
     'objective model sets up goal relationship',
     async apdTests => {
       const self = {
@@ -128,6 +184,26 @@ tap.test('activity data model', async activityModelTests => {
         'sets up the relationship mapping to goal'
       );
       apdTests.equal(output, 'floppity', 'returns the expected value');
+    }
+  );
+
+  activityModelTests.test(
+    'activity objective model overrides toJSON method',
+    async apdTests => {
+      const self = {
+        get: sinon
+          .stub()
+          .withArgs('description')
+          .returns('solar flares are deadly')
+      };
+
+      const output = activity.apdActivityGoalObjective.toJSON.bind(self)();
+
+      apdTests.equal(
+        output,
+        'solar flares are deadly',
+        'gives us back the right JSON-ified object'
+      );
     }
   );
 });

--- a/api/db/activity.test.js
+++ b/api/db/activity.test.js
@@ -50,13 +50,13 @@ tap.test('activity data model', async activityModelTests => {
     'activity model sets up apd relationship',
     async apdTests => {
       const self = {
-        hasOne: sinon.stub().returns('baz')
+        belongsTo: sinon.stub().returns('baz')
       };
 
       const output = activity.apdActivity.apd.bind(self)();
 
       apdTests.ok(
-        self.hasOne.calledWith('apd', 'id', 'apd_id'),
+        self.belongsTo.calledWith('apd'),
         'sets up the relationship mapping to a apd'
       );
       apdTests.equal(output, 'baz', 'returns the expected value');

--- a/api/routes/apds/activities/goals/put.js
+++ b/api/routes/apds/activities/goals/put.js
@@ -1,0 +1,109 @@
+const logger = require('../../../../logger')('apd activites route put');
+const {
+  apdActivity: defaultActivityModel,
+  apdActivityGoal: defaultGoalModel,
+  apdActivityGoalObjective: defaultObjectiveModel
+} = require('../../../../db').models;
+const { userCanEditAPD } = require('../../utils');
+const loggedIn = require('../../../../auth/middleware').loggedIn;
+
+module.exports = (
+  app,
+  ActivityModel = defaultActivityModel,
+  GoalModel = defaultGoalModel,
+  ObjectiveModel = defaultObjectiveModel
+) => {
+  logger.silly('setting up PUT /activities/:id/goals route');
+  app.put('/activities/:id/goals', loggedIn, async (req, res) => {
+    logger.silly(req, 'handling PUT /activities/:id/goals route');
+    logger.silly(
+      req,
+      `attempting to update goals on activity [${req.params.id}]`
+    );
+
+    try {
+      const activityID = +req.params.id;
+      const activity = await ActivityModel.where({ id: activityID }).fetch({
+        withRelated: ['apd', 'goals.objectives']
+      });
+      if (!activity) {
+        logger.verbose(req, 'activity not found');
+        return res.status(404).end();
+      }
+      const apdID = activity.related('apd').get('id');
+
+      if (!userCanEditAPD(req.user.id, apdID)) {
+        logger.verbose(
+          req,
+          'user (state) not associated with the apd this activity belongs to'
+        );
+        return res.status(404).end();
+      }
+
+      if (!Array.isArray(req.body)) {
+        logger.verbose('request is not an array');
+        return res
+          .status(400)
+          .send({ error: 'edit-activity-invalid-goals' })
+          .end();
+      }
+
+      // Delete the previous goals and objectives for this activity
+      logger.silly('deleting previous goals and objectives for this activity');
+      activity.related('goals').forEach(async goal => {
+        goal.related('objectives').forEach(async objective => {
+          await objective.destroy();
+        });
+        await goal.destroy();
+      });
+
+      const awaiting = req.body.map(async goal => {
+        if (goal.description) {
+          const goalModel = GoalModel.forge({
+            description: goal.description,
+            activity_id: activityID
+          });
+          await goalModel.save();
+          const goalID = goalModel.get('id');
+
+          if (Array.isArray(goal.objectives)) {
+            goal.objectives.forEach(async objective => {
+              if (typeof objective === 'string' && objective) {
+                const objectiveModel = ObjectiveModel.forge({
+                  description: objective,
+                  activity_goal_id: goalID
+                });
+                await objectiveModel.save();
+              }
+            });
+          }
+        }
+      });
+
+      await Promise.all(awaiting);
+
+      const updatedActivity = await ActivityModel.where({
+        id: activityID
+      }).fetch({
+        withRelated: ['goals.objectives']
+      });
+
+      return res.send(updatedActivity.toJSON());
+    } catch (e) {
+      logger.error(req, e);
+      return res.status(500).end();
+    }
+  });
+};
+
+/*
+
+PUT /apds/:apd_id/activities
+  - replaces the list of activities for the APD with the new list
+
+PUT /apds/:apd_id/activities/:activity_id
+  - replaces the name and/or description for the activity
+
+PUT /apds/:apd_id/activities/:activity_id/goals
+  - replaces the list of goals for the activity with the new list
+*/

--- a/api/routes/apds/activities/goals/put.js
+++ b/api/routes/apds/activities/goals/put.js
@@ -4,14 +4,15 @@ const {
   apdActivityGoal: defaultGoalModel,
   apdActivityGoalObjective: defaultObjectiveModel
 } = require('../../../../db').models;
-const { userCanEditAPD } = require('../../utils');
+const { userCanEditAPD: defaultUserCanEditAPD } = require('../../utils');
 const loggedIn = require('../../../../auth/middleware').loggedIn;
 
 module.exports = (
   app,
   ActivityModel = defaultActivityModel,
   GoalModel = defaultGoalModel,
-  ObjectiveModel = defaultObjectiveModel
+  ObjectiveModel = defaultObjectiveModel,
+  userCanEditAPD = defaultUserCanEditAPD
 ) => {
   logger.silly('setting up PUT /activities/:id/goals route');
   app.put('/activities/:id/goals', loggedIn, async (req, res) => {
@@ -32,7 +33,7 @@ module.exports = (
       }
       const apdID = activity.related('apd').get('id');
 
-      if (!userCanEditAPD(req.user.id, apdID)) {
+      if (!await userCanEditAPD(req.user.id, apdID)) {
         logger.verbose(
           req,
           'user (state) not associated with the apd this activity belongs to'

--- a/api/routes/apds/activities/goals/put.js
+++ b/api/routes/apds/activities/goals/put.js
@@ -95,15 +95,3 @@ module.exports = (
     }
   });
 };
-
-/*
-
-PUT /apds/:apd_id/activities
-  - replaces the list of activities for the APD with the new list
-
-PUT /apds/:apd_id/activities/:activity_id
-  - replaces the name and/or description for the activity
-
-PUT /apds/:apd_id/activities/:activity_id/goals
-  - replaces the list of goals for the activity with the new list
-*/

--- a/api/routes/apds/activities/goals/put.test.js
+++ b/api/routes/apds/activities/goals/put.test.js
@@ -1,0 +1,274 @@
+const tap = require('tap');
+const sinon = require('sinon');
+
+const loggedInMiddleware = require('../../../../auth/middleware').loggedIn;
+const putEndpoint = require('./put');
+
+tap.test('apd activity goal PUT endpoint', async endpointTest => {
+  const sandbox = sinon.createSandbox();
+  const app = { put: sandbox.stub() };
+
+  const ActivityModel = {
+    where: sandbox.stub(),
+    fetch: sandbox.stub()
+  };
+  const GoalModel = {
+    forge: sandbox.stub(),
+    where: sandbox.stub(),
+    fetch: sandbox.stub()
+  };
+  const ObjectiveModel = {
+    forge: sandbox.stub(),
+    where: sandbox.stub(),
+    fetch: sandbox.stub()
+  };
+
+  const activityObj = {
+    related: sandbox.stub(),
+    get: sandbox.stub()
+  };
+
+  const apdObj = {
+    related: sandbox.stub(),
+    get: sandbox.stub()
+  };
+
+  const userCanEditAPD = sandbox.stub();
+
+  const res = {
+    status: sandbox.stub(),
+    send: sandbox.stub(),
+    end: sandbox.stub()
+  };
+
+  endpointTest.beforeEach(done => {
+    sandbox.resetBehavior();
+    sandbox.resetHistory();
+
+    ActivityModel.where.returns(ActivityModel);
+    ActivityModel.fetch.resolves(activityObj);
+    activityObj.related.withArgs('apd').returns(apdObj);
+
+    GoalModel.where.returns(GoalModel);
+    ObjectiveModel.where.returns(ObjectiveModel);
+
+    res.status.returns(res);
+    res.send.returns(res);
+    res.end.returns(res);
+
+    done();
+  });
+
+  endpointTest.test('setup', async setupTest => {
+    putEndpoint(app, ActivityModel, GoalModel, ObjectiveModel, userCanEditAPD);
+
+    setupTest.ok(
+      app.put.calledWith(
+        '/activities/:id/goals',
+        loggedInMiddleware,
+        sinon.match.func
+      ),
+      'apd activity PUT endpoint is registered'
+    );
+  });
+
+  endpointTest.test('edit APD activity handler', async handlerTest => {
+    let handler;
+    handlerTest.beforeEach(async () => {
+      putEndpoint(
+        app,
+        ActivityModel,
+        GoalModel,
+        ObjectiveModel,
+        userCanEditAPD
+      );
+      handler = app.put.args.find(
+        args => args[0] === '/activities/:id/goals'
+      )[2];
+    });
+
+    handlerTest.test(
+      'sends a server error if anything goes wrong',
+      async saveTest => {
+        const req = {
+          user: { id: 1 },
+          params: { id: 1 },
+          body: { status: 'foo' }
+        };
+        ActivityModel.fetch.rejects();
+
+        await handler(req, res);
+
+        saveTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
+      }
+    );
+
+    handlerTest.test(
+      'sends a not found error if requesting to edit an activity that does not exist',
+      async notFoundTest => {
+        const req = { params: { id: 1 } };
+        ActivityModel.fetch.resolves(null);
+
+        await handler(req, res);
+
+        notFoundTest.ok(res.status.calledWith(404), 'HTTP status set to 404');
+        notFoundTest.ok(res.send.notCalled, 'no body is sent');
+        notFoundTest.ok(res.end.calledOnce, 'response is terminated');
+      }
+    );
+
+    handlerTest.test(
+      'sends an error if requesting to edit a apd not associated with user',
+      async notFoundTest => {
+        const req = {
+          user: { id: 1 },
+          params: { id: 1 }
+        };
+        activityObj.get.withArgs('id').returns('apd-id');
+        userCanEditAPD.resolves(false);
+
+        await handler(req, res);
+
+        notFoundTest.ok(res.status.calledWith(404), 'HTTP status set to 404');
+        notFoundTest.ok(res.send.notCalled, 'no body is sent');
+        notFoundTest.ok(res.end.calledOnce, 'response is terminated');
+      }
+    );
+
+    handlerTest.test(
+      'sends an error if request body is not an array',
+      async invalidTest => {
+        const req = {
+          user: { id: 1 },
+          params: { id: 1 },
+          body: 'hello'
+        };
+        activityObj.get.withArgs('id').returns('apd-id');
+        userCanEditAPD.resolves(true);
+
+        await handler(req, res);
+
+        invalidTest.ok(res.status.calledWith(400), 'HTTP status set to 400');
+        invalidTest.ok(
+          res.send.calledWith({ error: 'edit-activity-invalid-goals' }),
+          'sends an error string'
+        );
+        invalidTest.ok(res.end.calledOnce, 'response is terminated');
+      }
+    );
+
+    handlerTest.test('updates valid goals', async validTest => {
+      const req = {
+        user: { id: 1 },
+        params: { id: 1 },
+        body: [
+          {
+            description: 'goal 1',
+            objectives: ['objective 1.1', 'objective 1.2']
+          },
+          { description: 'goal 2', objectives: ['objective 2.1'] },
+          { hello: 'world', objectives: ['objective 3.1', 'objective 3.2'] }
+        ]
+      };
+      activityObj.get.withArgs('id').returns('apd-id');
+
+      const existingGoals = [];
+      for (let i = 0; i < 3; i += 1) {
+        const goalObjectives = [];
+
+        for (let j = 0; j < 3; j += 1) {
+          goalObjectives.push({
+            destroy: sinon.stub().resolves()
+          });
+        }
+
+        existingGoals.push({
+          related: sinon.stub().returns(goalObjectives),
+          destroy: sinon.stub().resolves()
+        });
+      }
+
+      activityObj.related.withArgs('goals').returns(existingGoals);
+      userCanEditAPD.resolves(true);
+
+      const goal = {
+        save: sandbox.stub().resolves(),
+        get: sandbox.stub().returns('goal-id')
+      };
+
+      GoalModel.forge.returns(goal);
+
+      const objective = {
+        save: sandbox.stub().resolves()
+      };
+
+      ObjectiveModel.forge.returns(objective);
+
+      ActivityModel.fetch.onSecondCall().resolves({
+        toJSON: sandbox.stub().returns('activity-from-json')
+      });
+
+      await handler(req, res);
+
+      validTest.ok(res.status.notCalled, 'HTTP status not explicitly set');
+      validTest.ok(
+        res.send.calledWith('activity-from-json'),
+        'sends JSON-ified activity'
+      );
+
+      validTest.ok(
+        existingGoals.every(oldGoal =>
+          oldGoal
+            .related()
+            .every(
+              oldObjective =>
+                oldObjective.destroy.calledOnce &&
+                oldObjective.destroy.calledBefore(oldGoal.destroy)
+            )
+        ),
+        'all of the old objectives are deleted, before deleting their containing goals'
+      );
+      validTest.ok(
+        existingGoals.every(
+          oldGoal =>
+            oldGoal.destroy.calledOnce &&
+            oldGoal.destroy.calledBefore(GoalModel.forge) &&
+            oldGoal.destroy.calledBefore(ObjectiveModel.forge)
+        ),
+        'all of the old goals are deleted before new goals/objectives are created'
+      );
+      validTest.ok(
+        GoalModel.forge.calledTwice,
+        'two goals are created (the invalid one is left out)'
+      );
+      validTest.ok(
+        GoalModel.forge.calledWith({ description: 'goal 1', activity_id: 1 }) &&
+          GoalModel.forge.calledWith({ description: 'goal 2', activity_id: 1 }),
+        'the two expected goals are created'
+      );
+      validTest.ok(
+        goal.save.calledBefore(ObjectiveModel.forge),
+        'goals are saved before objectives are created'
+      );
+      validTest.ok(
+        ObjectiveModel.forge.calledThrice,
+        'three objectives are created (objectives for invalid goal are left out)'
+      );
+      validTest.ok(
+        ObjectiveModel.forge.calledWith({
+          description: 'objective 1.1',
+          activity_goal_id: 'goal-id'
+        }) &&
+          ObjectiveModel.forge.calledWith({
+            description: 'objective 1.2',
+            activity_goal_id: 'goal-id'
+          }) &&
+          ObjectiveModel.forge.calledWith({
+            description: 'objective 2.1',
+            activity_goal_id: 'goal-id'
+          }),
+        'the three expected objectives are created'
+      );
+    });
+  });
+});

--- a/api/routes/apds/activities/index.js
+++ b/api/routes/apds/activities/index.js
@@ -1,0 +1,18 @@
+const logger = require('../../../logger')('apd activites route index');
+const post = require('./post');
+const put = require('./put');
+const goals = require('./goals/put');
+
+module.exports = (
+  app,
+  postEndpoint = post,
+  putEndpoint = put,
+  goalsEndpoints = goals
+) => {
+  logger.silly('setting up POST endpoint');
+  postEndpoint(app);
+  logger.silly('setting up PUT endpoint');
+  putEndpoint(app);
+  logger.silly('settin up goals endpoints');
+  goalsEndpoints(app);
+};

--- a/api/routes/apds/activities/index.test.js
+++ b/api/routes/apds/activities/index.test.js
@@ -1,0 +1,27 @@
+const tap = require('tap');
+const sinon = require('sinon');
+
+const apdsIndex = require('./index');
+
+tap.test('apd activities endpoint setup', async endpointTest => {
+  const app = {};
+  const postEndpoint = sinon.spy();
+  const putEndpoint = sinon.spy();
+  const goalsEndpoint = sinon.spy();
+
+  apdsIndex(app, postEndpoint, putEndpoint, goalsEndpoint);
+
+  endpointTest.ok(
+    postEndpoint.calledWith(app),
+    'apd activity POST endpoint is setup with the app'
+  );
+  endpointTest.ok(
+    putEndpoint.calledWith(app),
+    'apd activity PUT endpoint is setup with the app'
+  );
+
+  endpointTest.ok(
+    goalsEndpoint.calledWith(app),
+    'apd activity goals endpoints are setup with the app'
+  );
+});

--- a/api/routes/apds/activities/post.js
+++ b/api/routes/apds/activities/post.js
@@ -3,13 +3,14 @@ const {
   apdActivity: defaultActivityModel,
   apd: defaultApdModel
 } = require('../../../db').models;
-const { userCanEditAPD } = require('../utils');
+const { userCanEditAPD: defaultUserCanEditAPD } = require('../utils');
 const loggedIn = require('../../../auth/middleware').loggedIn;
 
 module.exports = (
   app,
   ActivityModel = defaultActivityModel,
-  ApdModel = defaultApdModel
+  ApdModel = defaultApdModel,
+  userCanEditAPD = defaultUserCanEditAPD
 ) => {
   const check404 = async req => {
     const apdID = +req.params.apdID;
@@ -74,15 +75,3 @@ module.exports = (
     }
   });
 };
-
-/*
-
-PUT /apds/:apd_id/activities
-  - replaces the list of activities for the APD with the new list
-
-PUT /apds/:apd_id/activities/:activity_id
-  - replaces the name and/or description for the activity
-
-PUT /apds/:apd_id/activities/:activity_id/goals
-  - replaces the list of goals for the activity with the new list
-*/

--- a/api/routes/apds/activities/post.js
+++ b/api/routes/apds/activities/post.js
@@ -12,12 +12,12 @@ module.exports = (
   ApdModel = defaultApdModel,
   userCanEditAPD = defaultUserCanEditAPD
 ) => {
-  const check404 = async req => {
+  const getApd = async req => {
     const apdID = +req.params.apdID;
 
     if (!await userCanEditAPD(req.user.id, apdID)) {
       logger.verbose(req, 'user (state) not associated with this apd');
-      return false;
+      return null;
     }
 
     const apd = await ApdModel.where({ id: apdID }).fetch({
@@ -25,7 +25,6 @@ module.exports = (
     });
     if (!apd) {
       logger.verbose(req, `no such apd [${apdID}]`);
-      return false;
     }
 
     return apd;
@@ -40,7 +39,7 @@ module.exports = (
     );
 
     try {
-      const apd = await check404(req, res);
+      const apd = await getApd(req, res);
       if (!apd) {
         return res.status(404).end();
       }

--- a/api/routes/apds/activities/post.js
+++ b/api/routes/apds/activities/post.js
@@ -1,0 +1,88 @@
+const logger = require('../../../logger')('apd activites route put');
+const {
+  apdActivity: defaultActivityModel,
+  apd: defaultApdModel
+} = require('../../../db').models;
+const { userCanEditAPD } = require('../utils');
+const loggedIn = require('../../../auth/middleware').loggedIn;
+
+module.exports = (
+  app,
+  ActivityModel = defaultActivityModel,
+  ApdModel = defaultApdModel
+) => {
+  const check404 = async req => {
+    const apdID = +req.params.apdID;
+
+    if (!await userCanEditAPD(req.user.id, apdID)) {
+      logger.verbose(req, 'user (state) not associated with this apd');
+      return false;
+    }
+
+    const apd = await ApdModel.where({ id: apdID }).fetch({
+      withRelated: ['activities']
+    });
+    if (!apd) {
+      logger.verbose(req, `no such apd [${apdID}]`);
+      return false;
+    }
+
+    return apd;
+  };
+
+  logger.silly('setting up POST /apds/:apdID/activities route');
+  app.post('/apds/:apdID/activities', loggedIn, async (req, res) => {
+    logger.silly(req, 'handling POST /apds/:apdID/activities route');
+    logger.silly(
+      req,
+      `attempting to add an activity on apd [${req.params.apdID}]`
+    );
+
+    try {
+      const apd = await check404(req, res);
+      if (!apd) {
+        return res.status(404).end();
+      }
+
+      if (typeof req.body.name !== 'string' || req.body.name.length < 1) {
+        logger.verbose(req, 'Invalid activity name');
+        return res
+          .status(400)
+          .send({ error: 'add-activity-invalid-name' })
+          .end();
+      }
+
+      const existingNames = apd.related('activities').pluck(['name']);
+      if (existingNames.includes(req.body.name)) {
+        logger.verbose(req, 'Activity name already exists for this APD');
+        return res
+          .status(400)
+          .send({ error: 'add-activity-name-exists' })
+          .end();
+      }
+
+      const activity = ActivityModel.forge({
+        name: req.body.name,
+        apd_id: apd.get('id')
+      });
+
+      await activity.save();
+      return res.send(activity.toJSON());
+    } catch (e) {
+      logger.error(req, e);
+      return res.status(500).end();
+    }
+  });
+};
+
+/*
+
+PUT /apds/:apd_id/activities
+  - replaces the list of activities for the APD with the new list
+
+PUT /apds/:apd_id/activities/:activity_id
+  - replaces the name and/or description for the activity
+
+PUT /apds/:apd_id/activities/:activity_id/goals
+  - replaces the list of goals for the activity with the new list
+*/

--- a/api/routes/apds/activities/post.test.js
+++ b/api/routes/apds/activities/post.test.js
@@ -1,0 +1,260 @@
+const tap = require('tap');
+const sinon = require('sinon');
+
+const loggedInMiddleware = require('../../../auth/middleware').loggedIn;
+const postEndpoint = require('./post');
+
+tap.test('apd activity POST endpoint', async endpointTest => {
+  const sandbox = sinon.createSandbox();
+  const app = { post: sandbox.stub() };
+
+  const ActivityModel = {
+    where: sandbox.stub(),
+    fetch: sandbox.stub(),
+    forge: sandbox.stub()
+  };
+
+  const ApdModel = {
+    where: sandbox.stub(),
+    fetch: sandbox.stub()
+  };
+
+  const userCanEditAPD = sandbox.stub();
+
+  const res = {
+    status: sandbox.stub(),
+    send: sandbox.stub(),
+    end: sandbox.stub()
+  };
+
+  endpointTest.beforeEach(done => {
+    sandbox.resetBehavior();
+    sandbox.resetHistory();
+
+    ActivityModel.where.returns(ActivityModel);
+    ApdModel.where.returns(ApdModel);
+
+    res.status.returns(res);
+    res.send.returns(res);
+    res.end.returns(res);
+
+    done();
+  });
+
+  endpointTest.test('setup', async setupTest => {
+    postEndpoint(app, ActivityModel, ApdModel, userCanEditAPD);
+
+    setupTest.ok(
+      app.post.calledWith(
+        '/apds/:apdID/activities',
+        loggedInMiddleware,
+        sinon.match.func
+      ),
+      'apd activity POST endpoint is registered'
+    );
+  });
+
+  endpointTest.test('create APD activity handler', async handlerTest => {
+    let handler;
+    handlerTest.beforeEach(async () => {
+      postEndpoint(app, ActivityModel, ApdModel, userCanEditAPD);
+      handler = app.post.args.find(
+        args => args[0] === '/apds/:apdID/activities'
+      )[2];
+    });
+
+    handlerTest.test(
+      'sends a server error if anything goes wrong',
+      async errorTest => {
+        const req = { params: { apdID: 'apd-id' } };
+
+        await handler(req, res);
+
+        errorTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
+        errorTest.ok(res.end.called, 'response is terminated');
+      }
+    );
+
+    handlerTest.test(
+      'sends an error if requesting to edit a apd not associated with user',
+      async notFoundTest => {
+        const req = {
+          user: { id: 1 },
+          params: { id: 1 }
+        };
+        userCanEditAPD.resolves(false);
+
+        await handler(req, res);
+
+        notFoundTest.ok(res.status.calledWith(404), 'HTTP status set to 404');
+        notFoundTest.ok(res.send.notCalled, 'no body is sent');
+        notFoundTest.ok(res.end.calledOnce, 'response is terminated');
+      }
+    );
+
+    handlerTest.test(
+      'sends an error if requesting to edit a apd that does not exist',
+      async notFoundTest => {
+        const req = {
+          user: { id: 'user-id' },
+          params: { apdID: 'apd-id' }
+        };
+        userCanEditAPD.resolves(true);
+        ApdModel.where.withArgs({ id: 'apd-id' }).returns(ApdModel);
+        ApdModel.fetch.resolves(false);
+
+        await handler(req, res);
+
+        notFoundTest.ok(res.status.calledWith(404), 'HTTP status set to 404');
+        notFoundTest.ok(res.send.notCalled, 'no body is sent');
+        notFoundTest.ok(res.end.calledOnce, 'response is terminated');
+      }
+    );
+
+    handlerTest.test(
+      'sends an error if activity name is not a string',
+      async invalidTest => {
+        const req = {
+          user: { id: 'user-id' },
+          params: { apdID: 'apd-id' },
+          body: {
+            name: 7,
+            description: 'bloop blorp'
+          }
+        };
+        userCanEditAPD.resolves(true);
+        ApdModel.where.withArgs({ id: 'apd-id' }).returns(ApdModel);
+        ApdModel.fetch.resolves(true);
+
+        await handler(req, res);
+
+        invalidTest.ok(res.status.calledWith(400), 'HTTP status set to 400');
+        invalidTest.ok(
+          res.send.calledWith({ error: 'add-activity-invalid-name' }),
+          'sends back an error string'
+        );
+        invalidTest.ok(res.end.calledOnce, 'response is terminated');
+      }
+    );
+
+    handlerTest.test(
+      'sends an error if activity name is an empty string',
+      async invalidTest => {
+        const req = {
+          user: { id: 'user-id' },
+          params: { apdID: 'apd-id' },
+          body: {
+            name: '',
+            description: 'bloop blorp'
+          }
+        };
+        userCanEditAPD.resolves(true);
+        ApdModel.where.withArgs({ id: 'apd-id' }).returns(ApdModel);
+        ApdModel.fetch.resolves(true);
+
+        await handler(req, res);
+
+        invalidTest.ok(res.status.calledWith(400), 'HTTP status set to 400');
+        invalidTest.ok(
+          res.send.calledWith({ error: 'add-activity-invalid-name' }),
+          'sends back an error string'
+        );
+        invalidTest.ok(res.end.calledOnce, 'response is terminated');
+      }
+    );
+
+    handlerTest.test(
+      'sends an error if activity name already exists in the APD',
+      async invalidTest => {
+        const req = {
+          user: { id: 'user-id' },
+          params: { apdID: 'apd-id' },
+          body: {
+            name: 'activity name',
+            description: 'bloop blorp'
+          }
+        };
+        userCanEditAPD.resolves(true);
+        ApdModel.where.withArgs({ id: 'apd-id' }).returns(ApdModel);
+
+        const apdObj = {
+          related: sinon
+            .stub()
+            .withArgs('activities')
+            .returns({
+              pluck: sinon
+                .stub()
+                .withArgs(['name'])
+                .returns(['other name', 'activity name'])
+            })
+        };
+
+        ApdModel.fetch.resolves(apdObj);
+
+        await handler(req, res);
+
+        invalidTest.ok(res.status.calledWith(400), 'HTTP status set to 400');
+        invalidTest.ok(
+          res.send.calledWith({ error: 'add-activity-name-exists' }),
+          'sends back an error string'
+        );
+        invalidTest.ok(res.end.calledOnce, 'response is terminated');
+      }
+    );
+
+    handlerTest.test(
+      'sends back the new activity if everything is valid',
+      async validTest => {
+        const req = {
+          user: { id: 'user-id' },
+          params: { apdID: 'apd-id' },
+          body: {
+            name: 'activity name',
+            description: 'bloop blorp'
+          }
+        };
+        userCanEditAPD.resolves(true);
+        ApdModel.where.withArgs({ id: 'apd-id' }).returns(ApdModel);
+
+        const apdObj = {
+          related: sinon
+            .stub()
+            .withArgs('activities')
+            .returns({
+              pluck: sinon
+                .stub()
+                .withArgs(['name'])
+                .returns(['other name', 'third name'])
+            }),
+          get: sinon
+            .stub()
+            .withArgs('id')
+            .returns('apd-id-from-db')
+        };
+
+        ApdModel.fetch.resolves(apdObj);
+
+        const activityObj = {
+          toJSON: sandbox.stub().returns('activity-as-json'),
+          save: sandbox.stub().resolves()
+        };
+        ActivityModel.forge.returns(activityObj);
+
+        await handler(req, res);
+
+        validTest.ok(res.status.notCalled, 'HTTP status not explicitly set');
+        validTest.ok(
+          res.send.calledWith('activity-as-json'),
+          'sends back activity object as JSON'
+        );
+        validTest.ok(
+          ActivityModel.forge.calledWith({
+            name: 'activity name',
+            apd_id: 'apd-id-from-db'
+          })
+        );
+        validTest.ok(activityObj.save.calledOnce, 'activity model is saved');
+      }
+    );
+  });
+});

--- a/api/routes/apds/activities/put.js
+++ b/api/routes/apds/activities/put.js
@@ -1,0 +1,57 @@
+const logger = require('../../../logger')('apd activites route put');
+const pick = require('lodash.pick');
+const { apdActivity: defaultActivityModel } = require('../../../db').models;
+const { userCanEditAPD } = require('../utils');
+const loggedIn = require('../../../auth/middleware').loggedIn;
+
+module.exports = (app, ActivityModel = defaultActivityModel) => {
+  logger.silly('setting up PUT /activities/:id route');
+  app.put('/activities/:id', loggedIn, async (req, res) => {
+    logger.silly(req, 'handling PUT /activities/:id route');
+    logger.silly(req, `attempting to update activity [${req.params.id}]`);
+
+    try {
+      const activityID = +req.params.id;
+      const activity = await ActivityModel.where({ id: activityID }).fetch({
+        withRelated: ['apd.activities']
+      });
+      if (!activity) {
+        logger.verbose(req, 'activity not found');
+        return res.status(404).end();
+      }
+      const apdID = activity.related('apd').get('id');
+
+      if (!userCanEditAPD(req.user.id, apdID)) {
+        logger.verbose(
+          req,
+          'user (state) not associated with the apd this activity belongs to'
+        );
+        return res.status(404).end();
+      }
+
+      const newData = pick(req.body, ['name', 'description']);
+
+      const hasNameConflict = activity
+        .related('apd')
+        .related('activities')
+        .some(
+          a => a.get('id') !== activityID && a.get('name') === newData.name
+        );
+
+      if (hasNameConflict) {
+        logger.verbose(req, 'Activity name already exists for this APD');
+        return res
+          .status(400)
+          .send({ error: 'add-activity-name-exists' })
+          .end();
+      }
+
+      activity.set(newData);
+      await activity.save();
+      return res.send(activity.toJSON());
+    } catch (e) {
+      logger.error(req, e);
+      return res.status(500).end();
+    }
+  });
+};

--- a/api/routes/apds/activities/put.js
+++ b/api/routes/apds/activities/put.js
@@ -1,10 +1,14 @@
 const logger = require('../../../logger')('apd activites route put');
 const pick = require('lodash.pick');
 const { apdActivity: defaultActivityModel } = require('../../../db').models;
-const { userCanEditAPD } = require('../utils');
+const { userCanEditAPD: defaultUserCanEditAPD } = require('../utils');
 const loggedIn = require('../../../auth/middleware').loggedIn;
 
-module.exports = (app, ActivityModel = defaultActivityModel) => {
+module.exports = (
+  app,
+  ActivityModel = defaultActivityModel,
+  userCanEditAPD = defaultUserCanEditAPD
+) => {
   logger.silly('setting up PUT /activities/:id route');
   app.put('/activities/:id', loggedIn, async (req, res) => {
     logger.silly(req, 'handling PUT /activities/:id route');
@@ -21,7 +25,7 @@ module.exports = (app, ActivityModel = defaultActivityModel) => {
       }
       const apdID = activity.related('apd').get('id');
 
-      if (!userCanEditAPD(req.user.id, apdID)) {
+      if (!await userCanEditAPD(req.user.id, apdID)) {
         logger.verbose(
           req,
           'user (state) not associated with the apd this activity belongs to'

--- a/api/routes/apds/activities/put.test.js
+++ b/api/routes/apds/activities/put.test.js
@@ -1,0 +1,234 @@
+const tap = require('tap');
+const sinon = require('sinon');
+
+const loggedInMiddleware = require('../../../auth/middleware').loggedIn;
+const putEndpoint = require('./put');
+
+tap.test('apd activity PUT endpoint', async endpointTest => {
+  const sandbox = sinon.createSandbox();
+  const app = { put: sandbox.stub() };
+
+  const ActivityModel = {
+    where: sandbox.stub(),
+    fetch: sandbox.stub()
+  };
+
+  const userCanEditAPD = sandbox.stub();
+
+  const res = {
+    status: sandbox.stub(),
+    send: sandbox.stub(),
+    end: sandbox.stub()
+  };
+
+  endpointTest.beforeEach(done => {
+    sandbox.resetBehavior();
+    sandbox.resetHistory();
+
+    ActivityModel.where.returns(ActivityModel);
+
+    res.status.returns(res);
+    res.send.returns(res);
+    res.end.returns(res);
+
+    done();
+  });
+
+  endpointTest.test('setup', async setupTest => {
+    putEndpoint(app, ActivityModel, userCanEditAPD);
+
+    setupTest.ok(
+      app.put.calledWith(
+        '/activities/:id',
+        loggedInMiddleware,
+        sinon.match.func
+      ),
+      'apd activity PUT endpoint is registered'
+    );
+  });
+
+  endpointTest.test('edit APD activity handler', async handlerTest => {
+    let handler;
+    handlerTest.beforeEach(async () => {
+      putEndpoint(app, ActivityModel, userCanEditAPD);
+      handler = app.put.args.find(args => args[0] === '/activities/:id')[2];
+    });
+
+    handlerTest.test(
+      'sends a not found error if requesting to edit an activity that does not exist',
+      async notFoundTest => {
+        const req = { params: { id: 1 } };
+        ActivityModel.fetch.resolves(null);
+
+        await handler(req, res);
+
+        notFoundTest.ok(res.status.calledWith(404), 'HTTP status set to 404');
+        notFoundTest.ok(res.send.notCalled, 'no body is sent');
+        notFoundTest.ok(res.end.calledOnce, 'response is terminated');
+      }
+    );
+
+    handlerTest.test(
+      'sends an error if requesting to edit a apd not associated with user',
+      async notFoundTest => {
+        const req = {
+          user: { id: 1 },
+          params: { id: 1 }
+        };
+        ActivityModel.fetch.resolves({
+          related: sinon.stub().returns({ get: sinon.stub().returns('apd-id') })
+        });
+        userCanEditAPD.resolves(false);
+
+        await handler(req, res);
+
+        notFoundTest.ok(res.status.calledWith(404), 'HTTP status set to 404');
+        notFoundTest.ok(res.send.notCalled, 'no body is sent');
+        notFoundTest.ok(res.end.calledOnce, 'response is terminated');
+      }
+    );
+
+    handlerTest.test(
+      'sends a server error if anything goes wrong',
+      async saveTest => {
+        const req = {
+          user: { id: 1 },
+          params: { id: 1 },
+          body: { status: 'foo' }
+        };
+        ActivityModel.fetch.rejects();
+
+        await handler(req, res);
+
+        saveTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
+      }
+    );
+
+    handlerTest.test(
+      'sends an error if the activity name already exists within the APD',
+      async invalidTest => {
+        const req = {
+          user: { id: 1 },
+          params: { id: 1 },
+          body: {
+            name: 'ice fishing',
+            description: 'fishing on the ice'
+          }
+        };
+        const related = sinon.stub();
+        const some = sinon.stub();
+        related
+          .withArgs('apd')
+          .returns({ get: sinon.stub().returns('apd-id'), related });
+        related.withArgs('activities').returns({ some });
+        some.returns(true);
+        ActivityModel.fetch.resolves({ related });
+        userCanEditAPD.resolves(true);
+
+        await handler(req, res);
+
+        invalidTest.ok(res.status.calledWith(400), 'HTTP status set to 400');
+        invalidTest.ok(
+          res.send.calledWith({ error: 'add-activity-name-exists' }),
+          'sends back an error string'
+        );
+        invalidTest.ok(res.end.calledOnce, 'response is terminated');
+
+        invalidTest.test(
+          '"some" function works as expected',
+          async someTests => {
+            const someFn = some.args[0][0];
+            const obj = {
+              get: sandbox.stub()
+            };
+
+            someTests.test(
+              'returns false if the input activity has the same ID as the current activity, but different name',
+              async falseTest => {
+                obj.get.withArgs('id').returns(1);
+                obj.get.withArgs('name').returns('bloop');
+                const result = someFn(obj);
+                falseTest.notOk(result, 'returns false');
+              }
+            );
+
+            someTests.test(
+              'returns false if the input activity has the same ID as the current activity, and the same name',
+              async falseTest => {
+                obj.get.withArgs('id').returns(1);
+                obj.get.withArgs('name').returns('ice fishing');
+                const result = someFn(obj);
+                falseTest.notOk(result, 'returns false');
+              }
+            );
+
+            someTests.test(
+              'returns false if the input activity has a different ID as the current activity, and different name',
+              async falseTest => {
+                obj.get.withArgs('id').returns('some fake ID');
+                obj.get.withArgs('name').returns('bloop');
+                const result = someFn(obj);
+                falseTest.notOk(result, 'returns false');
+              }
+            );
+
+            someTests.test(
+              'returns true if the input activity has the same ID as the current activity, but different name',
+              async trueTest => {
+                obj.get.withArgs('id').returns('some fake ID');
+                obj.get.withArgs('name').returns('ice fishing');
+                const result = someFn(obj);
+                trueTest.ok(result, 'returns true');
+              }
+            );
+          }
+        );
+      }
+    );
+
+    handlerTest.test('updates a valid APD activity', async validTest => {
+      const req = {
+        user: { id: 1 },
+        params: { id: 1 },
+        body: {
+          name: 'ice fishing',
+          description: 'fishing on the ice'
+        }
+      };
+      const related = sinon.stub();
+      const some = sinon.stub();
+      userCanEditAPD.resolves(true);
+      related
+        .withArgs('apd')
+        .returns({ get: sinon.stub().returns('apd-id'), related });
+      related.withArgs('activities').returns({ some });
+      some.returns(false);
+      const activityObj = {
+        related,
+        set: sinon.spy(),
+        save: sinon.stub().resolves(),
+        toJSON: sinon.stub().returns('Nick Aretakis')
+      };
+      ActivityModel.fetch.resolves(activityObj);
+
+      await handler(req, res);
+
+      validTest.ok(res.status.notCalled, 'HTTP status not explicitly set');
+      validTest.ok(
+        res.send.calledWith('Nick Aretakis'),
+        'sends back the toJSON results'
+      );
+      validTest.ok(
+        activityObj.set.calledWith({
+          name: 'ice fishing',
+          description: 'fishing on the ice'
+        }),
+        'model is updated with data from the request body'
+      );
+      validTest.ok(
+        activityObj.save.calledAfter(activityObj.set),
+        'model is saved after updating'
+      );
+    });
+  });
+});

--- a/api/routes/apds/index.js
+++ b/api/routes/apds/index.js
@@ -1,10 +1,19 @@
 const logger = require('../../logger')('apds route index');
 const get = require('./get');
 const put = require('./put');
+const activities = require('./activities');
 
-module.exports = (app, getEndpoint = get, putEndpoint = put) => {
+module.exports = (
+  app,
+  getEndpoint = get,
+  putEndpoint = put,
+  activitiesEndpoints = activities
+) => {
   logger.silly('setting up GET endpoint');
   getEndpoint(app);
   logger.silly('setting up PUT endpoint');
   putEndpoint(app);
+
+  logger.silly('setting up APD activities endpoints');
+  activitiesEndpoints(app);
 };

--- a/api/routes/apds/index.test.js
+++ b/api/routes/apds/index.test.js
@@ -7,8 +7,9 @@ tap.test('apds endpoint setup', async endpointTest => {
   const app = {};
   const getEndpoint = sinon.spy();
   const putEndpoint = sinon.spy();
+  const activitiesEndpoint = sinon.spy();
 
-  apdsIndex(app, getEndpoint, putEndpoint);
+  apdsIndex(app, getEndpoint, putEndpoint, activitiesEndpoint);
 
   endpointTest.ok(
     getEndpoint.calledWith(app),
@@ -17,5 +18,10 @@ tap.test('apds endpoint setup', async endpointTest => {
   endpointTest.ok(
     putEndpoint.calledWith(app),
     'apds PUT endpoint is setup with the app'
+  );
+
+  endpointTest.ok(
+    activitiesEndpoint.calledWith(app),
+    'apds activities endpoints are setup with the app'
   );
 });

--- a/api/routes/apds/put.js
+++ b/api/routes/apds/put.js
@@ -3,7 +3,7 @@ const pick = require('lodash.pick');
 const logger = require('../../logger')('apds route put');
 const defaultApdModel = require('../../db').models.apd;
 const loggedIn = require('../../auth/middleware').loggedIn;
-const { defaultUserCanEditAPD } = require('./utils');
+const { userCanEditAPD: defaultUserCanEditAPD } = require('./utils');
 
 module.exports = (
   app,

--- a/api/routes/apds/put.js
+++ b/api/routes/apds/put.js
@@ -2,13 +2,13 @@ const pick = require('lodash.pick');
 
 const logger = require('../../logger')('apds route put');
 const defaultApdModel = require('../../db').models.apd;
-const defaultUserModel = require('../../db').models.user;
 const loggedIn = require('../../auth/middleware').loggedIn;
+const { defaultUserCanEditAPD } = require('./utils');
 
 module.exports = (
   app,
   ApdModel = defaultApdModel,
-  UserModel = defaultUserModel
+  userCanEditAPD = defaultUserCanEditAPD
 ) => {
   logger.silly('setting up PUT /apds/:id route');
   app.put('/apds/:id', loggedIn, async (req, res) => {
@@ -24,10 +24,7 @@ module.exports = (
         return res.status(404).end();
       }
 
-      const user = await UserModel.where({ id: req.user.id }).fetch();
-      const userApds = await user.apds();
-
-      if (!userApds.includes(apdID)) {
+      if (!await userCanEditAPD(req.user.id, apdID)) {
         logger.verbose(req, 'user (state) not associated with this apd');
         return res.status(404).end();
       }

--- a/api/routes/apds/put.test.js
+++ b/api/routes/apds/put.test.js
@@ -11,15 +11,12 @@ tap.test('apds PUT endpoint', async endpointTest => {
     where: sandbox.stub(),
     fetch: sandbox.stub()
   };
-  const UserModel = {
-    where: sandbox.stub(),
-    fetch: sandbox.stub()
-  };
   const Apd = {
     set: sandbox.stub(),
     save: sandbox.stub(),
     toJSON: sandbox.stub()
   };
+  const userCanEditAPD = sandbox.stub();
   const res = {
     status: sandbox.stub(),
     send: sandbox.stub(),
@@ -31,7 +28,6 @@ tap.test('apds PUT endpoint', async endpointTest => {
     sandbox.resetHistory();
 
     ApdModel.where.returns(ApdModel);
-    UserModel.where.returns(UserModel);
 
     res.status.returns(res);
     res.send.returns(res);
@@ -41,7 +37,7 @@ tap.test('apds PUT endpoint', async endpointTest => {
   });
 
   endpointTest.test('setup', async setupTest => {
-    putEndpoint(app, ApdModel, UserModel);
+    putEndpoint(app, ApdModel, userCanEditAPD);
 
     setupTest.ok(
       app.put.calledWith('/apds/:id', loggedInMiddleware, sinon.match.func),
@@ -52,7 +48,7 @@ tap.test('apds PUT endpoint', async endpointTest => {
   endpointTest.test('edit apds handler', async handlerTest => {
     let handler;
     handlerTest.beforeEach(async () => {
-      putEndpoint(app, ApdModel, UserModel);
+      putEndpoint(app, ApdModel, userCanEditAPD);
       handler = app.put.args.find(args => args[0] === '/apds/:id')[2];
     });
 
@@ -79,7 +75,7 @@ tap.test('apds PUT endpoint', async endpointTest => {
           body: { status: 'foo' }
         };
         ApdModel.fetch.resolves(true);
-        UserModel.fetch.resolves({ apds: () => [2, 3, 4] });
+        userCanEditAPD.resolves(false);
 
         await handler(req, res);
 
@@ -111,7 +107,7 @@ tap.test('apds PUT endpoint', async endpointTest => {
       Apd.toJSON.returns({ status: 'json-status' });
       Apd.save.resolves();
       ApdModel.fetch.resolves(Apd);
-      UserModel.fetch.resolves({ apds: () => [1, 2, 3] });
+      userCanEditAPD.resolves(true);
 
       await handler(req, res);
 

--- a/api/routes/apds/utils.js
+++ b/api/routes/apds/utils.js
@@ -1,0 +1,10 @@
+const { user: defaultUserModel } = require('../../db').models;
+
+const userCanEditAPD = async (userID, apdID, UserModel = defaultUserModel) => {
+  const user = await UserModel.where({ id: userID }).fetch();
+  const userApds = await user.apds();
+
+  return userApds.includes(apdID);
+};
+
+module.exports = { userCanEditAPD };

--- a/api/routes/apds/utils.test.js
+++ b/api/routes/apds/utils.test.js
@@ -1,0 +1,56 @@
+const tap = require('tap');
+const sinon = require('sinon');
+
+const utils = require('./utils');
+
+tap.test('apd route utils', async tests => {
+  const sandbox = sinon.createSandbox();
+
+  tests.test(
+    'whether a user can edit a particular APD',
+    async userCanEditTest => {
+      const UserModel = {
+        where: sandbox.stub(),
+        fetch: sandbox.stub()
+      };
+      const user = {
+        apds: sandbox.stub()
+      };
+      userCanEditTest.beforeEach(async () => {
+        sandbox.resetBehavior();
+        sandbox.resetHistory();
+
+        UserModel.where.returns(UserModel);
+        UserModel.fetch.resolves(user);
+      });
+
+      userCanEditTest.test(
+        'returns false if the user does not belong to the state that owns the APD',
+        async falseTest => {
+          user.apds.resolves([5, 10, 15]);
+          const result = await utils.userCanEditAPD(1, 2, UserModel);
+
+          falseTest.ok(
+            UserModel.where.calledWith({ id: 1 }),
+            'queries for the user we wanted'
+          );
+          falseTest.notOk(result, 'returns a false result');
+        }
+      );
+
+      userCanEditTest.test(
+        'returns true if the user belongs to the state that owns the APD',
+        async trueTest => {
+          user.apds.resolves([2]);
+          const result = await utils.userCanEditAPD(1, 2, UserModel);
+
+          trueTest.ok(
+            UserModel.where.calledWith({ id: 1 }),
+            'queries for the user we wanted'
+          );
+          trueTest.ok(result, 'returns a true result');
+        }
+      );
+    }
+  );
+});

--- a/api/seeds/test.js
+++ b/api/seeds/test.js
@@ -1,4 +1,4 @@
-const apds = require('./shared/apds');
+const apds = require('./test/apds');
 const truncate = require('./shared/delete-everything');
 const states = require('./shared/states');
 const roles = require('./test/roles');

--- a/api/seeds/test/apds.js
+++ b/api/seeds/test/apds.js
@@ -1,0 +1,83 @@
+exports.seed = async knex => {
+  await knex('apds').insert({
+    id: 1000,
+    state_id: 'mo',
+    status: 'draft'
+  });
+
+  await knex('activities').insert([
+    {
+      id: 1000,
+      name: 'Find Success',
+      description: 'Some text goes here',
+      apd_id: 1000
+    },
+    {
+      id: 1001,
+      name: 'My Second Activity',
+      description: 'More gunk',
+      apd_id: 1000
+    }
+  ]);
+
+  await knex('activity_goals').insert([
+    {
+      id: 1000,
+      description: 'Be a super successful artist',
+      activity_id: 1000
+    },
+    {
+      id: 1001,
+      description: 'Win a Nobel prize for physics',
+      activity_id: 1000
+    },
+    {
+      id: 1002,
+      description: 'Go on Ellen',
+      activity_id: 1000
+    }
+  ]);
+
+  await knex('activity_goal_objectives').insert([
+    {
+      id: 1000,
+      description: 'Paint a pretty picture',
+      activity_goal_id: 1000
+    },
+    {
+      id: 1001,
+      description: 'Paint a confusing picture',
+      activity_goal_id: 1000
+    },
+    {
+      id: 1002,
+      description: 'Paint an offensive picture',
+      activity_goal_id: 1000
+    },
+    {
+      id: 1003,
+      description: '...Profit',
+      activity_goal_id: 1000
+    },
+    {
+      id: 1004,
+      description: 'Discover a new particle',
+      activity_goal_id: 1001
+    },
+    {
+      id: 1005,
+      description: 'Lie about the Moonmen',
+      activity_goal_id: 1001
+    },
+    {
+      id: 1006,
+      description: 'Learn to dance',
+      activity_goal_id: 1002
+    },
+    {
+      id: 1007,
+      description: 'Bring audience gifts',
+      activity_goal_id: 1002
+    }
+  ]);
+};


### PR DESCRIPTION
Creates all the API-side stuff to support creating and editing APD activities, goals, and objectives.

This PR got pretty big so I'm going to split it into a few.  This one adds the API changes, the next one will add the frontend changes, and then I will create more to add the handful of things missing:

* unit tests on the frontend
* endpoint tests on the backend
* OpenAPI documentation
* logging on the backend

## Endpoints

* POST `/apds/:apd_id/activities`
  Create a new activity on the APD specified by `apd_id`.  This just creates an activity with a name, no description.  This is based on the UI section for selecting and creating new activities - it begins with just names.  Descriptions are added in a separate form.  The activity name must be unique within the APD (that is, a single APD may not have multiple activities with the same name).

* PUT `/activities/:id`
  Updates the activity specified by `id`.  This lets you change the name or description for an existing activity.

* PUT `/activities/:id/goals`
  Add goals to the activity specified by `id`.  This will remove all goals and objectives associated with the activity and replace them with the new values.  I decided to do this because the UI is hooked up in such a way that it will send us all of the goals and objectives when it saves, and deleting and inserting new was easier than doing a diff and dancing around to figure out which ones had changed, etc.

## Models

* Added `toJSON` overrides for all the activity-related models (activity, goal, objective) to get rid of extraneous mapping IDs in most cases, but also to return objectives as just strings.  Since they cannot be updated individually, only replaced with goals, there was no reason to make them objects with IDs.  Similarly, no longer returns goal IDs since goals cannot be modified individually.

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
  - no updated endpoint tests, but this PR was already too big so I will add those in the next one 😬
- [x] This code has been reviewed by someone other than the original author
- ~~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~~
- ~~The change has been documented~~
  - ~~Associated OpenAPI documentation has been updated~~
  - will add OpenAPI documentation in an upcoming PR, because this thing is already enormous

### This feature is done when...
- ~~Design has approved the experience~~
- ~~Product has approved the experience~~
