### PR TITLE
Add activity schedule endpoints

### DIFF
--- a/api/db/activity.js
+++ b/api/db/activity.js
@@ -50,7 +50,8 @@ module.exports = () => ({
         description: this.get('description'),
         goals: this.related('goals'),
         approaches: this.related('approaches'),
-        expenses: this.related('expenses')
+        expenses: this.related('expenses'),
+        schedule: this.related('schedule')
       };
     }
   },

--- a/api/endpoint-tests/activities/put.js
+++ b/api/endpoint-tests/activities/put.js
@@ -136,7 +136,8 @@ tap.test(
                   description: 'Go on Ellen',
                   objectives: ['Learn to dance', 'Bring audience gifts']
                 }
-              ]
+              ],
+              schedule: []
             },
             'sends back the updated activity object'
           );

--- a/api/routes/apds/activities/index.js
+++ b/api/routes/apds/activities/index.js
@@ -4,6 +4,7 @@ const put = require('./put');
 const goals = require('./goals/put');
 const approaches = require('./approaches/put');
 const expenses = require('./expenses/put');
+const schedule = require('./schedule/put');
 
 module.exports = (
   app,
@@ -11,7 +12,8 @@ module.exports = (
   putEndpoint = put,
   approachesEndpoint = approaches,
   expensesEndpoints = expenses,
-  goalsEndpoints = goals
+  goalsEndpoints = goals,
+  scheduleEndpoints = schedule
 ) => {
   logger.silly('setting up POST endpoint');
   postEndpoint(app);
@@ -23,4 +25,6 @@ module.exports = (
   expensesEndpoints(app);
   logger.silly('setting up goals endpoints');
   goalsEndpoints(app);
+  logger.silly('setting up schedule endpoints');
+  scheduleEndpoints(app);
 };

--- a/api/routes/apds/activities/index.test.js
+++ b/api/routes/apds/activities/index.test.js
@@ -10,6 +10,7 @@ tap.test('apd activities endpoint setup', async endpointTest => {
   const approachesEndpoint = sinon.spy();
   const goalsEndpoint = sinon.spy();
   const expensesEndpoints = sinon.spy();
+  const scheduleEndpoints = sinon.spy();
 
   apdsIndex(
     app,
@@ -17,7 +18,8 @@ tap.test('apd activities endpoint setup', async endpointTest => {
     putEndpoint,
     approachesEndpoint,
     expensesEndpoints,
-    goalsEndpoint
+    goalsEndpoint,
+    scheduleEndpoints
   );
 
   endpointTest.ok(
@@ -39,5 +41,9 @@ tap.test('apd activities endpoint setup', async endpointTest => {
   endpointTest.ok(
     goalsEndpoint.calledWith(app),
     'apd activity goals endpoints are setup with the app'
+  );
+  endpointTest.ok(
+    scheduleEndpoints.calledWith(app),
+    'apd activity schedule endpoints are setup with the app'
   );
 });

--- a/api/routes/apds/activities/schedule/openAPI.js
+++ b/api/routes/apds/activities/schedule/openAPI.js
@@ -1,0 +1,92 @@
+const {
+  requiresAuth,
+  schema: { arrayOf, errorToken, jsonResponse }
+} = require('../../../openAPI/helpers');
+
+const activityObjectSchema = {
+  type: 'object',
+  properties: {
+    id: {
+      type: 'number',
+      description: 'Activity globally-unique ID'
+    },
+    name: {
+      type: 'string',
+      description: 'Activity name, unique within an APD'
+    },
+    description: {
+      type: 'string',
+      description: 'Activity description'
+    },
+    goals: arrayOf({
+      type: 'object',
+      description: 'Activity goal',
+      properties: {
+        description: {
+          type: 'string',
+          description: 'Goal description'
+        },
+        objectives: arrayOf({
+          type: 'string',
+          description: 'Goal objective'
+        })
+      }
+    })
+  }
+};
+
+const openAPI = {
+  '/activities/{id}/approaches': {
+    put: {
+      description: 'Set the approaches for a specific activity',
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          description: 'The ID of the activity to set the approaches for',
+          required: true
+        }
+      ],
+      requestBody: {
+        description: 'The new approaches',
+        required: true,
+        content: jsonResponse(
+          arrayOf({
+            type: 'object',
+            properties: {
+              description: {
+                type: 'string',
+                description: 'The description of this approach'
+              },
+              alternatives: {
+                type: 'string',
+                description: 'The alternatives considered for this approach'
+              },
+              explanation: {
+                type: 'string',
+                description:
+                  'An explanation of why this approach was chosen over the alternatives'
+              }
+            }
+          })
+        )
+      },
+      responses: {
+        200: {
+          description: 'The updated activity',
+          content: jsonResponse(activityObjectSchema)
+        },
+        400: {
+          description: 'The approaches are invalid (e.g., not an array)',
+          content: errorToken
+        },
+        404: {
+          description:
+            'The specified activity was not found, or the user does not have access to it'
+        }
+      }
+    }
+  }
+};
+
+module.exports = requiresAuth(openAPI);

--- a/api/routes/apds/activities/schedule/openAPI.js
+++ b/api/routes/apds/activities/schedule/openAPI.js
@@ -36,36 +36,51 @@ const activityObjectSchema = {
 };
 
 const openAPI = {
-  '/activities/{id}/approaches': {
+  '/activities/{id}/schedule': {
     put: {
-      description: 'Set the approaches for a specific activity',
+      description: 'Set the schedule for a specific activity',
       parameters: [
         {
           name: 'id',
           in: 'path',
-          description: 'The ID of the activity to set the approaches for',
+          description: 'The ID of the activity to set the schedule for',
           required: true
         }
       ],
       requestBody: {
-        description: 'The new approaches',
+        description: 'The new schedule',
         required: true,
         content: jsonResponse(
           arrayOf({
             type: 'object',
             properties: {
-              description: {
+              milestone: {
                 type: 'string',
-                description: 'The description of this approach'
+                description: 'The milestone this schedule entry applies to'
               },
-              alternatives: {
+              status: {
                 type: 'string',
-                description: 'The alternatives considered for this approach'
+                description: 'The current status of the milestone'
               },
-              explanation: {
+              plannedStart: {
                 type: 'string',
                 description:
-                  'An explanation of why this approach was chosen over the alternatives'
+                  'The planned start date for the milestone as an ISO-8601 date string.'
+              },
+              actualStart: {
+                type: 'string',
+                description:
+                  'The actual start date for the milestone, if known, as an ISO-8601 date string.'
+              },
+              plannedEnd: {
+                type: 'string',
+                description:
+                  'The planned end date for the milestone as an ISO-8601 date string.'
+              },
+              actualEnd: {
+                type: 'string',
+                description:
+                  'The actual end date for the milestone, if known, as an ISO-8601 date string.'
               }
             }
           })
@@ -77,7 +92,7 @@ const openAPI = {
           content: jsonResponse(activityObjectSchema)
         },
         400: {
-          description: 'The approaches are invalid (e.g., not an array)',
+          description: 'The schedule entries are invalid (e.g., not an array)',
           content: errorToken
         },
         404: {

--- a/api/routes/apds/activities/schedule/put.js
+++ b/api/routes/apds/activities/schedule/put.js
@@ -1,0 +1,81 @@
+const logger = require('../../../../logger')(
+  'apd activity approaches route post'
+);
+const {
+  apdActivity: defaultActivityModel,
+  apdActivityApproach: defaultApproachModel
+} = require('../../../../db').models;
+const {
+  loggedIn,
+  loadActivity,
+  userCanEditAPD
+} = require('../../../../middleware');
+
+module.exports = (
+  app,
+  ActivityModel = defaultActivityModel,
+  ApproachModel = defaultApproachModel
+) => {
+  const route = '/activities/:id/approaches';
+  logger.silly(`setting up PUT ${route} route`);
+  app.put(
+    route,
+    loggedIn,
+    loadActivity(),
+    userCanEditAPD(ActivityModel),
+    async (req, res) => {
+      logger.silly(req, `handling PUT ${route} route`);
+      logger.silly(
+        req,
+        `attempting to set approaches on apd activity [${req.params.id}]`
+      );
+
+      try {
+        const activityID = +req.params.id;
+        const activity = req.meta.activity;
+
+        if (!Array.isArray(req.body)) {
+          logger.verbose('request is not an array');
+          return res
+            .status(400)
+            .send({ error: 'edit-activity-invalid-approaches' })
+            .end();
+        }
+
+        // Delete the previous approaches for this activity
+        logger.silly('deleting previous approaches activity');
+        await Promise.all(
+          activity
+            .related('approaches')
+            .map(async approach => approach.destroy())
+        );
+
+        await Promise.all(
+          req.body.map(async ({ description, alternatives, explanation }) => {
+            // don't insert empty objects, that's silly
+            if (description || alternatives || explanation) {
+              const approach = ApproachModel.forge({
+                description,
+                alternatives,
+                explanation,
+                activity_id: activityID
+              });
+              await approach.save();
+            }
+          })
+        );
+
+        const updatedActivity = await ActivityModel.where({
+          id: activityID
+        }).fetch({
+          withRelated: ['goals.objectives', 'approaches']
+        });
+
+        return res.send(updatedActivity.toJSON());
+      } catch (e) {
+        logger.error(req, e);
+        return res.status(500).end();
+      }
+    }
+  );
+};

--- a/api/routes/apds/activities/schedule/put.js
+++ b/api/routes/apds/activities/schedule/put.js
@@ -1,5 +1,5 @@
 const logger = require('../../../../logger')(
-  'apd activity approaches route post'
+  'apd activity schedule route post'
 );
 const {
   apdActivity: defaultActivityModel,
@@ -27,7 +27,7 @@ module.exports = (
       logger.silly(req, `handling PUT ${route} route`);
       logger.silly(
         req,
-        `attempting to set approaches on apd activity [${req.params.id}]`
+        `attempting to set schedule on apd activity [${req.params.id}]`
       );
 
       try {
@@ -52,12 +52,12 @@ module.exports = (
           req.body.map(async ({ milestone, status }) => {
             // don't insert empty objects, that's silly
             if (milestone || status) {
-              const approach = ScheduleModel.forge({
+              const schedule = ScheduleModel.forge({
                 milestone,
                 status,
                 activity_id: activityID
               });
-              await approach.save();
+              await schedule.save();
             }
           })
         );

--- a/api/routes/apds/activities/schedule/put.test.js
+++ b/api/routes/apds/activities/schedule/put.test.js
@@ -8,7 +8,7 @@ const {
 } = require('../../../../middleware');
 const putEndpoint = require('./put');
 
-tap.test('apd activity approach PUT endpoint', async endpointTest => {
+tap.test('apd activity schedule PUT endpoint', async endpointTest => {
   const sandbox = sinon.createSandbox();
   const app = { put: sandbox.stub() };
 
@@ -16,7 +16,7 @@ tap.test('apd activity approach PUT endpoint', async endpointTest => {
     where: sandbox.stub(),
     fetch: sandbox.stub()
   };
-  const ApproachModel = {
+  const ScheduleModel = {
     forge: sandbox.stub()
   };
 
@@ -52,144 +52,137 @@ tap.test('apd activity approach PUT endpoint', async endpointTest => {
   });
 
   endpointTest.test('setup', async setupTest => {
-    putEndpoint(app, ActivityModel, ApproachModel);
+    putEndpoint(app, ActivityModel, ScheduleModel);
 
     setupTest.ok(
       app.put.calledWith(
-        '/activities/:id/approaches',
+        '/activities/:id/schedule',
         loggedIn,
         loadActivity(),
         userCanEditAPD(ActivityModel),
         sinon.match.func
       ),
-      'apd activity approach PUT endpoint is registered'
+      'apd activity schedule PUT endpoint is registered'
     );
   });
 
-  endpointTest.test(
-    'set APD activity approaches handler',
-    async handlerTest => {
-      let handler;
-      handlerTest.beforeEach(async () => {
-        putEndpoint(app, ActivityModel, ApproachModel);
-        handler = app.put.args.find(
-          args => args[0] === '/activities/:id/approaches'
-        )[4];
-      });
+  endpointTest.test('set APD activity schedule handler', async handlerTest => {
+    let handler;
+    handlerTest.beforeEach(async () => {
+      putEndpoint(app, ActivityModel, ScheduleModel);
+      handler = app.put.args.find(
+        args => args[0] === '/activities/:id/schedule'
+      )[4];
+    });
 
-      handlerTest.test(
-        'sends a server error if anything goes wrong',
-        async saveTest => {
-          const req = {
-            user: { id: 1 },
-            params: { id: 1 },
-            body: { status: 'foo' },
-            meta: null
-          };
-
-          await handler(req, res);
-
-          saveTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
-        }
-      );
-
-      handlerTest.test(
-        'sends an error if request body is not an array',
-        async invalidTest => {
-          const req = {
-            user: { id: 1 },
-            params: { id: 1 },
-            body: 'hello',
-            meta: { activity: activityObj }
-          };
-          activityObj.get.withArgs('id').returns('apd-id');
-
-          await handler(req, res);
-
-          invalidTest.ok(res.status.calledWith(400), 'HTTP status set to 400');
-          invalidTest.ok(
-            res.send.calledWith({ error: 'edit-activity-invalid-approaches' }),
-            'sends an error string'
-          );
-          invalidTest.ok(res.end.calledOnce, 'response is terminated');
-        }
-      );
-
-      handlerTest.test('updates valid approaches', async validTest => {
+    handlerTest.test(
+      'sends a server error if anything goes wrong',
+      async saveTest => {
         const req = {
           user: { id: 1 },
           params: { id: 1 },
-          body: [
-            {
-              description: 'approach 1',
-              alternatives: 'alt 1',
-              explanation: 'exp 1'
-            },
-            {
-              description: 'approach 2',
-              alternatives: 'alt 2',
-              explanation: 'exp 2'
-            },
-            {
-              invalid: 'this one is ignored',
-              because: 'it does not have any expected fields'
-            }
-          ],
+          body: { status: 'foo' },
+          meta: null
+        };
+
+        await handler(req, res);
+
+        saveTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
+      }
+    );
+
+    handlerTest.test(
+      'sends an error if request body is not an array',
+      async invalidTest => {
+        const req = {
+          user: { id: 1 },
+          params: { id: 1 },
+          body: 'hello',
           meta: { activity: activityObj }
         };
         activityObj.get.withArgs('id').returns('apd-id');
 
-        const destroyExisting = sinon.stub();
-        const existingApproaches = [
-          { destroy: destroyExisting },
-          { destroy: destroyExisting },
-          { destroy: destroyExisting }
-        ];
-
-        activityObj.related.withArgs('approaches').returns(existingApproaches);
-
-        const approach = {
-          save: sandbox.stub().resolves()
-        };
-
-        ApproachModel.forge.returns(approach);
-
-        ActivityModel.fetch.resolves({
-          toJSON: sandbox.stub().returns('activity-from-json')
-        });
-
         await handler(req, res);
 
-        validTest.ok(res.status.notCalled, 'HTTP status not explicitly set');
-        validTest.ok(
-          res.send.calledWith('activity-from-json'),
-          'sends JSON-ified activity'
+        invalidTest.ok(res.status.calledWith(400), 'HTTP status set to 400');
+        invalidTest.ok(
+          res.send.calledWith({ error: 'edit-activity-invalid-schedule' }),
+          'sends an error string'
         );
+        invalidTest.ok(res.end.calledOnce, 'response is terminated');
+      }
+    );
 
-        validTest.ok(
-          destroyExisting.calledThrice,
-          'all of the old approaches are deleted'
-        );
-        validTest.ok(
-          ApproachModel.forge.calledTwice,
-          'two approaches are created'
-        );
-        validTest.ok(
-          ApproachModel.forge.calledWith({
-            description: 'approach 1',
-            alternatives: 'alt 1',
-            explanation: 'exp 1',
-            activity_id: 1
-          }) &&
-            ApproachModel.forge.calledWith({
-              description: 'approach 2',
-              alternatives: 'alt 2',
-              explanation: 'exp 2',
-              activity_id: 1
-            }),
-          'the two expected approaches are created'
-        );
+    handlerTest.test('updates valid schedule entries', async validTest => {
+      const req = {
+        user: { id: 1 },
+        params: { id: 1 },
+        body: [
+          {
+            milestone: 'milestone 1',
+            status: 'status 1'
+          },
+          {
+            milestone: 'milestone 2',
+            status: 'status 2'
+          },
+          {
+            invalid: 'this one is ignored',
+            because: 'it does not have any expected fields'
+          }
+        ],
+        meta: { activity: activityObj }
+      };
+      activityObj.get.withArgs('id').returns('apd-id');
+
+      const destroyExisting = sinon.stub();
+      const existingSchedule = [
+        { destroy: destroyExisting },
+        { destroy: destroyExisting },
+        { destroy: destroyExisting }
+      ];
+
+      activityObj.related.withArgs('schedule').returns(existingSchedule);
+
+      const schedule = {
+        save: sandbox.stub().resolves()
+      };
+
+      ScheduleModel.forge.returns(schedule);
+
+      ActivityModel.fetch.resolves({
+        toJSON: sandbox.stub().returns('activity-from-json')
       });
-    }
-  );
+
+      await handler(req, res);
+
+      validTest.ok(res.status.notCalled, 'HTTP status not explicitly set');
+      validTest.ok(
+        res.send.calledWith('activity-from-json'),
+        'sends JSON-ified activity'
+      );
+
+      validTest.ok(
+        destroyExisting.calledThrice,
+        'all of the old schedules are deleted'
+      );
+      validTest.ok(
+        ScheduleModel.forge.calledTwice,
+        'two schedule entries are created'
+      );
+      validTest.ok(
+        ScheduleModel.forge.calledWith({
+          milestone: 'milestone 1',
+          status: 'status 1',
+          activity_id: 1
+        }) &&
+          ScheduleModel.forge.calledWith({
+            milestone: 'milestone 2',
+            status: 'status 2',
+            activity_id: 1
+          }),
+        'the two expected schedule entries are created'
+      );
+    });
+  });
 });

--- a/api/routes/apds/activities/schedule/put.test.js
+++ b/api/routes/apds/activities/schedule/put.test.js
@@ -1,0 +1,195 @@
+const tap = require('tap');
+const sinon = require('sinon');
+
+const {
+  loggedIn,
+  loadActivity,
+  userCanEditAPD
+} = require('../../../../middleware');
+const putEndpoint = require('./put');
+
+tap.test('apd activity approach PUT endpoint', async endpointTest => {
+  const sandbox = sinon.createSandbox();
+  const app = { put: sandbox.stub() };
+
+  const ActivityModel = {
+    where: sandbox.stub(),
+    fetch: sandbox.stub()
+  };
+  const ApproachModel = {
+    forge: sandbox.stub()
+  };
+
+  const activityObj = {
+    related: sandbox.stub(),
+    get: sandbox.stub()
+  };
+
+  const apdObj = {
+    related: sandbox.stub(),
+    get: sandbox.stub()
+  };
+
+  const res = {
+    status: sandbox.stub(),
+    send: sandbox.stub(),
+    end: sandbox.stub()
+  };
+
+  endpointTest.beforeEach(done => {
+    sandbox.resetBehavior();
+    sandbox.resetHistory();
+
+    ActivityModel.where.returns(ActivityModel);
+    ActivityModel.fetch.resolves(activityObj);
+    activityObj.related.withArgs('apd').returns(apdObj);
+
+    res.status.returns(res);
+    res.send.returns(res);
+    res.end.returns(res);
+
+    done();
+  });
+
+  endpointTest.test('setup', async setupTest => {
+    putEndpoint(app, ActivityModel, ApproachModel);
+
+    setupTest.ok(
+      app.put.calledWith(
+        '/activities/:id/approaches',
+        loggedIn,
+        loadActivity(),
+        userCanEditAPD(ActivityModel),
+        sinon.match.func
+      ),
+      'apd activity approach PUT endpoint is registered'
+    );
+  });
+
+  endpointTest.test(
+    'set APD activity approaches handler',
+    async handlerTest => {
+      let handler;
+      handlerTest.beforeEach(async () => {
+        putEndpoint(app, ActivityModel, ApproachModel);
+        handler = app.put.args.find(
+          args => args[0] === '/activities/:id/approaches'
+        )[4];
+      });
+
+      handlerTest.test(
+        'sends a server error if anything goes wrong',
+        async saveTest => {
+          const req = {
+            user: { id: 1 },
+            params: { id: 1 },
+            body: { status: 'foo' },
+            meta: null
+          };
+
+          await handler(req, res);
+
+          saveTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
+        }
+      );
+
+      handlerTest.test(
+        'sends an error if request body is not an array',
+        async invalidTest => {
+          const req = {
+            user: { id: 1 },
+            params: { id: 1 },
+            body: 'hello',
+            meta: { activity: activityObj }
+          };
+          activityObj.get.withArgs('id').returns('apd-id');
+
+          await handler(req, res);
+
+          invalidTest.ok(res.status.calledWith(400), 'HTTP status set to 400');
+          invalidTest.ok(
+            res.send.calledWith({ error: 'edit-activity-invalid-approaches' }),
+            'sends an error string'
+          );
+          invalidTest.ok(res.end.calledOnce, 'response is terminated');
+        }
+      );
+
+      handlerTest.test('updates valid approaches', async validTest => {
+        const req = {
+          user: { id: 1 },
+          params: { id: 1 },
+          body: [
+            {
+              description: 'approach 1',
+              alternatives: 'alt 1',
+              explanation: 'exp 1'
+            },
+            {
+              description: 'approach 2',
+              alternatives: 'alt 2',
+              explanation: 'exp 2'
+            },
+            {
+              invalid: 'this one is ignored',
+              because: 'it does not have any expected fields'
+            }
+          ],
+          meta: { activity: activityObj }
+        };
+        activityObj.get.withArgs('id').returns('apd-id');
+
+        const destroyExisting = sinon.stub();
+        const existingApproaches = [
+          { destroy: destroyExisting },
+          { destroy: destroyExisting },
+          { destroy: destroyExisting }
+        ];
+
+        activityObj.related.withArgs('approaches').returns(existingApproaches);
+
+        const approach = {
+          save: sandbox.stub().resolves()
+        };
+
+        ApproachModel.forge.returns(approach);
+
+        ActivityModel.fetch.resolves({
+          toJSON: sandbox.stub().returns('activity-from-json')
+        });
+
+        await handler(req, res);
+
+        validTest.ok(res.status.notCalled, 'HTTP status not explicitly set');
+        validTest.ok(
+          res.send.calledWith('activity-from-json'),
+          'sends JSON-ified activity'
+        );
+
+        validTest.ok(
+          destroyExisting.calledThrice,
+          'all of the old approaches are deleted'
+        );
+        validTest.ok(
+          ApproachModel.forge.calledTwice,
+          'two approaches are created'
+        );
+        validTest.ok(
+          ApproachModel.forge.calledWith({
+            description: 'approach 1',
+            alternatives: 'alt 1',
+            explanation: 'exp 1',
+            activity_id: 1
+          }) &&
+            ApproachModel.forge.calledWith({
+              description: 'approach 2',
+              alternatives: 'alt 2',
+              explanation: 'exp 2',
+              activity_id: 1
+            }),
+          'the two expected approaches are created'
+        );
+      });
+    }
+  );
+});


### PR DESCRIPTION
Adds API endpoints for updating the activity schedule.  Basically a copy+paste job from activity approaches.

Endpoint tests will be in a separate PR.

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- [x] The change has been documented
  - [x] Associated OpenAPI documentation has been updated

### This feature is done when...
- ~Design has approved the experience~
- ~Product has approved the experience~
