### PR TITLE
Make the rich textbox into a reusable component

### DIFF
--- a/web/src/components/Inputs.js
+++ b/web/src/components/Inputs.js
@@ -1,5 +1,47 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component } from 'react';
+import { Editor } from 'react-draft-wysiwyg';
+
+import { EDITOR_CONFIG, htmlToEditor, editorToHtml } from '../util/editor';
+
+class RichText extends Component {
+  constructor(props) {
+    super(props);
+
+    const { content, onSync } = props;
+
+    this.state = {
+      content: htmlToEditor(content)
+    };
+
+    this.onEditorChange = newContent => {
+      this.setState({ content: newContent });
+    };
+
+    this.onBlur = () => {
+      const html = editorToHtml(this.state.content);
+      onSync(html);
+    };
+  }
+
+  render() {
+    return (
+      <Editor
+        toolbar={EDITOR_CONFIG}
+        editorState={this.state.content}
+        onEditorStateChange={this.onEditorChange}
+        onBlur={this.onBlur}
+      />
+    );
+  }
+}
+RichText.propTypes = {
+  content: PropTypes.string.isRequired,
+  onSync: PropTypes.func
+};
+RichText.defaultProps = {
+  onSync: () => {}
+};
 
 const Input = props => <input className="m0 input" {...props} />;
 const Textarea = props => (
@@ -52,4 +94,4 @@ makeInput.propTypes = {
 const InputHolder = makeInput(Input);
 const TextareaHolder = makeInput(Textarea);
 
-export { InputHolder as Input, TextareaHolder as Textarea };
+export { InputHolder as Input, TextareaHolder as Textarea, RichText };

--- a/web/src/components/Inputs.js
+++ b/web/src/components/Inputs.js
@@ -8,21 +8,19 @@ class RichText extends Component {
   constructor(props) {
     super(props);
 
-    const { content, onSync } = props;
-
     this.state = {
-      content: htmlToEditor(content)
-    };
-
-    this.onEditorChange = newContent => {
-      this.setState({ content: newContent });
-    };
-
-    this.onBlur = () => {
-      const html = editorToHtml(this.state.content);
-      onSync(html);
+      content: htmlToEditor(props.content)
     };
   }
+
+  onEditorChange = newContent => {
+    this.setState({ content: newContent });
+  };
+
+  onBlur = () => {
+    const html = editorToHtml(this.state.content);
+    this.props.onSync(html);
+  };
 
   render() {
     return (

--- a/web/src/containers/ActivityDetailCostAllocate.js
+++ b/web/src/containers/ActivityDetailCostAllocate.js
@@ -1,78 +1,52 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import { Editor } from 'react-draft-wysiwyg';
+import React from 'react';
 import { connect } from 'react-redux';
 
 import { t } from '../i18n';
 import { updateActivity as updateActivityAction } from '../actions/activities';
 import Collapsible from '../components/Collapsible';
-import { Input } from '../components/Inputs';
-import { EDITOR_CONFIG, htmlToEditor, editorToHtml } from '../util/editor';
+import { Input, RichText } from '../components/Inputs';
 
-class ActivityDetailCostAllocate extends Component {
-  constructor(props) {
-    super(props);
+const ActivityDetailCostAllocate = props => {
+  const { activity, updateActivity } = props;
+  const { costAllocateDesc, otherFundingDesc } = activity;
 
-    const { costAllocateDesc, otherFundingDesc } = props.activity;
-
-    this.state = {
-      costAllocateDesc: htmlToEditor(costAllocateDesc),
-      otherFundingDesc: htmlToEditor(otherFundingDesc)
-    };
-  }
-
-  onEditorChange = name => editorState => {
-    this.setState({ [name]: editorState });
-  };
-
-  syncEditorState = name => () => {
-    const html = editorToHtml(this.state[name]);
-    const { activity, updateActivity } = this.props;
-
+  const sync = name => html => {
     updateActivity(activity.id, { [name]: html });
   };
 
-  render() {
-    const { activity, updateActivity } = this.props;
-    const { costAllocateDesc, otherFundingDesc } = this.state;
-
-    return (
-      <Collapsible title={t('activities.costAllocate.title')}>
-        <div className="mb3">
-          <div className="mb-tiny bold">
-            {t('activities.costAllocate.label.costAllocateDesc')}
-          </div>
-          <Editor
-            toolbar={EDITOR_CONFIG}
-            editorState={costAllocateDesc}
-            onEditorStateChange={this.onEditorChange('costAllocateDesc')}
-            onBlur={this.syncEditorState('costAllocateDesc')}
-          />
+  return (
+    <Collapsible title={t('activities.costAllocate.title')}>
+      <div className="mb3">
+        <div className="mb-tiny bold">
+          {t('activities.costAllocate.label.costAllocateDesc')}
         </div>
-        <div className="mb3">
-          <div className="mb-tiny bold">
-            {t('activities.costAllocate.label.otherFundingDesc')}
-          </div>
-          <Editor
-            toolbar={EDITOR_CONFIG}
-            editorState={otherFundingDesc}
-            onEditorStateChange={this.onEditorChange('otherFundingDesc')}
-            onBlur={this.syncEditorState('otherFundingDesc')}
-          />
-        </div>
-        <Input
-          name="other-funding-amt"
-          label={t('activities.costAllocate.label.otherFundingAmt')}
-          wrapperClass="mb2 sm-col-4"
-          value={activity.otherFundingAmt}
-          onChange={e =>
-            updateActivity(activity.id, { otherFundingAmt: e.target.value })
-          }
+        <RichText
+          content={costAllocateDesc}
+          onSync={sync('costAllocateDesc')}
         />
-      </Collapsible>
-    );
-  }
-}
+      </div>
+      <div className="mb3">
+        <div className="mb-tiny bold">
+          {t('activities.costAllocate.label.otherFundingDesc')}
+        </div>
+        <RichText
+          content={otherFundingDesc}
+          onSync={sync('otherFundingDesc')}
+        />
+      </div>
+      <Input
+        name="other-funding-amt"
+        label={t('activities.costAllocate.label.otherFundingAmt')}
+        wrapperClass="mb2 sm-col-4"
+        value={activity.otherFundingAmt}
+        onChange={e =>
+          updateActivity(activity.id, { otherFundingAmt: e.target.value })
+        }
+      />
+    </Collapsible>
+  );
+};
 
 ActivityDetailCostAllocate.propTypes = {
   activity: PropTypes.object.isRequired,

--- a/web/src/containers/ActivityDetailDescription.js
+++ b/web/src/containers/ActivityDetailDescription.js
@@ -1,88 +1,58 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import { Editor } from 'react-draft-wysiwyg';
+import React from 'react';
 import { connect } from 'react-redux';
 
 import { t } from '../i18n';
 import { updateActivity as updateActivityAction } from '../actions/activities';
 import Collapsible from '../components/Collapsible';
 import Icon, { faHelp } from '../components/Icons';
-import { EDITOR_CONFIG, htmlToEditor, editorToHtml } from '../util/editor';
+import { RichText } from '../components/Inputs';
 
-class ActivityDetailDescription extends Component {
-  constructor(props) {
-    super(props);
+const ActivityDetailDescription = props => {
+  const { activity, updateActivity } = props;
+  const { descLong, altApproach } = activity;
 
-    const { descLong, altApproach } = props.activity;
-
-    this.state = {
-      descLong: htmlToEditor(descLong),
-      altApproach: htmlToEditor(altApproach)
-    };
-  }
-
-  onEditorChange = name => editorState => {
-    this.setState({ [name]: editorState });
-  };
-
-  syncEditorState = name => () => {
-    const html = editorToHtml(this.state[name]);
-    const { activity, updateActivity } = this.props;
-
+  const sync = name => html => {
     updateActivity(activity.id, { [name]: html });
   };
 
-  render() {
-    const { activity, updateActivity } = this.props;
-    const { descLong, altApproach } = this.state;
+  return (
+    <Collapsible title={t('activities.description.title')}>
+      <div className="mb-tiny bold">
+        {t('activities.description.summaryHeader')}
+        <Icon icon={faHelp} className="ml-tiny teal" size="sm" />
+      </div>
+      <div className="mb3">
+        <textarea
+          className="m0 textarea"
+          rows="5"
+          maxLength="280"
+          spellCheck="true"
+          value={activity.descShort}
+          onChange={e =>
+            updateActivity(activity.id, { descShort: e.target.value })
+          }
+        />
+      </div>
 
-    return (
-      <Collapsible title={t('activities.description.title')}>
+      <div className="mb3">
         <div className="mb-tiny bold">
-          {t('activities.description.summaryHeader')}
+          {t('activities.description.detailHeader')}
           <Icon icon={faHelp} className="ml-tiny teal" size="sm" />
         </div>
-        <div className="mb3">
-          <textarea
-            className="m0 textarea"
-            rows="5"
-            maxLength="280"
-            spellCheck="true"
-            value={activity.descShort}
-            onChange={e =>
-              updateActivity(activity.id, { descShort: e.target.value })
-            }
-          />
-        </div>
+        <RichText content={descLong} onSync={sync('descLong')} />
+      </div>
 
-        <div className="mb3">
-          <div className="mb-tiny bold">
-            {t('activities.description.detailHeader')}
-            <Icon icon={faHelp} className="ml-tiny teal" size="sm" />
-          </div>
-          <Editor
-            toolbar={EDITOR_CONFIG}
-            editorState={descLong}
-            onEditorStateChange={this.onEditorChange('descLong')}
-            onBlur={this.syncEditorState('descLong')}
-          />
+      <div className="mb3">
+        <div className="mb-tiny bold">
+          {t('activities.description.alternativesHeader')}
         </div>
-
-        <div className="mb3">
-          <div className="mb-tiny bold">
-            {t('activities.description.alternativesHeader')}
-          </div>
-          <Editor
-            toolbar={EDITOR_CONFIG}
-            editorState={altApproach}
-            onEditorStateChange={this.onEditorChange('altApproach')}
-            onBlur={this.syncEditorState('altApproach')}
-          />
-        </div>
-      </Collapsible>
-    );
-  }
-}
+        <RichText content={altApproach} onSync={sync('altApproach')} />
+      </div>
+    </Collapsible>
+  );
+};
+// }
 
 ActivityDetailDescription.propTypes = {
   activity: PropTypes.object.isRequired,

--- a/web/src/i18n/index.test.js
+++ b/web/src/i18n/index.test.js
@@ -1,10 +1,18 @@
-import I18n, { t } from './index';
+import I18n, { initI18n, t } from './index';
 
 import fr from './locales/fr.json';
 
 describe('i18n translations', () => {
   beforeEach(() => {
     I18n.locale = 'en';
+  });
+
+  describe('initialization', () => {
+    test('defaults if browser language is not detected', () => {
+      global.navigator.initI18n();
+
+      expect(I18n.locale).toBe('en');
+    });
   });
 
   test('t function', () => {

--- a/web/src/i18n/index.test.js
+++ b/web/src/i18n/index.test.js
@@ -1,18 +1,10 @@
-import I18n, { initI18n, t } from './index';
+import I18n, { t } from './index';
 
 import fr from './locales/fr.json';
 
 describe('i18n translations', () => {
   beforeEach(() => {
     I18n.locale = 'en';
-  });
-
-  describe('initialization', () => {
-    test('defaults if browser language is not detected', () => {
-      global.navigator.initI18n();
-
-      expect(I18n.locale).toBe('en');
-    });
   });
 
   test('t function', () => {


### PR DESCRIPTION
The rich textbox exists in the several places in the code, each with its own distinct state management and configuration.  This pull request extracts that so the state management and configuration is in just one place in the code.

### This pull request changes...
- no visible changes, sorry!

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- ~The change has been documented~
  - ~Associated OpenAPI documentation has been updated~

### This feature is done when...
- ~Design has approved the experience~
- ~Product has approved the experience~
