### PR TITLE
delete activity (with confirmation)

### DIFF
--- a/web/src/actions/activities.js
+++ b/web/src/actions/activities.js
@@ -1,6 +1,7 @@
 export const ADD_ACTIVITY = 'ADD_ACTIVITY';
 export const ADD_ACTIVITY_GOAL = 'ADD_ACTIVITY_GOAL';
 export const ADD_ACTIVITY_MILESTONE = 'ADD_ACTIVITY_MILESTONE';
+export const REMOVE_ACTIVITY = 'REMOVE_ACTIVITY';
 export const REMOVE_ACTIVITY_MILESTONE = 'REMOVE_ACTIVITY_MILESTONE';
 export const UPDATE_ACTIVITY = 'UPDATE_ACTIVITY';
 
@@ -12,6 +13,8 @@ export const addActivityMilestone = id => ({
   type: ADD_ACTIVITY_MILESTONE,
   id
 });
+
+export const removeActivity = id => ({ type: REMOVE_ACTIVITY, id });
 
 export const removeActivityMilestone = (id, milestoneIdx) => ({
   type: REMOVE_ACTIVITY_MILESTONE,

--- a/web/src/components/ConfirmAlert.js
+++ b/web/src/components/ConfirmAlert.js
@@ -1,0 +1,150 @@
+/*
+
+This is forked from https://github.com/GA-MO/react-confirm-alert
+It alleviates some out-of-date dependencies and fixes a bug around
+the application of the "react-confirm-alert-blur" class
+
+*/
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { render, unmountComponentAtNode } from 'react-dom';
+
+function getAppWrapper() {
+  const bodyKids = [...document.body.children];
+  return bodyKids.filter(el => el.nodeName === 'DIV')[0] || bodyKids[0];
+}
+
+function createSVGBlurReconfirm() {
+  const svgNS = 'http://www.w3.org/2000/svg';
+  const feGaussianBlur = document.createElementNS(svgNS, 'feGaussianBlur');
+  feGaussianBlur.setAttribute('stdDeviation', '0.7');
+
+  const filter = document.createElementNS(svgNS, 'filter');
+  filter.setAttribute('id', 'gaussian-blur');
+  filter.appendChild(feGaussianBlur);
+
+  const svgElem = document.createElementNS(svgNS, 'svg');
+  svgElem.setAttribute('id', 'react-confirm-alert-firm-svg');
+  svgElem.setAttribute('class', 'react-confirm-alert-svg');
+  svgElem.appendChild(filter);
+
+  document.body.appendChild(svgElem);
+}
+
+function removeSVGBlurReconfirm() {
+  const svg = document.getElementById('react-confirm-alert-firm-svg');
+  svg.parentNode.removeChild(svg);
+
+  const appWrapper = getAppWrapper();
+  appWrapper.classList.remove('react-confirm-alert-blur');
+}
+
+function createElementReconfirm(props) {
+  const appWrapper = getAppWrapper();
+  appWrapper.classList.add('react-confirm-alert-blur');
+
+  const divTarget = document.createElement('div');
+  divTarget.id = 'react-confirm-alert';
+  document.body.appendChild(divTarget);
+
+  render(<ConfirmAlert {...props} />, divTarget);
+}
+
+function removeElementReconfirm() {
+  const target = document.getElementById('react-confirm-alert');
+  unmountComponentAtNode(target);
+  target.parentNode.removeChild(target);
+}
+
+export function confirmAlert(props) {
+  createSVGBlurReconfirm();
+  createElementReconfirm(props);
+}
+
+class ConfirmAlert extends Component {
+  static propTypes = {
+    title: PropTypes.string,
+    message: PropTypes.string,
+    buttons: PropTypes.array,
+    customUI: PropTypes.func,
+    childrenElement: PropTypes.func,
+    willUnmount: PropTypes.func
+  };
+
+  static defaultProps = {
+    title: 'Please confirm',
+    message: '',
+    buttons: [
+      {
+        label: 'Cancel',
+        onClick: () => null
+      },
+      {
+        label: 'Confirm',
+        onClick: () => null
+      }
+    ],
+    customUI: null,
+    childrenElement: () => null,
+    willUnmount: () => null
+  };
+
+  componentWillUnmount = () => {
+    this.props.willUnmount();
+  };
+
+  handleClickButton = button => {
+    if (button.onClick) button.onClick();
+    this.close();
+  };
+
+  close = () => {
+    removeElementReconfirm();
+    removeSVGBlurReconfirm();
+  };
+
+  renderCustomUI = () => {
+    const { title, message, customUI } = this.props;
+    const dataCustomUI = {
+      title,
+      message,
+      onClose: this.close
+    };
+
+    return customUI(dataCustomUI);
+  };
+
+  render() {
+    const { title, message, buttons, childrenElement, customUI } = this.props;
+
+    return (
+      <div className="react-confirm-alert-overlay">
+        <div className="react-confirm-alert">
+          {customUI ? (
+            this.renderCustomUI()
+          ) : (
+            <div className="react-confirm-alert-body">
+              {title && <h1 className="mt0">{title}</h1>}
+              {message}
+              {childrenElement()}
+              <div className="react-confirm-alert-button-group">
+                {buttons.map((button, i) => (
+                  <button
+                    key={i}
+                    onClick={() => this.handleClickButton(button)}
+                    className="btn btn-small btn-primary bg-black mr1"
+                  >
+                    {button.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+}
+
+export default ConfirmAlert;

--- a/web/src/containers/Activities.js
+++ b/web/src/containers/Activities.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Fragment } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 
 import ActivityDetailAll from './ActivityDetailAll';
@@ -29,9 +29,7 @@ const Activities = ({ activityIds, addActivity }) => (
         </button>
       </Collapsible>
       {activityIds.map((aId, idx) => (
-        <Fragment key={aId}>
-          <ActivityDetailAll aId={aId} num={idx + 1} />
-        </Fragment>
+        <ActivityDetailAll key={aId} aId={aId} num={idx + 1} />
       ))}
     </Section>
   </Container>

--- a/web/src/containers/ActivityDetailAll.js
+++ b/web/src/containers/ActivityDetailAll.js
@@ -6,6 +6,7 @@ import ActivityDetailDescription from './ActivityDetailDescription';
 import ActivityDetailGoals from './ActivityDetailGoals';
 import ActivityDetailSchedule from './ActivityDetailSchedule';
 import ActivityDetailStandardsAndConditions from './ActivityDetailStandardsAndConditions';
+import DeleteActivity from './DeleteActivity';
 import Collapsible from '../components/Collapsible';
 
 const activityTitle = (a, i) => {
@@ -21,6 +22,7 @@ const ActivityDetailAll = ({ aId, title }) => (
     <ActivityDetailGoals aId={aId} />
     <ActivityDetailSchedule aId={aId} />
     <ActivityDetailStandardsAndConditions aId={aId} />
+    <DeleteActivity aId={aId} />
   </Collapsible>
 );
 

--- a/web/src/containers/ActivityDetailSchedule.js
+++ b/web/src/containers/ActivityDetailSchedule.js
@@ -27,7 +27,7 @@ class ActivityDetailSchedule extends Component {
     } = this.props;
 
     return (
-      <Collapsible title="Activity Schedule" open>
+      <Collapsible title="Activity Schedule">
         <div className="mb2">
           List the major milestones you’re working towards as part of this
           activity:

--- a/web/src/containers/DeleteActivity.js
+++ b/web/src/containers/DeleteActivity.js
@@ -1,0 +1,70 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+import { removeActivity as removeActivityAction } from '../actions/activities';
+import { confirmAlert } from '../components/ConfirmAlert';
+
+const DeleteConfirm = ({ onClose, onConfirm }) => (
+  <div className="p2 sm-p3 bg-white rounded confirm-body">
+    <h2 className="mt0">Please confirm.</h2>
+    <p>Are you sure you’d like to remove this activity?</p>
+    <button
+      className="btn btn-small btn-primary bg-black h6"
+      onClick={() => {
+        onConfirm();
+        onClose();
+      }}
+    >
+      Yes
+    </button>{' '}
+    <button className="btn btn-small btn-outline h6" onClick={onClose}>
+      Cancel
+    </button>
+  </div>
+);
+
+DeleteConfirm.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired
+};
+
+class DeleteActivity extends Component {
+  handleClick = () => {
+    confirmAlert({
+      customUI: ({ onClose }) => (
+        <DeleteConfirm onClose={onClose} onConfirm={this.handleConfirm} />
+      )
+    });
+  };
+
+  handleConfirm = () => {
+    const { aId, removeActivity } = this.props;
+    removeActivity(aId);
+  };
+
+  render() {
+    return (
+      <div>
+        <button
+          type="button"
+          className="btn btn-small btn-primary bg-black h6"
+          onClick={this.handleClick}
+        >
+          Remove Activity
+        </button>
+      </div>
+    );
+  }
+}
+
+DeleteActivity.propTypes = {
+  aId: PropTypes.number.isRequired,
+  removeActivity: PropTypes.func.isRequired
+};
+
+const mapDispatchToProps = {
+  removeActivity: removeActivityAction
+};
+
+export default connect(null, mapDispatchToProps)(DeleteActivity);

--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -4,6 +4,7 @@ import {
   ADD_ACTIVITY,
   ADD_ACTIVITY_GOAL,
   ADD_ACTIVITY_MILESTONE,
+  REMOVE_ACTIVITY,
   REMOVE_ACTIVITY_MILESTONE,
   UPDATE_ACTIVITY
 } from '../actions/activities';
@@ -75,6 +76,15 @@ const reducer = (state = initialState, action) => {
         },
         state
       );
+    case REMOVE_ACTIVITY: {
+      const byId = { ...state.byId };
+      delete byId[action.id];
+
+      return {
+        byId,
+        allIds: state.allIds.filter(id => id !== action.id)
+      };
+    }
     case REMOVE_ACTIVITY_MILESTONE:
       return u(
         {

--- a/web/src/styles/app/confirm.css
+++ b/web/src/styles/app/confirm.css
@@ -1,0 +1,80 @@
+/* forked from https://github.com/GA-MO/react-confirm-alert */
+
+.react-confirm-alert-blur {
+  filter: url(#gaussian-blur);
+  filter: blur(2px);
+}
+
+.react-confirm-alert-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 99;
+  background: rgba(255, 255, 255, 0.9);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  opacity: 0;
+  animation: react-confirm-alert-fadeIn 0.5s 0.2s forwards;
+}
+
+.react-confirm-alert-body {
+  width: 400px;
+  padding: 30px;
+  text-align: left;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 1rem 4rem rgba(0, 0, 0, 0.125);
+  color: #666;
+}
+
+.react-confirm-alert-svg {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+@-webkit-keyframes react-confirm-alert-fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@-moz-keyframes react-confirm-alert-fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@-o-keyframes react-confirm-alert-fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes react-confirm-alert-fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+/* overrides / additions */
+
+.confirm-body {
+  box-shadow: 0 1rem 4rem rgba(0, 0, 0, 0.125);
+  max-width: 300px;
+}

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -5,6 +5,7 @@
 @import 'app/alert';
 @import 'app/border';
 @import 'app/color';
+@import 'app/confirm';
 @import 'app/form';
 @import 'app/layout';
 @import 'app/spacing';


### PR DESCRIPTION
### This pull request...
- adds ability to remove/delete an activity
- adds a confirmation modal (forked from https://github.com/GA-MO/react-confirm-alert) so that user doesn't hastily delete an activity and lose all the associated info unless they're sure.

Preview:
https://cl.ly/r7F9

<img width="686" alt="screen shot 2018-04-24 at 11 27 28 am" src="https://user-images.githubusercontent.com/1060893/39197449-78b0e3d2-47b2-11e8-85c6-65f5993266b4.png">

Adding @lauraponce as well to get feedback on the look and feel of this

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- ~The change has been documented~
  - ~Associated OpenAPI documentation has been updated~

### This feature is done when...
- [x] Design has approved the experience
- ~Product has approved the experience~
