### PR TITLE
img upload in wysiwyg

### DIFF
--- a/web/src/styles/app/editor.css
+++ b/web/src/styles/app/editor.css
@@ -18,12 +18,16 @@
   border-radius: var(--border-radius);
 }
 
+.rdw-emoji-modal {
+  height: auto;
+}
+
 .rdw-editor-main {
   overflow: inherit;
 }
 
 .DraftEditor-root {
-  height: 15rem;
+  height: 400px;
 }
 
 .public-DraftEditor-content {

--- a/web/src/util/editor.js
+++ b/web/src/util/editor.js
@@ -15,10 +15,44 @@ export const editorToHtml = editorState => {
   return draftToHtml(content);
 };
 
+const uploadImageCallBack = file =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = e => resolve({ data: { link: e.target.result } });
+    reader.onerror = e => reject(e);
+    reader.readAsDataURL(file);
+  });
+
 export const EDITOR_CONFIG = {
-  options: ['inline', 'blockType', 'fontSize', 'image', 'list', 'link'],
+  options: [
+    'inline',
+    'blockType',
+    'fontSize',
+    'emoji',
+    'image',
+    'list',
+    'link'
+  ],
   inline: {
     options: ['bold', 'italic', 'underline']
+  },
+  emoji: {
+    emojis: [
+      '😀',
+      '😉',
+      '😎',
+      '👈',
+      '👉',
+      '👉',
+      '👆',
+      '👌',
+      '👍',
+      '👎',
+      '💰',
+      '📅',
+      '✅',
+      '❎'
+    ]
   },
   image: {
     className: undefined,
@@ -26,9 +60,9 @@ export const EDITOR_CONFIG = {
     popupClassName: undefined,
     urlEnabled: true,
     uploadEnabled: true,
-    alignmentEnabled: true,
-    uploadCallback: undefined,
-    previewImage: false,
+    alignmentEnabled: false,
+    uploadCallback: uploadImageCallBack,
+    previewImage: true,
     inputAccept: 'image/gif,image/jpeg,image/jpg,image/png,image/svg',
     alt: { present: false, mandatory: false },
     defaultSize: {


### PR DESCRIPTION
### This pull request...
* adds image upload capability in the wysiwyg editor; upon a successful image upload, a base64 data-URI is generated and added to the editor content (what's nice about this is that we don't have to worry about storing images somewhere, like imgur or an s3 bucket, though maybe this adds too much bulk to the store/db...)

Preview:
https://cl.ly/rmeH

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author

### This feature is done when...
- [ ] Product has approved the experience
