### PR TITLE
Fix contractor resources date strings

### DIFF
--- a/api/db/activity/contractorResource.js
+++ b/api/db/activity/contractorResource.js
@@ -1,5 +1,7 @@
 const moment = require('moment');
 
+const getDate = date => (date ? moment(date).format('YYYY-MM-DD') : null);
+
 module.exports = {
   apdActivityContractorResource: {
     tableName: 'activity_contractor_resources',
@@ -37,8 +39,8 @@ module.exports = {
         id: this.get('id'),
         name: this.get('name'),
         description: this.get('description'),
-        start: moment(this.get('start')).format('YYYY-MM-DD'),
-        end: moment(this.get('end')).format('YYYY-MM-DD'),
+        start: getDate(this.get('start')),
+        end: getDate(this.get('end')),
         years: this.related('years')
       };
     },

--- a/api/db/activity/schedule.js
+++ b/api/db/activity/schedule.js
@@ -1,5 +1,7 @@
 const moment = require('moment');
 
+const getDate = date => (date ? moment(date).format('YYYY-MM-DD') : null);
+
 module.exports = {
   apdActivitySchedule: {
     tableName: 'activity_schedule',
@@ -49,11 +51,11 @@ module.exports = {
     toJSON() {
       return {
         id: this.get('id'),
-        actualEnd: moment(this.get('actual_end')).format('YYYY-MM-DD'),
-        actualStart: moment(this.get('actual_start')).format('YYYY-MM-DD'),
+        actualEnd: getDate(this.get('actual_end')),
+        actualStart: getDate(this.get('actual_start')),
         milestone: this.get('milestone'),
-        plannedEnd: moment(this.get('planned_end')).format('YYYY-MM-DD'),
-        plannedStart: moment(this.get('planned_start')).format('YYYY-MM-DD'),
+        plannedEnd: getDate(this.get('planned_end')),
+        plannedStart: getDate(this.get('planned_start')),
         status: this.get('status')
       };
     },


### PR DESCRIPTION
Following on from #556, uses the `moment` library to validate dates, and accepts/returns dates as `YYYY-MM-DD` format instead of the full date-time format.

### This pull request changes...
- no visible changes

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- ~The change has been documented~
  - ~Associated OpenAPI documentation has been updated~

### This feature is done when...
- ~Design has approved the experience~
- ~Product has approved the experience~
