### PR TITLE
Update auth management endpoints

### DIFF
--- a/api/db/authorization.js
+++ b/api/db/authorization.js
@@ -10,6 +10,13 @@ module.exports = () => ({
         'activity_id',
         'role_id'
       );
+    },
+
+    toJSON() {
+      return {
+        id: this.get('id'),
+        name: this.get('name')
+      };
     }
   },
 
@@ -22,6 +29,18 @@ module.exports = () => ({
         'role_id',
         'activity_id'
       );
+    },
+
+    toJSON() {
+      return {
+        id: this.get('id'),
+        name: this.get('name'),
+        activities: this.related('activities').map(a => a.get('name'))
+      };
+    },
+
+    static: {
+      withRelated: ['activities']
     },
 
     async getActivities() {

--- a/api/endpoint-tests/auth/roles/put.js
+++ b/api/endpoint-tests/auth/roles/put.js
@@ -83,11 +83,15 @@ tap.test(
       authenticatedTests.test('with a valid updated role', async validTest => {
         const { response, body } = await request.put(url(1102), {
           jar: cookies,
-          json: { activities: [1001] }
+          json: { name: 'new name', activities: [1001] }
         });
 
-        validTest.equal(response.statusCode, 204, 'gives a 204 status code');
-        validTest.notOk(body, 'does not send a body');
+        validTest.equal(response.statusCode, 200, 'gives a 200 status code');
+        validTest.match(
+          body,
+          { name: 'new name', activities: ['view-users'] },
+          'sends the updated role'
+        );
 
         const activities = await db()('auth_role_activity_mapping')
           .where({ role_id: 1102 })

--- a/api/routes/auth/activities/index.js
+++ b/api/routes/auth/activities/index.js
@@ -1,18 +1,16 @@
 const logger = require('../../../logger')('auth activities route index');
 const defaultActivityModel = require('../../../db').models.activity;
-const can = require('../../../middleware').can;
+const { can } = require('../../../middleware');
 
 module.exports = (app, ActivityModel = defaultActivityModel) => {
   logger.silly('setting up GET /auth/activities route');
   app.get('/auth/activities', can('view-roles'), async (req, res) => {
     logger.silly(req, 'handling GET /auth/activities');
     try {
-      const activities = (await ActivityModel.fetchAll({
-        columns: ['id', 'name']
-      })).map(a => ({ id: a.get('id'), name: a.get('name') }));
-      logger.silly(req, `got activities:`);
+      const activities = await ActivityModel.fetchAll();
+      logger.silly(req, 'got activities:');
       logger.silly(req, activities);
-      res.send(activities);
+      res.send(activities.toJSON());
     } catch (e) {
       logger.error(req, e);
       res.status(500).end();

--- a/api/routes/auth/activities/index.test.js
+++ b/api/routes/auth/activities/index.test.js
@@ -55,12 +55,6 @@ tap.test('auth activities GET endpoint', async endpointTest => {
 
         await handler({}, res);
 
-        invalidTest.ok(
-          ActivityModel.fetchAll.calledWith({
-            columns: sinon.match.array.deepEquals(['id', 'name'])
-          }),
-          'selects only user ID and email'
-        );
         invalidTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
         invalidTest.ok(res.send.notCalled, 'no body is sent');
         invalidTest.ok(res.end.called, 'response is terminated');
@@ -68,34 +62,17 @@ tap.test('auth activities GET endpoint', async endpointTest => {
     );
 
     handlerTest.test('sends back a list of activities', async validTest => {
-      const get = sinon.stub();
-      get
-        .withArgs('id')
-        .onFirstCall()
-        .returns(1)
-        .onSecondCall()
-        .returns(2);
-      get
-        .withArgs('name')
-        .onFirstCall()
-        .returns('hi')
-        .onSecondCall()
-        .returns('bye');
-      const activities = [{ get }, { get }];
+      const toJSON = sinon.stub();
+      toJSON.returns('json stuff');
+      const activities = { toJSON };
       ActivityModel.fetchAll.resolves(activities);
 
       await handler({}, res);
 
-      validTest.ok(
-        ActivityModel.fetchAll.calledWith({
-          columns: sinon.match.array.deepEquals(['id', 'name'])
-        }),
-        'selects only activity ID and name'
-      );
       validTest.ok(res.status.notCalled, 'HTTP status is not explicitly set');
       validTest.ok(
-        res.send.calledWith([{ id: 1, name: 'hi' }, { id: 2, name: 'bye' }]),
-        'body is set to the list of activities'
+        res.send.calledWith('json stuff'),
+        'body is JSON-ified activities'
       );
     });
   });

--- a/api/routes/auth/roles/get.js
+++ b/api/routes/auth/roles/get.js
@@ -1,24 +1,18 @@
 const logger = require('../../../logger')('auth roles route get');
 const defaultRoleModel = require('../../../db').models.role;
-const can = require('../../../middleware').can;
+const { can } = require('../../../middleware');
 
 module.exports = (app, RoleModel = defaultRoleModel) => {
   logger.silly('setting up GET /auth/roles route');
   app.get('/auth/roles', can('view-roles'), async (req, res) => {
     logger.silly(req, 'handling up GET /auth/roles route');
     try {
-      const roles = await RoleModel.fetchAll({ columns: ['id', 'name'] });
-      logger.silly(req, 'getting all the activities for all the roles...');
-      const sendRoles = await Promise.all(
-        roles.map(async role => ({
-          id: role.get('id'),
-          name: role.get('name'),
-          activities: await role.getActivities()
-        }))
-      );
+      const roles = await RoleModel.fetchAll({
+        withRelated: RoleModel.withRelated
+      });
       logger.silly(req, 'got all the roles');
-      logger.silly(req, sendRoles);
-      res.send(sendRoles);
+      logger.silly(req, roles);
+      res.send(roles.toJSON());
     } catch (e) {
       logger.error(req, e);
       res.status(500).end();

--- a/api/routes/auth/roles/get.test.js
+++ b/api/routes/auth/roles/get.test.js
@@ -10,7 +10,8 @@ tap.test('auth roles GET endpoint', async endpointTest => {
     get: sandbox.stub()
   };
   const RoleModel = {
-    fetchAll: sandbox.stub()
+    fetchAll: sandbox.stub(),
+    withRelated: 'related-stuff'
   };
   const res = {
     status: sandbox.stub(),
@@ -53,9 +54,9 @@ tap.test('auth roles GET endpoint', async endpointTest => {
 
         invalidTest.ok(
           RoleModel.fetchAll.calledWith({
-            columns: sinon.match.array.deepEquals(['id', 'name'])
+            withRelated: 'related-stuff'
           }),
-          'selects only role ID and name'
+          'also fetches related data'
         );
         invalidTest.ok(res.status.calledWith(500), 'HTTP status set to 500');
         invalidTest.ok(res.send.notCalled, 'no body is sent');
@@ -64,31 +65,22 @@ tap.test('auth roles GET endpoint', async endpointTest => {
     );
 
     handlerTest.test('sends back a list of roles', async validTest => {
-      const get = sinon.stub();
-      get.withArgs('id').returns(1);
-      get.withArgs('name').returns('hi');
-
-      const getActivities = sinon
-        .stub()
-        .resolves(['activity1.1', 'activity1.2']);
-
-      const roles = [{ get, getActivities }];
-      RoleModel.fetchAll.resolves(roles);
+      RoleModel.fetchAll.resolves({
+        toJSON: sinon.stub().returns('roles as json')
+      });
 
       await handler({}, res);
 
       validTest.ok(
         RoleModel.fetchAll.calledWith({
-          columns: sinon.match.array.deepEquals(['id', 'name'])
+          withRelated: 'related-stuff'
         }),
-        'selects only role ID and name'
+        'also fetches related data'
       );
       validTest.ok(res.status.notCalled, 'HTTP status is not explicitly set');
       validTest.ok(
-        res.send.calledWith([
-          { id: 1, name: 'hi', activities: ['activity1.1', 'activity1.2'] }
-        ]),
-        'body is set to the list of roles'
+        res.send.calledWith('roles as json'),
+        'body is JSON-ified roles'
       );
     });
   });

--- a/api/routes/auth/roles/post.js
+++ b/api/routes/auth/roles/post.js
@@ -1,6 +1,6 @@
 const logger = require('../../../logger')('roles route post');
 const defaultRoleModel = require('../../../db').models.role;
-const can = require('../../../middleware').can;
+const { can } = require('../../../middleware');
 
 module.exports = (app, RoleModel = defaultRoleModel) => {
   logger.silly('setting up POST /auth/roles route');
@@ -33,11 +33,7 @@ module.exports = (app, RoleModel = defaultRoleModel) => {
       await role.load('activities');
 
       logger.silly(req, 'all done');
-      return res.status(201).send({
-        name: role.get('name'),
-        id: role.get('id'),
-        activities: await role.getActivities()
-      });
+      return res.status(201).send(role.toJSON());
     } catch (e) {
       logger.error(req, e);
       return res.status(500).end();

--- a/api/routes/auth/roles/post.test.js
+++ b/api/routes/auth/roles/post.test.js
@@ -19,7 +19,8 @@ tap.test('auth roles POST endpoint', async endpointTest => {
     getActivities: sandbox.stub(),
     load: sandbox.stub(),
     save: sandbox.stub(),
-    validate: sandbox.stub()
+    validate: sandbox.stub(),
+    toJSON: sandbox.stub().returns('as json')
   };
   const RoleModel = {
     fetch: sandbox.stub(),
@@ -90,11 +91,6 @@ tap.test('auth roles POST endpoint', async endpointTest => {
       const req = { body: { name: 'bob', activities: [1, 2] } };
       roleObj.validate.resolves();
       roleObj.save.resolves();
-      roleObj.get
-        .withArgs('id')
-        .returns('bob-id')
-        .withArgs('name')
-        .returns('bob-role');
       roleObj.getActivities.resolves(['activity1', 'activity2']);
       roleObj.load.withArgs('activities').resolves();
 
@@ -122,12 +118,8 @@ tap.test('auth roles POST endpoint', async endpointTest => {
       );
       saveTest.ok(res.status.calledWith(201), 'HTTP status set to 201');
       saveTest.ok(
-        res.send.calledWith({
-          name: 'bob-role',
-          id: 'bob-id',
-          activities: sinon.match.array.deepEquals(['activity1', 'activity2'])
-        }),
-        'sends back the new role object'
+        res.send.calledWith('as-json'),
+        'sends back the JSON-ified new role object'
       );
     });
   });

--- a/api/routes/auth/roles/post.test.js
+++ b/api/routes/auth/roles/post.test.js
@@ -20,7 +20,7 @@ tap.test('auth roles POST endpoint', async endpointTest => {
     load: sandbox.stub(),
     save: sandbox.stub(),
     validate: sandbox.stub(),
-    toJSON: sandbox.stub().returns('as json')
+    toJSON: sandbox.stub()
   };
   const RoleModel = {
     fetch: sandbox.stub(),
@@ -93,6 +93,7 @@ tap.test('auth roles POST endpoint', async endpointTest => {
       roleObj.save.resolves();
       roleObj.getActivities.resolves(['activity1', 'activity2']);
       roleObj.load.withArgs('activities').resolves();
+      roleObj.toJSON.returns('as json');
 
       await handler(req, res);
 
@@ -118,7 +119,7 @@ tap.test('auth roles POST endpoint', async endpointTest => {
       );
       saveTest.ok(res.status.calledWith(201), 'HTTP status set to 201');
       saveTest.ok(
-        res.send.calledWith('as-json'),
+        res.send.calledWith('as json'),
         'sends back the JSON-ified new role object'
       );
     });

--- a/api/routes/auth/roles/put.js
+++ b/api/routes/auth/roles/put.js
@@ -17,9 +17,9 @@ module.exports = (app, RoleModel = defaultRoleModel) => {
       const userRole = await RoleModel.where({
         id: req.params.id,
         name: req.user.role
-      }).fetch({ withRelated: RoleModel.withRelated });
+      }).fetch();
       if (userRole) {
-        logger.verbose(req, `attempting to delete own role [${req.params.id}]`);
+        logger.verbose(req, `attempting to update own role [${req.params.id}]`);
         return res.status(403).end();
       }
 

--- a/api/routes/auth/roles/put.js
+++ b/api/routes/auth/roles/put.js
@@ -1,6 +1,6 @@
 const logger = require('../../../logger')('roles route put');
 const defaultRoleModel = require('../../../db').models.role;
-const can = require('../../../middleware').can;
+const { can } = require('../../../middleware');
 
 module.exports = (app, RoleModel = defaultRoleModel) => {
   logger.silly('setting up PUT /auth/roles/:id route');
@@ -17,17 +17,13 @@ module.exports = (app, RoleModel = defaultRoleModel) => {
       const userRole = await RoleModel.where({
         id: req.params.id,
         name: req.user.role
-      }).fetch();
+      }).fetch({ withRelated: RoleModel.withRelated });
       if (userRole) {
         logger.verbose(req, `attempting to delete own role [${req.params.id}]`);
         return res.status(403).end();
       }
 
-      logger.silly(
-        req,
-        'attempting to update role',
-        JSON.parse(JSON.stringify(role))
-      );
+      logger.silly(req, 'attempting to update role', role.toJSON());
 
       try {
         logger.silly(req, 'validing the request', req.body);
@@ -43,6 +39,10 @@ module.exports = (app, RoleModel = defaultRoleModel) => {
 
       logger.silly(req, 'request is valid');
 
+      if (req.body.name) {
+        role.set({ name: req.body.name });
+      }
+
       logger.silly(req, 'removing previous activities');
       role.activities().detach();
       await role.save();
@@ -51,8 +51,12 @@ module.exports = (app, RoleModel = defaultRoleModel) => {
       role.activities().attach(req.body.activities);
       await role.save();
 
+      const updated = await RoleModel.where({ id: req.params.id }).fetch({
+        withRelated: RoleModel.withRelated
+      });
+
       logger.silly(req, 'all done');
-      return res.status(204).end();
+      return res.send(updated.toJSON()).end();
     } catch (e) {
       logger.error(req, e);
       return res.status(500).end();


### PR DESCRIPTION
Updates the endpoints to get, create, and update roles and activities to use the same patterns that we're using elsewhere (e.g., defining related properties on the model itself, defining the model's `toJSON` method).

Closes #510

### This pull request changes...
- no visible changes, but code maintenance should get a little easier

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- ~The change has been documented~
  - ~Associated OpenAPI documentation has been updated~

### This feature is done when...
- ~Design has approved the experience~
- ~Product has approved the experience~
