### PR TITLE
Fix API URL

### DIFF
--- a/bin/deploy-ux-testing.sh
+++ b/bin/deploy-ux-testing.sh
@@ -10,7 +10,7 @@ API="https://api.fr.cloud.gov"
 ORG="sandbox-gsa"
 SPACE="michael.walker"
 
-export API_URL="https://hitech-api-ux.app.cloud.gov/"
+export API_URL="https://hitech-api-ux.app.cloud.gov"
 export LOG_FORM_INTERACTIONS="true"
 
 # Install `cf` cli

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -10,7 +10,7 @@ API="https://api.fr.cloud.gov"
 ORG="sandbox-gsa"
 SPACE="brendan.sudol"
 
-export API_URL="https://hitech-api.app.cloud.gov/"
+export API_URL="https://hitech-api.app.cloud.gov"
 
 # Install `cf` cli
 curl -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&source=github'


### PR DESCRIPTION
The API URL environment variable has a trailing slash, and we use relative URLs with a leading slash.  That results in API calls that begin with a double slash, creating a 404 condition.

### This pull request is ready to merge when...
- ~Tests have been updated (and all tests are passing)~
- [ ] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- ~The change has been documented~
  - ~Associated OpenAPI documentation has been updated~

### This feature is done when...
- ~Design has approved the experience~
- ~Product has approved the experience~
