### PR TITLE
Fix staging deployment, setup all deploys for easier fixing/updating

### DIFF
--- a/bin/deploy-storybook.sh
+++ b/bin/deploy-storybook.sh
@@ -5,11 +5,6 @@
 
 set -e
 
-# CF environment
-API="https://api.fr.cloud.gov"
-ORG="sandbox-gsa"
-SPACE="brendan.sudol"
-
 # Install `cf` cli
 curl -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&source=github'
 dpkg -i cf-cli_amd64.deb
@@ -25,5 +20,5 @@ npm run build-storybook
 cd ..
 
 # Log into CF and push
-cf login -a $API -u $CF_USER -p $CF_PASSWORD -o $ORG -s $SPACE
+cf login -a $SB_CF_API -u $SB_CF_USER -p $SB_CF_PASSWORD -o $SB_CF_ORG -s $SB_CF_SPACE
 cf push -f manifest-storybook.yml

--- a/bin/deploy-ux-testing.sh
+++ b/bin/deploy-ux-testing.sh
@@ -5,12 +5,7 @@
 
 set -e
 
-# CF environment
-API="https://api.fr.cloud.gov"
-ORG="sandbox-gsa"
-SPACE="michael.walker"
-
-export API_URL="https://hitech-api-ux.app.cloud.gov"
+export API_URL=$UX_API_URL
 export LOG_FORM_INTERACTIONS="true"
 
 # Install `cf` cli
@@ -37,7 +32,7 @@ rm seeds/test.js
 cd ..
 
 # Log into CF
-cf login -a $API -u $CF_USER_UX -p $CF_PASSWORD_UX -o $ORG -s $SPACE
+cf login -a $UX_CF_API -u $UX_CF_USER -p $UX_CF_PASSWORD -o $UX_CF_ORG -s $UX_CF_SPACE
 
 # Double-check that we're pointing at the UX
 # testing instance, and if so...

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -5,12 +5,7 @@
 
 set -e
 
-# CF environment
-API="https://api.fr.cloud.gov"
-ORG="sandbox-gsa"
-SPACE="brendan.sudol"
-
-export API_URL="https://hitech-api.app.cloud.gov"
+export API_URL=$STAGING_API_URL
 
 # Install `cf` cli
 curl -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&source=github'
@@ -36,7 +31,7 @@ rm seeds/shared/delete-everything.js
 cd ..
 
 # Log into CF and push
-cf login -a $API -u $CF_USER -p $CF_PASSWORD -o $ORG -s $SPACE
+cf login -a $STAGING_CF_API -u $STAGING_CF_USER -p $STAGING_CF_PASSWORD -o $STAGING_CF_ORG -s $STAGING_CF_SPACE
 cf push -f manifest.yml
 
 # Migrate and seed the database


### PR DESCRIPTION
This pull request takes the deployment target info (cloud.gov org and space) out of our deployment scripts and puts it into CI environment variables where we can easily change it later without having to modify code.

I added a deployer account and setup the "staging" environment variables in CircleCI, so hopefully this PR will get our staging environment deploying again.  Getting the other environments back into deployment should just be a matter of setting the environment variables in CircleCI.

### This pull request is ready to merge when...
- ~Tests have been updated (and all tests are passing)~
- [ ] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- ~The change has been documented~
  - ~Associated OpenAPI documentation has been updated~

### This feature is done when...
- ~Design has approved the experience~
- ~Product has approved the experience~
