### PR TITLE
Add help text

### DIFF
--- a/web/src/components/HelpText.js
+++ b/web/src/components/HelpText.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { t } from '../i18n';
+
+const HelpText = ({ text, reminder }) => (
+  <div style={{ marginBottom: '1em', whiteSpace: 'pre-line' }}>
+    <div>{t(text)}</div>
+    {reminder ? <div style={{ color: 'red' }}>{t(reminder)}</div> : null}
+  </div>
+);
+HelpText.propTypes = {
+  text: PropTypes.string.isRequired,
+  reminder: PropTypes.string
+};
+HelpText.defaultProps = {
+  reminder: null
+};
+
+export default HelpText;

--- a/web/src/containers/ActivityDetailContractorResources.js
+++ b/web/src/containers/ActivityDetailContractorResources.js
@@ -10,6 +10,7 @@ import {
 } from '../actions/activities';
 import Collapsible from '../components/Collapsible';
 import { Input, Textarea } from '../components/Inputs';
+import HelpText from '../components/HelpText';
 
 class ActivityDetailContractorExpenses extends Component {
   handleChange = (index, key) => e => {
@@ -40,7 +41,7 @@ class ActivityDetailContractorExpenses extends Component {
 
     return (
       <Collapsible title={t('activities.contractorResources.title')}>
-        <p>{t('activities.contractorResources.subheader')}</p>
+        <HelpText text="activities.contractorResources.helpText" />
         <div>
           <div className="overflow-auto">
             <table

--- a/web/src/containers/ActivityDetailCostAllocate.js
+++ b/web/src/containers/ActivityDetailCostAllocate.js
@@ -6,6 +6,7 @@ import { t } from '../i18n';
 import { updateActivity as updateActivityAction } from '../actions/activities';
 import Collapsible from '../components/Collapsible';
 import { Input, RichText } from '../components/Inputs';
+import HelpText from '../components/HelpText';
 
 const ActivityDetailCostAllocate = props => {
   const { activity, updateActivity } = props;
@@ -18,6 +19,10 @@ const ActivityDetailCostAllocate = props => {
   return (
     <Collapsible title={t('activities.costAllocate.title')}>
       <div className="mb3">
+        <HelpText
+          text="activities.costAllocate.help.costAllocate"
+          reminder="activities.costAllocate.reminder.costAllocate"
+        />
         <div className="mb-tiny bold">
           {t('activities.costAllocate.label.costAllocateDesc')}
         </div>
@@ -27,6 +32,10 @@ const ActivityDetailCostAllocate = props => {
         />
       </div>
       <div className="mb3">
+        <HelpText
+          text="activities.costAllocate.help.otherFunding"
+          reminder="activities.costAllocate.reminder.otherFunding"
+        />
         <div className="mb-tiny bold">
           {t('activities.costAllocate.label.otherFundingDesc')}
         </div>

--- a/web/src/containers/ActivityDetailDescription.js
+++ b/web/src/containers/ActivityDetailDescription.js
@@ -7,6 +7,7 @@ import { updateActivity as updateActivityAction } from '../actions/activities';
 import Collapsible from '../components/Collapsible';
 import Icon, { faHelp } from '../components/Icons';
 import { RichText } from '../components/Inputs';
+import HelpText from '../components/HelpText';
 
 const ActivityDetailDescription = props => {
   const { activity, updateActivity } = props;
@@ -22,6 +23,7 @@ const ActivityDetailDescription = props => {
         {t('activities.description.summaryHeader')}
         <Icon icon={faHelp} className="ml-tiny teal" size="sm" />
       </div>
+      <HelpText text="activities.description.helpText" />
       <div className="mb3">
         <textarea
           className="m0 textarea"
@@ -47,6 +49,10 @@ const ActivityDetailDescription = props => {
         <div className="mb-tiny bold">
           {t('activities.description.alternativesHeader')}
         </div>
+        <HelpText
+          text="activities.description.alternativesHelpText"
+          reminder="activities.description.alternativesHelpReminder"
+        />
         <RichText content={altApproach} onSync={sync('altApproach')} />
       </div>
     </Collapsible>

--- a/web/src/containers/ActivityDetailExpenses.js
+++ b/web/src/containers/ActivityDetailExpenses.js
@@ -10,6 +10,7 @@ import {
 import Collapsible from '../components/Collapsible';
 import { Input, Textarea } from '../components/Inputs';
 import Select from '../components/Select';
+import HelpText from '../components/HelpText';
 
 class ActivityDetailExpenses extends Component {
   handleChange = (index, key) => e => {
@@ -38,7 +39,7 @@ class ActivityDetailExpenses extends Component {
 
     return (
       <Collapsible title="Expenses">
-        <p>Tell us about your expenses.</p>
+        <HelpText text="activities.expenses.helpText" />
         <div className="overflow-auto">
           <table
             className="mb2 h5 table table-condensed table-fixed"

--- a/web/src/containers/ActivityDetailGoals.js
+++ b/web/src/containers/ActivityDetailGoals.js
@@ -9,6 +9,7 @@ import {
 } from '../actions/activities';
 import Collapsible from '../components/Collapsible';
 import { Textarea } from '../components/Inputs';
+import HelpText from '../components/HelpText';
 
 class ActivityDetailGoals extends Component {
   handleChange = (idx, key) => e => {
@@ -24,7 +25,12 @@ class ActivityDetailGoals extends Component {
 
     return (
       <Collapsible title={t('activities.goals.title')}>
-        <div className="mb2">{t('activities.goals.subheader')}</div>
+        <div className="mb2">
+          <HelpText
+            text="activities.goals.helpText"
+            reminder="activities.goals.reminder"
+          />
+        </div>
         {activity.goals.map((d, i) => (
           <div key={i} className="mb3">
             <Textarea

--- a/web/src/containers/ActivityDetailSchedule.js
+++ b/web/src/containers/ActivityDetailSchedule.js
@@ -10,6 +10,7 @@ import {
 } from '../actions/activities';
 import Collapsible from '../components/Collapsible';
 import { Input } from '../components/Inputs';
+import HelpText from '../components/HelpText';
 
 class ActivityDetailSchedule extends Component {
   handleChange = (idx, key) => e => {
@@ -29,7 +30,7 @@ class ActivityDetailSchedule extends Component {
 
     return (
       <Collapsible title={t('activities.schedule.title')}>
-        <div className="mb2">{t('activities.schedule.subheader')}</div>
+        <HelpText text="activities.schedule.helpText" />
 
         {activity.milestones.length === 0 ? (
           <div className="mb2 p1 h6 alert">

--- a/web/src/containers/ActivityDetailStatePersonnel.js
+++ b/web/src/containers/ActivityDetailStatePersonnel.js
@@ -9,6 +9,7 @@ import {
 } from '../actions/activities';
 import Collapsible from '../components/Collapsible';
 import { Input, Textarea } from '../components/Inputs';
+import HelpText from '../components/HelpText';
 import { t } from '../i18n';
 
 class ActivityDetailStatePersonnel extends Component {
@@ -36,7 +37,7 @@ class ActivityDetailStatePersonnel extends Component {
 
     return (
       <Collapsible title={t('activities.statePersonnel.title')}>
-        <p>{t('activities.statePersonnel.subheader')}</p>
+        <HelpText text="activities.statePersonnel.helpText" />
         <div className="overflow-auto">
           <table
             className="mb2 h5 table table-condensed table-fixed"

--- a/web/src/containers/ApdSummary.js
+++ b/web/src/containers/ApdSummary.js
@@ -8,6 +8,7 @@ import Collapsible from '../components/Collapsible';
 import { RichText } from '../components/Inputs';
 import Section from '../components/Section';
 import SectionTitle from '../components/SectionTitle';
+import HelpText from '../components/HelpText';
 
 const YEAR_OPTIONS = ['2018', '2019', '2020'];
 
@@ -41,6 +42,10 @@ class ApdSummary extends Component {
       <Section id="apd-summary">
         <SectionTitle>{t('apd.sectionTitle')}</SectionTitle>
         <Collapsible title={t('apd.overview.title')}>
+          <HelpText
+            text="apd.overview.helpText"
+            reminder="apd.overview.reminder"
+          />
           <div className="mb3">
             <div className="mb-tiny bold">{t('apd.overview.yearsCovered')}</div>
             {YEAR_OPTIONS.map(option => (
@@ -63,22 +68,22 @@ class ApdSummary extends Component {
             />
           </div>
         </Collapsible>
-        <Collapsible title={t('apd.hit')}>
-          <div className="mb-tiny bold">{t('apd.hit')}</div>
+        <Collapsible title={t('apd.hit.title')}>
+          <HelpText text="apd.hit.helpText" />
           <RichText
             content={hitNarrative}
             onSync={this.syncRichText('hitNarrative')}
           />
         </Collapsible>
-        <Collapsible title={t('apd.hie')}>
-          <div className="mb-tiny bold">{t('apd.hie')}</div>
+        <Collapsible title={t('apd.hie.title')}>
+          <HelpText text="apd.hie.helpText" />
           <RichText
             content={hieNarrative}
             onSync={this.syncRichText('hieNarrative')}
           />
         </Collapsible>
-        <Collapsible title={t('apd.mmis')}>
-          <div className="mb-tiny bold">{t('apd.mmis')}</div>
+        <Collapsible title={t('apd.mmis.title')}>
+          <HelpText text="apd.mmis.helpText" />
           <RichText
             content={mmisNarrative}
             onSync={this.syncRichText('mmisNarrative')}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -133,7 +133,7 @@
     },
     "expenses": {
       "helpText":
-        "7) “Miscellaneous expenses” include materials and supplies, communications‐related expenses, printing costs and facilities expenses; these costs can be broken out into distinct cost categories in the budget detail per the state’s Chart of Account\n\n8) Provide an explanation of these projected expenditures"
+        "1) “Miscellaneous expenses” include materials and supplies, communications‐related expenses, printing costs and facilities expenses; these costs can be broken out into distinct cost categories in the budget detail per the state’s Chart of Account\n\n2) Provide an explanation of these projected expenditures"
     },
     "costAllocate": {
       "title": "Cost Allocation and Other Funding Sources",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -9,14 +9,30 @@
     "sectionTitle": "Program Summary",
     "overview": {
       "title": "Overview",
+      "helpText":
+        "Describe your state's program. Provide context for your funding request by providing information such as current size of program and future vision.",
+      "reminder":
+        "DON'T FORGET!: Review the SMHP to make sure that it aligns with the IAPD",
       "yearsCovered": "What years does this APD cover?",
       "labels": {
         "desc": "Please provide an overview of your program."
       }
     },
-    "hit": "HIT Narrative",
-    "hie": "HIE Narrative",
-    "mmis": "MMIS Narrative"
+    "hit": {
+      "title": "HIT Narrative",
+      "helpText":
+        "Briefly summarize your program HIT activities contained within this APD."
+    },
+    "hie": {
+      "title": "HIE Narrative",
+      "helpText":
+        "Briefly summarize your program HIE activities contained within this APD."
+    },
+    "mmis": {
+      "title": "MMIS Narrative",
+      "helpText":
+        "Briefly summarize your program MMIS activities contained within this APD."
+    }
   },
 
   "activities": {
@@ -36,15 +52,25 @@
     "namePrefix": "Activity",
     "description": {
       "title": "Activity Description",
+      "helpText":
+        "Describe at a high level the needs of the project for which requested funding will be used (e.g. Administrative, Outreach, Auditing, Public Health Registry Development, etc)",
       "summaryHeader": "Summary",
       "detailHeader": "Please describe the activity in detail",
       "alternativesHeader":
-        "State of alternative considerations and supporting justification"
+        "State of alternative considerations and supporting justification",
+      "alternativesHelpText":
+        "If no substantive changes have been made to the activity, include a statement that refers back to the Statement of Alternative Considerations contained in previous versions of the IAPD or in the SMHP.\n\nIf substantive changes have been made, include a statement describing the alternatives that the state considered when making the change.",
+      "alternativesHelpReminder":
+        "DON'T FORGET: Remember to update the SMHP as necessary with any substantive changes to the approach for implementing EHR incentives."
     },
     "goals": {
       "title": "Needs and Objectives",
       "subheader":
         "List the goals you're hoping to accomplish as part of this activity.",
+      "helpText":
+        "Consider organizing the objectives of the projects as they relate to specific goals and vision for the overall HIT program (see example in the Addendum)\n\nDescribe how the state will measure progress toward goals and objectives (refer to the latest version of the SMHP as deemed appropriate) ",
+      "reminder":
+        "DON'T FORGET: Add a clear statement of goals and/or objectives and how the state will measure and monitor progress toward them.",
       "goalHeader": "Goal #{{number}}",
       "objectiveHeader":
         "Tell us how you'll know when you've achieved this goal",
@@ -54,6 +80,8 @@
       "title": "Activity Schedule",
       "subheader":
         "List the major milestones you’re working towards as part of this activity.",
+      "helpText":
+        "1) List out all activity milestones, including activities that have occurred under previously approved APDs.\n2) For each activity, include start date, end date or projected end date, and status (completed, ongoing, not started, etc.)",
       "noMilestonesNotice": "Oh no! Please add milestones for this activity.",
       "milestoneHeader": "Milestone",
       "milestoneLabel": "milestone name",
@@ -67,6 +95,8 @@
     "contractorResources": {
       "title": "Contracting Resources",
       "subheader": "Tell us about your contracting resources.",
+      "helpText":
+        "Contracts and projected contracts must be itemized, with estimated costs per contract including FFY costs",
       "labels": {
         "entryNumber": "#",
         "contractorName": "Name",
@@ -89,6 +119,7 @@
     "statePersonnel": {
       "title": "State Personnel",
       "subheader": "Tell us about your state personnel.",
+      "helpText": "Personnel costs must include salaries and benefits",
       "labels": {
         "entryNum": "#",
         "title": "Title",
@@ -100,12 +131,28 @@
       "removeLabel": "Remove personnel",
       "addButtonText": "Add personnel"
     },
+    "expenses": {
+      "helpText":
+        "7) “Miscellaneous expenses” include materials and supplies, communications‐related expenses, printing costs and facilities expenses; these costs can be broken out into distinct cost categories in the budget detail per the state’s Chart of Account\n\n8) Provide an explanation of these projected expenditures"
+    },
     "costAllocate": {
       "title": "Cost Allocation and Other Funding Sources",
       "label": {
         "costAllocateDesc": "Cost allocation methodology",
         "otherFundingDesc": "Other funding description",
         "otherFundingAmt": "Other funding amount"
+      },
+      "help": {
+        "costAllocate":
+          "1) As specified in OMB Circular A‐87, a cost allocation plan must be included that identifies all participants and their associated cost allocation to depict non‐Medicaid activities and non‐Medicaid FTEs participating in this project, if any\n2) HITECH cost allocation formulas should be based on the direct benefit to the Medicaid EHR Incentive Program, taking into account State projections of eligible Medicaid provider participation in the incentive program (leveraging actual data/experience as deemed appropriate)\n3) Cost allocation must account for other available Federal funding sources, the division of resources and activities across relevant payers, and the relative benefit to the State Medicaid program, among other factors\n4) Be sure that cost allocations involve the timely and insured financial participation of all parties. States should demonstrate that other payers who stand to benefit are contributing their share, ideally from the beginning of the program/activity/service for which funding is being requested.",
+        "otherFunding":
+          "1) Make sure that the State accounts for all grant funding that is used to support any activities mentioned in the IAPD‐U request\n2) Review the State Medicaid Director Letter 10‐016 for examples of grants that might need to be included as well as other guidance\n3) Consider using the table in the addendum to make sure key information regarding each grant is provided\n4) Make sure that any new grants are included and any expired grants are removed"
+      },
+      "reminder": {
+        "costAllocate":
+          "REMEMBER: Do not assume that the absence of other payers is sufficient cause for Medicaid to be the primary payer. Also, limit ambiguity about other potential federal funding sources; for example, if no CHIP funds are being requested, include a statement to that effect in this section.",
+        "otherFunding":
+          "1) Do not get bogged down in detailed descriptions of the grant activities; high level descriptions are appropriate (see addendum for example)\n\n2) Don’t forget to make sure any funding amounts are consistent with the IAPD‐U request"
       }
     },
     "standardsAndConditions": {
@@ -115,68 +162,68 @@
       "modularity": {
         "title": "Modularity",
         "description":
-          "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto...",
+          "This condition requires the use of a modular, flexible approach to systems development, including the use of open interfaces and exposed application programming interfaces (API); the separation of business rules from core programming; and the availability of business rules in both human and machine-readable formats. The commitment to formal system development methodology and open, reusable system architecture is extremely important in order to ensure that states can more easily change and maintain systems, as well as integrate and interoperate with a clinical and administrative ecosystem designed to deliver person-centric services and benefits. Modularity is breaking down systems requirements into component parts. Extremely complex systems can be developed as part of a service-oriented architecture (SOA). Modularity also helps address the challenges of customization. Baseline web services and capabilities can be developed for and used by anyone, with exceptions for specific business processes handled by a separate module that interoperates with the baseline modules. With modularity, changes can be made independently to the baseline capabilities without affecting how the extension works. By doing so, the design ensures that future iterations of software can be deployed without breaking custom functionality. A critical element of compliance with this condition is providing CMS with an understanding of where services and code will be tightly coupled, and where the state will pursue a more aggressive decoupling strategy.CMS description text goes here.",
         "prompt": "Describe how you'll meet the Modularity condition"
       },
       "mita": {
         "title": "Medicaid Information Technology Architecture (MITA)",
         "description":
-          "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto...",
+          "This condition requires states to align to and advance increasingly in MITA maturity for business, architecture, and data. CMS expects the states to complete and continue to make measurable progress in implementing their MITA roadmaps. Already the MITA investments by federal, state, and private partners have allowed us to make important incremental improvements to share data and reuse business models, applications, and components. CMS strives, however, to build on and accelerate the modernization of the Medicaid enterprise that has thus far been achieved.CMS description text goes here.",
         "prompt": "Describe how you'll meet the MITA condition"
       },
       "industry": {
         "title": "Industry Standards",
         "description":
-          "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto...",
+          "States must ensure alignment with, and incorporation of, industry standards: the Health Insurance Portability and Accountability Act of 1996 (HIPAA) security, privacy and transaction standards; accessibility standards established under section 508 of the Rehabilitation Act, or standards that provide greater accessibility for individuals with disabilities, and compliance with federal civil rights laws; standards adopted by the Secretary under section 1104 of the Affordable Care Act; and standards and protocols adopted by the Secretary under section 1561 of the Affordable Care Act. CMS must ensure that Medicaid infrastructure and information system investments are made with the assurance that timely and reliable adoption of industry standards and productive use of those standards are part of the investments. Industry standards promote reuse, data exchange, and reduction of administrative burden on patients, providers, and applicants.CMS description text goes here.",
         "prompt": "Describe how you'll meet the Industry Standards condition"
       },
       "leverage": {
         "title": "Leverage",
         "description":
-          "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto...",
+          "State solutions should promote sharing, leverage, and reuse of Medicaid technologies and systems within and among states. States can benefit substantially from the experience and investments of other states through the reuse of components and technologies already developed, consistent with a service-oriented architecture, from publicly available or commercially sold components and products, and from the use of cloud technologies to share infrastructure and applications. CMS commits to work assertively with the states to identify promising state systems that can be leveraged and used by other states. Further, CMS would strongly encourage the states to move to regional or multistate solutions when cost effective, and will seek to support and facilitate such solutions. In addition, CMS will expedite APD approvals for states that are participating in shared development activities with other states, and that are developing components and solutions expressly intended for successful reuse by other states. CMS will also review carefully any proposed investments in sub-state systems when the federal government is asked to share in the costs of updating or maintaining multiple systems performing essentially the same functions within the same state.CMS description text goes here.",
         "prompt": "Describe how you'll meet the Leverage condition"
       },
       "bizResults": {
         "title": "Business Results",
         "description":
-          "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto...",
+          "Systems should support accurate and timely processing of claims (including claims of eligibility), adjudications, and effective communications with providers, beneficiaries, and the public. Ultimately, the test of an effective and efficient system is whether it supports and enables an effective and efficient business process, producing and communicating the intended operational results with a high degree of reliability and accuracy. It would be inappropriate to provide enhanced federal funding for systems that are unable to support desired business outcomes. CMS description text goes here.",
         "prompt": "Describe how you'll meet the Business Results condition"
       },
       "reporting": {
         "title": "Reporting",
         "description":
-          "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto...",
+          "Solutions should produce transaction data, reports, and performance information that would contribute to program evaluation, continuous improvement in business operations, and transparency and accountability. Systems should be able to produce and to expose electronically the accurate data that are necessary for oversight, administration, evaluation, integrity, and transparency. These reports should be automatically generated through open interfaces to designated federal repositories or data hubs, with appropriate audit trails. MITA 3.0 will provide additional detail about reporting requirements and needs that arise from the Affordable Care Act. Additional details about data definitions, specifications, timing, and routing of information will be supplied later this year. CMS description text goes here.",
         "prompt": "Describe how you'll meet the Reporting condition"
       },
       "interoperability": {
         "title": "Interoperability",
         "description":
-          "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto...",
+          "Systems must ensure seamless coordination and integration with the Exchange (whether run by the state or federal government), and allow interoperability with health information exchanges, public health agencies, human services programs, and community organizations providing outreach and enrollment assistance services. CMS expects that a key outcome of the government’s technology investments will be a much higher degree of interaction and interoperability in order to maximize value and minimize burden and costs on providers, beneficiaries, and other stakeholders. CMS is emphasizing in this standard and condition an expectation that Medicaid agencies work in concert with Exchanges (whether state or federally administered) to share business services and technology investments in order to produce seamless and efficient customer experiences. Systems must also be built with the appropriate architecture and using standardized messaging and communication protocols in order to preserve the ability to efficiently, effectively, and appropriately exchange data with other participants in the health and human services enterprise. As stated in MITA Framework 2.0, each state is “responsible for knowing and understanding its environment (data, applications and infrastructure) in order to map its data to information sharing requirements. The data-sharing architecture also addresses the conceptual and logical mechanisms used for data sharing (i.e., data hubs, repositories, and registries). The data-sharing architecture will also address data semantics, data harmonization strategies, shared-data ownership, security and privacy implications of shared data, and the quality of shared data.CMS description text goes here.",
         "prompt": "Describe how you'll meet the Interoperability condition"
       },
       "mitigation": {
         "title": "Mitigation Strategy",
         "description":
-          "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto...",
+          "The condition described at § 433.112(b)(18) requires that states submit mitigation plans addressing strategies to reduce the consequences of failure for all major milestones and functionality. Maintaining a mitigation plan is an industry standard best practice for any major IT build; CMS expects that states will identify potential risks and develop strategies to address those risks throughout the system lifecycle. Mitigation plans for major Medicaid E&E system or MMIS projects should address minimum expected functionality, critical success factors, and risk factors as tied to major milestones identified in the APD. The mitigation plans should also reflect key events and dates that would trigger the mitigation, and projected timeframe for the mitigation sunset. States should consider strategies to address risks for the M&O phase of the project, such as staffing issues and software upgrades. CMS expects states to revise and resubmit their plans to CMS as risks and mitigations change along the system life cycle. States’ proposed mitigations should be commensurate with the nature and scope of the identified risks. We also expect that states will submit their mitigation plans with the APDs to demonstrate compliance with this condition.CMS description text goes here.",
         "prompt": "Describe how you'll meet the Mitigation Strategy condition"
       },
       "keyPersonnel": {
         "title": "Key Personnel",
         "description":
-          "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto...",
+          "The condition described at § 433.112(b)(19) requires that states identify their key state personnel assigned to each major project by name, role, and time commitment. Before we approve a state to launch a major IT initiative, CMS wants to ensure that the state team is adequately resourced. States do not need to provide key vendor personnel for this requirement. As stated in the provision, this information must be included in the APD. For changes to key personnel that occur after an APD is approved, states should notify their CMS points of contact in writing (including by email) and formally reflect the change in the next planned APD update. This condition refines and strengthens the existing APD requirements regarding personnel resource statements as required under 45 CFR 95.610. For Medicaid E&E APDs, states should include this information in the “Medicaid Eligibility and Enrollment (EE) Implementation Advance Planning Document (IAPD) Template” (OMB Approval Number: 0938-1268). Although there is currently no APD template for MMIS APDs, states must include this information in all MMIS APDs for major IT initiatives.CMS description text goes here.",
         "prompt": "Describe how you'll meet the Key Personnel condition"
       },
       "documentation": {
         "title": "Documentation",
         "description":
-          "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto...",
+          "The condition described at § 433.112(b)(20) requires that states maintain documentation for certain software such that the software could be operated by contractors and other users. This condition is limited to software that is developed using federal funds; it does not apply to Commercial Off-the-Shelf (COTS) software, Software-as-a-Service, or Business-Solutions-as-a-Service. Adequate documentation means that other users could operate the software with reasonable alterations for a specific hardware or operating system. CMS is neutral as to the specific hardware or operating system that the software uses. Documentation must follow industry standards and best practices, and must include components, procedures, layouts, interfaces, inputs, outputs, and other necessary information so that the systems could be installed and operated by a variety of contractors or other users. While the APD should address how the state plans to maintain documentation, such documentation is not required to be submitted along with the APD. It is the state’s responsibility to make the documentation available upon request and to upload documentation to CALT or successor systems as needed for gate reviews or for reuse. Submission to other repositories may be required as CMS explores other options.CMS description text goes here.",
         "prompt": "Describe how you'll meet the Documentation condition"
       },
       "minimizeCost": {
         "title":
           "Strategies to Minimize Cost and Difficulty on Alternative Hardware or Operating System",
         "description":
-          "Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto...",
+          "The condition described at § 433.112(b)(21) requires that states consider strategies to minimize the costs and difficulty of operating the software on alternate hardware or operating systems. This condition recognizes the significant federal and state investments that are involved with major Medicaid IT projects and requires that states consider options beyond software that will reduce costs or promote reuse. States should describe in the APD the strategies that were considered when deciding which solution was the most economical and efficient. States are not required to adopt a particular strategy, but CMS must have sufficient description to evaluate the extent to which the state looked at other solutions. States should consider, at a minimum, the options that offer more opportunities for reuse, lower development costs, lower long-term operating costs, and shorter development time as well as the extent to which the solutions can be readily implemented with alternate hardware and operating systems. States should consider this new condition in conjunction with existing APD requirements regarding cost benefit analyses required at 45 CFR 95.605 or § 95.610. CMS description text goes here.",
         "prompt": "Describe how you'll meet the Cost Minimization condition"
       }
     }


### PR DESCRIPTION
From Ron's content design work, add help text to the resource file and use that to populate help text in various parts of the site.

[See it here](http://cms-hitech.darkcooger.net.s3-website-us-east-1.amazonaws.com/)

Note: Several sections of the help text content doc aren't represented in the web app yet, so I left the text out for sections.
- HIE checklist
- Proposed budget
- Expenses summary
- Assurances & compliance
- Executive/overall summary
- Budget tables
- Certify and submit

### This pull request changes...
- adds help and "REMEMBER!" text

### This pull request is ready to merge when...
- ~Tests have been updated (and all tests are passing)~
- [x] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- ~The change has been documented~
  - ~Associated OpenAPI documentation has been updated~

### This feature is done when...
- [x] Design has approved the experience - @quarterback 
- [x] Product has approved the experience - @NAretakis 
