### PR TITLE
add markdown component

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -772,7 +772,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true,
       "requires": {
         "sprintf-js": "1.0.3"
       }
@@ -4486,8 +4485,7 @@
     "entities": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
-      "dev": true
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
     },
     "enzyme": {
       "version": "3.3.0",
@@ -9302,6 +9300,18 @@
         "object-visit": "1.0.1"
       }
     },
+    "markdown-it": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.1.tgz",
+      "integrity": "sha512-CzzqSSNkFRUf9vlWvhK1awpJreMRqdCrBvZ8DIoDWTOkESMIF741UPAhuAmbyWmdiFPA6WARNhnu2M6Nrhwa+A==",
+      "requires": {
+        "argparse": "1.0.9",
+        "entities": "1.1.1",
+        "linkify-it": "2.0.3",
+        "mdurl": "1.0.1",
+        "uc.micro": "1.0.5"
+      }
+    },
     "markdown-loader": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/markdown-loader/-/markdown-loader-2.0.2.tgz",
@@ -9345,6 +9355,11 @@
           }
         }
       }
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -14511,8 +14526,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.13.1",

--- a/web/package.json
+++ b/web/package.json
@@ -56,6 +56,7 @@
     "html-to-draftjs": "^1.3.0",
     "i18n-js": "^3.0.3",
     "lodash.kebabcase": "^4.1.1",
+    "markdown-it": "^8.4.1",
     "numeral": "^2.0.6",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",

--- a/web/src/components/Md.js
+++ b/web/src/components/Md.js
@@ -1,0 +1,22 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import md from '../util/md';
+
+const Md = ({ content, wrapper: Wrapper, ...rest }) => (
+  <Wrapper
+    dangerouslySetInnerHTML={{ __html: md.renderInline(content) }}
+    {...rest}
+  />
+);
+
+Md.propTypes = {
+  content: PropTypes.string.isRequired,
+  wrapper: PropTypes.string
+};
+
+Md.defaultProps = {
+  wrapper: 'span'
+};
+
+export default Md;

--- a/web/src/i18n/index.js
+++ b/web/src/i18n/index.js
@@ -27,14 +27,8 @@ export const initI18n = () => {
 };
 
 export const t =
-  process.env.NODE_ENV === 'production'
-    ? (name, params = {}) => I18n.t(name, params)
-    : (name, params = {}) => {
-        // eslint-disable-next-line no-restricted-globals
-        if (location.hash.includes('i18n')) {
-          return `[${Array.isArray(name) ? name.join('.') : name}]`;
-        }
-        return I18n.t(name, params);
-      };
+  process.env.NODE_ENV !== 'production' && window.location.hash.includes('i18n')
+    ? name => `[${Array.isArray(name) ? name.join('.') : name}]`
+    : (name, params = {}) => I18n.t(name, params);
 
 export default I18n;

--- a/web/src/util/md.js
+++ b/web/src/util/md.js
@@ -1,0 +1,5 @@
+import MarkdownIt from 'markdown-it';
+
+const md = new MarkdownIt({ xhtmlOut: true, breaks: true });
+
+export default md;


### PR DESCRIPTION
I did a bunch of experimenting with a good way to integrate our translation strings with markdown support. Wasn't super happy with any of the component APIs I was creating, but here's something to get the conversation started. I'm very happy with alternative ideas.

This keeps the translations strings and the convert-markdown-to-html steps separate, mainly because there are times when we want both i think.

Example usage of this component:
`<Md wrapper="h3" content={t('apd.helpText')} className="regular h1" />`

The wrapper represents the enclosing html element and any additional props (i.e.,  `className`) get passed along too. Why `md.renderInline` and not `md.render`? Because `render` adds paragraph tags around the text which we probably don't want. I would like to support passing in either an element string or a component, but that can come down the road. (i.e., `Md wrapper={SectionTitle}... `)

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
