### PR TITLE
open / close activity sections via redux actions

### DIFF
--- a/web/src/actions/activities.js
+++ b/web/src/actions/activities.js
@@ -4,11 +4,13 @@ export const ADD_ACTIVITY_GOAL = 'ADD_ACTIVITY_GOAL';
 export const ADD_ACTIVITY_EXPENSE = 'ADD_ACTIVITY_EXPENSE';
 export const ADD_ACTIVITY_MILESTONE = 'ADD_ACTIVITY_MILESTONE';
 export const ADD_ACTIVITY_STATE_PERSON = 'ADD_ACTIVITY_STATE_PERSON';
+export const EXPAND_ACTIVITY_SECTION = 'EXPAND_ACTIVITY_SECTION';
 export const REMOVE_ACTIVITY = 'REMOVE_ACTIVITY';
 export const REMOVE_ACTIVITY_CONTRACTOR = 'REMOVE_ACTIVITY_CONTRACTOR';
 export const REMOVE_ACTIVITY_EXPENSE = 'REMOVE_ACTIVITY_EXPENSE';
 export const REMOVE_ACTIVITY_MILESTONE = 'REMOVE_ACTIVITY_MILESTONE';
 export const REMOVE_ACTIVITY_STATE_PERSON = 'REMOVE_ACTIVITY_STATE_PERSON';
+export const TOGGLE_ACTIVITY_SECTION = 'TOGGLE_ACTIVITY_SECTION';
 export const UPDATE_ACTIVITY = 'UPDATE_ACTIVITY';
 
 export const addActivity = () => ({ type: ADD_ACTIVITY });
@@ -29,6 +31,11 @@ export const addActivityMilestone = id => ({
 
 export const addActivityStatePerson = id => ({
   type: ADD_ACTIVITY_STATE_PERSON,
+  id
+});
+
+export const expandActivitySection = id => ({
+  type: EXPAND_ACTIVITY_SECTION,
   id
 });
 
@@ -56,6 +63,11 @@ export const removeActivityStatePerson = (id, personId) => ({
   type: REMOVE_ACTIVITY_STATE_PERSON,
   id,
   personId
+});
+
+export const toggleActivitySection = id => ({
+  type: TOGGLE_ACTIVITY_SECTION,
+  id
 });
 
 export const updateActivity = (id, updates) => ({

--- a/web/src/components/Collapsible.js
+++ b/web/src/components/Collapsible.js
@@ -8,17 +8,16 @@ import { faChevronDown, faChevronUp } from './Icons';
 class Collapsible extends Component {
   constructor(props) {
     super(props);
-    this.state = { isOpen: !!props.open };
+    this.state = { open: props.open };
   }
 
   handleClick = () => {
-    this.setState(prev => ({ isOpen: !prev.isOpen }));
+    this.setState(prev => ({ open: !prev.open }));
   };
 
   render() {
-    const { bgColor, children, id, title } = this.props;
-    const { isOpen } = this.state;
-
+    const { bgColor, children, id, title, onChange } = this.props;
+    const isOpen = onChange ? this.props.open : this.state.open;
     const contentId = kebabCase(title);
 
     return (
@@ -28,7 +27,7 @@ class Collapsible extends Component {
           className="btn block col-12 left-align h3 py2 line-height-1"
           aria-expanded={isOpen}
           aria-controls={contentId}
-          onClick={this.handleClick}
+          onClick={onChange || this.handleClick}
         >
           <span className="right">
             {isOpen ? (
@@ -57,14 +56,16 @@ Collapsible.propTypes = {
   children: PropTypes.node,
   id: PropTypes.string,
   open: PropTypes.bool,
-  title: PropTypes.string.isRequired
+  title: PropTypes.string.isRequired,
+  onChange: PropTypes.func
 };
 
 Collapsible.defaultProps = {
   bgColor: 'white',
   children: null,
   id: null,
-  open: false
+  open: false,
+  onChange: null
 };
 
 export default Collapsible;

--- a/web/src/components/SidebarLink.js
+++ b/web/src/components/SidebarLink.js
@@ -1,13 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const SidebarLink = ({ anchor, children, isActive }) => (
+const SidebarLink = ({ anchor, children, isActive, ...rest }) => (
   <li className="mb-tiny">
     <a
       href={`#${anchor || '!'}`}
       className={`inline-block white text-decoration-none truncate ${
         isActive ? 'bold border-bottom border-width-3 border-blue' : ''
       }`}
+      {...rest}
     >
       {children}
     </a>

--- a/web/src/containers/ActivityDetailAll.js
+++ b/web/src/containers/ActivityDetailAll.js
@@ -11,6 +11,7 @@ import ActivityDetailExpenses from './ActivityDetailExpenses';
 import ActivityDetailStandardsAndConditions from './ActivityDetailStandardsAndConditions';
 import ActivityDetailStatePersonnel from './ActivityDetailStatePersonnel';
 import DeleteActivity from './DeleteActivity';
+import { toggleActivitySection } from '../actions/activities';
 import Collapsible from '../components/Collapsible';
 import { t } from '../i18n';
 
@@ -21,8 +22,14 @@ const activityTitle = (a, i) => {
   return title;
 };
 
-const ActivityDetailAll = ({ aId, title }) => (
-  <Collapsible id={`activity-${aId}`} title={title} bgColor="darken-1">
+const ActivityDetailAll = ({ aId, expanded, title, toggleSection }) => (
+  <Collapsible
+    id={`activity-${aId}`}
+    title={title}
+    bgColor="darken-1"
+    open={expanded}
+    onChange={() => toggleSection(aId)}
+  >
     <ActivityDetailDescription aId={aId} />
     <ActivityDetailGoals aId={aId} />
     <ActivityDetailSchedule aId={aId} />
@@ -37,14 +44,21 @@ const ActivityDetailAll = ({ aId, title }) => (
 
 ActivityDetailAll.propTypes = {
   aId: PropTypes.number.isRequired,
-  title: PropTypes.string.isRequired
+  expanded: PropTypes.bool.isRequired,
+  title: PropTypes.string.isRequired,
+  toggleSection: PropTypes.func.isRequired
 };
 
 const mapStateToProps = ({ activities: { byId } }, { aId, num }) => {
   const activity = byId[aId];
+  const { expanded } = activity.meta;
   const title = `${t('activities.header')} › ${activityTitle(activity, num)}`;
 
-  return { title };
+  return { expanded, title };
 };
 
-export default connect(mapStateToProps)(ActivityDetailAll);
+const mapDispatchToProps = {
+  toggleSection: toggleActivitySection
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(ActivityDetailAll);

--- a/web/src/containers/Sidebar.js
+++ b/web/src/containers/Sidebar.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
+import { expandActivitySection } from '../actions/activities';
 import SidebarLink from '../components/SidebarLink';
 
 const linkGroup1 = [
@@ -17,7 +18,7 @@ const linkGroup2 = [
   { id: 'certify-submit', name: 'Certify and Submit' }
 ];
 
-const Sidebar = ({ activities, place, hash }) => (
+const Sidebar = ({ activities, place, hash, expandSection }) => (
   <div className="site-sidebar bg-navy">
     <div className="p2 xs-hide sm-hide">
       <div className="mb2">
@@ -41,6 +42,7 @@ const Sidebar = ({ activities, place, hash }) => (
               key={a.id}
               anchor={a.anchor}
               isActive={a.anchor === hash}
+              onClick={() => expandSection(a.id)}
             >
               Activity {i + 1}
               {a.name ? `: ${a.name}` : ''}
@@ -66,7 +68,8 @@ const Sidebar = ({ activities, place, hash }) => (
 Sidebar.propTypes = {
   activities: PropTypes.array.isRequired,
   place: PropTypes.object.isRequired,
-  hash: PropTypes.string.isRequired
+  hash: PropTypes.string.isRequired,
+  expandSection: PropTypes.func.isRequired
 };
 
 const mapStateToProps = ({ activities: { byId, allIds }, router }) => ({
@@ -78,4 +81,8 @@ const mapStateToProps = ({ activities: { byId, allIds }, router }) => ({
   hash: router.location.hash.slice(1) || ''
 });
 
-export default connect(mapStateToProps)(Sidebar);
+const mapDispatchToProps = {
+  expandSection: expandActivitySection
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(Sidebar);

--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -7,11 +7,13 @@ import {
   ADD_ACTIVITY_EXPENSE,
   ADD_ACTIVITY_MILESTONE,
   ADD_ACTIVITY_STATE_PERSON,
+  EXPAND_ACTIVITY_SECTION,
   REMOVE_ACTIVITY,
   REMOVE_ACTIVITY_CONTRACTOR,
   REMOVE_ACTIVITY_EXPENSE,
   REMOVE_ACTIVITY_MILESTONE,
   REMOVE_ACTIVITY_STATE_PERSON,
+  TOGGLE_ACTIVITY_SECTION,
   UPDATE_ACTIVITY
 } from '../actions/activities';
 
@@ -78,6 +80,9 @@ const newActivity = (id, name = '') => ({
     keyPersonnel: '',
     documentation: '',
     minimizeCost: ''
+  },
+  meta: {
+    expanded: false
   }
 });
 
@@ -185,6 +190,8 @@ const reducer = (state = initialState, action) => {
         },
         state
       );
+    case EXPAND_ACTIVITY_SECTION:
+      return u({ byId: { [action.id]: { meta: { expanded: true } } } }, state);
     case REMOVE_ACTIVITY_EXPENSE:
       return u(
         {
@@ -218,6 +225,11 @@ const reducer = (state = initialState, action) => {
             }
           }
         },
+        state
+      );
+    case TOGGLE_ACTIVITY_SECTION:
+      return u(
+        { byId: { [action.id]: { meta: { expanded: val => !val } } } },
         state
       );
     case UPDATE_ACTIVITY:


### PR DESCRIPTION
### This pull request changes...
- allows for programmatic opening / closing of activity sections
- updates to `Collapsible` component so that it can be a controlled vs controlled component
- opens activity section if activity link clicked on from sidebar

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author