### PR TITLE
Enforce activity name uniqueness

### DIFF
--- a/api/db/activity.js
+++ b/api/db/activity.js
@@ -1,3 +1,5 @@
+const logger = require('../logger')('db activity model');
+
 module.exports = () => ({
   apdActivity: {
     tableName: 'activities',
@@ -16,6 +18,25 @@ module.exports = () => ({
 
     expenses() {
       return this.hasMany('apdActivityExpense');
+    },
+
+    async validate() {
+      logger.silly('validating');
+
+      if (this.hasChanged('name')) {
+        const name = this.attributes.name;
+
+        if (typeof name !== 'string' || name.length < 1) {
+          logger.verbose('name is not a string or is empty');
+          throw new Error('invalid-name');
+        }
+
+        const hasName = await this.where({ name }).fetchAll();
+        if (hasName.length) {
+          logger.verbose('another activity already has this name');
+          throw new Error('name-exists');
+        }
+      }
     },
 
     toJSON() {


### PR DESCRIPTION
Adds validation to the APD activity model, and modifies the `/apd/:id/activities` POST endpoint handler to use model validation instead of trying to do validation itself.  This fixes a bug where activity name uniqueness was not enforced when submitting multiple activities at once.

This PR will close #367.

This merges into #378.  When this and #379 are both merged, the tests on #378 should pass so it can be merged too.  :tada:

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- ~The change has been documented~
  - ~Associated OpenAPI documentation has been updated~

### This feature is done when...
- ~Design has approved the experience~
- ~Product has approved the experience~
