### PR TITLE
Add state personnel and contractor resource data models

### DIFF
--- a/api/db/activity/activity.js
+++ b/api/db/activity/activity.js
@@ -16,6 +16,10 @@ module.exports = {
       return this.hasMany('apdActivityApproach');
     },
 
+    contractorResources() {
+      return this.hasMany('apdActivityContractorResource');
+    },
+
     expenses() {
       return this.hasMany('apdActivityExpense');
     },
@@ -24,21 +28,31 @@ module.exports = {
       return this.hasMany('apdActivitySchedule');
     },
 
+    statePersonnel() {
+      return this.hasMany('apdActivityStatePersonnel');
+    },
+
     static: {
       updateableFields: ['name', 'description'],
       owns: {
         goals: 'apdActivityGoal',
         approaches: 'apdActivityApproach',
+        contractorResources: 'apdActivityContractorResource',
         expenses: 'apdActivityExpense',
-        schedule: 'apdActivitySchedule'
+        schedule: 'apdActivitySchedule',
+        statePersonnel: 'apdActivityStatePersonnel'
       },
       foreignKey: 'activity_id',
       withRelated: [
         'approaches',
+        'contractorResources',
+        'contractorResources.years',
         'goals',
         'goals.objectives',
         'expenses',
         'expenses.entries',
+        'personnel',
+        'personnel.years',
         'schedule'
       ]
     },
@@ -69,8 +83,10 @@ module.exports = {
         description: this.get('description'),
         goals: this.related('goals'),
         approaches: this.related('approaches'),
+        contractorResources: this.related('contractorResources'),
         expenses: this.related('expenses'),
-        schedule: this.related('schedule')
+        schedule: this.related('schedule'),
+        statePersonnel: this.related('statePersonnel')
       };
     }
   }

--- a/api/db/activity/activity.js
+++ b/api/db/activity/activity.js
@@ -51,9 +51,9 @@ module.exports = {
         'goals.objectives',
         'expenses',
         'expenses.entries',
-        'personnel',
-        'personnel.years',
-        'schedule'
+        'schedule',
+        'statePersonnel',
+        'statePersonnel.years'
       ]
     },
 

--- a/api/db/activity/activity.test.js
+++ b/api/db/activity/activity.test.js
@@ -10,57 +10,42 @@ tap.test('activity data model', async activityModelTests => {
       {
         apdActivity: {
           tableName: 'activities',
+
+          apd: Function,
+          goals: Function,
+          approaches: Function,
+          contractorResources: Function,
+          expenses: Function,
+          schedule: Function,
+          statePersonnel: Function,
+
           static: {
             updateableFields: ['name', 'description'],
             owns: {
               goals: 'apdActivityGoal',
               approaches: 'apdActivityApproach',
+              contractorResources: 'apdActivityContractorResource',
               expenses: 'apdActivityExpense',
-              schedule: 'apdActivitySchedule'
+              schedule: 'apdActivitySchedule',
+              statePersonnel: 'apdActivityStatePersonnel'
             },
             foreignKey: 'activity_id',
             withRelated: [
               'approaches',
+              'contractorResources',
+              'contractorResources.years',
               'goals',
               'goals.objectives',
               'expenses',
               'expenses.entries',
-              'schedule'
+              'schedule',
+              'statePersonnel',
+              'statePersonnel.years'
             ]
           }
         }
       },
       'get the expected model definitions'
-    );
-
-    setupTests.type(
-      activity.apdActivity.apd,
-      'function',
-      'creates a apd relationship for the activity model'
-    );
-
-    setupTests.type(
-      activity.apdActivity.goals,
-      'function',
-      'creates a goals relationship for the activity model'
-    );
-
-    setupTests.type(
-      activity.apdActivity.approaches,
-      'function',
-      'creates an approaches relationship for the activity model'
-    );
-
-    setupTests.type(
-      activity.apdActivity.expenses,
-      'function',
-      'creates a expenses relationship for the activity model'
-    );
-
-    setupTests.type(
-      activity.apdActivity.schedule,
-      'function',
-      'creates a schedule relationship for the activity model'
     );
   });
 
@@ -117,6 +102,23 @@ tap.test('activity data model', async activityModelTests => {
     );
 
     relationshipTests.test(
+      'activity model sets up contract resources relationship',
+      async apdTests => {
+        const self = {
+          hasMany: sinon.stub().returns('southwest')
+        };
+
+        const output = activity.apdActivity.contractorResources.bind(self)();
+
+        apdTests.ok(
+          self.hasMany.calledWith('apdActivityContractorResource'),
+          'sets up the relationship mapping to contractor resources'
+        );
+        apdTests.equal(output, 'southwest', 'returns the expected value');
+      }
+    );
+
+    relationshipTests.test(
       'activity model sets up expenses relationship',
       async apdTests => {
         const self = {
@@ -130,6 +132,23 @@ tap.test('activity data model', async activityModelTests => {
           'sets up the relationship mapping to expense'
         );
         apdTests.equal(output, 'bag', 'returns the expected value');
+      }
+    );
+
+    relationshipTests.test(
+      'activity model sets up state personnel relationship',
+      async apdTests => {
+        const self = {
+          hasMany: sinon.stub().returns('locomotion')
+        };
+
+        const output = activity.apdActivity.statePersonnel.bind(self)();
+
+        apdTests.ok(
+          self.hasMany.calledWith('apdActivityStatePersonnel'),
+          'sets up the relationship mapping to state personnel'
+        );
+        apdTests.equal(output, 'locomotion', 'returns the expected value');
       }
     );
 

--- a/api/db/activity/contractorResource.js
+++ b/api/db/activity/contractorResource.js
@@ -47,7 +47,7 @@ module.exports = {
   apdActivityContractorResourceCost: {
     tableName: 'activity_contractor_resources_yearly',
 
-    personnel() {
+    contractorResource() {
       return this.belongsTo(
         'apdActivityContractorResource',
         'contractor_resource_id'

--- a/api/db/activity/contractorResource.js
+++ b/api/db/activity/contractorResource.js
@@ -1,0 +1,75 @@
+module.exports = {
+  apdActivityContractorResource: {
+    tableName: 'activity_contractor_resources',
+
+    activity() {
+      return this.belongsTo('apdActivity');
+    },
+
+    years() {
+      return this.hasMany(
+        'apdActivityContractorResourceCost',
+        'contractor_resource_id'
+      );
+    },
+
+    async validate() {
+      if (Number.isNaN(Date.parse(this.attributes.start))) {
+        throw new Error('start-date-invalid');
+      }
+      if (Number.isNaN(Date.parse(this.attributes.end))) {
+        throw new Error('end-date-invalid');
+      }
+
+      // Once we've validated the dates, go ahead and convert them
+      this.attributes.start = new Date(this.attributes.start);
+      this.attributes.end = new Date(this.attributes.end);
+    },
+
+    toJSON() {
+      return {
+        id: this.get('id'),
+        name: this.get('name'),
+        description: this.get('description'),
+        start: this.get('start'),
+        end: this.get('end'),
+        years: this.related('years')
+      };
+    },
+
+    static: {
+      updateableFields: ['name', 'description', 'start', 'end'],
+      owns: { years: 'apdActivityContractorResourceCost' },
+      foreignKey: 'contractor_resource_id'
+    }
+  },
+
+  apdActivityContractorResourceCost: {
+    tableName: 'activity_contractor_resources_yearly',
+
+    personnel() {
+      return this.belongsTo(
+        'apdActivityContractorResource',
+        'contractor_resource_id'
+      );
+    },
+
+    async validate() {
+      if (this.attributes.year < 2010 || this.attributes.year > 3000) {
+        throw new Error('year-out-of-range');
+      }
+    },
+
+    toJSON() {
+      return {
+        id: this.get('id'),
+        cost: this.get('cost'),
+        year: this.get('year')
+      };
+    },
+
+    static: {
+      updateableFields: ['year', 'cost']
+    }
+  }
+};

--- a/api/db/activity/contractorResource.test.js
+++ b/api/db/activity/contractorResource.test.js
@@ -1,0 +1,196 @@
+const tap = require('tap');
+const sinon = require('sinon');
+
+const {
+  apdActivityContractorResource: contractor,
+  apdActivityContractorResourceCost: cost
+} = require('./contractorResource');
+
+tap.test(
+  'contractor resource data model',
+  async contractorResourceModelTests => {
+    contractorResourceModelTests.test('setup', async setupTests => {
+      setupTests.match(
+        contractor,
+        {
+          tableName: 'activity_contractor_resources',
+          activity: Function,
+          years: Function,
+          static: {
+            updateableFields: ['name', 'description', 'start', 'end'],
+            owns: { years: 'apdActivityContractorResourceCost' },
+            foreignKey: 'contractor_resource_id'
+          }
+        },
+        'get the expected model definitions'
+      );
+    });
+
+    contractorResourceModelTests.test(
+      'expense model sets up activity relationship',
+      async relationTest => {
+        const self = {
+          belongsTo: sinon.stub().returns('baz')
+        };
+
+        const output = contractor.activity.bind(self)();
+
+        relationTest.ok(
+          self.belongsTo.calledWith('apdActivity'),
+          'sets up the relationship mapping to an activity'
+        );
+        relationTest.equal(output, 'baz', 'returns the expected value');
+      }
+    );
+
+    contractorResourceModelTests.test(
+      'expense model sets up resource cost relationship',
+      async relationTest => {
+        const self = {
+          hasMany: sinon.stub().returns('baz')
+        };
+
+        const output = contractor.years.bind(self)();
+
+        relationTest.ok(
+          self.hasMany.calledWith(
+            'apdActivityContractorResourceCost',
+            'contractor_resource_id'
+          ),
+          'sets up the relationship mapping to years'
+        );
+        relationTest.equal(output, 'baz', 'returns the expected value');
+      }
+    );
+
+    contractorResourceModelTests.test('validation', async validationTests => {
+      validationTests.test('fails if dates cannot be parsed', async test => {
+        const self = { attributes: { start: 'invalid date', end: 0 } };
+
+        test.rejects(
+          contractor.validate.bind(self),
+          'rejects if start date is invalid'
+        );
+
+        self.attributes.start = 0;
+        self.attributes.end = 'invalidate date';
+
+        test.rejects(
+          contractor.validate.bind(self),
+          'rejects if end date is invalid'
+        );
+      });
+
+      validationTests.test('pass if dates are valid', async test => {
+        const self = { attributes: { start: 0, end: 0 } };
+        test.resolves(contractor.validate.bind(self), 'resolves');
+      });
+    });
+
+    contractorResourceModelTests.test(
+      'overrides toJSON method',
+      async jsonTests => {
+        const self = { get: sinon.stub(), related: sinon.stub() };
+        self.get.returns('--- unknown field ---');
+        self.get.withArgs('id').returns('id field');
+        self.get.withArgs('name').returns('name field');
+        self.get.withArgs('description').returns('description field');
+        self.get.withArgs('start').returns('start field');
+        self.get.withArgs('end').returns('end field');
+        self.related.withArgs('years').returns('some times');
+
+        const output = contractor.toJSON.bind(self)();
+
+        jsonTests.same(output, {
+          id: 'id field',
+          name: 'name field',
+          description: 'description field',
+          start: 'start field',
+          end: 'end field',
+          years: 'some times'
+        });
+      }
+    );
+  }
+);
+
+tap.test(
+  'contractor resource cost data model',
+  async contractorResourceCostModelTests => {
+    contractorResourceCostModelTests.test('setup', async setupTests => {
+      setupTests.match(
+        cost,
+        {
+          tableName: 'activity_contractor_resources_yearly',
+          contractorResource: Function,
+          static: {
+            updateableFields: ['year', 'cost']
+          }
+        },
+        'get the expected model definitions'
+      );
+    });
+
+    contractorResourceCostModelTests.test(
+      'expense model sets up contractor resource relationship',
+      async relationTest => {
+        const self = {
+          belongsTo: sinon.stub().returns('baz')
+        };
+
+        const output = cost.contractorResource.bind(self)();
+
+        relationTest.ok(
+          self.belongsTo.calledWith('apdActivityContractorResource'),
+          'sets up the relationship mapping to a contractor resource'
+        );
+        relationTest.equal(output, 'baz', 'returns the expected value');
+      }
+    );
+
+    contractorResourceCostModelTests.test(
+      'validation',
+      async validationTests => {
+        validationTests.test(
+          'fails if the year is too early or too late',
+          async test => {
+            const self = { attributes: { year: 2009 } };
+            test.rejects(
+              cost.validate.bind(self),
+              'rejects if year is too early'
+            );
+            self.attributes.year = 3001;
+            test.rejects(
+              cost.validate.bind(self),
+              'rejects if year is too late'
+            );
+          }
+        );
+
+        validationTests.test('succeeds if year is valid', async test => {
+          const self = { attributes: { year: 2019 } };
+          test.resolves(cost.validate.bind(self), 'resolves if year is valid');
+        });
+      }
+    );
+
+    contractorResourceCostModelTests.test(
+      'overrides toJSON method',
+      async jsonTests => {
+        const self = { get: sinon.stub() };
+        self.get.returns('--- unknown field ---');
+        self.get.withArgs('id').returns('id field');
+        self.get.withArgs('cost').returns('cost field');
+        self.get.withArgs('year').returns('year field');
+
+        const output = cost.toJSON.bind(self)();
+
+        jsonTests.same(output, {
+          id: 'id field',
+          cost: 'cost field',
+          year: 'year field'
+        });
+      }
+    );
+  }
+);

--- a/api/db/activity/index.js
+++ b/api/db/activity/index.js
@@ -1,17 +1,21 @@
 const activity = require('./activity');
 const approach = require('./approach');
+const contractorResource = require('./contractorResource');
 const expense = require('./expense');
 const expenseEntry = require('./expenseEntry');
 const goal = require('./goal');
 const goalObjective = require('./goalObjective');
 const schedule = require('./schedule');
+const statePersonnel = require('./statePersonnel');
 
 module.exports = () => ({
   ...activity,
   ...approach,
+  ...contractorResource,
   ...expense,
   ...expenseEntry,
   ...goal,
   ...goalObjective,
-  ...schedule
+  ...schedule,
+  ...statePersonnel
 });

--- a/api/db/activity/index.test.js
+++ b/api/db/activity/index.test.js
@@ -12,11 +12,15 @@ tap.test('activity model index', async activityIndexTests => {
     [
       'apdActivity',
       'apdActivityApproach',
+      'apdActivityContractorResource',
+      'apdActivityContractorResourceCost',
       'apdActivityExpense',
       'apdActivityExpenseEntry',
       'apdActivityGoal',
       'apdActivityGoalObjective',
-      'apdActivitySchedule'
+      'apdActivitySchedule',
+      'apdActivityStatePersonnel',
+      'apdActivityStatePersonnelCost'
     ],
     'exports the expected models'
   );

--- a/api/db/activity/statePersonnel.js
+++ b/api/db/activity/statePersonnel.js
@@ -1,0 +1,58 @@
+module.exports = {
+  apdActivityStatePersonnel: {
+    tableName: 'activity_state_peronnel',
+
+    activity() {
+      return this.belongsTo('apdActivity');
+    },
+
+    years() {
+      return this.hasMany('apdActivityStatePersonnelCost', 'personnel_id');
+    },
+
+    toJSON() {
+      return {
+        id: this.get('id'),
+        title: this.get('title'),
+        description: this.get('description'),
+        years: this.related('years')
+      };
+    },
+
+    static: {
+      updateableFields: ['title', 'description'],
+      owns: { years: 'apdActivityStatePersonnelCost' },
+      foreignKey: 'personnel_id'
+    }
+  },
+
+  apdActivityStatePersonnelCost: {
+    tableName: 'activity_state_personnel_yearly',
+
+    personnel() {
+      return this.belongsTo('apdActivityStatePersonnel', 'personnel_id');
+    },
+
+    async validate() {
+      if (this.attributes.fte < 0 || this.attributes.fte > 1) {
+        throw new Error('fte-out-of-range');
+      }
+      if (this.attributes.year < 2010 || this.attributes.year > 3000) {
+        throw new Error('year-out-of-range');
+      }
+    },
+
+    toJSON() {
+      return {
+        id: this.get('id'),
+        cost: this.get('cost'),
+        fte: this.get('fte'),
+        year: this.get('year')
+      };
+    },
+
+    static: {
+      updateableFields: ['year', 'cost', 'fte']
+    }
+  }
+};

--- a/api/db/activity/statePersonnel.test.js
+++ b/api/db/activity/statePersonnel.test.js
@@ -1,0 +1,172 @@
+const tap = require('tap');
+const sinon = require('sinon');
+
+const {
+  apdActivityStatePersonnel: personnel,
+  apdActivityStatePersonnelCost: cost
+} = require('./statePersonnel');
+
+tap.test('state personnel data model', async statePersonnelModelTests => {
+  statePersonnelModelTests.test('setup', async setupTests => {
+    setupTests.match(
+      personnel,
+      {
+        tableName: 'activity_state_peronnel',
+        activity: Function,
+        years: Function,
+        static: {
+          updateableFields: ['title', 'description'],
+          owns: { years: 'apdActivityStatePersonnelCost' },
+          foreignKey: 'personnel_id'
+        }
+      },
+      'get the expected model definitions'
+    );
+  });
+
+  statePersonnelModelTests.test(
+    'expense model sets up activity relationship',
+    async relationTest => {
+      const self = {
+        belongsTo: sinon.stub().returns('baz')
+      };
+
+      const output = personnel.activity.bind(self)();
+
+      relationTest.ok(
+        self.belongsTo.calledWith('apdActivity'),
+        'sets up the relationship mapping to an activity'
+      );
+      relationTest.equal(output, 'baz', 'returns the expected value');
+    }
+  );
+
+  statePersonnelModelTests.test(
+    'personnel model sets up yearly cost relationship',
+    async relationTest => {
+      const self = {
+        hasMany: sinon.stub().returns('baz')
+      };
+
+      const output = personnel.years.bind(self)();
+
+      relationTest.ok(
+        self.hasMany.calledWith(
+          'apdActivityStatePersonnelCost',
+          'personnel_id'
+        ),
+        'sets up the relationship mapping to years'
+      );
+      relationTest.equal(output, 'baz', 'returns the expected value');
+    }
+  );
+
+  statePersonnelModelTests.test('overrides toJSON method', async jsonTests => {
+    const self = { get: sinon.stub(), related: sinon.stub() };
+    self.get.returns('--- unknown field ---');
+    self.get.withArgs('id').returns('id field');
+    self.get.withArgs('title').returns('title field');
+    self.get.withArgs('description').returns('description field');
+    self.related.withArgs('years').returns('some times');
+
+    const output = personnel.toJSON.bind(self)();
+
+    jsonTests.same(output, {
+      id: 'id field',
+      title: 'title field',
+      description: 'description field',
+      years: 'some times'
+    });
+  });
+});
+
+tap.test(
+  'state personnel cost data model',
+  async statePersonnelCostModelTests => {
+    statePersonnelCostModelTests.test('setup', async setupTests => {
+      setupTests.match(
+        cost,
+        {
+          tableName: 'activity_state_personnel_yearly',
+          personnel: Function,
+          static: {
+            updateableFields: ['year', 'cost', 'fte']
+          }
+        },
+        'get the expected model definitions'
+      );
+    });
+
+    statePersonnelCostModelTests.test(
+      'personnel cost model sets up personnel relationship',
+      async relationTest => {
+        const self = {
+          belongsTo: sinon.stub().returns('baz')
+        };
+
+        const output = cost.personnel.bind(self)();
+
+        relationTest.ok(
+          self.belongsTo.calledWith('apdActivityStatePersonnel'),
+          'sets up the relationship mapping to a state personnel'
+        );
+        relationTest.equal(output, 'baz', 'returns the expected value');
+      }
+    );
+
+    statePersonnelCostModelTests.test('validation', async validationTests => {
+      const self = { attributes: { fte: 0, year: 0 } };
+      validationTests.test(
+        'fails if the year is too early or too late',
+        async test => {
+          self.attributes.year = 2009;
+          test.rejects(
+            cost.validate.bind(self),
+            'rejects if year is too early'
+          );
+          self.attributes.year = 3001;
+          test.rejects(cost.validate.bind(self), 'rejects if year is too late');
+        }
+      );
+
+      validationTests.test(
+        'fails if FTE is too small or too large',
+        async test => {
+          self.attributes.year = 2019;
+          self.attributes.fte = -0.3;
+          test.rejects(cost.validate.bind(self), 'rejects if fte is negative');
+
+          self.attributes.fte = 1.3;
+          test.rejects(cost.validate.bind(self), 'rejects if fte is over 100%');
+        }
+      );
+
+      validationTests.test('succeeds if data is valid', async test => {
+        self.attributes.year = 2019;
+        self.attributes.fte = 0.5;
+        test.resolves(cost.validate.bind(self), 'resolves if year is valid');
+      });
+    });
+
+    statePersonnelCostModelTests.test(
+      'overrides toJSON method',
+      async jsonTests => {
+        const self = { get: sinon.stub() };
+        self.get.returns('--- unknown field ---');
+        self.get.withArgs('id').returns('id field');
+        self.get.withArgs('cost').returns('cost field');
+        self.get.withArgs('fte').returns('fte field');
+        self.get.withArgs('year').returns('year field');
+
+        const output = cost.toJSON.bind(self)();
+
+        jsonTests.same(output, {
+          id: 'id field',
+          cost: 'cost field',
+          fte: 'fte field',
+          year: 'year field'
+        });
+      }
+    );
+  }
+);

--- a/api/db/apd.js
+++ b/api/db/apd.js
@@ -17,11 +17,15 @@ module.exports = () => ({
       withRelated: [
         { activities: query => query.orderBy('id') },
         'activities.approaches',
+        'activities.contractorResources',
+        'activities.contractorResources.years',
         'activities.goals',
         'activities.goals.objectives',
         'activities.expenses',
         'activities.expenses.entries',
-        'activities.schedule'
+        'activities.schedule',
+        'activities.statePersonnel',
+        'activities.statePersonnel.years'
       ]
     }
   }

--- a/api/db/apd.test.js
+++ b/api/db/apd.test.js
@@ -17,11 +17,15 @@ tap.test('apd data model', async apdModelTests => {
             withRelated: [
               { activities: Function },
               'activities.approaches',
+              'activities.contractorResources',
+              'activities.contractorResources.years',
               'activities.goals',
               'activities.goals.objectives',
               'activities.expenses',
               'activities.expenses.entries',
-              'activities.schedule'
+              'activities.schedule',
+              'activities.statePersonnel',
+              'activities.statePersonnel.years'
             ]
           }
         }

--- a/api/endpoint-tests/activities/put.js
+++ b/api/endpoint-tests/activities/put.js
@@ -114,6 +114,7 @@ tap.test(
               name: 'updated name',
               description: 'updated description',
               approaches: [],
+              contractorResources: [],
               expenses: [],
               goals: [
                 {
@@ -140,7 +141,8 @@ tap.test(
                   objectives: ['Learn to dance', 'Bring audience gifts']
                 }
               ],
-              schedule: []
+              schedule: [],
+              statePersonnel: []
             },
             'sends back the updated activity object'
           );

--- a/api/migrations/20180417181354_activity-personnel.js
+++ b/api/migrations/20180417181354_activity-personnel.js
@@ -1,0 +1,52 @@
+exports.up = async knex => {
+  await knex.schema.createTable('activity_state_peronnel', table => {
+    table.increments('id');
+    table.text('title');
+    table.text('description');
+
+    table.integer('activity_id');
+    table.foreign('activity_id').references('activities.id');
+  });
+
+  await knex.schema.createTable('activity_state_personnel_yearly', table => {
+    table.increments('id');
+    table.integer('year');
+    table.decimal('cost', 15, 2);
+    table.decimal('fte', 3, 2);
+
+    table.integer('personnel_id');
+    table.foreign('personnel_id').references('activity_state_peronnel.id');
+  });
+
+  await knex.schema.createTable('activity_contractor_resources', table => {
+    table.increments('id');
+    table.text('name');
+    table.text('description');
+    table.date('start');
+    table.date('end');
+
+    table.integer('activity_id');
+    table.foreign('activity_id').references('activities.id');
+  });
+
+  await knex.schema.createTable(
+    'activity_contractor_resources_yearly',
+    table => {
+      table.increments('id');
+      table.integer('year');
+      table.decimal('cost', 15, 2);
+
+      table.integer('contractor_resource_id');
+      table
+        .foreign('contractor_resource_id')
+        .references('activity_contractor_resources.id');
+    }
+  );
+};
+
+exports.down = async knex => {
+  await knex.schema.dropTable('activity_contractor_resources_yearly');
+  await knex.schema.dropTable('activity_contractor_resources');
+  await knex.schema.dropTable('activity_state_personnel_yearly');
+  await knex.schema.dropTable('activity_state_peronnel');
+};


### PR DESCRIPTION
Adds the migration and data model info for activity personnel and contractor resources.

Closes #290.

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- ~The change has been documented~
  - ~Associated OpenAPI documentation has been updated~

### This feature is done when...
- ~Design has approved the experience~
- ~Product has approved the experience~
