### PR TITLE
Fix a couple of bugs with the database migration tooling

### DIFF
--- a/api/migrations/0001-initial.js
+++ b/api/migrations/0001-initial.js
@@ -183,7 +183,7 @@ exports.down = async knex => {
 
   await knex.schema.dropTable('activities');
 
-  await knex.schema.dropTable('apd');
+  await knex.schema.dropTable('apds');
   await knex.schema.dropTable('users');
 
   await knex.schema.dropTable('auth_role_activity_mapping');

--- a/api/seeds/shared/delete-everything.js
+++ b/api/seeds/shared/delete-everything.js
@@ -1,20 +1,32 @@
 exports.seed = async knex => {
-  // has a foreign key relationship on auth_roles and states
-  await knex('users').del();
+  // These need to be deleted in a particular order to handle
+  // relationships between them, otherwise we get a key
+  // constraint violation.
 
-  // has a foreign key relationship on auth_roles and auth_activities
-  await knex('auth_role_activity_mapping').del();
+  await knex('activity_contractor_resources_yearly').del();
+  await knex('activity_contractor_resources').del();
 
-  await knex('auth_roles').del();
-  await knex('auth_activities').del();
+  await knex('activity_expense_entries').del();
+  await knex('activity_expenses').del();
 
-  // have cascading foreign key relationships, so make sure we
-  // delete them in the right order
   await knex('activity_goal_objectives').del();
   await knex('activity_goals').del();
+
   await knex('activity_approaches').del();
+  await knex('activity_state_peronnel').del();
+  await knex('activity_state_personnel_yearly').del();
+
+  await knex('activity_schedule').del();
+
   await knex('activities').del();
 
   await knex('apds').del();
+
+  await knex('users').del();
+
+  await knex('auth_role_activity_mapping').del();
+  await knex('auth_activities').del();
+  await knex('auth_roles').del();
+
   await knex('states').del();
 };


### PR DESCRIPTION
- the new squashed migration couldn't rollback properly because it tried to delete a table that did not exist ('apd' instead of 'apds')
- the `delete-everything` shared seed was missing a couple of tables that reference the activities table, so if anything happened to be in those tables, the seed would fail with a key constraint violation
- the `roles-and-activities` shared seed (the one that's responsible for setting up roles and activities in staging, production, etc.) tried to do some fancy asynchronous logic for setting up the mapping between roles and activities, but that was breaking.  Instead, just build the mappings up and do one big insert.  This works consistently.  The old way was super silly.

### This pull request is ready to merge when...
- ~Tests have been updated (and all tests are passing)~
- [ ] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- ~The change has been documented~
  - ~Associated OpenAPI documentation has been updated~

### This feature is done when...
- ~Design has approved the experience~
- ~Product has approved the experience~
