### PR TITLE
add form field masking

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13308,6 +13308,14 @@
         "prop-types": "15.6.0"
       }
     },
+    "react-text-mask": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/react-text-mask/-/react-text-mask-5.4.1.tgz",
+      "integrity": "sha512-mGx1n0x0skktwsKcpgAGnrgExFlXDflbWEHh8PC1UaQP8+EdHkW7JYczTghsBo2rnVwU9/4A9x/2bVt3HY46/w==",
+      "requires": {
+        "prop-types": "15.6.0"
+      }
+    },
     "react-transition-group": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
@@ -15070,6 +15078,11 @@
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+    },
+    "text-mask-addons": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/text-mask-addons/-/text-mask-addons-3.7.2.tgz",
+      "integrity": "sha512-uezfAuWcDJ/B/lu5ooz38DEdI8NfIVX2xKwshLs40Er8MBGSppklOqOYw32wEmCUP7XPVX2u3u2TdQcIRuBLXA=="
     },
     "text-table": {
       "version": "0.2.0",

--- a/web/package.json
+++ b/web/package.json
@@ -65,9 +65,11 @@
     "react-redux": "^5.0.7",
     "react-router-dom": "^4.2.2",
     "react-router-redux": "^5.0.0-alpha.9",
+    "react-text-mask": "^5.4.1",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",
     "sinon": "^4.4.2",
+    "text-mask-addons": "^3.7.2",
     "tippy.js": "^2.5.0",
     "updeep": "^1.0.0"
   },

--- a/web/src/components/Inputs.js
+++ b/web/src/components/Inputs.js
@@ -4,6 +4,7 @@ import { Editor } from 'react-draft-wysiwyg';
 import TextMask from 'react-text-mask';
 
 import { EDITOR_CONFIG, htmlToEditor, editorToHtml } from '../util/editor';
+import MASKS from '../util/masks';
 
 class RichText extends Component {
   constructor(props) {
@@ -43,10 +44,47 @@ RichText.defaultProps = {
 };
 
 const Input = props => <input className="m0 input" {...props} />;
-const MaskedInput = props => <TextMask className="m0 input mono" {...props} />;
 const Textarea = props => (
   <textarea className="m0 textarea" spellCheck="true" {...props} />
 );
+
+const makeMaskedInput = ({ mask, unmask }) => {
+  // TODO: split some of these components into their own file
+  // eslint-disable-next-line react/no-multi-comp
+  class MaskedInput extends Component {
+    handleChange = e => {
+      if (!this.props.onChange) return;
+
+      const { value } = e.target;
+      const newEvent = { target: { value: unmask(value), masked: value } };
+
+      this.props.onChange(newEvent);
+    };
+
+    render() {
+      const { onChange, ...rest } = this.props;
+
+      return (
+        <TextMask
+          mask={mask}
+          className="m0 input mono"
+          onChange={this.handleChange}
+          {...rest}
+        />
+      );
+    }
+  }
+
+  MaskedInput.propTypes = {
+    onChange: PropTypes.func
+  };
+
+  MaskedInput.defaultProps = {
+    onChange: null
+  };
+
+  return MaskedInput;
+};
 
 // a HOC for Text / Textarea input that includes
 // div wrapper and accompanying label
@@ -92,12 +130,14 @@ makeInput.propTypes = {
 };
 
 const InputHolder = makeInput(Input);
-const MaskedInputHolder = makeInput(MaskedInput);
 const TextareaHolder = makeInput(Textarea);
+const DollarInputHolder = makeInput(makeMaskedInput(MASKS.dollar));
+const PercentInputHolder = makeInput(makeMaskedInput(MASKS.percent));
 
 export {
   InputHolder as Input,
-  MaskedInputHolder as MaskedInput,
   TextareaHolder as Textarea,
+  DollarInputHolder as DollarInput,
+  PercentInputHolder as PercentInput,
   RichText
 };

--- a/web/src/components/Inputs.js
+++ b/web/src/components/Inputs.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Editor } from 'react-draft-wysiwyg';
+import TextMask from 'react-text-mask';
 
 import { EDITOR_CONFIG, htmlToEditor, editorToHtml } from '../util/editor';
 
@@ -42,6 +43,7 @@ RichText.defaultProps = {
 };
 
 const Input = props => <input className="m0 input" {...props} />;
+const MaskedInput = props => <TextMask className="m0 input mono" {...props} />;
 const Textarea = props => (
   <textarea className="m0 textarea" spellCheck="true" {...props} />
 );
@@ -90,6 +92,12 @@ makeInput.propTypes = {
 };
 
 const InputHolder = makeInput(Input);
+const MaskedInputHolder = makeInput(MaskedInput);
 const TextareaHolder = makeInput(Textarea);
 
-export { InputHolder as Input, TextareaHolder as Textarea, RichText };
+export {
+  InputHolder as Input,
+  MaskedInputHolder as MaskedInput,
+  TextareaHolder as Textarea,
+  RichText
+};

--- a/web/src/containers/ActivityDetailContractorResources.js
+++ b/web/src/containers/ActivityDetailContractorResources.js
@@ -9,8 +9,9 @@ import {
   updateActivity as updateActivityAction
 } from '../actions/activities';
 import Collapsible from '../components/Collapsible';
-import { Input, Textarea } from '../components/Inputs';
+import { Input, MaskedInput, Textarea } from '../components/Inputs';
 import HelpText from '../components/HelpText';
+import { dollarMask } from '../util/masks';
 
 class ActivityDetailContractorExpenses extends Component {
   handleChange = (index, key) => e => {
@@ -26,7 +27,7 @@ class ActivityDetailContractorExpenses extends Component {
     const { activity, updateActivity } = this.props;
 
     const updates = {
-      contractorResources: { [index]: { years: { [year]: +value } } }
+      contractorResources: { [index]: { years: { [year]: value } } }
     };
     updateActivity(activity.id, updates);
   };
@@ -138,14 +139,14 @@ class ActivityDetailContractorExpenses extends Component {
                     </td>
                     {years.map(year => (
                       <td key={year}>
-                        <Input
+                        <MaskedInput
+                          mask={dollarMask}
                           name={`contractor-${i}-cost-${year}`}
                           label={t(
                             'activities.contractorResources.srLabels.cost',
                             { year }
                           )}
                           hideLabel
-                          type="number"
                           value={contractor.years[year]}
                           onChange={this.handleYearChange(i, year)}
                         />

--- a/web/src/containers/ActivityDetailContractorResources.js
+++ b/web/src/containers/ActivityDetailContractorResources.js
@@ -9,9 +9,8 @@ import {
   updateActivity as updateActivityAction
 } from '../actions/activities';
 import Collapsible from '../components/Collapsible';
-import { Input, MaskedInput, Textarea } from '../components/Inputs';
+import { Input, DollarInput, Textarea } from '../components/Inputs';
 import HelpText from '../components/HelpText';
-import { dollarMask } from '../util/masks';
 
 class ActivityDetailContractorExpenses extends Component {
   handleChange = (index, key) => e => {
@@ -139,8 +138,7 @@ class ActivityDetailContractorExpenses extends Component {
                     </td>
                     {years.map(year => (
                       <td key={year}>
-                        <MaskedInput
-                          mask={dollarMask}
+                        <DollarInput
                           name={`contractor-${i}-cost-${year}`}
                           label={t(
                             'activities.contractorResources.srLabels.cost',

--- a/web/src/containers/ActivityDetailCostAllocate.js
+++ b/web/src/containers/ActivityDetailCostAllocate.js
@@ -5,8 +5,9 @@ import { connect } from 'react-redux';
 import { t } from '../i18n';
 import { updateActivity as updateActivityAction } from '../actions/activities';
 import Collapsible from '../components/Collapsible';
-import { Input, RichText } from '../components/Inputs';
+import { MaskedInput, RichText } from '../components/Inputs';
 import HelpText from '../components/HelpText';
+import { dollarMask } from '../util/masks';
 
 const ActivityDetailCostAllocate = props => {
   const { activity, updateActivity } = props;
@@ -44,7 +45,8 @@ const ActivityDetailCostAllocate = props => {
           onSync={sync('otherFundingDesc')}
         />
       </div>
-      <Input
+      <MaskedInput
+        mask={dollarMask}
         name="other-funding-amt"
         label={t('activities.costAllocate.label.otherFundingAmt')}
         wrapperClass="mb2 sm-col-4"

--- a/web/src/containers/ActivityDetailCostAllocate.js
+++ b/web/src/containers/ActivityDetailCostAllocate.js
@@ -5,9 +5,8 @@ import { connect } from 'react-redux';
 import { t } from '../i18n';
 import { updateActivity as updateActivityAction } from '../actions/activities';
 import Collapsible from '../components/Collapsible';
-import { MaskedInput, RichText } from '../components/Inputs';
+import { DollarInput, RichText } from '../components/Inputs';
 import HelpText from '../components/HelpText';
-import { dollarMask } from '../util/masks';
 
 const ActivityDetailCostAllocate = props => {
   const { activity, updateActivity } = props;
@@ -45,8 +44,7 @@ const ActivityDetailCostAllocate = props => {
           onSync={sync('otherFundingDesc')}
         />
       </div>
-      <MaskedInput
-        mask={dollarMask}
+      <DollarInput
         name="other-funding-amt"
         label={t('activities.costAllocate.label.otherFundingAmt')}
         wrapperClass="mb2 sm-col-4"

--- a/web/src/containers/ActivityDetailExpenses.js
+++ b/web/src/containers/ActivityDetailExpenses.js
@@ -8,10 +8,9 @@ import {
   updateActivity as updateActivityAction
 } from '../actions/activities';
 import Collapsible from '../components/Collapsible';
-import { MaskedInput, Textarea } from '../components/Inputs';
+import { DollarInput, Textarea } from '../components/Inputs';
 import Select from '../components/Select';
 import HelpText from '../components/HelpText';
-import { dollarMask } from '../util/masks';
 
 class ActivityDetailExpenses extends Component {
   handleChange = (index, key) => e => {
@@ -92,8 +91,7 @@ class ActivityDetailExpenses extends Component {
                   </td>
                   {years.map(year => (
                     <td key={year}>
-                      <MaskedInput
-                        mask={dollarMask}
+                      <DollarInput
                         name={`expense-${i}-${year}-cost`}
                         label={`Cost for ${year}`}
                         hideLabel

--- a/web/src/containers/ActivityDetailExpenses.js
+++ b/web/src/containers/ActivityDetailExpenses.js
@@ -8,9 +8,10 @@ import {
   updateActivity as updateActivityAction
 } from '../actions/activities';
 import Collapsible from '../components/Collapsible';
-import { Input, Textarea } from '../components/Inputs';
+import { MaskedInput, Textarea } from '../components/Inputs';
 import Select from '../components/Select';
 import HelpText from '../components/HelpText';
+import { dollarMask } from '../util/masks';
 
 class ActivityDetailExpenses extends Component {
   handleChange = (index, key) => e => {
@@ -25,7 +26,7 @@ class ActivityDetailExpenses extends Component {
     const { value } = e.target;
     const { activity, updateActivity } = this.props;
 
-    const updates = { expenses: { [index]: { years: { [year]: +value } } } };
+    const updates = { expenses: { [index]: { years: { [year]: value } } } };
     updateActivity(activity.id, updates);
   };
 
@@ -91,11 +92,11 @@ class ActivityDetailExpenses extends Component {
                   </td>
                   {years.map(year => (
                     <td key={year}>
-                      <Input
+                      <MaskedInput
+                        mask={dollarMask}
                         name={`expense-${i}-${year}-cost`}
                         label={`Cost for ${year}`}
                         hideLabel
-                        type="number"
                         value={expense.years[year]}
                         onChange={this.handleYearChange(i, year)}
                       />

--- a/web/src/containers/ActivityDetailStatePersonnel.js
+++ b/web/src/containers/ActivityDetailStatePersonnel.js
@@ -8,10 +8,14 @@ import {
   updateActivity as updateActivityAction
 } from '../actions/activities';
 import Collapsible from '../components/Collapsible';
-import { Input, MaskedInput, Textarea } from '../components/Inputs';
+import {
+  Input,
+  DollarInput,
+  PercentInput,
+  Textarea
+} from '../components/Inputs';
 import HelpText from '../components/HelpText';
 import { t } from '../i18n';
-import { dollarMask, percentMask } from '../util/masks';
 
 class ActivityDetailStatePersonnel extends Component {
   handleChange = (idx, key, year) => e => {
@@ -103,8 +107,7 @@ class ActivityDetailStatePersonnel extends Component {
                   {years.map(year => (
                     <Fragment key={year}>
                       <td>
-                        <MaskedInput
-                          mask={dollarMask}
+                        <DollarInput
                           name={`state-person-${d.id}-${year}-amt`}
                           label={t('activities.statePersonnel.labels.costAmt')}
                           hideLabel
@@ -113,8 +116,7 @@ class ActivityDetailStatePersonnel extends Component {
                         />
                       </td>
                       <td>
-                        <MaskedInput
-                          mask={percentMask}
+                        <PercentInput
                           name={`state-person-${d.id}-${year}-perc`}
                           label={t('activities.statePersonnel.labels.costPerc')}
                           hideLabel

--- a/web/src/containers/ActivityDetailStatePersonnel.js
+++ b/web/src/containers/ActivityDetailStatePersonnel.js
@@ -8,9 +8,10 @@ import {
   updateActivity as updateActivityAction
 } from '../actions/activities';
 import Collapsible from '../components/Collapsible';
-import { Input, Textarea } from '../components/Inputs';
+import { Input, MaskedInput, Textarea } from '../components/Inputs';
 import HelpText from '../components/HelpText';
 import { t } from '../i18n';
+import { dollarMask, percentMask } from '../util/masks';
 
 class ActivityDetailStatePersonnel extends Component {
   handleChange = (idx, key, year) => e => {
@@ -102,7 +103,8 @@ class ActivityDetailStatePersonnel extends Component {
                   {years.map(year => (
                     <Fragment key={year}>
                       <td>
-                        <Input
+                        <MaskedInput
+                          mask={dollarMask}
                           name={`state-person-${d.id}-${year}-amt`}
                           label={t('activities.statePersonnel.labels.costAmt')}
                           hideLabel
@@ -111,8 +113,9 @@ class ActivityDetailStatePersonnel extends Component {
                         />
                       </td>
                       <td>
-                        <Input
-                          name={`state-person-${d.id}-${year}-amt`}
+                        <MaskedInput
+                          mask={percentMask}
+                          name={`state-person-${d.id}-${year}-perc`}
                           label={t('activities.statePersonnel.labels.costPerc')}
                           hideLabel
                           value={d.years[year].perc}

--- a/web/src/util/masks.js
+++ b/web/src/util/masks.js
@@ -1,6 +1,7 @@
 import createNumberMask from 'text-mask-addons/dist/createNumberMask';
 
-const toNum = x => (x.length ? +x.replace(/\D+/g, '') : '');
+// eslint-disable-next-line no-useless-escape
+const toNum = x => (x.length ? +x.replace(/[^0-9\.]+/g, '') : '');
 
 const MASKS = {
   dollar: {

--- a/web/src/util/masks.js
+++ b/web/src/util/masks.js
@@ -1,0 +1,4 @@
+import createNumberMask from 'text-mask-addons/dist/createNumberMask';
+
+export const dollarMask = createNumberMask({ allowDecimal: true });
+export const percentMask = createNumberMask({ suffix: '%', prefix: '' });

--- a/web/src/util/masks.js
+++ b/web/src/util/masks.js
@@ -1,4 +1,16 @@
 import createNumberMask from 'text-mask-addons/dist/createNumberMask';
 
-export const dollarMask = createNumberMask({ allowDecimal: true });
-export const percentMask = createNumberMask({ suffix: '%', prefix: '' });
+const toNum = x => (x.length ? +x.replace(/\D+/g, '') : '');
+
+const MASKS = {
+  dollar: {
+    mask: createNumberMask({ allowDecimal: true }),
+    unmask: toNum
+  },
+  percent: {
+    mask: createNumberMask({ suffix: '%', prefix: '' }),
+    unmask: toNum
+  }
+};
+
+export default MASKS;


### PR DESCRIPTION
### This pull request...
- adds this nifty library (https://text-mask.github.io/text-mask/) so we can have nicely formatted inputs as users type stuff
- adds dollar and percent `MaskedInput`s to the appropriate activity form fields 

Addresses: https://github.com/18F/cms-hitech-apd/issues/515

Preview:
https://cl.ly/rdPp

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author

### This feature is done when...
- [ ] Design has approved the experience
