### PR TITLE
Extract text from sidebar

### DIFF
--- a/web/src/containers/Sidebar.js
+++ b/web/src/containers/Sidebar.js
@@ -2,20 +2,21 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
+import { t } from '../i18n';
 import { expandActivitySection } from '../actions/activities';
 import SidebarLink from '../components/SidebarLink';
 
 const linkGroup1 = [
-  { id: 'apd-summary', name: 'Program Summary' },
-  { id: 'prev-activities', name: 'Results of Previous Activities' },
-  { id: 'activities', name: 'Program Activities' }
+  { id: 'apd-summary', name: t('sidebar.titles.programSummary') },
+  { id: 'prev-activities', name: t('sidebar.titles.previousActivities') },
+  { id: 'activities', name: t('sidebar.titles.activities') }
 ];
 
 const linkGroup2 = [
-  { id: 'budget', name: 'Proposed Budget' },
-  { id: 'assurances-compliance', name: 'Assurances and Compliance' },
-  { id: 'executive-summary', name: 'Executive/Overall Summary' },
-  { id: 'certify-submit', name: 'Certify and Submit' }
+  { id: 'budget', name: t('sidebar.titles.budget') },
+  { id: 'assurances-compliance', name: t('sidebar.titles.assurances') },
+  { id: 'executive-summary', name: t('sidebar.titles.summary') },
+  { id: 'certify-submit', name: t('sidebar.titles.submit') }
 ];
 
 const Sidebar = ({ activities, place, hash, expandSection }) => (
@@ -44,8 +45,11 @@ const Sidebar = ({ activities, place, hash, expandSection }) => (
               isActive={a.anchor === hash}
               onClick={() => expandSection(a.id)}
             >
-              Activity {i + 1}
-              {a.name ? `: ${a.name}` : ''}
+              {t('sidebar.titles.activity', {
+                number: i + 1,
+                count: a.name ? a.name.length : 0,
+                name: a.name
+              })}
             </SidebarLink>
           ))}
         </ul>
@@ -58,7 +62,7 @@ const Sidebar = ({ activities, place, hash, expandSection }) => (
 
       <div className="mt2 pt2 border-top border-white">
         <button type="button" className="btn btn-primary bg-white navy">
-          Save as PDF
+          {t('sidebar.savePdfButtonText')}
         </button>
       </div>
     </div>

--- a/web/src/containers/Sidebar.js
+++ b/web/src/containers/Sidebar.js
@@ -45,9 +45,8 @@ const Sidebar = ({ activities, place, hash, expandSection }) => (
               isActive={a.anchor === hash}
               onClick={() => expandSection(a.id)}
             >
-              {t('sidebar.titles.activity', {
+              {t(`sidebar.titles.activity-${a.name ? 'set' : 'unset'}`, {
                 number: i + 1,
-                count: a.name ? a.name.length : 0,
                 name: a.name
               })}
             </SidebarLink>

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -5,6 +5,23 @@
   "notifications": "Notifications",
   "help": "Help",
 
+  "sidebar": {
+    "titles": {
+      "programSummary": "Program Summary",
+      "previousActivities": "Results of Previous Activities",
+      "activities": "Program Activities",
+      "activity": {
+        "zero": "Activity {{number}}",
+        "other": "Activity {{number}}: {{name}}"
+      },
+      "budget": "Proposed Budget",
+      "assurances": "Assurances and Compliance",
+      "summary": "Executive/Overall Summary",
+      "submit": "Certify and Submit"
+    },
+    "savePdfButtonText": "Save as PDF"
+  },
+
   "apd": {
     "sectionTitle": "Program Summary",
     "overview": {
@@ -97,7 +114,8 @@
         "List the major milestones you’re working towards as part of this activity.",
       "helpText":
         "1) List out all activity milestones, including activities that have occurred under previously approved APDs.\n2) For each activity, include start date, end date or projected end date, and status (completed, ongoing, not started, etc.)",
-      "noMilestonesNotice": "Did you forget to add milestones? Please add milestones for this activity.",
+      "noMilestonesNotice":
+        "Did you forget to add milestones? Please add milestones for this activity.",
       "milestoneHeader": "Milestone",
       "milestoneLabel": "milestone name",
       "startHeader": "Planned start",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -10,10 +10,8 @@
       "programSummary": "Program Summary",
       "previousActivities": "Results of Previous Activities",
       "activities": "Program Activities",
-      "activity": {
-        "zero": "Activity {{number}}",
-        "other": "Activity {{number}}: {{name}}"
-      },
+      "activity-set": "Activity {{number}}: {{name}}",
+      "activity-unset": "Activity {{number}}",
       "budget": "Proposed Budget",
       "assurances": "Assurances and Compliance",
       "summary": "Executive/Overall Summary",


### PR DESCRIPTION
Moves sidebar text into the resource file.  There's one little quirk here for @quarterback and @brendansudol to be aware of:  there are basically two entries for the title of individual activities in the side bar:

![sidebar text](https://user-images.githubusercontent.com/1775733/39766452-f88e9138-52a9-11e8-831e-8f8fc17303a2.png)

The one for `Activity 1` references the `activity-unset` title, and is used when the activity name hasn't been set yet.  The one for `Activity 2: ...` references the `activity-set` title, and it's used then the activity name has been set.

### This pull request changes...
- no immediately visible changes
- allows @quarterback to tweak sidebar text without having to deal with code

### This pull request is ready to merge when...
- ~Tests have been updated (and all tests are passing)~
- [ ] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- ~The change has been documented~
  - ~Associated OpenAPI documentation has been updated~

### This feature is done when...
- [ ] Design has approved the experience
- ~Product has approved the experience~
