### PR TITLE
Start prototyping submission experience mockup

### DIFF
--- a/web/src/components/PoC.js
+++ b/web/src/components/PoC.js
@@ -1,47 +1,203 @@
-import React from 'react';
+import PropTypes from 'prop-types';
+import React, { Component, Fragment } from 'react';
 
 import Collapsible from './Collapsible';
 import TopNav from '../containers/TopNav';
 
-const Sidebar = () => (
-  <div className="site-sidebar bg-navy">
-    <div className="p2 xs-hide sm-hide">
-      <ul className="list-reset">
-        <li className="mb1">
-          <a href="#!" className="inline-block white text-decoration-none">
-            Foo
-          </a>
-        </li>
-      </ul>
-    </div>
-  </div>
-);
+const sections = [
+  'Short Summary of Activity',
+  'Activity Description',
+  'Goals and Objectives'
+];
 
-const PoC = () => (
-  <div className="site-body">
-    <Sidebar />
-    <div className="site-content">
-      <TopNav />
-      <div className="p2 pb4 sm-p3">
-        <Collapsible title="Activity List" open>
-          <p>Boom!</p>
-        </Collapsible>
+const Sidebar = ({ activities }) => {
+  const linkClass = 'inline-block white text-decoration-none truncate';
 
-        <Collapsible title="Activity List" open>
-          <p>Boom!</p>
-        </Collapsible>
-        <Collapsible title="Activity List" open>
-          <p>Boom!</p>
-        </Collapsible>
-        <Collapsible title="Activity List" open>
-          <p>Boom!</p>
-        </Collapsible>
-        <Collapsible title="Activity List" open>
-          <p>Boom!</p>
-        </Collapsible>
+  return (
+    <div className="site-sidebar bg-navy">
+      <div className="p2 xs-hide sm-hide">
+        <ul className="list-reset">
+          <li className="mb1">
+            <a href="#!" className={linkClass}>
+              Program Summary
+            </a>
+          </li>
+          <li className="mb1">
+            <a href="#!" className={linkClass}>
+              Program Activities
+            </a>
+          </li>
+          <ul className="ml3 list-reset">
+            {activities.map((a, i) => (
+              <Fragment key={a.id}>
+                <li className="mb1">
+                  <a href="#!" className={linkClass}>
+                    {i + 1}. {a.name || 'N/A'} ({a.type})
+                  </a>
+                </li>
+                <ul className="ml3 list-reset">
+                  {sections.map((s, j) => (
+                    <li key={j} className="mb1">
+                      <a href="#!" className={linkClass}>
+                        {s}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </Fragment>
+            ))}
+          </ul>
+        </ul>
       </div>
     </div>
-  </div>
-);
+  );
+};
+
+Sidebar.propTypes = {
+  activities: PropTypes.array.isRequired
+};
+
+class PoC extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      activities: [
+        {
+          id: 1,
+          name: 'Test',
+          type: 'HIT'
+        },
+        {
+          id: 2,
+          name: 'Test 2',
+          type: 'MMIS'
+        }
+      ]
+    };
+  }
+
+  addActivity = () => {
+    this.setState(({ activities }) => ({
+      activities: [
+        ...activities,
+        {
+          id: activities.reduce((maxId, a) => Math.max(a.id, maxId), -1) + 1,
+          name: '',
+          type: 'HIT'
+        }
+      ]
+    }));
+  };
+
+  editActivity = e => {
+    const { name: nameRaw, value } = e.target;
+    const [id, name] = nameRaw.split('.');
+
+    this.setState(({ activities }) => ({
+      activities: activities.map(
+        a => (a.id === +id ? { ...a, [name]: value } : a)
+      )
+    }));
+  };
+
+  render() {
+    const { activities } = this.state;
+
+    return (
+      <div className="site-body">
+        <Sidebar activities={activities} />
+        <div className="site-content">
+          <TopNav />
+          <div className="p2 pb4 sm-p3">
+            <Collapsible title="Activity List" open>
+              <div className="mb2">
+                {activities.map((a, i) => (
+                  <div key={a.id} className="flex mb1">
+                    <div className="mr1 bold mono">{i + 1}.</div>
+                    <div className="mr1 col-4">
+                      <input
+                        type="text"
+                        className="col-12"
+                        name={`${a.id}.name`}
+                        value={a.name}
+                        onChange={this.editActivity}
+                      />
+                    </div>
+                    <div>
+                      <label>
+                        <input
+                          type="radio"
+                          name={`${a.id}.type`}
+                          value="HIT"
+                          checked={a.type === 'HIT'}
+                          onChange={this.editActivity}
+                        />{' '}
+                        HIT
+                      </label>
+                      <label>
+                        <input
+                          type="radio"
+                          name={`${a.id}.type`}
+                          value="HIE"
+                          checked={a.type === 'HIE'}
+                          onChange={this.editActivity}
+                        />{' '}
+                        HIE
+                      </label>
+                      <label>
+                        <input
+                          type="radio"
+                          name={`${a.id}.type`}
+                          value="MMIS"
+                          checked={a.type === 'MMIS'}
+                          onChange={this.editActivity}
+                        />{' '}
+                        MMIS
+                      </label>
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={this.addActivity}
+              >
+                Add activity
+              </button>
+            </Collapsible>
+
+            {activities.map((a, i) => (
+              <div key={a.id} className="mb3">
+                <h3>
+                  Activity {i + 1}: {a.name || 'N/A'} ({a.type})
+                </h3>
+                <Collapsible title="Short Summary of Activity" open>
+                  <div className="mb1 bold">Summary of the activity</div>
+                  <textarea
+                    className="textarea col-10"
+                    rows="5"
+                    spellCheck="true"
+                    placeholder="A brief statement of what the activity involves..."
+                  />
+                </Collapsible>
+                <Collapsible title="Activity Description">
+                  <div className="py2 h1 center">...</div>
+                </Collapsible>
+                <Collapsible title="Goals and Objectives">
+                  <div className="py2 h1 center">...</div>
+                </Collapsible>
+                <Collapsible title="Alternative Analysis">
+                  <div className="py2 h1 center">...</div>
+                </Collapsible>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
 
 export default PoC;

--- a/web/src/components/PoC.js
+++ b/web/src/components/PoC.js
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import Collapsible from './Collapsible';
+import TopNav from '../containers/TopNav';
+
+const Sidebar = () => (
+  <div className="site-sidebar bg-navy">
+    <div className="p2 xs-hide sm-hide">
+      <ul className="list-reset">
+        <li className="mb1">
+          <a href="#!" className="inline-block white text-decoration-none">
+            Foo
+          </a>
+        </li>
+      </ul>
+    </div>
+  </div>
+);
+
+const PoC = () => (
+  <div className="site-body">
+    <Sidebar />
+    <div className="site-content">
+      <TopNav />
+      <div className="p2 pb4 sm-p3">
+        <Collapsible title="Activity List" open>
+          <p>Boom!</p>
+        </Collapsible>
+
+        <Collapsible title="Activity List" open>
+          <p>Boom!</p>
+        </Collapsible>
+        <Collapsible title="Activity List" open>
+          <p>Boom!</p>
+        </Collapsible>
+        <Collapsible title="Activity List" open>
+          <p>Boom!</p>
+        </Collapsible>
+        <Collapsible title="Activity List" open>
+          <p>Boom!</p>
+        </Collapsible>
+      </div>
+    </div>
+  </div>
+);
+
+export default PoC;

--- a/web/src/containers/TopNav.js
+++ b/web/src/containers/TopNav.js
@@ -25,7 +25,7 @@ class TopNav extends Component {
       <header className="clearfix py1 border-bottom border-silver">
         <div className="sm-col">
           <Link to="/" className="btn">
-            CMS HITECH APD
+            2018 HITECH APD
           </Link>
         </div>
         <div className="sm-col-right h5">

--- a/web/src/routes.js
+++ b/web/src/routes.js
@@ -12,6 +12,7 @@ import ActivityOverview from './containers/ActivityOverview';
 import ActivitySchedule from './containers/ActivitySchedule';
 import ApdOverview from './containers/ApdOverview';
 import Login from './containers/Login';
+import PoC from './components/PoC';
 import ReviewAndSubmit from './containers/ReviewAndSubmit';
 import StateContacts from './containers/StateContacts';
 import StateStart from './containers/StateStart';
@@ -20,6 +21,7 @@ import StatePersonnel from './containers/StatePersonnel';
 const routes = [
   { path: '/', component: Hello, exact: true, nonPrivate: true },
   { path: '/login', component: Login, nonPrivate: true },
+  { path: '/poc', component: PoC, nonPrivate: true },
   { path: '/activities-list', component: ActivitiesList },
   { path: '/activities-start', component: ActivitiesStart },
   { path: '/activity-approach/:activityName', component: ActivityApproach },

--- a/web/src/styles/app/layout.css
+++ b/web/src/styles/app/layout.css
@@ -39,5 +39,6 @@ footer {
   .site-sidebar {
     display: block;
     flex: 0 0 18rem;
+    overflow: auto;
   }
 }

--- a/web/src/styles/app/type.css
+++ b/web/src/styles/app/type.css
@@ -1,0 +1,3 @@
+.mono {
+  font-family: Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace;
+}

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -8,6 +8,7 @@
 @import 'app/layout';
 @import 'app/spacing';
 @import 'app/table';
+@import 'app/type';
 
 @custom-media --breakpoint-sm (min-width: 40rem);
 @custom-media --breakpoint-md (min-width: 52rem);


### PR DESCRIPTION
Starts implementation of activities add/edit mockup.

Still lots more to do; this is just the start, but you can start to see the dynamic bits.

Viewable at `/poc`

Preview:
<img width="1012" alt="screen shot 2018-03-30 at 4 58 13 pm" src="https://user-images.githubusercontent.com/1060893/38153591-8da7ebd0-343b-11e8-857b-b235a2e1ef40.png">

### This pull request is ready to merge when...
- ~Tests have been updated (and all tests are passing)~
- [ ] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- ~The change has been documented~
  - ~Associated OpenAPI documentation has been updated~

### This feature is done when...
- [ ] Design has approved the experience
- ~Product has approved the experience~
