### PR TITLE
Fix expense model

### DIFF
--- a/api/db/activity/expense.js
+++ b/api/db/activity/expense.js
@@ -13,13 +13,14 @@ module.exports = {
     toJSON() {
       return {
         id: this.get('id'),
-        name: this.get('name'),
+        description: this.get('description'),
+        category: this.get('category'),
         entries: this.related('entries')
       };
     },
 
     static: {
-      updateableFields: ['name'],
+      updateableFields: ['category', 'description'],
       owns: { entries: 'apdActivityExpenseEntry' },
       foreignKey: 'expense_id'
     }

--- a/api/db/activity/expense.test.js
+++ b/api/db/activity/expense.test.js
@@ -10,7 +10,7 @@ tap.test('expense data model', async expenseModelTests => {
       {
         tableName: 'activity_expenses',
         static: {
-          updateableFields: ['name'],
+          updateableFields: ['category', 'description'],
           owns: { entries: 'apdActivityExpenseEntry' },
           foreignKey: 'expense_id'
         }
@@ -68,14 +68,16 @@ tap.test('expense data model', async expenseModelTests => {
   expenseModelTests.test('overrides toJSON method', async jsonTests => {
     const self = { get: sinon.stub(), related: sinon.stub() };
     self.get.withArgs('id').returns('Jerome Lee');
-    self.get.withArgs('name').returns('at');
+    self.get.withArgs('description').returns('at');
+    self.get.withArgs('category').returns('HHS');
     self.related.withArgs('entries').returns('CMS');
 
     const output = expense.toJSON.bind(self)();
 
     jsonTests.match(output, {
       id: 'Jerome Lee',
-      name: 'at',
+      description: 'at',
+      category: 'HHS',
       entries: 'CMS'
     });
   });

--- a/api/db/activity/expenseEntry.js
+++ b/api/db/activity/expenseEntry.js
@@ -10,13 +10,12 @@ module.exports = {
       return {
         id: this.get('id'),
         year: this.get('year'),
-        amount: this.get('amount'),
-        description: this.get('description')
+        amount: this.get('amount')
       };
     },
 
     static: {
-      updateableFields: ['year', 'amount', 'description']
+      updateableFields: ['year', 'amount']
     }
   }
 };

--- a/api/db/activity/expenseEntry.test.js
+++ b/api/db/activity/expenseEntry.test.js
@@ -10,7 +10,7 @@ tap.test('expense entry data model', async expenseEntryModelTests => {
       {
         tableName: 'activity_expense_entries',
         static: {
-          updateableFields: ['year', 'amount', 'description']
+          updateableFields: ['year', 'amount']
         }
       },
       'get the expected model definitions'
@@ -44,16 +44,14 @@ tap.test('expense entry data model', async expenseEntryModelTests => {
     const self = { get: sinon.stub() };
     self.get.withArgs('id').returns('Sharks');
     self.get.withArgs('year').returns('drown');
-    self.get.withArgs('amount').returns('if');
-    self.get.withArgs('description').returns('immobile');
+    self.get.withArgs('amount').returns('if immobile');
 
     const output = expenseEntry.toJSON.bind(self)();
 
     jsonTests.match(output, {
       id: 'Sharks',
       year: 'drown',
-      amount: 'if',
-      description: 'immobile'
+      amount: 'if immobile'
     });
   });
 });

--- a/api/migrations/20180516002722_fix-expense-model.js
+++ b/api/migrations/20180516002722_fix-expense-model.js
@@ -1,0 +1,13 @@
+exports.up = async knex => {
+  await knex.schema.alterTable('activity_expenses', table => {
+    table.text('description');
+    table.text('category');
+    table.dropColumn('name');
+  });
+
+  await knex.schema.alterTable('activity_expense_entries', table => {
+    table.dropColumn('description');
+  });
+};
+
+exports.down = async () => {};


### PR DESCRIPTION
Moves the `description` field out of the expense years and into the expense itself.  Drops the `name` field, adds a `category` field.

Closes #548

### This pull request changes...
- no visible changes

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- ~The change has been documented~
  - ~Associated OpenAPI documentation has been updated~

### This feature is done when...
- ~Design has approved the experience~
- ~Product has approved the experience~
