### PR TITLE
Removed help text to skip HIT Narrative sections.

### DIFF
--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -52,7 +52,7 @@
     "hit": {
       "title": "HIT Narrative",
       "helpText":
-        "Briefly summarize your program HIT activities contained within this APD. If you don't have any HIT activities, you can skip this section."
+        "Briefly summarize your program HIT activities contained within this APD."
     },
     "hie": {
       "title": "HIE Narrative",


### PR DESCRIPTION
This is required for all submissions, so adjusting help text to reflect this. HIE and MMIS sections are optional, so this text can remain, but it should be removed for HIT.


### This pull request changes...
- HIT Overview section help text.

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author

### This feature is done when...
- [x] Design has approved the experience
