### PR TITLE
Hookup APD frontend to backend

### DIFF
--- a/web/src/actions/apd.js
+++ b/web/src/actions/apd.js
@@ -22,7 +22,10 @@ export const fetchApd = () => dispatch => {
 
   return axios
     .get(url)
-    .then(req => dispatch(receiveApd(req.data)))
+    .then(req => {
+      const apd = Array.isArray(req.data) ? req.data[0] : null;
+      dispatch(receiveApd(apd));
+    })
     .catch(error => {
       const reason = error.response ? error.response.data : 'N/A';
       dispatch(failApd(reason));

--- a/web/src/actions/apd.js
+++ b/web/src/actions/apd.js
@@ -140,5 +140,8 @@ export const saveApd = () => (dispatch, state) => {
     });
   });
 
-  console.log(JSON.stringify(apd));
+  return axios
+    .put(`/apds/${updatedApd.id}`, apd)
+    .then(res => dispatch(saveSuccess(res.data)))
+    .catch(() => dispatch(saveFailure())); // TODO handle the error
 };

--- a/web/src/actions/apd.js
+++ b/web/src/actions/apd.js
@@ -84,7 +84,11 @@ export const saveApd = () => (dispatch, state) => {
         description: g.desc,
         objectives: [{ description: g.obj }]
       })),
-      schedule: null, // TODO
+      schedule: activity.milestones.map(m => ({
+        milestone: m.name,
+        plannedStart: m.start,
+        plannedEnd: m.end
+      })),
       statePersonnel: activity.statePersonnel.map(s => ({
         title: s.title,
         description: s.desc,
@@ -97,8 +101,8 @@ export const saveApd = () => (dispatch, state) => {
       contractorResources: activity.contractorResources.map(c => ({
         name: c.name,
         description: c.desc,
-        start: new Date(c.start).toISOString(),
-        end: new Date(c.end).toISOString(),
+        start: c.start,
+        end: c.end,
         years: Object.keys(c.years).map(year => ({
           cost: +c.years[year],
           year

--- a/web/src/actions/apd.js
+++ b/web/src/actions/apd.js
@@ -59,7 +59,15 @@ export const saveApd = () => (dispatch, state) => {
 
   const apd = {
     activities: [],
-    keyPersonnel: updatedApd.keyPersonnel,
+    keyPersonnel: updatedApd.keyPersonnel.map(p => ({
+      title: p.title,
+      description: p.desc,
+      years: Object.keys(p.years).map(year => ({
+        year,
+        cost: p.years[year].amt,
+        fte: p.years[year].perc
+      }))
+    })),
     narrativeHIE: updatedApd.hieNarrative,
     narrativeHIT: updatedApd.hitNarrative,
     narrativeMMIS: updatedApd.mmisNarrative,
@@ -75,14 +83,14 @@ export const saveApd = () => (dispatch, state) => {
       summary: activity.descShort,
       description: activity.descLong,
       alternatives: activity.altApproach,
-      costAllocationDescription: activity.costAllocateDesc,
+      costAllocationMethodology: activity.costAllocateDesc,
       otherFundingSources: {
         description: activity.otherFundingDesc,
         amount: activity.otherFundingAmt
       },
       goals: activity.goals.map(g => ({
         description: g.desc,
-        objectives: [{ description: g.obj }]
+        objectives: [{ description: g.obj }] // TODO - objective should mape 1:1 to goals, instead of being an array (needs backend change first)
       })),
       schedule: activity.milestones.map(m => ({
         milestone: m.name,
@@ -115,7 +123,20 @@ export const saveApd = () => (dispatch, state) => {
           amount: +e.years[year],
           year
         }))
-      }))
+      })),
+      standardsAndConditions: {
+        businessResults: activity.standardsAndConditions.bizResults,
+        documentation: activity.standardsAndConditions.documentation,
+        industryStandards: activity.standardsAndConditions.industry,
+        interoperability: activity.standardsAndConditions.interoperability,
+        keyPersonnel: activity.standardsAndConditions.keyPersonnel,
+        leverage: activity.standardsAndConditions.leverage,
+        minimizeCost: activity.standardsAndConditions.minimizeCost,
+        mitigationStrategy: activity.standardsAndConditions.mitigation,
+        modularity: activity.standardsAndConditions.modularity,
+        mita: activity.standardsAndConditions.mita,
+        reporting: activity.standardsAndConditions.reporting
+      }
     });
   });
 

--- a/web/src/actions/apd.js
+++ b/web/src/actions/apd.js
@@ -86,7 +86,7 @@ export const saveApd = () => (dispatch, state) => {
       costAllocationMethodology: activity.costAllocateDesc,
       otherFundingSources: {
         description: activity.otherFundingDesc,
-        amount: activity.otherFundingAmt
+        amount: +activity.otherFundingAmt || 0
       },
       goals: activity.goals.map(g => ({
         description: g.desc,
@@ -94,8 +94,8 @@ export const saveApd = () => (dispatch, state) => {
       })),
       schedule: activity.milestones.map(m => ({
         milestone: m.name,
-        plannedStart: m.start,
-        plannedEnd: m.end
+        plannedStart: m.start || undefined,
+        plannedEnd: m.end || undefined
       })),
       statePersonnel: activity.statePersonnel.map(s => ({
         title: s.title,
@@ -109,8 +109,8 @@ export const saveApd = () => (dispatch, state) => {
       contractorResources: activity.contractorResources.map(c => ({
         name: c.name,
         description: c.desc,
-        start: c.start,
-        end: c.end,
+        start: c.start || undefined,
+        end: c.end || undefined,
         years: Object.keys(c.years).map(year => ({
           cost: +c.years[year],
           year

--- a/web/src/actions/apd.js
+++ b/web/src/actions/apd.js
@@ -5,6 +5,9 @@ export const GET_APD_REQUEST = 'GET_APD_REQUEST';
 export const GET_APD_SUCCESS = 'GET_APD_SUCCESS';
 export const GET_APD_FAILURE = 'GET_APD_FAILURE';
 export const REMOVE_APD_KEY_PERSON = 'REMOVE_APD_KEY_PERSON';
+export const SAVE_APD_REQUEST = 'SAVE_APD_REQUEST';
+export const SAVE_APD_SUCCESS = 'SAVE_APD_SUCCESS';
+export const SAVE_APD_FAILURE = 'SAVE_APD_FAILURE';
 export const UPDATE_APD = 'UPDATE_APD';
 
 export const requestApd = () => ({ type: GET_APD_REQUEST });
@@ -14,6 +17,10 @@ export const failApd = error => ({ type: GET_APD_FAILURE, error });
 export const addApdKeyPerson = () => ({ type: ADD_APD_KEY_PERSON });
 export const removeApdKeyPerson = id => ({ type: REMOVE_APD_KEY_PERSON, id });
 export const updateApd = updates => ({ type: UPDATE_APD, updates });
+
+export const requestSave = () => ({ type: SAVE_APD_REQUEST });
+export const saveSuccess = () => ({ type: SAVE_APD_SUCCESS });
+export const saveFailure = () => ({ type: SAVE_APD_FAILURE });
 
 export const fetchApd = () => dispatch => {
   dispatch(requestApd());
@@ -40,4 +47,73 @@ export const fetchApdDataIfNeeded = () => (dispatch, getState) => {
   }
 
   return null;
+};
+
+export const saveApd = () => (dispatch, state) => {
+  dispatch(requestSave());
+
+  const {
+    apd: { data: updatedApd },
+    activities: { byId: activitiesByID }
+  } = state();
+
+  const apd = {
+    activities: [],
+    keyPersonnel: updatedApd.keyPersonnel,
+    narrativeHIE: updatedApd.hieNarrative,
+    narrativeHIT: updatedApd.hitNarrative,
+    narrativeMMIS: updatedApd.mmisNarrative,
+    programOverview: updatedApd.overview,
+    years: updatedApd.years
+  };
+
+  Object.keys(activitiesByID).forEach(id => {
+    const activity = activitiesByID[id];
+    apd.activities.push({
+      name: activity.name,
+      types: activity.types,
+      summary: activity.descShort,
+      description: activity.descLong,
+      alternatives: activity.altApproach,
+      costAllocationDescription: activity.costAllocateDesc,
+      otherFundingSources: {
+        description: activity.otherFundingDesc,
+        amount: activity.otherFundingAmt
+      },
+      goals: activity.goals.map(g => ({
+        description: g.desc,
+        objectives: [{ description: g.obj }]
+      })),
+      schedule: null, // TODO
+      statePersonnel: activity.statePersonnel.map(s => ({
+        title: s.title,
+        description: s.desc,
+        years: Object.keys(s.years).map(year => ({
+          cost: +s.years[year].amt,
+          fte: +s.years[year].perc,
+          year
+        }))
+      })),
+      contractorResources: activity.contractorResources.map(c => ({
+        name: c.name,
+        description: c.desc,
+        start: new Date(c.start).toISOString(),
+        end: new Date(c.end).toISOString(),
+        years: Object.keys(c.years).map(year => ({
+          cost: +c.years[year],
+          year
+        }))
+      })),
+      expenses: activity.expenses.map(e => ({
+        category: e.category,
+        description: e.desc,
+        entries: Object.keys(e.years).map(year => ({
+          amount: +e.years[year],
+          year
+        }))
+      }))
+    });
+  });
+
+  console.log(JSON.stringify(apd));
 };

--- a/web/src/actions/apd.test.js
+++ b/web/src/actions/apd.test.js
@@ -35,7 +35,7 @@ describe('state actions', () => {
 
     it('creates GET_APD_SUCCESS after successful APD fetch', () => {
       const store = mockStore({});
-      fetchMock.onGet('/apds').reply(200, { foo: 'bar' });
+      fetchMock.onGet('/apds').reply(200, [{ foo: 'bar' }]);
 
       const expectedActions = [
         { type: actions.GET_APD_REQUEST },

--- a/web/src/actions/auth.js
+++ b/web/src/actions/auth.js
@@ -1,5 +1,7 @@
 import axios from '../util/api';
 
+import { fetchApd } from './apd';
+
 const API_URL = process.env.API_URL || 'http://localhost:8000';
 
 export const AUTH_CHECK_REQUEST = 'AUTH_CHECK_REQUEST';
@@ -27,7 +29,10 @@ export const login = (username, password) => dispatch => {
 
   return axios
     .post(`${API_URL}/auth/login`, { username, password })
-    .then(() => dispatch(completeLogin()))
+    .then(() => {
+      dispatch(completeLogin());
+      dispatch(fetchApd());
+    })
     .catch(error => {
       const reason = error.response ? error.response.data : 'N/A';
       dispatch(failLogin(reason));
@@ -42,6 +47,9 @@ export const checkAuth = () => dispatch => {
 
   return axios
     .get(`${API_URL}/me`)
-    .then(() => dispatch(completeAuthCheck()))
+    .then(() => {
+      dispatch(completeAuthCheck());
+      dispatch(fetchApd());
+    })
     .catch(() => dispatch(failAuthCheck()));
 };

--- a/web/src/actions/auth.test.js
+++ b/web/src/actions/auth.test.js
@@ -3,6 +3,7 @@ import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
 import * as actions from './auth';
+import * as apdActions from './apd';
 import axios from '../util/api';
 
 const mockStore = configureStore([thunk]);
@@ -39,7 +40,8 @@ describe('auth actions', () => {
 
       const expectedActions = [
         { type: actions.LOGIN_REQUEST },
-        { type: actions.LOGIN_SUCCESS }
+        { type: actions.LOGIN_SUCCESS },
+        { type: apdActions.GET_APD_REQUEST }
       ];
 
       return store.dispatch(actions.login()).then(() => {
@@ -90,7 +92,8 @@ describe('auth actions', () => {
 
       const expectedActions = [
         { type: actions.AUTH_CHECK_REQUEST },
-        { type: actions.AUTH_CHECK_SUCCESS }
+        { type: actions.AUTH_CHECK_SUCCESS },
+        { type: apdActions.GET_APD_REQUEST }
       ];
 
       return store.dispatch(actions.checkAuth()).then(() => {

--- a/web/src/components/Inputs.js
+++ b/web/src/components/Inputs.js
@@ -9,8 +9,19 @@ class RichText extends Component {
     super(props);
 
     this.state = {
-      content: htmlToEditor(props.content)
+      content: htmlToEditor(props.content),
+      lastContent: props.content
     };
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    if (nextProps.content !== this.state.lastContent) {
+      this.setState({
+        content: htmlToEditor(nextProps.content),
+        lastContent: nextProps.content
+      });
+    }
+    return nextState.content !== this.state.content;
   }
 
   onEditorChange = newContent => {

--- a/web/src/containers/Sidebar.js
+++ b/web/src/containers/Sidebar.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 
 import { t } from '../i18n';
 import { expandActivitySection } from '../actions/activities';
+import { saveApd } from '../actions/apd';
 import SidebarLink from '../components/SidebarLink';
 
 const linkGroup1 = [
@@ -19,7 +20,7 @@ const linkGroup2 = [
   { id: 'certify-submit', name: t('sidebar.titles.submit') }
 ];
 
-const Sidebar = ({ activities, place, hash, expandSection }) => (
+const Sidebar = ({ activities, place, hash, expandSection, saveApdToAPI }) => (
   <div className="site-sidebar bg-navy">
     <div className="p2 xs-hide sm-hide">
       <div className="mb2">
@@ -60,6 +61,14 @@ const Sidebar = ({ activities, place, hash, expandSection }) => (
       </ul>
 
       <div className="mt2 pt2 border-top border-white">
+        <button
+          type="button"
+          className="btn btn-primary mb1"
+          onClick={() => saveApdToAPI()}
+        >
+          Save APD
+        </button>
+
         <button type="button" className="btn btn-primary bg-white navy">
           {t('sidebar.savePdfButtonText')}
         </button>
@@ -72,7 +81,8 @@ Sidebar.propTypes = {
   activities: PropTypes.array.isRequired,
   place: PropTypes.object.isRequired,
   hash: PropTypes.string.isRequired,
-  expandSection: PropTypes.func.isRequired
+  expandSection: PropTypes.func.isRequired,
+  saveApdToAPI: PropTypes.func.isRequired
 };
 
 const mapStateToProps = ({ activities: { byId, allIds }, router }) => ({
@@ -85,7 +95,8 @@ const mapStateToProps = ({ activities: { byId, allIds }, router }) => ({
 });
 
 const mapDispatchToProps = {
-  expandSection: expandActivitySection
+  expandSection: expandActivitySection,
+  saveApdToAPI: saveApd
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Sidebar);

--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -273,7 +273,7 @@ const reducer = (state = initialState, action) => {
           otherFundingAmt: +a.otherFundingSources.amount,
           goals: a.goals.map(g => ({
             desc: g.description,
-            obj: g.objectives[0]
+            obj: g.objectives[0] // TODO - don't assume there's one objective; tie objective directly to the goal instead of a mapped table
           })),
           milestones: a.schedule.map(s => ({
             id: s.id,
@@ -312,8 +312,8 @@ const reducer = (state = initialState, action) => {
           })),
           expenses: a.expenses.map(e => ({
             id: e.id,
-            category: 'Hardware, software, and licensing', // TODO
-            desc: '', // TODO
+            category: e.category,
+            desc: e.description,
             years: e.entries.reduce(
               (years, y) => ({
                 ...years,
@@ -324,6 +324,7 @@ const reducer = (state = initialState, action) => {
           })),
 
           standardsAndConditions: {
+            // TODO
             modularity: '',
             mita: '',
             industry: '',

--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -314,7 +314,7 @@ const reducer = (state = initialState, action) => {
             id: e.id,
             category: 'Hardware, software, and licensing', // TODO
             desc: '', // TODO
-            years: e.years.reduce(
+            years: e.entries.reduce(
               (years, y) => ({
                 ...years,
                 [y.year]: +y.amount

--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -260,11 +260,6 @@ const reducer = (state = initialState, action) => {
       );
     case GET_APD_SUCCESS: {
       const byId = {};
-      const htmlDate = date =>
-        `${date.getFullYear()}-${
-          date.getMonth() > 8 ? date.getMonth() + 1 : `0${date.getMonth() + 1}`
-        }-${date.getDate() > 9 ? date.getDate() : `0${date.getDate()}`}`;
-
       action.data.activities.forEach(a => {
         byId[a.id] = {
           id: a.id,
@@ -280,7 +275,12 @@ const reducer = (state = initialState, action) => {
             desc: g.description,
             obj: g.objectives[0]
           })),
-          milestones: [newMilestone(), newMilestone(), newMilestone()], // TODO
+          milestones: a.schedule.map(s => ({
+            id: s.id,
+            name: s.milestone,
+            start: s.plannedStart,
+            end: s.plannedEnd
+          })),
           statePersonnel: a.statePersonnel.map(s => ({
             id: s.id,
             title: s.title,
@@ -300,8 +300,8 @@ const reducer = (state = initialState, action) => {
             id: c.id,
             name: c.name,
             desc: c.description,
-            start: htmlDate(new Date(c.start)),
-            end: htmlDate(new Date(c.end)),
+            start: c.start,
+            end: c.end,
             years: c.years.reduce(
               (years, y) => ({
                 ...years,

--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -17,6 +17,8 @@ import {
   TOGGLE_ACTIVITY_SECTION,
   UPDATE_ACTIVITY
 } from '../actions/activities';
+import { GET_APD_SUCCESS } from '../actions/apd';
+
 import { nextSequence } from '../util';
 
 const newGoal = () => ({ desc: '', obj: '' });
@@ -256,6 +258,95 @@ const reducer = (state = initialState, action) => {
         },
         state
       );
+    case GET_APD_SUCCESS: {
+      const byId = {};
+      const htmlDate = date =>
+        `${date.getFullYear()}-${
+          date.getMonth() > 8 ? date.getMonth() + 1 : `0${date.getMonth() + 1}`
+        }-${date.getDate() > 9 ? date.getDate() : `0${date.getDate()}`}`;
+
+      action.data.activities.forEach(a => {
+        byId[a.id] = {
+          id: a.id,
+          name: a.name,
+          types: ['HIT'], // TODO
+          descShort: '', // TODO
+          descLong: a.description,
+          altApproach: '', // TODO
+          costAllocateDesc: '', // TODO
+          otherFundingDesc: a.otherFundingSources.description,
+          otherFundingAmt: +a.otherFundingSources.amount,
+          goals: a.goals.map(g => ({
+            desc: g.description,
+            obj: g.objectives[0]
+          })),
+          milestones: [newMilestone(), newMilestone(), newMilestone()], // TODO
+          statePersonnel: a.statePersonnel.map(s => ({
+            id: s.id,
+            title: s.title,
+            desc: s.description,
+            years: s.years.reduce(
+              (years, y) => ({
+                ...years,
+                [y.year]: {
+                  amt: y.cost,
+                  perc: y.fte
+                }
+              }),
+              {}
+            )
+          })),
+          contractorResources: a.contractorResources.map(c => ({
+            id: c.id,
+            name: c.name,
+            desc: c.description,
+            start: htmlDate(new Date(c.start)),
+            end: htmlDate(new Date(c.end)),
+            years: c.years.reduce(
+              (years, y) => ({
+                ...years,
+                [y.year]: +y.cost
+              }),
+              {}
+            )
+          })),
+          expenses: a.expenses.map(e => ({
+            id: e.id,
+            category: 'Hardware, software, and licensing', // TODO
+            desc: '', // TODO
+            years: e.years.reduce(
+              (years, y) => ({
+                ...years,
+                [y.year]: +y.amount
+              }),
+              {}
+            )
+          })),
+
+          standardsAndConditions: {
+            modularity: '',
+            mita: '',
+            industry: '',
+            leverage: '',
+            bizResults: '',
+            reporting: '',
+            interoperability: '',
+            mitigation: '',
+            keyPersonnel: '',
+            documentation: '',
+            minimizeCost: ''
+          },
+          meta: {
+            expanded: false
+          }
+        };
+      });
+
+      return {
+        byId,
+        allIds: action.data.activities.map(a => a.id)
+      };
+    }
     default:
       return state;
   }

--- a/web/src/reducers/apd.js
+++ b/web/src/reducers/apd.js
@@ -44,7 +44,15 @@ const reducer = (state = initialState, action) => {
         ...state,
         fetching: false,
         loaded: true,
-        data: { ...action.data[0] }
+        data: {
+          id: action.data.id,
+          years: ['2018'], // TODO
+          overview: action.data.programOverview,
+          keyPersonnel: [], // TODO
+          hitNarrative: action.data.narrativeHIT,
+          hieNarrative: action.data.narrativeHIE,
+          mmisNarrative: action.data.narrativeMMIS
+        }
       };
     case GET_APD_FAILURE:
       return { ...state, fetching: false, error: action.error };

--- a/web/src/reducers/apd.test.js
+++ b/web/src/reducers/apd.test.js
@@ -33,10 +33,24 @@ describe('APD reducer', () => {
     expect(
       apd(initialState, {
         type: 'GET_APD_SUCCESS',
-        data: [{ name: 'Bob' }]
+        data: {
+          id: 'apd-id',
+          programOverview: 'moop moop',
+          narrativeHIT: 'HIT, but as a play',
+          narrativeHIE: 'HIE, but as a novel',
+          narrativeMMIS: 'MMIS, but as a script'
+        }
       })
     ).toEqual({
-      data: { name: 'Bob' },
+      data: {
+        id: 'apd-id',
+        years: ['2018'],
+        overview: 'moop moop',
+        keyPersonnel: [],
+        hitNarrative: 'HIT, but as a play',
+        hieNarrative: 'HIE, but as a novel',
+        mmisNarrative: 'MMIS, but as a script'
+      },
       fetching: false,
       loaded: true,
       error: ''

--- a/web/src/routes.js
+++ b/web/src/routes.js
@@ -6,10 +6,10 @@ import PoC from './components/PoC';
 import Login from './containers/Login';
 
 const routes = [
-  { path: '/', component: PoC, exact: true, nonPrivate: true },
+  { path: '/', component: PoC, exact: true, nonPrivate: false },
   { path: '/login', component: Login, nonPrivate: true },
   { path: '/hello', component: Hello, nonPrivate: true },
-  { path: '/poc', component: PoC, nonPrivate: true },
+  { path: '/poc', component: PoC, nonPrivate: false },
   { path: '/activities', component: ActivitiesPage, nonPrivate: true },
   { path: '/budget', component: Budget, nonPrivate: true },
   { component: NoMatch, nonPrivate: true }


### PR DESCRIPTION
https://hitech-apd-pr544.app.cloud.gov/

- makes the main page "protected" (meaning, you have to login)
- on successful login or auth check, go ahead and fetch the user's APDs and use the first one returned as the current APD
  - an "auth check" happens when you first load the page - if you're already logged in, it just proceeds; otherwise it drops you at the login screen
  - there's some future work indicated here: how to pick which APD the user should be looking at, maybe there's a landing page before this, etc.
- populates the application state with the data from the API
- adds a temporary save button that saves the application state to the API

Addresses #394

### This pull request changes...
- can save and resume editing an APD

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- ~The change has been documented~
  - ~Associated OpenAPI documentation has been updated~

### This feature is done when...
- ~Design has approved the experience~
- ~Product has approved the experience~
