### PR TITLE
Fix nightly CircleCI task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,6 +192,7 @@ jobs:
     docker:
       - image: node:8
     steps:
+      - checkout
       - run:
           name: run nightly script
           command: ./bin/nightly.sh


### PR DESCRIPTION
Currently attempts to run a script that exists in our repo without first checking out the repo.  Whoops, can't run code that isn't there.  :)  This fix adds a checkout step before trying to run the script.

### This pull request changes...
- the nightly CI script that prunes unneeded PR-specific deploys will run

### This pull request is ready to merge when...
- ~Tests have been updated (and all tests are passing)~
- [ ] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- ~The change has been documented~
  - ~Associated OpenAPI documentation has been updated~

### This feature is done when...
- ~Design has approved the experience~
- ~Product has approved the experience~
