### PR TITLE
Move some text into resource files

### DIFF
--- a/web/src/components/Hello.js
+++ b/web/src/components/Hello.js
@@ -8,7 +8,7 @@ const Hello = () => (
   <Container>
     <div className="my3 py4 center">
       <UsaAnimated />
-      <p className="mt3">{t('test')}</p>
+      <p className="mt3">{t('title', { year: 2018 })}</p>
     </div>
   </Container>
 );

--- a/web/src/components/__snapshots__/Hello.test.js.snap
+++ b/web/src/components/__snapshots__/Hello.test.js.snap
@@ -24,7 +24,7 @@ ShallowWrapper {
         <p
           className="mt3"
         >
-          Hello!
+          2018 HITECH APD
         </p>
       </div>,
     },
@@ -39,7 +39,7 @@ ShallowWrapper {
           <p
             className="mt3"
           >
-            Hello!
+            2018 HITECH APD
           </p>,
         ],
         "className": "my3 py4 center",
@@ -60,11 +60,11 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "host",
           "props": Object {
-            "children": "Hello!",
+            "children": "2018 HITECH APD",
             "className": "mt3",
           },
           "ref": null,
-          "rendered": "Hello!",
+          "rendered": "2018 HITECH APD",
           "type": "p",
         },
       ],
@@ -85,7 +85,7 @@ ShallowWrapper {
           <p
             className="mt3"
           >
-            Hello!
+            2018 HITECH APD
           </p>
         </div>,
       },
@@ -100,7 +100,7 @@ ShallowWrapper {
             <p
               className="mt3"
             >
-              Hello!
+              2018 HITECH APD
             </p>,
           ],
           "className": "my3 py4 center",
@@ -121,11 +121,11 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "host",
             "props": Object {
-              "children": "Hello!",
+              "children": "2018 HITECH APD",
               "className": "mt3",
             },
             "ref": null,
-            "rendered": "Hello!",
+            "rendered": "2018 HITECH APD",
             "type": "p",
           },
         ],

--- a/web/src/containers/Activities.js
+++ b/web/src/containers/Activities.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
+import { t } from '../i18n';
 
 import ActivityDetailAll from './ActivityDetailAll';
 import ActivityListEntry from './ActivityListEntry';
@@ -13,8 +14,8 @@ import SectionTitle from '../components/SectionTitle';
 const Activities = ({ activityIds, addActivity }) => (
   <Container>
     <Section>
-      <SectionTitle>Program Activities</SectionTitle>
-      <Collapsible title="Activity List" open>
+      <SectionTitle>{t('activities.title')}</SectionTitle>
+      <Collapsible title={t('activities.listTitle')} open>
         <div className="mb2">
           {activityIds.map((aId, idx) => (
             <ActivityListEntry key={aId} aId={aId} num={idx + 1} />
@@ -25,7 +26,7 @@ const Activities = ({ activityIds, addActivity }) => (
           className="mt2 btn btn-primary"
           onClick={addActivity}
         >
-          Add activity
+          {t('activities.addActivityButtonText')}
         </button>
       </Collapsible>
       {activityIds.map((aId, idx) => (

--- a/web/src/containers/ActivityDetailAll.js
+++ b/web/src/containers/ActivityDetailAll.js
@@ -7,9 +7,10 @@ import ActivityDetailGoals from './ActivityDetailGoals';
 import ActivityDetailSchedule from './ActivityDetailSchedule';
 import ActivityDetailStandardsAndConditions from './ActivityDetailStandardsAndConditions';
 import Collapsible from '../components/Collapsible';
+import { t } from '../i18n';
 
 const activityTitle = (a, i) => {
-  let title = `Activity ${i}`;
+  let title = `${t('activities.namePrefix')} ${i}`;
   if (a.name) title += `: ${a.name}`;
   if (a.types.length) title += ` (${a.types.join(', ')})`;
   return title;
@@ -31,7 +32,7 @@ ActivityDetailAll.propTypes = {
 
 const mapStateToProps = ({ activities: { byId } }, { aId, num }) => {
   const activity = byId[aId];
-  const title = `Program Activities › ${activityTitle(activity, num)}`;
+  const title = `${t('activities.header')} › ${activityTitle(activity, num)}`;
 
   return { title };
 };

--- a/web/src/containers/ActivityDetailDescription.js
+++ b/web/src/containers/ActivityDetailDescription.js
@@ -6,6 +6,7 @@ import React, { Component } from 'react';
 import { Editor } from 'react-draft-wysiwyg';
 import { connect } from 'react-redux';
 
+import { t } from '../i18n';
 import { updateActivity as updateActivityAction } from '../actions/activities';
 import Collapsible from '../components/Collapsible';
 import Icon, { faHelp } from '../components/Icons';
@@ -52,9 +53,9 @@ class ActivityDetailDescription extends Component {
     const { descLong, altApproach } = this.state;
 
     return (
-      <Collapsible title="Activity Description">
+      <Collapsible title={t('activities.description.title')}>
         <div className="mb-tiny bold">
-          Summary
+          {t('activities.description.summaryHeader')}
           <Icon icon={faHelp} className="ml-tiny teal" size="sm" />
         </div>
         <div className="mb3">
@@ -72,7 +73,7 @@ class ActivityDetailDescription extends Component {
 
         <div className="mb3">
           <div className="mb-tiny bold">
-            Please describe the activity in detail
+            {t('activities.description.detailHeader')}
             <Icon icon={faHelp} className="ml-tiny teal" size="sm" />
           </div>
           <Editor
@@ -85,7 +86,7 @@ class ActivityDetailDescription extends Component {
 
         <div className="mb3">
           <div className="mb-tiny bold">
-            Statement of alternative considerations and supporting justification
+            {t('activities.description.alternativesHeader')}
           </div>
           <Editor
             toolbar={EDITOR_CONFIG}

--- a/web/src/containers/ActivityDetailGoals.js
+++ b/web/src/containers/ActivityDetailGoals.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
+import { t } from '../i18n';
 import {
   addActivityGoal as addActivityGoalAction,
   updateActivity as updateActivityAction
@@ -22,22 +23,20 @@ class ActivityDetailGoals extends Component {
     const { activity, addActivityGoal } = this.props;
 
     return (
-      <Collapsible title="Needs and Objectives">
-        <div className="mb2">
-          List the goals you’re hoping to accomplish as part of this activity:
-        </div>
+      <Collapsible title={t('activities.goals.title')}>
+        <div className="mb2">{t('activities.goals.subheader')}</div>
         {activity.goals.map((d, i) => (
           <div key={i} className="mb3">
             <Textarea
               name={`goal-${i}`}
-              label={`Goal #${i + 1}`}
+              label={t('activities.goals.goalHeader', { number: i + 1 })}
               rows="5"
               value={d.desc}
               onChange={this.handleChange(i, 'desc')}
             />
             <Textarea
               name={`obj-${i}`}
-              label="Tell us how you’ll know when you’ve achieved this goal"
+              label={t('activities.goals.objectiveHeader')}
               value={d.obj}
               onChange={this.handleChange(i, 'obj')}
             />
@@ -49,7 +48,7 @@ class ActivityDetailGoals extends Component {
           className="btn btn-primary bg-black"
           onClick={() => addActivityGoal(activity.id)}
         >
-          Add goal
+          {t('activities.goals.addGoalButtonText')}
         </button>
       </Collapsible>
     );

--- a/web/src/containers/ActivityDetailSchedule.js
+++ b/web/src/containers/ActivityDetailSchedule.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
+import { t } from '../i18n';
 import {
   addActivityMilestone as addActivityMilestoneAction,
   removeActivityMilestone as removeActivityMilestoneAction,
@@ -27,24 +28,27 @@ class ActivityDetailSchedule extends Component {
     } = this.props;
 
     return (
-      <Collapsible title="Activity Schedule" open>
-        <div className="mb2">
-          List the major milestones you’re working towards as part of this
-          activity:
-        </div>
+      <Collapsible title={t('activities.schedule.title')} open>
+        <div className="mb2">{t('activities.schedule.subheader')}</div>
 
         {activity.milestones.length === 0 ? (
           <div className="mb2 p1 h6 alert">
-            <strong>Oh no!</strong> Please add milestones for this activity.
+            {t('activities.schedule.noMilestonesNotice')}
           </div>
         ) : (
           <div className="mb3 overflow-auto">
             <table className="h5 table table-fixed" style={{ minWidth: 500 }}>
               <thead>
                 <tr>
-                  <th className="col-4 sm-col-5">Milestone</th>
-                  <th className="col-4 sm-col-3">Planned start</th>
-                  <th className="col-4 sm-col-3">Planned end</th>
+                  <th className="col-4 sm-col-5">
+                    {t('activities.schedule.milestoneHeader')}
+                  </th>
+                  <th className="col-4 sm-col-3">
+                    {t('activities.schedule.startHeader')}
+                  </th>
+                  <th className="col-4 sm-col-3">
+                    {t('activities.schedule.endHeader')}
+                  </th>
                   <th className="col-1" />
                 </tr>
               </thead>
@@ -54,7 +58,7 @@ class ActivityDetailSchedule extends Component {
                     <td>
                       <Input
                         name={`milestone-${i}-name`}
-                        label="Name"
+                        label={t('activities.schedule.milestoneLabel')}
                         className="m0"
                         hideLabel
                         value={d.name}
@@ -64,7 +68,7 @@ class ActivityDetailSchedule extends Component {
                     <td>
                       <Input
                         name={`milestone-${i}-start`}
-                        label="Planned start date"
+                        label={t('activities.schedule.startLabel')}
                         type="date"
                         className="m0"
                         hideLabel
@@ -75,7 +79,7 @@ class ActivityDetailSchedule extends Component {
                     <td>
                       <Input
                         name={`milestone-${i}-end`}
-                        label="Planned end date"
+                        label={t('activities.schedule.endLabel')}
                         type="date"
                         className="m0"
                         hideLabel
@@ -87,7 +91,7 @@ class ActivityDetailSchedule extends Component {
                       <button
                         type="button"
                         className="btn btn-outline border-silver px1 py-tiny"
-                        title="Remove Milestone"
+                        title={t('activities.schedule.removeLabel')}
                         onClick={() => removeActivityMilestone(activity.id, i)}
                       >
                         ✗
@@ -104,7 +108,7 @@ class ActivityDetailSchedule extends Component {
           className="btn btn-primary bg-black"
           onClick={() => addActivityMilestone(activity.id)}
         >
-          Add milestone
+          {t('activities.schedule.addMilestoneButtonText')}
         </button>
       </Collapsible>
     );

--- a/web/src/containers/ActivityDetailStandardsAndConditions.js
+++ b/web/src/containers/ActivityDetailStandardsAndConditions.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { STANDARDS } from '../util';
 
+import { t } from '../i18n';
 import { updateActivity as updateActivityAction } from '../actions/activities';
 import Collapsible from '../components/Collapsible';
 import { Textarea } from '../components/Inputs2';
@@ -20,22 +21,30 @@ class ActivityDetailStandardsAndConditions extends Component {
     const { activity } = this.props;
 
     return (
-      <Collapsible title="Standards & Conditions">
-        <p>Tell us how you’ll meet the Medicaid standards and conditions.</p>
+      <Collapsible title={t('activities.standardsAndConditions.title')}>
+        <p>{t('activities.standardsAndConditions.subheader')}</p>
         {STANDARDS.map(std => {
           const inputId = `a-${activity.id}-standards-${std.id}`;
           return (
             <div key={std.id}>
-              <h3>{std.title}</h3>
+              <h3>
+                {t([`activities.standardsAndConditions`, std.id, 'title'])}
+              </h3>
               <p>
-                Sed ut perspiciatis unde omnis iste natus error sit voluptatem
-                accusantium doloremque laudantium, totam rem aperiam, eaque ipsa
-                quae ab illo inventore veritatis et quasi architecto...
+                {t([
+                  `activities.standardsAndConditions`,
+                  std.id,
+                  'description'
+                ])}
               </p>
               <Textarea
                 id={inputId}
                 name={`condition-${std.id}`}
-                label={`Describe how you'll meet the ${std.title} condition`}
+                label={t([
+                  `activities.standardsAndConditions`,
+                  std.id,
+                  'prompt'
+                ])}
                 rows="3"
                 spellCheck="true"
                 value={activity.standardsAndConditions[std.id]}

--- a/web/src/containers/DeleteActivity.js
+++ b/web/src/containers/DeleteActivity.js
@@ -2,13 +2,14 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
+import { t } from '../i18n';
 import { removeActivity as removeActivityAction } from '../actions/activities';
 import { confirmAlert } from '../components/ConfirmAlert';
 
 const DeleteConfirm = ({ onClose, onConfirm }) => (
   <div className="p2 sm-p3 bg-white rounded confirm-body">
-    <h2 className="mt0">Please confirm.</h2>
-    <p>Are you sure you’d like to remove this activity?</p>
+    <h2 className="mt0">{t('activities.delete.header')}</h2>
+    <p>{t('activities.delete.body')}</p>
     <button
       className="btn btn-small btn-primary bg-black h6"
       onClick={() => {
@@ -16,10 +17,10 @@ const DeleteConfirm = ({ onClose, onConfirm }) => (
         onClose();
       }}
     >
-      Yes
+      {t('activities.delete.yes')}
     </button>{' '}
     <button className="btn btn-small btn-outline h6" onClick={onClose}>
-      Cancel
+      {t('activities.delete.no')}
     </button>
   </div>
 );
@@ -51,7 +52,7 @@ class DeleteActivity extends Component {
           className="btn btn-small btn-primary bg-black h6"
           onClick={this.handleClick}
         >
-          Remove Activity
+          {t('activities.deleteActivityButtonText')}
         </button>
       </div>
     );

--- a/web/src/containers/TopNav.js
+++ b/web/src/containers/TopNav.js
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import Icon from '@fortawesome/react-fontawesome';
 
+import { t } from '../i18n';
 import { faHelp, faBell, faSignOut } from '../components/Icons';
 import { logout } from '../actions/auth';
 
@@ -20,18 +21,18 @@ class TopNav extends Component {
       <header className="clearfix py1 border-bottom border-silver">
         <div className="sm-col">
           <Link to="/" className="btn">
-            2018 HITECH APD
+            {t('title', { year: 2018 })}
           </Link>
         </div>
         <div className="sm-col-right h5">
           {authenticated ? (
             <div>
               <button type="button" className="btn h5 regular">
-                <span className="mr-tiny">Notifications</span>
+                <span className="mr-tiny">{t('notifications')}</span>
                 <Icon icon={faBell} />
               </button>
               <button type="button" className="btn h5 regular">
-                <span className="mr-tiny">Help</span>
+                <span className="mr-tiny">{t('notifications')}</span>
                 <Icon icon={faHelp} />
               </button>
               <button
@@ -39,13 +40,13 @@ class TopNav extends Component {
                 className="btn h5 regular"
                 onClick={this.handleLogout}
               >
-                <span className="mr-tiny">Log out</span>
+                <span className="mr-tiny">{t('logout')}</span>
                 <Icon icon={faSignOut} />
               </button>
             </div>
           ) : (
             <Link to="/login" className="btn h5 regular">
-              Log in
+              {t('login')}
             </Link>
           )}
         </div>

--- a/web/src/i18n/index.js
+++ b/web/src/i18n/index.js
@@ -26,6 +26,15 @@ export const initI18n = () => {
   I18n.locale = locale;
 };
 
-export const t = (name, params = {}) => I18n.t(name, params);
+export const t =
+  process.env.NODE_ENV === 'production'
+    ? (name, params = {}) => I18n.t(name, params)
+    : (name, params = {}) => {
+        // eslint-disable-next-line no-restricted-globals
+        if (location.hash.includes('i18n')) {
+          return `[${Array.isArray(name) ? name.join('.') : name}]`;
+        }
+        return I18n.t(name, params);
+      };
 
 export default I18n;

--- a/web/src/i18n/index.test.js
+++ b/web/src/i18n/index.test.js
@@ -1,6 +1,5 @@
 import I18n, { t } from './index';
 
-import en from './locales/en.json';
 import fr from './locales/fr.json';
 
 describe('i18n translations', () => {

--- a/web/src/i18n/index.test.js
+++ b/web/src/i18n/index.test.js
@@ -9,7 +9,7 @@ describe('i18n translations', () => {
   });
 
   test('t function', () => {
-    expect(t('test')).toBe(en.test);
+    expect(t('title', { year: 2018 })).toBe('2018 HITECH APD');
     expect(t('nonsense')).toBe('[missing "en.nonsense" translation]');
   });
 

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1,3 +1,117 @@
 {
-  "test": "Hello!"
+  "title": "{{year}} HITECH APD",
+  "login": "Log in",
+  "logout": "Log out",
+  "notifications": "Notifications",
+  "help": "Help",
+
+  "activities": {
+    "title": "Program Activities",
+    "listTitle": "Activity List",
+    "addActivityButtonText": "Add activity",
+    "header": "Program Activities",
+    "namePrefix": "Activity",
+    "description": {
+      "title": "Activity Description",
+      "summaryHeader": "Summary",
+      "detailHeader": "Please describe the activity in detail",
+      "alternativesHeader":
+        "State of alternative considerations and supporting justification"
+    },
+    "goals": {
+      "title": "Needs and Objectives",
+      "subheader":
+        "List the goals you're hoping to accomplish as part of this activity:",
+      "goalHeader": "Goal #{{number}}",
+      "objectiveHeader":
+        "Tell us how you'll know when you've achieved this goal",
+      "addGoalButtonText": "Add goal"
+    },
+    "schedule": {
+      "title": "Activity Schedule",
+      "subheader":
+        "List the major milestones you're working towards as part of this activity",
+      "noMilestonesNotice": "Oh no! Please add milestones for this activity.",
+      "milestoneHeader": "Milestone",
+      "milestoneLabel": "milestone name",
+      "startHeader": "Planned start",
+      "startLabel": "planned start date",
+      "endHeader": "Planned end",
+      "endLabel": "planned end date",
+      "removeLabel": "remove milestone",
+      "addMilestoneButtonText": "Add milestone"
+    },
+    "standardsAndConditions": {
+      "title": "Standards & Conditions",
+      "subheader":
+        "Tell us how you'll meet the Medicaid standards and conditions",
+      "modularity": {
+        "title": "Modularity",
+        "description":
+          "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto...",
+        "prompt": "Describe how you'll meet the Modularity condition"
+      },
+      "mita": {
+        "title": "Medicaid Information Technology Architecture (MITA)",
+        "description":
+          "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto...",
+        "prompt": "Describe how you'll meet the MITA condition"
+      },
+      "industry": {
+        "title": "Industry Standards",
+        "description":
+          "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto...",
+        "prompt": "Describe how you'll meet the Industry Standards condition"
+      },
+      "leverage": {
+        "title": "Leverage",
+        "description":
+          "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto...",
+        "prompt": "Describe how you'll meet the Leverage condition"
+      },
+      "bizResults": {
+        "title": "Business Results",
+        "description":
+          "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto...",
+        "prompt": "Describe how you'll meet the Business Results condition"
+      },
+      "reporting": {
+        "title": "Reporting",
+        "description":
+          "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto...",
+        "prompt": "Describe how you'll meet the Reporting condition"
+      },
+      "interoperability": {
+        "title": "Interoperability",
+        "description":
+          "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto...",
+        "prompt": "Describe how you'll meet the Interoperability condition"
+      },
+      "mitigation": {
+        "title": "Mitigation Strategy",
+        "description":
+          "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto...",
+        "prompt": "Describe how you'll meet the Mitigation Strategy condition"
+      },
+      "keyPersonnel": {
+        "title": "Key Personnel",
+        "description":
+          "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto...",
+        "prompt": "Describe how you'll meet the Key Personnel condition"
+      },
+      "documentation": {
+        "title": "Documentation",
+        "description":
+          "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto...",
+        "prompt": "Describe how you'll meet the Documentation condition"
+      },
+      "minimizeCost": {
+        "title":
+          "Strategies to Minimize Cost and Difficulty on Alternative Hardware or Operating System",
+        "description":
+          "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto...",
+        "prompt": "Describe how you'll meet the Cost Minimization condition"
+      }
+    }
+  }
 }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -9,6 +9,13 @@
     "title": "Program Activities",
     "listTitle": "Activity List",
     "addActivityButtonText": "Add activity",
+    "deleteActivityButtonText": "Remove Activity",
+    "delete": {
+      "header": "Please confirm",
+      "body": "Are you sure you’d like to remove this activity?",
+      "yes": "Yes",
+      "no": "Cancel"
+    },
     "header": "Program Activities",
     "namePrefix": "Activity",
     "description": {


### PR DESCRIPTION
For the reduxified "activities" section components that are currently in master, moves most (hopefully *all*) of the user-oriented text into resource files.  To make it easier on @quarterback, I also added a way to see what keys the components are looking for to get their text.

### This pull request changes...
- hopefully no immediately visible changes
- in a non-production environment, add `#i18n` to the address to turn off text resolution and see the keys that the components are looking for:

![screen shot 2018-04-24 at 9 48 54 am](https://user-images.githubusercontent.com/1775733/39195066-9dff6018-47a4-11e8-975a-90c448d58c46.png)

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- ~The change has been documented~
  - ~Associated OpenAPI documentation has been updated~

### This feature is done when...
- [x] Design has approved the experience (ping @quarterback)
- [ ] Product has approved the experience (ping @jeromeleecms or @NAretakis)
