### PR TITLE
add basic spellcheck

### DIFF
--- a/web/src/components/Inputs.js
+++ b/web/src/components/Inputs.js
@@ -2,7 +2,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 const Input = props => <input className="m0 input" {...props} />;
-const Textarea = props => <textarea className="m0 textarea" {...props} />;
+const Textarea = props => (
+  <textarea className="m0 textarea" spellCheck="true" {...props} />
+);
 
 // a HOC for Text / Textarea input that includes
 // div wrapper and accompanying label


### PR DESCRIPTION
There exists a `spellcheck` attribute (that's actually well supported across browsers) that we can tap into for our `textarea` inputs. And on right click, it even gives a list of suggested correct spellings! 

https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/spellcheck

Preview:
![spellcheck](https://user-images.githubusercontent.com/1060893/37715351-2a1c08da-2cf2-11e8-931e-9658afde6e7d.gif)

### This pull request is ready to merge when...
- ~Tests have been updated (and all tests are passing)~
- [x] This code has been reviewed by someone other than the original author
- [x] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- ~The change has been documented~
  - ~Associated OpenAPI documentation has been updated~

### This feature is done when...
- [x] Design has approved the experience
- [ ] Product has approved the experience
