### PR TITLE
Reduxify contractor resources

### DIFF
--- a/web/src/actions/activities.js
+++ b/web/src/actions/activities.js
@@ -17,13 +17,10 @@ export const addActivityContractorResource = id => ({
   type: ADD_ACTIVITY_CONTRACTOR_RESOURCE,
   id
 });
-export const removeActivityContractorResource = (
-  id,
-  contractorResourceIdx
-) => ({
+export const removeActivityContractorResource = (id, contractorResourceId) => ({
   type: REMOVE_ACTIVITY_CONTRACTOR_RESOURCE,
   id,
-  contractorResourceIdx
+  contractorResourceId
 });
 
 export const addActivityGoal = id => ({ type: ADD_ACTIVITY_GOAL, id });

--- a/web/src/actions/activities.js
+++ b/web/src/actions/activities.js
@@ -1,10 +1,27 @@
 export const ADD_ACTIVITY = 'ADD_ACTIVITY';
+export const ADD_ACTIVITY_CONTRACTOR_RESOURCE =
+  'ADD_ACTIVITY_CONTRACTOR_RESOURCE';
 export const ADD_ACTIVITY_GOAL = 'ADD_ACTIVITY_GOAL';
 export const ADD_ACTIVITY_MILESTONE = 'ADD_ACTIVITY_MILESTONE';
+export const REMOVE_ACTIVITY_CONTRACTOR_RESOURCE =
+  'REMOVE_ACTIVITY_CONTRACTOR_RESOURCE';
 export const REMOVE_ACTIVITY_MILESTONE = 'REMOVE_ACTIVITY_MILESTONE';
 export const UPDATE_ACTIVITY = 'UPDATE_ACTIVITY';
 
 export const addActivity = () => ({ type: ADD_ACTIVITY });
+
+export const addActivityContractorResource = id => ({
+  type: ADD_ACTIVITY_CONTRACTOR_RESOURCE,
+  id
+});
+export const removeActivityContractorResource = (
+  id,
+  contractorResourceIdx
+) => ({
+  type: REMOVE_ACTIVITY_CONTRACTOR_RESOURCE,
+  id,
+  contractorResourceIdx
+});
 
 export const addActivityGoal = id => ({ type: ADD_ACTIVITY_GOAL, id });
 

--- a/web/src/containers/ActivityDetailAll.js
+++ b/web/src/containers/ActivityDetailAll.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
+import ActivityDetailContractorResources from './ActivityDetailContractorResources';
 import ActivityDetailDescription from './ActivityDetailDescription';
 import ActivityDetailGoals from './ActivityDetailGoals';
 import ActivityDetailSchedule from './ActivityDetailSchedule';
@@ -20,6 +21,7 @@ const ActivityDetailAll = ({ aId, title }) => (
     <ActivityDetailDescription aId={aId} />
     <ActivityDetailGoals aId={aId} />
     <ActivityDetailSchedule aId={aId} />
+    <ActivityDetailContractorResources aId={aId} />
     <ActivityDetailStandardsAndConditions aId={aId} />
   </Collapsible>
 );

--- a/web/src/containers/ActivityDetailContractorResources.js
+++ b/web/src/containers/ActivityDetailContractorResources.js
@@ -1,0 +1,186 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+import {
+  addActivityContractorResource,
+  removeActivityContractorResource,
+  updateActivity as updateActivityAction
+} from '../actions/activities';
+import Collapsible from '../components/Collapsible';
+import { Input, Textarea } from '../components/Inputs2';
+
+class ActivityDetailContractorExpenses extends Component {
+  handleChange = (index, key) => e => {
+    const { value } = e.target;
+    const { activity, updateActivity } = this.props;
+
+    const updates = { contractorResources: { [index]: { [key]: value } } };
+    updateActivity(activity.id, updates);
+  };
+
+  handleYearChange = (index, year) => e => {
+    const { value } = e.target;
+    const { activity, updateActivity } = this.props;
+
+    const updates = {
+      contractorResources: { [index]: { years: { [year]: +value } } }
+    };
+    updateActivity(activity.id, updates);
+  };
+
+  render() {
+    const {
+      activity: { id: activityID, contractorResources },
+      years,
+      addContractor,
+      removeContractor
+    } = this.props;
+
+    return (
+      <Collapsible title="Contractor Resources" open>
+        <div>
+          <div className="overflow-auto">
+            <table
+              className="mb2 h5 table table-condensed table-fixed"
+              style={{ minWidth: 700 }}
+            >
+              <thead>
+                <tr>
+                  <th className="col-1">#</th>
+                  <th className="col-4">Name</th>
+                  <th className="col-5">Description of Services</th>
+                  <th className="col-4">Term Period</th>
+                  {years.map(year => (
+                    <th key={year} className="col-2">
+                      {year} Cost
+                    </th>
+                  ))}
+                  <th className="col-1" />
+                </tr>
+              </thead>
+              <tbody>
+                {contractorResources.map((contractor, i) => (
+                  <tr key={contractor.idx}>
+                    <td className="mono">{i + 1}.</td>
+                    <td>
+                      <Input
+                        name={`contractor-${i}-name`}
+                        label="Contractor's name"
+                        hideLabel
+                        type="text"
+                        value={contractor.name}
+                        onChange={this.handleChange(i, 'name')}
+                      />
+                    </td>
+                    <td>
+                      <Textarea
+                        id={`contractor-${i}-desc`}
+                        name={`contractor-${i}-desc`}
+                        label="Describe the services the contractor will provide"
+                        rows="3"
+                        hideLabel
+                        spellCheck="true"
+                        value={contractor.desc}
+                        onChange={this.handleChange(i, 'desc')}
+                      />
+                    </td>
+                    <td>
+                      <div className="mb1 flex items-baseline h6">
+                        <span className="mr-tiny w-3 right-align">Start:</span>
+                        <Input
+                          name={`contractor-${i}-start`}
+                          label="Contractor term start"
+                          hideLabel
+                          type="date"
+                          value={contractor.start}
+                          onChange={this.handleChange(i, 'start')}
+                        />
+                      </div>
+                      <div className="mb1 flex items-baseline h6">
+                        <span className="mr-tiny w-3 right-align">End:</span>
+                        <Input
+                          name={`contractor-${i}-end`}
+                          label="Contractor term end"
+                          hideLabel
+                          type="date"
+                          value={contractor.end}
+                          onChange={this.handleChange(i, 'end')}
+                        />
+                      </div>
+                    </td>
+                    {years.map(year => (
+                      <td key={year}>
+                        <Input
+                          name={`contractor-${i}-cost-${year}`}
+                          label={`Contractor cost for ${year}`}
+                          hideLabel
+                          type="number"
+                          value={contractor.years[year]}
+                          onChange={this.handleYearChange(i, year)}
+                        />
+                      </td>
+                    ))}
+                    <td className="center align-middle">
+                      <button
+                        type="button"
+                        className="btn btn-outline border-silver px1 py-tiny"
+                        title="Remove Contractor"
+                        onClick={() =>
+                          removeContractor(activityID, contractor.idx)
+                        }
+                      >
+                        ✗
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <button
+          type="button"
+          className="btn btn-primary bg-black"
+          onClick={() => addContractor(activityID)}
+        >
+          Add contractor resource
+        </button>
+      </Collapsible>
+    );
+  }
+}
+
+ActivityDetailContractorExpenses.propTypes = {
+  activity: PropTypes.object.isRequired,
+  years: PropTypes.array.isRequired,
+  addContractor: PropTypes.func.isRequired,
+  removeContractor: PropTypes.func.isRequired,
+  updateActivity: PropTypes.func.isRequired
+};
+
+const mapStateToProps = ({ activities: { byId } }, { aId }) => {
+  const { contractorResources } = byId[aId];
+  const contractorYears = contractorResources
+    .reduce((years, e) => {
+      years.push(...Object.keys(e.years));
+      return years;
+    }, [])
+    .filter((y, i, a) => a.lastIndexOf(y) === i)
+    .sort();
+
+  return {
+    activity: byId[aId],
+    years: contractorYears
+  };
+};
+
+const mapDispatchToProps = {
+  addContractor: addActivityContractorResource,
+  removeContractor: removeActivityContractorResource,
+  updateActivity: updateActivityAction
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(
+  ActivityDetailContractorExpenses
+);

--- a/web/src/containers/ActivityDetailContractorResources.js
+++ b/web/src/containers/ActivityDetailContractorResources.js
@@ -61,7 +61,7 @@ class ActivityDetailContractorExpenses extends Component {
               </thead>
               <tbody>
                 {contractorResources.map((contractor, i) => (
-                  <tr key={contractor.idx}>
+                  <tr key={contractor.id}>
                     <td className="mono">{i + 1}.</td>
                     <td>
                       <Input
@@ -127,7 +127,7 @@ class ActivityDetailContractorExpenses extends Component {
                         className="btn btn-outline border-silver px1 py-tiny"
                         title="Remove Contractor"
                         onClick={() =>
-                          removeContractor(activityID, contractor.idx)
+                          removeContractor(activityID, contractor.id)
                         }
                       >
                         ✗

--- a/web/src/containers/ActivityDetailContractorResources.js
+++ b/web/src/containers/ActivityDetailContractorResources.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
+import { t } from '../i18n';
 import {
   addActivityContractorResource,
   removeActivityContractorResource,
@@ -38,7 +39,7 @@ class ActivityDetailContractorExpenses extends Component {
     } = this.props;
 
     return (
-      <Collapsible title="Contractor Resources" open>
+      <Collapsible title={t('activities.contractorResources.title')} open>
         <div>
           <div className="overflow-auto">
             <table
@@ -47,13 +48,23 @@ class ActivityDetailContractorExpenses extends Component {
             >
               <thead>
                 <tr>
-                  <th className="col-1">#</th>
-                  <th className="col-4">Name</th>
-                  <th className="col-5">Description of Services</th>
-                  <th className="col-4">Term Period</th>
+                  <th className="col-1">
+                    {t('activities.contractorResources.labels.entryNumber')}
+                  </th>
+                  <th className="col-4">
+                    {t('activities.contractorResources.labels.contractorName')}
+                  </th>
+                  <th className="col-5">
+                    {t('activities.contractorResources.labels.description')}
+                  </th>
+                  <th className="col-4">
+                    {t('activities.contractorResources.labels.term')}
+                  </th>
                   {years.map(year => (
                     <th key={year} className="col-2">
-                      {year} Cost
+                      {t('activities.contractorResources.labels.yearCost', {
+                        year
+                      })}
                     </th>
                   ))}
                   <th className="col-1" />
@@ -66,7 +77,9 @@ class ActivityDetailContractorExpenses extends Component {
                     <td>
                       <Input
                         name={`contractor-${i}-name`}
-                        label="Contractor's name"
+                        label={t(
+                          'activities.contractorResources.srLabels.name'
+                        )}
                         hideLabel
                         type="text"
                         value={contractor.name}
@@ -77,7 +90,9 @@ class ActivityDetailContractorExpenses extends Component {
                       <Textarea
                         id={`contractor-${i}-desc`}
                         name={`contractor-${i}-desc`}
-                        label="Describe the services the contractor will provide"
+                        label={t(
+                          'activities.contractorResources.srLabels.description'
+                        )}
                         rows="3"
                         hideLabel
                         spellCheck="true"
@@ -87,10 +102,14 @@ class ActivityDetailContractorExpenses extends Component {
                     </td>
                     <td>
                       <div className="mb1 flex items-baseline h6">
-                        <span className="mr-tiny w-3 right-align">Start:</span>
+                        <span className="mr-tiny w-3 right-align">
+                          {t('activities.contractorResources.labels.start')}
+                        </span>
                         <Input
                           name={`contractor-${i}-start`}
-                          label="Contractor term start"
+                          label={t(
+                            'activities.contractorResources.srLabels.start'
+                          )}
                           hideLabel
                           type="date"
                           value={contractor.start}
@@ -98,10 +117,14 @@ class ActivityDetailContractorExpenses extends Component {
                         />
                       </div>
                       <div className="mb1 flex items-baseline h6">
-                        <span className="mr-tiny w-3 right-align">End:</span>
+                        <span className="mr-tiny w-3 right-align">
+                          {t('activities.contractorResources.labels.end')}
+                        </span>
                         <Input
                           name={`contractor-${i}-end`}
-                          label="Contractor term end"
+                          label={t(
+                            'activities.contractorResources.srLabels.end'
+                          )}
                           hideLabel
                           type="date"
                           value={contractor.end}
@@ -113,7 +136,10 @@ class ActivityDetailContractorExpenses extends Component {
                       <td key={year}>
                         <Input
                           name={`contractor-${i}-cost-${year}`}
-                          label={`Contractor cost for ${year}`}
+                          label={t(
+                            'activities.contractorResources.srLabels.cost',
+                            { year }
+                          )}
                           hideLabel
                           type="number"
                           value={contractor.years[year]}
@@ -125,7 +151,7 @@ class ActivityDetailContractorExpenses extends Component {
                       <button
                         type="button"
                         className="btn btn-outline border-silver px1 py-tiny"
-                        title="Remove Contractor"
+                        title={t('activities.contractorResources.removeLabel')}
                         onClick={() =>
                           removeContractor(activityID, contractor.id)
                         }
@@ -144,7 +170,7 @@ class ActivityDetailContractorExpenses extends Component {
           className="btn btn-primary bg-black"
           onClick={() => addContractor(activityID)}
         >
-          Add contractor resource
+          {t('activities.contractorResources.addContractorButtonText')}
         </button>
       </Collapsible>
     );

--- a/web/src/containers/ActivityDetailSchedule.js
+++ b/web/src/containers/ActivityDetailSchedule.js
@@ -27,7 +27,7 @@ class ActivityDetailSchedule extends Component {
     } = this.props;
 
     return (
-      <Collapsible title="Activity Schedule" open>
+      <Collapsible title="Activity Schedule">
         <div className="mb2">
           List the major milestones you’re working towards as part of this
           activity:

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -48,6 +48,27 @@
       "removeLabel": "remove milestone",
       "addMilestoneButtonText": "Add milestone"
     },
+    "contractorResources": {
+      "title": "Contractor Resources",
+      "labels": {
+        "entryNumber": "#",
+        "contractorName": "Name",
+        "description": "Description of Services",
+        "term": "Term Period",
+        "start": "Start:",
+        "end": "End:",
+        "yearCost": "{{year}} Cost"
+      },
+      "srLabels": {
+        "name": "Contractor's name",
+        "description": "Describe the services the contractor will provide",
+        "start": "Contractor term start",
+        "end": "Contractor term end",
+        "cost": "Contractor cost for {{year}}"
+      },
+      "removeLabel": "remove contractor",
+      "addContractorButtonText": "Add contractor resource"
+    },
     "costAllocate": {
       "title": "Cost Allocation and Other Funding Sources",
       "label": {

--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -2,13 +2,27 @@ import u from 'updeep';
 
 import {
   ADD_ACTIVITY,
+  ADD_ACTIVITY_CONTRACTOR_RESOURCE,
   ADD_ACTIVITY_GOAL,
   ADD_ACTIVITY_MILESTONE,
+  REMOVE_ACTIVITY_CONTRACTOR_RESOURCE,
   REMOVE_ACTIVITY_MILESTONE,
   UPDATE_ACTIVITY
 } from '../actions/activities';
 
 const newGoal = () => ({ desc: '', obj: '' });
+
+const newContractorResource = idx => ({
+  idx,
+  name: '',
+  desc: '',
+  start: '',
+  end: '',
+  years: {
+    2018: 0,
+    2019: 0
+  }
+});
 
 const newMilestone = () => ({ name: '', start: '', end: '' });
 
@@ -19,6 +33,11 @@ const newActivity = id => ({
   descShort: '',
   descLong: '',
   altApproach: '',
+  contractorResources: [
+    newContractorResource(0),
+    newContractorResource(1),
+    newContractorResource(2)
+  ],
   goals: [newGoal()],
   milestones: [newMilestone(), newMilestone(), newMilestone()],
   standardsAndConditions: {
@@ -53,6 +72,20 @@ const reducer = (state = initialState, action) => {
         allIds: [...state.allIds, id]
       };
     }
+    case ADD_ACTIVITY_CONTRACTOR_RESOURCE:
+      return u(
+        {
+          byId: {
+            [action.id]: {
+              contractorResources: contractors => [
+                ...contractors,
+                newContractorResource(contractors.length)
+              ]
+            }
+          }
+        },
+        state
+      );
     case ADD_ACTIVITY_GOAL:
       return u(
         {
@@ -75,6 +108,19 @@ const reducer = (state = initialState, action) => {
         },
         state
       );
+    case REMOVE_ACTIVITY_CONTRACTOR_RESOURCE:
+      return u(
+        {
+          byId: {
+            [action.id]: {
+              contractorResources: contractors =>
+                contractors.filter(c => c.idx !== action.contractorResourceIdx)
+            }
+          }
+        },
+        state
+      );
+
     case REMOVE_ACTIVITY_MILESTONE:
       return u(
         {

--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -15,8 +15,8 @@ import {
 
 const newGoal = () => ({ desc: '', obj: '' });
 
-const newContractorResource = idx => ({
-  idx,
+const newContractorResource = id => ({
+  id,
   name: '',
   desc: '',
   start: '',
@@ -98,7 +98,7 @@ const reducer = (state = initialState, action) => {
             [action.id]: {
               contractorResources: contractors => [
                 ...contractors,
-                newContractorResource(contractors.length)
+                newContractorResource(nextSequence(contractors.map(c => c.id)))
               ]
             }
           }
@@ -168,7 +168,7 @@ const reducer = (state = initialState, action) => {
           byId: {
             [action.id]: {
               contractorResources: contractors =>
-                contractors.filter(c => c.idx !== action.contractorResourceIdx)
+                contractors.filter(c => c.id !== action.contractorResourceId)
             }
           }
         },


### PR DESCRIPTION
Hooks up the contractor resources section to redux state.  There's a pretty glaring style problem where the start/end date inputs overflow and cover up part of the cost inputs.  I can bang on it and see if I can get something that makes sense, but I was hoping I could convince @brendansudol to take a look at it for me.  😬

Closes #437

### This pull request changes...
- On the `/activities` page, the "contractor resources" section is now visible

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- ~The change has been documented~
  - ~Associated OpenAPI documentation has been updated~

### This feature is done when...
- ~Design has approved the experience~
- ~Product has approved the experience~
