### PR TITLE
Fix middleware cacheing

### DIFF
--- a/api/middleware/apd.js
+++ b/api/middleware/apd.js
@@ -1,18 +1,17 @@
 const logger = require('../logger')('apd middleware');
+const { cache, modelIndex } = require('./cache');
+
 const {
   apd: defaultApdModel,
   apdActivity: defaultActivityModel
 } = require('../db').models;
 
-const cache = {};
-
 module.exports.loadApd = (
   model = defaultApdModel,
   idParam = 'id',
   ApdModel = defaultApdModel
-) => {
-  const key = ['loadApd', model, idParam, ApdModel];
-  if (!cache[key]) {
+) =>
+  cache(['loadApd', modelIndex(model), idParam, ApdModel], () => {
     const loadApd = async (req, res, next) => {
       logger.silly(req, 'loading APD for request');
       try {
@@ -44,14 +43,11 @@ module.exports.loadApd = (
         res.status(500).end();
       }
     };
-    cache[key] = loadApd;
-  }
-  return cache[key];
-};
+    return loadApd;
+  });
 
-module.exports.userCanEditAPD = (model = defaultApdModel, idParam = 'id') => {
-  const key = ['userCanEditAPD', model, idParam];
-  if (!cache[key]) {
+module.exports.userCanEditAPD = (model = defaultApdModel, idParam = 'id') =>
+  cache(['userCanEditAPD', modelIndex(model), idParam], () => {
     const userCanEditAPD = async (req, res, next) => {
       logger.silly(req, 'verifying the user can access this APD');
       await module.exports.loadApd(model, idParam)(req, res, async () => {
@@ -64,17 +60,11 @@ module.exports.userCanEditAPD = (model = defaultApdModel, idParam = 'id') => {
         }
       });
     };
-    cache[key] = userCanEditAPD;
-  }
-  return cache[key];
-};
+    return userCanEditAPD;
+  });
 
-module.exports.loadActivity = (
-  idParam = 'id',
-  model = defaultActivityModel
-) => {
-  const key = ['loadActivity', model, idParam];
-  if (!cache[key]) {
+module.exports.loadActivity = (idParam = 'id', model = defaultActivityModel) =>
+  cache(['loadActivity', modelIndex(model), idParam], () => {
     const loadActivity = async (req, res, next) => {
       try {
         logger.silly(req, 'loading APD activity for request');
@@ -98,7 +88,5 @@ module.exports.loadActivity = (
         res.status(500).end();
       }
     };
-    cache[key] = loadActivity;
-  }
-  return cache[key];
-};
+    return loadActivity;
+  });

--- a/api/middleware/auth.js
+++ b/api/middleware/auth.js
@@ -1,6 +1,5 @@
 const logger = require('../logger')('auth middleware');
-
-const canCache = {};
+const { cache } = require('./cache');
 
 const loggedIn = (req, res, next) => {
   logger.silly(req, 'got a loggedIn middleware request');
@@ -15,10 +14,8 @@ const loggedIn = (req, res, next) => {
 
 module.exports.loggedIn = loggedIn;
 
-const canCreator = activity => {
-  if (!canCache[activity]) {
-    logger.silly(`can[${activity}] cache miss`);
-
+const canCreator = activity =>
+  cache(['can', activity], () => {
     const can = (req, res, next) => {
       logger.silly(req, `got a can middleware request for [${activity}]`);
       // First check if they're logged in
@@ -33,10 +30,7 @@ const canCreator = activity => {
         }
       });
     };
-    canCache[activity] = can;
-    logger.silly(`added handler for [${activity}] can middleware`);
-  }
-  return canCache[activity];
-};
+    return can;
+  });
 
 module.exports = { loggedIn, can: canCreator };

--- a/api/middleware/cache.js
+++ b/api/middleware/cache.js
@@ -1,0 +1,18 @@
+const middlewareCache = {};
+const cache = (key, getMiddleware) => {
+  if (!middlewareCache[key]) {
+    middlewareCache[key] = getMiddleware();
+  }
+  return middlewareCache[key];
+};
+
+const knownModels = [];
+const modelIndex = model => {
+  if (knownModels.includes(model)) {
+    return knownModels.indexOf(model);
+  }
+  knownModels.push(model);
+  return knownModels.length - 1;
+};
+
+module.exports = { cache, modelIndex };

--- a/api/middleware/cache.test.js
+++ b/api/middleware/cache.test.js
@@ -1,0 +1,60 @@
+const tap = require('tap');
+const sinon = require('sinon');
+
+const { cache, modelIndex } = require('./cache');
+
+tap.test('middleware cache', async cacheTests => {
+  const key1 = ['something', 1, {}];
+  const key2 = ['another', 2];
+
+  cacheTests.test('gets middleware from cache', async test => {
+    const middleware1 = {};
+    const middleware2 = {};
+
+    const getter1 = sinon.stub().returns(middleware1);
+    const getter2 = sinon.stub().returns(middleware2);
+
+    const out1 = cache(key1, getter1);
+    const out2 = cache(key2, getter2);
+    const out3 = cache(key1, getter1);
+
+    test.ok(getter1.calledOnce, 'first middleware getter is only called once');
+    test.ok(getter2.calledOnce, 'second middleware getter is only called once');
+    test.equal(
+      out1,
+      out3,
+      'returns the same thing on subsequent cache calls with the same key'
+    );
+    test.equal(
+      out1,
+      middleware1,
+      'returns the result of the first middleware getter'
+    );
+    test.notEqual(out1, out2, 'returns the right middleware based on the key');
+    test.equal(
+      out2,
+      middleware2,
+      'returns the result of the second middleware getter'
+    );
+  });
+});
+
+tap.test('model indexer', async modelIndexTest => {
+  const model1 = {};
+  const model2 = {};
+
+  modelIndexTest.test('returns a number for a model', async test => {
+    const index1 = modelIndex(model1);
+    const index2 = modelIndex(model2);
+    const index3 = modelIndex(model1);
+
+    test.type(index1, 'number', 'returns a number for the first object');
+    test.type(index2, 'number', 'returns a number for the second object');
+    test.notEqual(
+      index1,
+      index2,
+      'the numbers for the two different objects are not the same'
+    );
+    test.equal(index1, index3, 'gives the same number for the same object');
+  });
+});


### PR DESCRIPTION
Fixes middleware cacheing by converting Bookshelf.js model objects into numbers.  The cache is being keyed on an array of the form `[middlewareName, model, other, stuff]` - but it is stored as a plain object with that key as the object property.  However, object properties must be strings, so internally JS is stringifying the key.  No big deal, except ***all Bookshelf.js model objects stringify to null***.

Thus, a cache keyed on `['userCanEditAPD`, APDModel]` is exactly the same as one keyed on `['userCanEditAPD', ActivityModel]`.  Blam, everything breaks - we check whether users can edit APDs based on whichever model happened to be passed in the first time the middleware was cached, and thereafter every access to the cache is a hit and returns the first instance.  (Boo.)

To get around that, I create an array of models as the middlewares are created.  If the model exists in the array, I return its index.  If it doesn't, I add it to the array and then return its index.  Numbers stringify really well, so that fixes the cache.

While I was fiddling with it, I pulled cacheing out into its own little module and modified the `can` middleware to use it.  No sense doing cacheing independently in several places.

## Merging

This one still has a broken endpoint test, related to #367.  Since we're not merging into master, though, it should be fine to go ahead and merge this one.  A fix for #367 is incoming in a separate PR.

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- ~The change has been documented~
  - ~Associated OpenAPI documentation has been updated~

### This feature is done when...
- ~Design has approved the experience~
- ~Product has approved the experience~
