### PR TITLE
Zip web build on deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,9 @@ jobs:
       - run:
           name: deploy to prod
           command: ./bin/deploy.sh
+      - store_artifacts:
+          path: /tmp/webapp.zip
+          destination: build
 
   deploy pr:
     docker:

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -7,6 +7,9 @@ set -e
 
 export API_URL=$STAGING_API_URL
 
+apt-get update
+apt-get install zip -y
+
 # Install `cf` cli
 curl -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&source=github'
 dpkg -i cf-cli_amd64.deb
@@ -19,6 +22,7 @@ cf install-plugin autopilot -f -r CF-Community
 cd web
 npm ci
 npm run build
+zip -r /tmp/webapp.zip dist/*
 cd ..
 
 # Don't deliver seed files that might be dangerous.


### PR DESCRIPTION
Make the built webapp available as a zip file.  It's stored as a CircleCI build artifact.  This one is for @NAretakis.  🙂

### This pull request changes...
- after merges to master, the most recent webapp build will be available as a CircleCI artifact for downloading and _doing whatever you want_ with

### This pull request is ready to merge when...
- [ ] This code has been reviewed by someone other than the original author