### PR TITLE
add h3 for help text for each section

### DIFF
--- a/web/src/components/AssurancesAndCompliance.js
+++ b/web/src/components/AssurancesAndCompliance.js
@@ -1,12 +1,16 @@
 import React from 'react';
 
+import { t } from '../i18n';
 import Section from './Section';
 import SectionTitle from './SectionTitle';
 import Collapsible from './Collapsible';
 
 const AssurancesAndCompliance = () => (
   <Section id="assurances-compliance">
-    <SectionTitle>Assurances and Compliance</SectionTitle>
+    <SectionTitle>{t('assurancesAndCompliance.title')}</SectionTitle>
+
+    <h3>{t('assurancesAndCompliance.helpText')}</h3>
+
     <Collapsible title="Procurement Standards">
       <div>...</div>
     </Collapsible>

--- a/web/src/components/CertifyAndSubmit.js
+++ b/web/src/components/CertifyAndSubmit.js
@@ -1,12 +1,16 @@
 import React from 'react';
 
+import { t } from '../i18n';
 import Section from './Section';
 import SectionTitle from './SectionTitle';
 import Collapsible from './Collapsible';
 
 const CertifyAndSubmit = () => (
   <Section id="certify-submit">
-    <SectionTitle>Certify and Submit</SectionTitle>
+    <SectionTitle>{t('certifyAndSubmit.title')}</SectionTitle>
+
+    <h3>{t('certifyAndSubmit.helpText')}</h3>
+
     <Collapsible title="Certify and Submit">
       <div>...</div>
     </Collapsible>

--- a/web/src/components/ExecutiveSummary.js
+++ b/web/src/components/ExecutiveSummary.js
@@ -1,12 +1,16 @@
 import React from 'react';
 
+import { t } from '../i18n';
 import Section from './Section';
 import SectionTitle from './SectionTitle';
 import Collapsible from './Collapsible';
 
 const ExecutiveSummary = () => (
   <Section id="executive-summary">
-    <SectionTitle>Executive/Overall Summary</SectionTitle>
+    <SectionTitle>{t('executiveSummary.title')}</SectionTitle>
+
+    <h3>{t('executiveSummary.helpText')}</h3>
+
     <Collapsible title="Executive Summary">
       <div>...</div>
     </Collapsible>

--- a/web/src/components/PreviousActivities.js
+++ b/web/src/components/PreviousActivities.js
@@ -1,19 +1,23 @@
 import React from 'react';
 
+import { t } from '../i18n';
 import Section from './Section';
 import SectionTitle from './SectionTitle';
 import Collapsible from './Collapsible';
 
 const PreviousActivities = () => (
   <Section id="prev-activities">
-    <SectionTitle>Results of Previous Activities</SectionTitle>
-    <Collapsible title="Prior Activities Outline">
+    <SectionTitle>{t('previousActivities.title')}</SectionTitle>
+
+    <h3>{t('previousActivities.helpText')}</h3>
+
+    <Collapsible title={t('previousActivities.sections.outline')}>
       <div>...</div>
     </Collapsible>
-    <Collapsible title="Approved Expenses">
+    <Collapsible title={t('previousActivities.sections.approvedExpenses')}>
       <div>...</div>
     </Collapsible>
-    <Collapsible title="Actual Expenses">
+    <Collapsible title={t('previousActivities.sections.actualExpenses')}>
       <div>...</div>
     </Collapsible>
   </Section>

--- a/web/src/components/ProposedBudget.js
+++ b/web/src/components/ProposedBudget.js
@@ -1,12 +1,16 @@
 import React from 'react';
 
+import { t } from '../i18n';
 import Section from './Section';
 import SectionTitle from './SectionTitle';
 import Collapsible from './Collapsible';
 
 const ProposedBudget = () => (
   <Section id="budget">
-    <SectionTitle>Proposed Budget</SectionTitle>
+    <SectionTitle>{t('proposedBudget.title')}</SectionTitle>
+
+    <h3>{t('proposedBudget.helpText')}</h3>
+
     <Collapsible title="Short Activity Summary Budget">
       <div>...</div>
     </Collapsible>

--- a/web/src/containers/Activities.js
+++ b/web/src/containers/Activities.js
@@ -13,6 +13,9 @@ import SectionTitle from '../components/SectionTitle';
 const Activities = ({ activityIds, addActivity }) => (
   <Section id="activities">
     <SectionTitle>{t('activities.title')}</SectionTitle>
+
+    <h3>{t('activities.helpText')}</h3>
+
     <Collapsible title={t('activities.listTitle')} open>
       {activityIds.length === 0 ? (
         <div className="mb2 p1 h6 alert">

--- a/web/src/containers/ApdSummary.js
+++ b/web/src/containers/ApdSummary.js
@@ -42,6 +42,9 @@ class ApdSummary extends Component {
     return (
       <Section id="apd-summary">
         <SectionTitle>{t('apd.sectionTitle')}</SectionTitle>
+
+        <h3>{t('apd.helpText')}</h3>
+
         <Collapsible title={t('apd.overview.title')}>
           <HelpText
             text="apd.overview.helpText"

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -22,6 +22,7 @@
 
   "apd": {
     "sectionTitle": "Program Summary",
+    "helpText": "Bloop bloop, program summary",
     "overview": {
       "title": "Overview",
       "helpText":
@@ -65,8 +66,19 @@
     }
   },
 
+  "previousActivities": {
+    "title": "Results of Previous Activities",
+    "helpText": "Zip zorp, previous activities",
+    "sections": {
+      "outline": "Prior Activities Outline",
+      "approvedExpenses": "Approved Expenses",
+      "actualExpenses": "Actual Expenses"
+    }
+  },
+
   "activities": {
     "title": "Program Activities",
+    "helpText": "Flip flop, program activities",
     "listTitle": "Activity List",
     "addActivityButtonText": "Add activity",
     "deleteActivityButtonText": "Remove Activity",
@@ -125,7 +137,8 @@
     },
     "contractorResources": {
       "title": "Contracting Resources",
-      "subheader": "Do you have contracting resources? In this section, outline contracts by vendor name or contract. Mirror your existing IAPD template structure for this section.",
+      "subheader":
+        "Do you have contracting resources? In this section, outline contracts by vendor name or contract. Mirror your existing IAPD template structure for this section.",
       "helpText":
         "Contracts and projected contracts must be itemized, with estimated costs per contract including FFY costs",
       "labels": {
@@ -149,7 +162,8 @@
     },
     "statePersonnel": {
       "title": "State Personnel",
-      "subheader": "Outline the personnel resources for this section. This includes anyone with FTE on your particular IAPD project(s). This does not include personnel listed in the contract section.",
+      "subheader":
+        "Outline the personnel resources for this section. This includes anyone with FTE on your particular IAPD project(s). This does not include personnel listed in the contract section.",
       "helpText": "Personnel costs must include salaries and benefits",
       "labels": {
         "entryNum": "#",
@@ -258,5 +272,22 @@
         "prompt": "Describe how you'll meet the Cost Minimization condition"
       }
     }
+  },
+  "proposedBudget": {
+    "title": "Proposed Budget",
+    "helpText": "Drip drop, proposed budget"
+  },
+
+  "assurancesAndCompliance": {
+    "title": "Assurances and Compliance",
+    "helpText": "Hippity hoppity, assurances and compliance"
+  },
+  "executiveSummary": {
+    "title": "Executive/Overall Summary",
+    "helpText": "Diggity doo, executive summary"
+  },
+  "certifyAndSubmit": {
+    "title": "Certify and Submit",
+    "helpText": "Moop moop, certify and submit"
   }
 }


### PR DESCRIPTION
Adds helper text to each section.  Right now it's an unstyled `h3`, but we can style it later.  😄

Closes #536

### This pull request changes...
- Every section has some placeholder "helper" text

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- ~The change has been documented~
  - ~Associated OpenAPI documentation has been updated~

### This feature is done when...
- [x] Design has approved the experience
- ~Product has approved the experience~
