### PR TITLE
De-duplicate a bunch of OpenAPI stuff

### DIFF
--- a/api/db/activity.js
+++ b/api/db/activity.js
@@ -149,7 +149,6 @@ module.exports = () => ({
 
     toJSON() {
       return {
-        id: this.get('id'),
         actualEnd: this.get('actual_end'),
         actualStart: this.get('actual_start'),
         milestone: this.get('milestone'),

--- a/api/db/activity.test.js
+++ b/api/db/activity.test.js
@@ -614,7 +614,6 @@ tap.test('activity data model', async activityModelTests => {
       const output = activity.apdActivitySchedule.toJSON.bind(self)();
 
       jsonTests.match(output, {
-        id: 'zaphod',
         actualEnd: 'beeblebrox',
         actualStart: 'is',
         milestone: 'one',

--- a/api/routes/apds/activities/approaches/openAPI.js
+++ b/api/routes/apds/activities/approaches/openAPI.js
@@ -3,38 +3,6 @@ const {
   schema: { arrayOf, errorToken, jsonResponse }
 } = require('../../../openAPI/helpers');
 
-const activityObjectSchema = {
-  type: 'object',
-  properties: {
-    id: {
-      type: 'number',
-      description: 'Activity globally-unique ID'
-    },
-    name: {
-      type: 'string',
-      description: 'Activity name, unique within an APD'
-    },
-    description: {
-      type: 'string',
-      description: 'Activity description'
-    },
-    goals: arrayOf({
-      type: 'object',
-      description: 'Activity goal',
-      properties: {
-        description: {
-          type: 'string',
-          description: 'Goal description'
-        },
-        objectives: arrayOf({
-          type: 'string',
-          description: 'Goal objective'
-        })
-      }
-    })
-  }
-};
-
 const openAPI = {
   '/activities/{id}/approaches': {
     put: {
@@ -74,7 +42,7 @@ const openAPI = {
       responses: {
         200: {
           description: 'The updated activity',
-          content: jsonResponse(activityObjectSchema)
+          content: jsonResponse({ $ref: '#/components/schemas/activity' })
         },
         400: {
           description: 'The approaches are invalid (e.g., not an array)',

--- a/api/routes/apds/activities/expenses/openAPI.js
+++ b/api/routes/apds/activities/expenses/openAPI.js
@@ -3,52 +3,6 @@ const {
   schema: { arrayOf, errorToken, jsonResponse }
 } = require('../../../openAPI/helpers');
 
-const activityObjectSchema = {
-  type: 'object',
-  properties: {
-    id: {
-      type: 'number',
-      description: 'Activity globally-unique ID'
-    },
-    name: {
-      type: 'string',
-      description: 'Activity name, unique within an APD'
-    },
-    description: {
-      type: 'string',
-      description: 'Activity description'
-    },
-    expenses: arrayOf({
-      type: 'object',
-      description: 'Activity expense',
-      properties: {
-        name: {
-          type: 'string',
-          description: 'Expense name'
-        },
-        entries: arrayOf({
-          type: 'object',
-          description: 'Expense entry',
-          properties: {
-            year: {
-              type: 'string',
-              description: 'Expense entry year'
-            },
-            amount: {
-              type: 'decimal',
-              description: 'Expense entry amount'
-            },
-            description: {
-              type: 'string',
-              description: 'Expense entry description'
-            }
-          }
-        })
-      }
-    })
-  }
-};
-
 const openAPI = {
   '/activities/{id}/expenses': {
     put: {
@@ -97,7 +51,7 @@ const openAPI = {
       responses: {
         200: {
           description: 'The updated activity',
-          content: jsonResponse(activityObjectSchema)
+          content: jsonResponse({ $ref: '#/components/schemas/activity' })
         },
         400: {
           description: 'The expenses are invalid (e.g., not an array)',

--- a/api/routes/apds/activities/goals/openAPI.js
+++ b/api/routes/apds/activities/goals/openAPI.js
@@ -3,38 +3,6 @@ const {
   schema: { arrayOf, errorToken, jsonResponse }
 } = require('../../../openAPI/helpers');
 
-const activityObjectSchema = {
-  type: 'object',
-  properties: {
-    id: {
-      type: 'number',
-      description: 'Activity globally-unique ID'
-    },
-    name: {
-      type: 'string',
-      description: 'Activity name, unique within an APD'
-    },
-    description: {
-      type: 'string',
-      description: 'Activity description'
-    },
-    goals: arrayOf({
-      type: 'object',
-      description: 'Activity goal',
-      properties: {
-        description: {
-          type: 'string',
-          description: 'Goal description'
-        },
-        objectives: arrayOf({
-          type: 'string',
-          description: 'Goal objective'
-        })
-      }
-    })
-  }
-};
-
 const openAPI = {
   '/activities/{id}/goals': {
     put: {
@@ -71,7 +39,7 @@ const openAPI = {
       responses: {
         200: {
           description: 'The updated activity',
-          content: jsonResponse(activityObjectSchema)
+          content: jsonResponse({ $ref: '#/components/schemas/activity' })
         },
         400: {
           description: 'The goals are invalid (e.g., not an array)',

--- a/api/routes/apds/activities/openAPI.js
+++ b/api/routes/apds/activities/openAPI.js
@@ -1,41 +1,10 @@
 const {
   requiresAuth,
-  schema: { arrayOf, errorToken, jsonResponse }
+  schema: { errorToken, jsonResponse }
 } = require('../../openAPI/helpers');
 const approaches = require('./approaches/openAPI');
 const goals = require('./goals/openAPI');
-
-const activityObjectSchema = {
-  type: 'object',
-  properties: {
-    id: {
-      type: 'number',
-      description: 'Activity globally-unique ID'
-    },
-    name: {
-      type: 'string',
-      description: 'Activity name, unique within an APD'
-    },
-    description: {
-      type: 'string',
-      description: 'Activity description'
-    },
-    goals: arrayOf({
-      type: 'object',
-      description: 'Activity goal',
-      properties: {
-        description: {
-          type: 'string',
-          description: 'Goal description'
-        },
-        objectives: arrayOf({
-          type: 'string',
-          description: 'Goal objective'
-        })
-      }
-    })
-  }
-};
+const schedule = require('./schedule/openAPI');
 
 const openAPI = {
   '/apds/{apdID}/activities': {
@@ -67,7 +36,7 @@ const openAPI = {
       responses: {
         200: {
           description: 'The newly-created activity',
-          content: jsonResponse(activityObjectSchema)
+          content: jsonResponse({ $ref: '#/components/schemas/activity' })
         },
         400: {
           description:
@@ -115,7 +84,7 @@ const openAPI = {
       responses: {
         200: {
           description: 'The update was successful',
-          content: jsonResponse(activityObjectSchema)
+          content: jsonResponse({ $ref: '#/components/schemas/activity' })
         },
         400: {
           description:
@@ -131,7 +100,8 @@ const openAPI = {
   },
 
   ...approaches,
-  ...goals
+  ...goals,
+  ...schedule
 };
 
 module.exports = requiresAuth(openAPI);

--- a/api/routes/apds/activities/schedule/openAPI.js
+++ b/api/routes/apds/activities/schedule/openAPI.js
@@ -3,38 +3,6 @@ const {
   schema: { arrayOf, errorToken, jsonResponse }
 } = require('../../../openAPI/helpers');
 
-const activityObjectSchema = {
-  type: 'object',
-  properties: {
-    id: {
-      type: 'number',
-      description: 'Activity globally-unique ID'
-    },
-    name: {
-      type: 'string',
-      description: 'Activity name, unique within an APD'
-    },
-    description: {
-      type: 'string',
-      description: 'Activity description'
-    },
-    goals: arrayOf({
-      type: 'object',
-      description: 'Activity goal',
-      properties: {
-        description: {
-          type: 'string',
-          description: 'Goal description'
-        },
-        objectives: arrayOf({
-          type: 'string',
-          description: 'Goal objective'
-        })
-      }
-    })
-  }
-};
-
 const openAPI = {
   '/activities/{id}/schedule': {
     put: {
@@ -89,7 +57,7 @@ const openAPI = {
       responses: {
         200: {
           description: 'The updated activity',
-          content: jsonResponse(activityObjectSchema)
+          content: jsonResponse({ $ref: '#/components/schemas/activity' })
         },
         400: {
           description: 'The schedule entries are invalid (e.g., not an array)',

--- a/api/routes/apds/openAPI.js
+++ b/api/routes/apds/openAPI.js
@@ -5,79 +5,6 @@ const {
 
 const activities = require('./activities/openAPI');
 
-const apdObjectSchema = {
-  type: 'object',
-  properties: {
-    id: {
-      type: 'number',
-      description: 'APD ID'
-    },
-    status: {
-      type: 'string',
-      description: 'Status'
-    },
-    period: {
-      type: 'string',
-      description: 'Covered time period'
-    },
-    created_at: {
-      type: 'dateTime',
-      description: 'Creation date'
-    },
-    updated_at: {
-      type: 'dateTime',
-      description: 'Last updated date'
-    },
-    approved_at: {
-      type: 'dateTime',
-      description: 'Approval date'
-    },
-    activities: arrayOf({
-      type: 'object',
-      properties: {
-        id: {
-          type: 'number',
-          description: 'Activity ID'
-        },
-        name: {
-          type: 'string',
-          description: 'Short name for the activity'
-        },
-        description: {
-          type: 'string',
-          description: 'A description of this activity'
-        },
-        goals: arrayOf({
-          type: 'object',
-          properties: {
-            id: {
-              type: 'number',
-              description: 'Goal ID'
-            },
-            description: {
-              type: 'string',
-              description: 'A description of this goal'
-            },
-            objectives: arrayOf({
-              type: 'object',
-              properties: {
-                id: {
-                  type: 'number',
-                  description: 'Objective ID'
-                },
-                description: {
-                  type: 'string',
-                  description: 'A description of this objective'
-                }
-              }
-            })
-          }
-        })
-      }
-    })
-  }
-};
-
 const openAPI = {
   '/apds': {
     get: {
@@ -85,7 +12,7 @@ const openAPI = {
       responses: {
         200: {
           description: 'The list of a user’s apds',
-          content: jsonResponse(arrayOf(apdObjectSchema))
+          content: jsonResponse(arrayOf({ $ref: '#/components/schemas/apd' }))
         }
       }
     }
@@ -122,7 +49,7 @@ const openAPI = {
       responses: {
         200: {
           description: 'The update was successful',
-          content: jsonResponse(apdObjectSchema)
+          content: jsonResponse({ $ref: '#/components/schemas/apd' })
         },
         404: {
           description: 'The apd ID does not match any known apds for the user'

--- a/api/routes/openAPI/index.js
+++ b/api/routes/openAPI/index.js
@@ -7,6 +7,7 @@ const authRoles = require('../auth/roles/openAPI');
 const me = require('../me/openAPI');
 const users = require('../users/openAPI');
 const states = require('../states/openAPI');
+const { arrayOf } = require('./helpers').schema;
 
 module.exports = {
   openapi: '3.0',
@@ -35,6 +36,196 @@ module.exports = {
     }
   },
   components: {
+    schemas: {
+      activity: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'number',
+            description: 'Activity globally-unique ID'
+          },
+          name: {
+            type: 'string',
+            description: 'Activity name, unique within an APD'
+          },
+          description: {
+            type: 'string',
+            description: 'Activity description'
+          },
+          expenses: arrayOf({
+            type: 'object',
+            description: 'Activity expense',
+            properties: {
+              name: {
+                type: 'string',
+                description: 'Expense name'
+              },
+              entries: arrayOf({
+                type: 'object',
+                description: 'Expense entry',
+                properties: {
+                  year: {
+                    type: 'string',
+                    description: 'Expense entry year'
+                  },
+                  amount: {
+                    type: 'decimal',
+                    description: 'Expense entry amount'
+                  },
+                  description: {
+                    type: 'string',
+                    description: 'Expense entry description'
+                  }
+                }
+              })
+            }
+          }),
+          goals: arrayOf({
+            type: 'object',
+            description: 'Activity goal',
+            properties: {
+              description: {
+                type: 'string',
+                description: 'Goal description'
+              },
+              objectives: arrayOf({
+                type: 'string',
+                description: 'Goal objective'
+              })
+            }
+          }),
+          schedule: arrayOf({
+            type: 'object',
+            description: 'Activity schedule item',
+            properties: {
+              actualEnd: {
+                type: 'string',
+                format: 'date-time',
+                description:
+                  'The actual date the milestone was completed, if known'
+              },
+              actualStart: {
+                type: 'string',
+                format: 'date-time',
+                description:
+                  'The actual date the milestone was started, if known'
+              },
+              milestone: {
+                type: 'string',
+                description:
+                  'The name of the milestone this schedule entry refers to'
+              },
+              plannedEnd: {
+                type: 'string',
+                format: 'date-time',
+                description: 'The planned milestone completion date'
+              },
+              plannedStart: {
+                type: 'string',
+                format: 'date-time',
+                description: 'The planned milestone start date'
+              },
+              status: {
+                type: 'string',
+                description: 'The status of the milestone'
+              }
+            }
+          })
+        }
+      },
+      apd: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'number',
+            description: 'APD ID'
+          },
+          status: {
+            type: 'string',
+            description: 'Status'
+          },
+          period: {
+            type: 'string',
+            description: 'Covered time period'
+          },
+          created_at: {
+            type: 'string',
+            format: 'date-time',
+            description: 'Creation date'
+          },
+          updated_at: {
+            type: 'string',
+            format: 'date-time',
+            description: 'Last updated date'
+          },
+          approved_at: {
+            type: 'string',
+            format: 'date-time',
+            description: 'Approval date'
+          },
+          activities: {
+            $ref: '#/components/schemas/activity'
+          }
+        }
+      },
+      state: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+            description:
+              'State, territory, or district ID (2-letter abbreviation, lowercase)'
+          },
+          medicaid_office: {
+            type: 'object',
+            description:
+              'Address of the state, territory, or district Medicaid office',
+            properties: {
+              address: {
+                type: 'string',
+                description: 'Street address'
+              },
+              city: {
+                type: 'string',
+                description: 'City'
+              },
+              zip: {
+                type: 'string',
+                description: 'ZIP code'
+              }
+            }
+          },
+          name: {
+            type: 'string',
+            description: 'State, territory, or district name'
+          },
+          program_vision: {
+            type: 'string',
+            description: 'Program vision statement'
+          },
+          program_benefits: {
+            type: 'string',
+            description: 'Planned benefits of the program'
+          },
+          state_pocs: arrayOf({
+            type: 'object',
+            description:
+              'A list of points of contact for the state, territory, or district',
+            properties: {
+              name: { type: 'string', description: `Point of contact's name` },
+              position: {
+                type: 'string',
+                description: `Point of contact's position in the state, territory, or district`
+              },
+              email: {
+                type: 'string',
+                description: `Point of contact's email address`
+              }
+            }
+          })
+        }
+      }
+    },
     securitySchemes: {
       sessionCookie: {
         type: 'apiKey',

--- a/api/routes/states/openAPI.js
+++ b/api/routes/states/openAPI.js
@@ -1,70 +1,7 @@
 const {
   requiresAuth,
-  schema: { arrayOf, errorToken, jsonResponse }
+  schema: { errorToken, jsonResponse }
 } = require('../openAPI/helpers');
-
-const stateObjectSchema = {
-  type: 'object',
-  properties: {
-    id: {
-      type: 'string',
-      description:
-        'State, territory, or district ID (2-letter abbreviation, lowercase)'
-    },
-    medicaid_office: {
-      type: 'object',
-      description:
-        'Address of the state, territory, or district Medicaid office',
-      properties: {
-        address: {
-          type: 'string',
-          description: 'Street address'
-        },
-        city: {
-          type: 'string',
-          description: 'City'
-        },
-        zip: {
-          type: 'string',
-          description: 'ZIP code'
-        }
-      }
-    },
-    name: {
-      type: 'string',
-      description: 'State, territory, or district name'
-    },
-    program_vision: {
-      type: 'string',
-      description: 'Program vision statement'
-    },
-    program_benefits: {
-      type: 'string',
-      description: 'Planned benefits of the program'
-    },
-    state_pocs: arrayOf({
-      type: 'object',
-      description:
-        'A list of points of contact for the state, territory, or district',
-      properties: {
-        name: { type: 'string', description: `Point of contact's name` },
-        position: {
-          type: 'string',
-          description: `Point of contact's position in the state, territory, or district`
-        },
-        email: {
-          type: 'string',
-          description: `Point of contact's email address`
-        }
-      }
-    })
-  }
-};
-
-// deeply clone
-const putSchema = JSON.parse(JSON.stringify(stateObjectSchema));
-delete putSchema.properties.id;
-delete putSchema.properties.name;
 
 const openAPI = {
   '/states': {
@@ -73,7 +10,7 @@ const openAPI = {
       responses: {
         200: {
           description: 'Information about the state, territory, or district',
-          content: jsonResponse(stateObjectSchema)
+          content: jsonResponse({ $ref: '#/components/schemas/state' })
         }
       }
     },
@@ -82,17 +19,13 @@ const openAPI = {
       requestBody: {
         description:
           'The new state information.  Any extraneous fields will be discarded.',
-        content: {
-          'application/json': {
-            schema: putSchema
-          }
-        }
+        content: jsonResponse({ $ref: '#/components/schemas/state' })
       },
       responses: {
         200: {
           description:
             'Information about the state, territory, or district was successfully updated. Returns the full, updated state object',
-          content: jsonResponse(stateObjectSchema)
+          content: jsonResponse({ $ref: '#/components/schemas/state' })
         },
         400: {
           description: 'The request was invalid',
@@ -117,7 +50,7 @@ const openAPI = {
       responses: {
         200: {
           description: 'Information about the state, territory, or district',
-          content: jsonResponse(stateObjectSchema)
+          content: jsonResponse({ $ref: '#/components/schemas/state' })
         },
         404: {
           description:
@@ -141,26 +74,22 @@ const openAPI = {
       requestBody: {
         description:
           'The new state information.  Any extraneous fields will be discarded.',
-        content: {
-          'application/json': {
-            schema: putSchema
-          }
-        }
+        content: jsonResponse({ $ref: '#/components/schemas/state' })
+      }
+    },
+    responses: {
+      200: {
+        description:
+          'Information about the state, territory, or district was successfully updated. Returns the full, updated state object.',
+        content: jsonResponse({ $ref: '#/components/schemas/state' })
       },
-      responses: {
-        200: {
-          description:
-            'Information about the state, territory, or district was successfully updated. Returns the full, updated state object.',
-          content: jsonResponse(stateObjectSchema)
-        },
-        400: {
-          description: 'The request was invalid',
-          content: errorToken
-        },
-        404: {
-          description:
-            'The requested ID does not match any known states, territories, or districts'
-        }
+      400: {
+        description: 'The request was invalid',
+        content: errorToken
+      },
+      404: {
+        description:
+          'The requested ID does not match any known states, territories, or districts'
       }
     }
   }


### PR DESCRIPTION
The activity schema was defined in several different files and they were (unsurprisingly) out of sync with each other.  This PR pulls those out into a `component` that can then be referenced elsewhere in the OpenAPI document.  Now as the activity or APD schemas change, we don't have to be careful to update the documentation freakin' everywhere - just do it in one place and it'll be correct by reference.

:tada:

### This pull request is ready to merge when...
- ~Tests have been updated (and all tests are passing)~
- [ ] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- ~The change has been documented~
  - ~Associated OpenAPI documentation has been updated~

### This feature is done when...
- ~Design has approved the experience~
- ~Product has approved the experience~
