### PR TITLE
index vs id tweaks

### DIFF
--- a/web/src/actions/activities.js
+++ b/web/src/actions/activities.js
@@ -13,10 +13,10 @@ export const addActivityGoal = id => ({ type: ADD_ACTIVITY_GOAL, id });
 
 export const addActivityExpense = id => ({ type: ADD_ACTIVITY_EXPENSE, id });
 
-export const removeActivityExpense = (id, expenseIdx) => ({
+export const removeActivityExpense = (id, expenseId) => ({
   type: REMOVE_ACTIVITY_EXPENSE,
   id,
-  expenseIdx
+  expenseId
 });
 
 export const addActivityMilestone = id => ({

--- a/web/src/components/Select.js
+++ b/web/src/components/Select.js
@@ -9,7 +9,7 @@ const Select = ({ name, options, label, hideLabel, wrapperClass, ...rest }) => (
     >
       {label}
     </label>
-    <select className="m0 select" {...rest}>
+    <select id={name} className="m0 select" {...rest}>
       {options.map(o => <option key={o}>{o}</option>)}
     </select>
   </div>

--- a/web/src/components/Select.js
+++ b/web/src/components/Select.js
@@ -1,0 +1,31 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const Select = ({ name, options, label, hideLabel, wrapperClass, ...rest }) => (
+  <div className={wrapperClass || 'mb2'}>
+    <label
+      htmlFor={name}
+      className={hideLabel ? 'sr-only' : 'block mb-tiny bold'}
+    >
+      {label}
+    </label>
+    <select className="m0 select" {...rest}>
+      {options.map(o => <option key={o}>{o}</option>)}
+    </select>
+  </div>
+);
+
+Select.propTypes = {
+  name: PropTypes.string.isRequired,
+  options: PropTypes.array.isRequired,
+  label: PropTypes.string.isRequired,
+  hideLabel: PropTypes.bool,
+  wrapperClass: PropTypes.string
+};
+
+Select.defaultProps = {
+  hideLabel: false,
+  wrapperClass: ''
+};
+
+export default Select;

--- a/web/src/containers/ActivityDetailExpenses.js
+++ b/web/src/containers/ActivityDetailExpenses.js
@@ -9,6 +9,7 @@ import {
 } from '../actions/activities';
 import Collapsible from '../components/Collapsible';
 import { Input, Textarea } from '../components/Inputs2';
+import Select from '../components/Select';
 
 class ActivityDetailExpenses extends Component {
   handleChange = (index, key) => e => {
@@ -58,27 +59,24 @@ class ActivityDetailExpenses extends Component {
             </thead>
             <tbody>
               {expenses.map((expense, i) => (
-                <tr key={expense.idx}>
+                <tr key={expense.id}>
                   <td className="mono">{i + 1}.</td>
                   <td>
-                    <select
-                      className="m0 select"
+                    <Select
+                      name={`expense-${i}-desc`}
+                      options={['Expense A', 'Expense B', 'Other']}
+                      label="Expense category"
+                      hideLabel
                       value={expense.category}
                       onChange={this.handleChange(i, 'category')}
-                    >
-                      <option>Expense A</option>
-                      <option>Expense B</option>
-                      <option>Expense C</option>
-                      <option>Other</option>
-                    </select>
+                    />
                   </td>
                   <td>
                     <Textarea
-                      id={`expense-${i}-desc`}
                       name={`expense-${i}-desc`}
                       label="Describe the expense"
+                      hideLabel
                       rows="3"
-                      spellCheck="true"
                       value={expense.desc}
                       onChange={this.handleChange(i, 'desc')}
                     />
@@ -88,18 +86,19 @@ class ActivityDetailExpenses extends Component {
                       <Input
                         name={`expense-${i}-${year}-cost`}
                         label={`Cost for ${year}`}
+                        hideLabel
                         type="number"
                         value={expense.years[year]}
                         onChange={this.handleYearChange(i, year)}
                       />
                     </td>
                   ))}
-                  <td className="center align-middle">
+                  <td className="center">
                     <button
                       type="button"
-                      className="btn btn-outline border-silver px1 py-tiny"
+                      className="btn btn-outline border-silver px1 py-tiny mt-tiny"
                       title="Remove Expense"
-                      onClick={() => removeExpense(activityID, i)}
+                      onClick={() => removeExpense(activityID, expense.id)}
                     >
                       ✗
                     </button>

--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -13,8 +13,8 @@ import {
 
 const newGoal = () => ({ desc: '', obj: '' });
 
-const newExpense = idx => ({
-  idx,
+const newExpense = id => ({
+  id,
   category: 'Expense A',
   desc: '',
   years: {
@@ -55,7 +55,7 @@ const initialState = {
   allIds: [1]
 };
 
-const nextSequence = list => Math.max(...list, 0) + 1;
+const nextSequence = arrOfNums => Math.max(...arrOfNums, 0) + 1;
 
 const reducer = (state = initialState, action) => {
   switch (action.type) {
@@ -87,7 +87,7 @@ const reducer = (state = initialState, action) => {
             [action.id]: {
               expenses: expenses => [
                 ...expenses,
-                newExpense(nextSequence(expenses.map(e => e.idx)))
+                newExpense(nextSequence(expenses.map(e => e.id)))
               ]
             }
           }
@@ -100,7 +100,7 @@ const reducer = (state = initialState, action) => {
           byId: {
             [action.id]: {
               expenses: expenses =>
-                expenses.filter(expense => expense.idx !== action.expenseIdx)
+                expenses.filter(e => e.id !== action.expenseId)
             }
           }
         },


### PR DESCRIPTION
Describe the pull request here, including any supplemental information needed to understand it.

### This pull request...
- changes expense id field to be `id`, to be more explicitly different than the index of an expense entry within the expenses array (which we also use to update a field within an entry).
- fixes a bug around expense deletion (we were using index instead of id)
- creates a `Select` component
- small style tweaks

### This pull request is ready to merge when...
- ~Tests have been updated (and all tests are passing)~
- [ ] This code has been reviewed by someone other than the original author
