### PR TITLE
Switch to Snyk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build status](https://img.shields.io/circleci/project/github/18F/cms-hitech-apd.svg)](https://circleci.com/gh/18F/workflows/cms-hitech-apd)
-[![Maintainability](https://img.shields.io/codeclimate/maintainability/18F/cms-hitech-apd.svg)](https://codeclimate.com/github/18F/cms-hitech-apd/maintainability)
 [![Test coverage](https://img.shields.io/codecov/c/github/18F/cms-hitech-apd.svg)](https://codecov.io/gh/18F/cms-hitech-apd)
-[![Dependency status](https://img.shields.io/gemnasium/18F/cms-hitech-apd.svg)](https://gemnasium.com/github.com/18F/cms-hitech-apd)
+[![Known Vulnerabilities](https://snyk.io/test/github/18f/cms-hitech-apd/badge.svg?targetFile=web%2Fpackage.json)](https://snyk.io/test/github/18f/cms-hitech-apd?targetFile=web%2Fpackage.json)
+[![Known Vulnerabilities](https://snyk.io/test/github/18f/cms-hitech-apd/badge.svg?targetFile=api%2Fpackage.json)](https://snyk.io/test/github/18f/cms-hitech-apd?targetFile=api%2Fpackage.json)
 
 # CMS HITECH APD app
 


### PR DESCRIPTION
Configured Snyk, disabled Gemnasium, and updated the README accordingly.

Snyk will report vulnerabilities as checks in our pull requests.  :tada:

Closes #517

### This pull request changes...
- on the front page of the repo, you will now see to vulnerability badges - one is for the web project, the other is for the API project
- the "code quality" badge is removed; we turned it off a long time ago and it has been a useless badge ever since (it was flagging a whole lot of things that weren't problems and was not flagging things that mattered to us)

### This pull request is ready to merge when...
- ~Tests have been updated (and all tests are passing)~
- [ ] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- ~The change has been documented~
  - ~Associated OpenAPI documentation has been updated~

### This feature is done when...
- ~Design has approved the experience~
- ~Product has approved the experience~
