### PR TITLE
Add standard text elements to sections/subsections

### DIFF
--- a/web/src/components/AssurancesAndCompliance.js
+++ b/web/src/components/AssurancesAndCompliance.js
@@ -1,27 +1,21 @@
 import React from 'react';
 
-import { t } from '../i18n';
-import Section from './Section';
-import SectionDesc from './SectionDesc';
-import SectionTitle from './SectionTitle';
-import Collapsible from './Collapsible';
+import { Section, Subsection } from './Section';
 
 const AssurancesAndCompliance = () => (
-  <Section id="assurances-compliance">
-    <SectionTitle>{t('assurancesAndCompliance.title')}</SectionTitle>
-    <SectionDesc>{t('assurancesAndCompliance.helpText')}</SectionDesc>
-    <Collapsible title="Procurement Standards">
+  <Section id="assurances-compliance" resource="assurancesAndCompliance">
+    <Subsection resource="assurancesAndCompliance.procurement">
       <div>...</div>
-    </Collapsible>
-    <Collapsible title="Access to Records">
+    </Subsection>
+    <Subsection resource="assurancesAndCompliance.recordsAccess">
       <div>...</div>
-    </Collapsible>
-    <Collapsible title="Software Rights">
+    </Subsection>
+    <Subsection resource="assurancesAndCompliance.softwareRights">
       <div>...</div>
-    </Collapsible>
-    <Collapsible title="Security">
+    </Subsection>
+    <Subsection resource="assurancesAndCompliance.security">
       <div>...</div>
-    </Collapsible>
+    </Subsection>
   </Section>
 );
 

--- a/web/src/components/CertifyAndSubmit.js
+++ b/web/src/components/CertifyAndSubmit.js
@@ -1,18 +1,12 @@
 import React from 'react';
 
-import { t } from '../i18n';
-import Section from './Section';
-import SectionDesc from './SectionDesc';
-import SectionTitle from './SectionTitle';
-import Collapsible from './Collapsible';
+import { Section, Subsection } from './Section';
 
 const CertifyAndSubmit = () => (
-  <Section id="certify-submit">
-    <SectionTitle>{t('certifyAndSubmit.title')}</SectionTitle>
-    <SectionDesc>{t('certifyAndSubmit.helpText')}</SectionDesc>
-    <Collapsible title="Certify and Submit">
+  <Section id="certify-submit" resource="certifyAndSubmit">
+    <Subsection resource="certifyAndSubmit.certify">
       <div>...</div>
-    </Collapsible>
+    </Subsection>
   </Section>
 );
 

--- a/web/src/components/ExecutiveSummary.js
+++ b/web/src/components/ExecutiveSummary.js
@@ -1,21 +1,15 @@
 import React from 'react';
 
-import { t } from '../i18n';
-import Section from './Section';
-import SectionDesc from './SectionDesc';
-import SectionTitle from './SectionTitle';
-import Collapsible from './Collapsible';
+import { Section, Subsection } from './Section';
 
 const ExecutiveSummary = () => (
-  <Section id="executive-summary">
-    <SectionTitle>{t('executiveSummary.title')}</SectionTitle>
-    <SectionDesc>{t('executiveSummary.helpText')}</SectionDesc>
-    <Collapsible title="Executive Summary">
+  <Section id="executive-summary" resource="executiveSummary">
+    <Subsection resource="executiveSummary.summary">
       <div>...</div>
-    </Collapsible>
-    <Collapsible title="Program Budget Table">
+    </Subsection>
+    <Subsection resource="executiveSummary.budgetTable">
       <div>...</div>
-    </Collapsible>
+    </Subsection>
   </Section>
 );
 

--- a/web/src/components/HelpText.js
+++ b/web/src/components/HelpText.js
@@ -3,12 +3,17 @@ import PropTypes from 'prop-types';
 
 import { t } from '../i18n';
 
-const HelpText = ({ text, reminder }) => (
-  <div className="mb2" style={{ whiteSpace: 'pre-line' }}>
-    <div>{t(text)}</div>
-    {reminder ? <div className="red">{t(reminder)}</div> : null}
-  </div>
-);
+const HelpText = ({ text: textResource, reminder: reminderResource }) => {
+  const text = t(textResource, { defaultValue: false });
+  const reminder = t(reminderResource, { defaultValue: false });
+
+  return (
+    <div className="mb2" style={{ whiteSpace: 'pre-line' }}>
+      {text && <div>{text}</div>}
+      {reminder && <div className="red">{reminder}</div>}
+    </div>
+  );
+};
 
 HelpText.propTypes = {
   text: PropTypes.string.isRequired,

--- a/web/src/components/PreviousActivities.js
+++ b/web/src/components/PreviousActivities.js
@@ -1,24 +1,18 @@
 import React from 'react';
 
-import { t } from '../i18n';
-import Section from './Section';
-import SectionDesc from './SectionDesc';
-import SectionTitle from './SectionTitle';
-import Collapsible from './Collapsible';
+import { Section, Subsection } from './Section';
 
 const PreviousActivities = () => (
-  <Section id="prev-activities">
-    <SectionTitle>{t('previousActivities.title')}</SectionTitle>
-    <SectionDesc>{t('previousActivities.helpText')}</SectionDesc>
-    <Collapsible title={t('previousActivities.sections.outline')}>
+  <Section id="prev-activities" resource="previousActivities">
+    <Subsection resource="previousActivities.outline">
       <div>...</div>
-    </Collapsible>
-    <Collapsible title={t('previousActivities.sections.approvedExpenses')}>
+    </Subsection>
+    <Subsection resource="previousActivities.approvedExpenses">
       <div>...</div>
-    </Collapsible>
-    <Collapsible title={t('previousActivities.sections.actualExpenses')}>
+    </Subsection>
+    <Subsection resource="previousActivities.actualExpenses">
       <div>...</div>
-    </Collapsible>
+    </Subsection>
   </Section>
 );
 

--- a/web/src/components/ProposedBudget.js
+++ b/web/src/components/ProposedBudget.js
@@ -1,22 +1,16 @@
 import React from 'react';
 
 import BudgetSummary from './BudgetSummary';
-import Collapsible from './Collapsible';
-import Section from './Section';
-import SectionDesc from './SectionDesc';
-import SectionTitle from './SectionTitle';
-import { t } from '../i18n';
+import { Section, Subsection } from './Section';
 
 const ProposedBudget = () => (
-  <Section id="budget">
-    <SectionTitle>{t('proposedBudget.title')}</SectionTitle>
-    <SectionDesc>{t('proposedBudget.helpText')}</SectionDesc>
-    <Collapsible title="Proposed Detailed Budget Table">
+  <Section id="budget" resource="proposedBudget">
+    <Subsection resource="proposedBudget.summaryBudget">
       <BudgetSummary />
-    </Collapsible>
-    <Collapsible title="Incentive Payments by FFY Quarter">
+    </Subsection>
+    <Subsection resource="proposedBudget.paymentsByFFYQuarter">
       <div>...</div>
-    </Collapsible>
+    </Subsection>
   </Section>
 );
 

--- a/web/src/components/Section.js
+++ b/web/src/components/Section.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Fragment } from 'react';
 import Collapsible from './Collapsible';
 import HelpText from './HelpText';
 import SectionTitle from './SectionTitle';
@@ -32,14 +32,13 @@ Section.defaultProps = {
   resource: null
 };
 
-const Subsection = ({ children, open, resource }) => {
-  const title = t([resource, 'title'], { defaultValue: false });
+const Chunk = ({ children, resource }) => {
   const subheader = t([resource, 'subheader'], { defaultValue: false });
   const helptext = t([resource, 'helpText'], { defaultValue: false });
 
   return (
-    <Collapsible title={title} open={open}>
-      {subheader && <div>{subheader}</div>}
+    <Fragment>
+      {subheader && <div className="mb-tiny bold">{subheader}</div>}
       {helptext && (
         <HelpText
           text={`${resource}.helpText`}
@@ -47,6 +46,24 @@ const Subsection = ({ children, open, resource }) => {
         />
       )}
       {children}
+    </Fragment>
+  );
+};
+Chunk.propTypes = {
+  children: PropTypes.node.isRequired,
+  resource: PropTypes.string
+};
+
+Chunk.defaultProps = {
+  resource: null
+};
+
+const Subsection = ({ children, open, resource }) => {
+  const title = t([resource, 'title'], { defaultValue: '' });
+
+  return (
+    <Collapsible title={title} open={open}>
+      <Chunk resource={resource}>{children}</Chunk>
     </Collapsible>
   );
 };
@@ -63,4 +80,4 @@ Subsection.defaultProps = {
 };
 
 export default Section;
-export { Section, Subsection };
+export { Chunk, Section, Subsection };

--- a/web/src/components/Section.js
+++ b/web/src/components/Section.js
@@ -1,19 +1,64 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import Collapsible from './Collapsible';
+import HelpText from './HelpText';
+import SectionTitle from './SectionTitle';
+import SectionDesc from './SectionDesc';
+import { t } from '../i18n';
 
-const Section = ({ children, id }) => (
-  <section id={id} className="p2 sm-px3 border-bottom border-gray">
-    {children}
-  </section>
-);
+const Section = ({ children, id, resource }) => {
+  const title = t([resource, 'title'], { defaultValue: false });
+  const subheader = t([resource, 'subheader'], { defaultValue: false });
+  const helptext = t([resource, 'helpText'], { defaultValue: false });
+
+  return (
+    <section id={id} className="p2 sm-px3 border-bottom border-gray">
+      {title ? <SectionTitle>{title}</SectionTitle> : null}
+      {subheader ? <div>{subheader}</div> : null}
+      {helptext ? <SectionDesc>{helptext}</SectionDesc> : null}
+      {children}
+    </section>
+  );
+};
 
 Section.propTypes = {
   children: PropTypes.node.isRequired,
-  id: PropTypes.string
+  id: PropTypes.string,
+  resource: PropTypes.string
 };
 
 Section.defaultProps = {
-  id: null
+  id: null,
+  resource: null
+};
+
+const Subsection = ({ children, resource }) => {
+  const title = t([resource, 'title'], { defaultValue: false });
+  const subheader = t([resource, 'subheader'], { defaultValue: false });
+  const helptext = t([resource, 'helpText'], { defaultValue: false });
+
+  return (
+    <Collapsible title={title}>
+      {subheader ? <div>{subheader}</div> : null}
+      {helptext ? (
+        <HelpText
+          text={`${resource}.helpText`}
+          reminder={`${resource}.reminder`}
+        />
+      ) : null}
+      {children}
+    </Collapsible>
+  );
+};
+
+Subsection.propTypes = {
+  children: PropTypes.node.isRequired,
+  resource: PropTypes.string
+};
+
+Subsection.defaultProps = {
+  resource: null
 };
 
 export default Section;
+export { Section, Subsection };

--- a/web/src/components/Section.js
+++ b/web/src/components/Section.js
@@ -13,9 +13,9 @@ const Section = ({ children, id, resource }) => {
 
   return (
     <section id={id} className="p2 sm-px3 border-bottom border-gray">
-      {title ? <SectionTitle>{title}</SectionTitle> : null}
-      {subheader ? <div>{subheader}</div> : null}
-      {helptext ? <SectionDesc>{helptext}</SectionDesc> : null}
+      {title && <SectionTitle>{title}</SectionTitle>}
+      {subheader && <div>{subheader}</div>}
+      {helptext && <SectionDesc>{helptext}</SectionDesc>}
       {children}
     </section>
   );
@@ -32,20 +32,20 @@ Section.defaultProps = {
   resource: null
 };
 
-const Subsection = ({ children, resource }) => {
+const Subsection = ({ children, open, resource }) => {
   const title = t([resource, 'title'], { defaultValue: false });
   const subheader = t([resource, 'subheader'], { defaultValue: false });
   const helptext = t([resource, 'helpText'], { defaultValue: false });
 
   return (
-    <Collapsible title={title}>
-      {subheader ? <div>{subheader}</div> : null}
-      {helptext ? (
+    <Collapsible title={title} open={open}>
+      {subheader && <div>{subheader}</div>}
+      {helptext && (
         <HelpText
           text={`${resource}.helpText`}
           reminder={`${resource}.reminder`}
         />
-      ) : null}
+      )}
       {children}
     </Collapsible>
   );
@@ -53,11 +53,13 @@ const Subsection = ({ children, resource }) => {
 
 Subsection.propTypes = {
   children: PropTypes.node.isRequired,
+  open: PropTypes.bool,
   resource: PropTypes.string
 };
 
 Subsection.defaultProps = {
-  resource: null
+  resource: null,
+  open: false
 };
 
 export default Section;

--- a/web/src/containers/Activities.js
+++ b/web/src/containers/Activities.js
@@ -6,16 +6,11 @@ import { t } from '../i18n';
 import ActivityDetailAll from './ActivityDetailAll';
 import ActivityListEntry from './ActivityListEntry';
 import { addActivity as addActivityAction } from '../actions/activities';
-import Collapsible from '../components/Collapsible';
-import Section from '../components/Section';
-import SectionDesc from '../components/SectionDesc';
-import SectionTitle from '../components/SectionTitle';
+import { Section, Subsection } from '../components/Section';
 
 const Activities = ({ activityIds, addActivity }) => (
-  <Section id="activities">
-    <SectionTitle>{t('activities.title')}</SectionTitle>
-    <SectionDesc>{t('activities.helpText')}</SectionDesc>
-    <Collapsible title={t('activities.listTitle')} open>
+  <Section id="activities" resource="activities">
+    <Subsection resource="activities.list" open>
       {activityIds.length === 0 ? (
         <div className="mb2 p1 h6 alert">
           {t('activities.noActivityMessage')}
@@ -30,7 +25,7 @@ const Activities = ({ activityIds, addActivity }) => (
       <button type="button" className="btn btn-primary" onClick={addActivity}>
         {t('activities.addActivityButtonText')}
       </button>
-    </Collapsible>
+    </Subsection>
     {activityIds.map((aId, idx) => (
       <ActivityDetailAll key={aId} aId={aId} num={idx + 1} />
     ))}

--- a/web/src/containers/ActivityDetailContractorResources.js
+++ b/web/src/containers/ActivityDetailContractorResources.js
@@ -8,7 +8,7 @@ import {
   removeActivityContractor,
   updateActivity as updateActivityAction
 } from '../actions/activities';
-import Collapsible from '../components/Collapsible';
+import { Subsection } from '../components/Section';
 import { Input, DollarInput, Textarea } from '../components/Inputs';
 import HelpText from '../components/HelpText';
 
@@ -40,9 +40,7 @@ class ActivityDetailContractorExpenses extends Component {
     } = this.props;
 
     return (
-      <Collapsible title={t('activities.contractorResources.title')}>
-        <p className="bold">{t('activities.contractorResources.subheader')}</p>
-        <HelpText text="activities.contractorResources.helpText" />
+      <Subsection resource="activities.contractorResources">
         <div>
           <div className="overflow-auto">
             <table
@@ -176,7 +174,7 @@ class ActivityDetailContractorExpenses extends Component {
         >
           {t('activities.contractorResources.addContractorButtonText')}
         </button>
-      </Collapsible>
+      </Subsection>
     );
   }
 }

--- a/web/src/containers/ActivityDetailContractorResources.js
+++ b/web/src/containers/ActivityDetailContractorResources.js
@@ -10,7 +10,6 @@ import {
 } from '../actions/activities';
 import { Subsection } from '../components/Section';
 import { Input, DollarInput, Textarea } from '../components/Inputs';
-import HelpText from '../components/HelpText';
 
 class ActivityDetailContractorExpenses extends Component {
   handleChange = (index, key) => e => {

--- a/web/src/containers/ActivityDetailCostAllocate.js
+++ b/web/src/containers/ActivityDetailCostAllocate.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 
 import { t } from '../i18n';
 import { updateActivity as updateActivityAction } from '../actions/activities';
-import Collapsible from '../components/Collapsible';
+import { Subsection } from '../components/Section';
 import { DollarInput, RichText } from '../components/Inputs';
 import HelpText from '../components/HelpText';
 
@@ -17,14 +17,14 @@ const ActivityDetailCostAllocate = props => {
   };
 
   return (
-    <Collapsible title={t('activities.costAllocate.title')}>
+    <Subsection resource="activities.costAllocate">
       <div className="mb3">
         <HelpText
-          text="activities.costAllocate.help.costAllocate"
-          reminder="activities.costAllocate.reminder.costAllocate"
+          text="activities.costAllocate.methodology.helpText"
+          reminder="activities.costAllocate.methodology.reminder"
         />
         <div className="mb-tiny bold">
-          {t('activities.costAllocate.label.costAllocateDesc')}
+          {t('activities.costAllocate.methodology.title')}
         </div>
         <RichText
           content={costAllocateDesc}
@@ -33,11 +33,11 @@ const ActivityDetailCostAllocate = props => {
       </div>
       <div className="mb3">
         <HelpText
-          text="activities.costAllocate.help.otherFunding"
-          reminder="activities.costAllocate.reminder.otherFunding"
+          text="activities.costAllocate.otherFunding.helpText"
+          reminder="activities.costAllocate.otherFunding.reminder"
         />
         <div className="mb-tiny bold">
-          {t('activities.costAllocate.label.otherFundingDesc')}
+          {t('activities.costAllocate.otherFunding.title')}
         </div>
         <RichText
           content={otherFundingDesc}
@@ -46,14 +46,14 @@ const ActivityDetailCostAllocate = props => {
       </div>
       <DollarInput
         name="other-funding-amt"
-        label={t('activities.costAllocate.label.otherFundingAmt')}
+        label={t('activities.costAllocate.otherFunding.amount')}
         wrapperClass="mb2 sm-col-4"
         value={activity.otherFundingAmt}
         onChange={e =>
           updateActivity(activity.id, { otherFundingAmt: e.target.value })
         }
       />
-    </Collapsible>
+    </Subsection>
   );
 };
 

--- a/web/src/containers/ActivityDetailDescription.js
+++ b/web/src/containers/ActivityDetailDescription.js
@@ -2,12 +2,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { t } from '../i18n';
 import { updateActivity as updateActivityAction } from '../actions/activities';
-import Collapsible from '../components/Collapsible';
-import Icon, { faHelp } from '../components/Icons';
+import { Chunk, Subsection } from '../components/Section';
 import { RichText } from '../components/Inputs';
-import HelpText from '../components/HelpText';
 
 const ActivityDetailDescription = props => {
   const { activity, updateActivity } = props;
@@ -18,44 +15,34 @@ const ActivityDetailDescription = props => {
   };
 
   return (
-    <Collapsible title={t('activities.description.title')}>
-      <div className="mb-tiny bold">
-        {t('activities.description.summaryHeader')}
-        <Icon icon={faHelp} className="ml-tiny teal" size="sm" />
-      </div>
-      <HelpText text="activities.description.helpText" />
-      <div className="mb3">
-        <textarea
-          className="m0 textarea"
-          rows="5"
-          maxLength="280"
-          spellCheck="true"
-          value={activity.descShort}
-          onChange={e =>
-            updateActivity(activity.id, { descShort: e.target.value })
-          }
-        />
-      </div>
-
-      <div className="mb3">
-        <div className="mb-tiny bold">
-          {t('activities.description.detailHeader')}
-          <Icon icon={faHelp} className="ml-tiny teal" size="sm" />
+    <Subsection resource="activities.description">
+      <Chunk resource="activities.description.summary">
+        <div className="mb3">
+          <textarea
+            className="m0 textarea"
+            rows="5"
+            maxLength="280"
+            spellCheck="true"
+            value={activity.descShort}
+            onChange={e =>
+              updateActivity(activity.id, { descShort: e.target.value })
+            }
+          />
         </div>
-        <RichText content={descLong} onSync={sync('descLong')} />
-      </div>
+      </Chunk>
 
-      <div className="mb3">
-        <div className="mb-tiny bold">
-          {t('activities.description.alternativesHeader')}
+      <Chunk resource="activities.description.detail">
+        <div className="mb3">
+          <RichText content={descLong} onSync={sync('descLong')} />
         </div>
-        <HelpText
-          text="activities.description.alternativesHelpText"
-          reminder="activities.description.alternativesHelpReminder"
-        />
-        <RichText content={altApproach} onSync={sync('altApproach')} />
-      </div>
-    </Collapsible>
+      </Chunk>
+
+      <Chunk resource="activities.description.alternatives">
+        <div className="mb3">
+          <RichText content={altApproach} onSync={sync('altApproach')} />
+        </div>
+      </Chunk>
+    </Subsection>
   );
 };
 // }

--- a/web/src/containers/ActivityDetailExpenses.js
+++ b/web/src/containers/ActivityDetailExpenses.js
@@ -7,10 +7,9 @@ import {
   removeActivityExpense,
   updateActivity as updateActivityAction
 } from '../actions/activities';
-import Collapsible from '../components/Collapsible';
+import { Subsection } from '../components/Section';
 import { DollarInput, Textarea } from '../components/Inputs';
 import Select from '../components/Select';
-import HelpText from '../components/HelpText';
 
 class ActivityDetailExpenses extends Component {
   handleChange = (index, key) => e => {
@@ -38,8 +37,7 @@ class ActivityDetailExpenses extends Component {
     } = this.props;
 
     return (
-      <Collapsible title="Expenses">
-        <HelpText text="activities.expenses.helpText" />
+      <Subsection resource="activities.expenses">
         <div className="overflow-auto">
           <table
             className="mb2 h5 table table-condensed table-fixed"
@@ -122,7 +120,7 @@ class ActivityDetailExpenses extends Component {
         >
           Add expense
         </button>
-      </Collapsible>
+      </Subsection>
     );
   }
 }

--- a/web/src/containers/ActivityDetailGoals.js
+++ b/web/src/containers/ActivityDetailGoals.js
@@ -8,9 +8,8 @@ import {
   removeActivityGoal as removeActivityGoalAction,
   updateActivity as updateActivityAction
 } from '../actions/activities';
-import Collapsible from '../components/Collapsible';
+import { Subsection } from '../components/Section';
 import { Textarea } from '../components/Inputs';
-import HelpText from '../components/HelpText';
 
 class ActivityDetailGoals extends Component {
   handleChange = (idx, key) => e => {
@@ -25,12 +24,7 @@ class ActivityDetailGoals extends Component {
     const { activity, addActivityGoal, removeActivityGoal } = this.props;
 
     return (
-      <Collapsible title={t('activities.goals.title')}>
-        <p className="bold">{t('activities.goals.subheader')}</p>
-        <HelpText
-          text="activities.goals.helpText"
-          reminder="activities.goals.reminder"
-        />
+      <Subsection resource="activities.goals">
         {activity.goals.map((d, i) => (
           <div key={i} className="mb3">
             {activity.goals.length > 1 && (
@@ -66,7 +60,7 @@ class ActivityDetailGoals extends Component {
         >
           {t('activities.goals.addGoalButtonText')}
         </button>
-      </Collapsible>
+      </Subsection>
     );
   }
 }

--- a/web/src/containers/ActivityDetailSchedule.js
+++ b/web/src/containers/ActivityDetailSchedule.js
@@ -8,9 +8,8 @@ import {
   removeActivityMilestone as removeActivityMilestoneAction,
   updateActivity as updateActivityAction
 } from '../actions/activities';
-import Collapsible from '../components/Collapsible';
+import { Subsection } from '../components/Section';
 import { Input } from '../components/Inputs';
-import HelpText from '../components/HelpText';
 
 class ActivityDetailSchedule extends Component {
   handleChange = (idx, key) => e => {
@@ -29,9 +28,7 @@ class ActivityDetailSchedule extends Component {
     } = this.props;
 
     return (
-      <Collapsible title={t('activities.schedule.title')}>
-        <p className="bold">{t('activities.schedule.subheader')}</p>
-        <HelpText text="activities.schedule.helpText" />
+      <Subsection resource="activities.schedule">
         {activity.milestones.length === 0 ? (
           <div className="mb2 p1 h6 alert">
             {t('activities.schedule.noMilestonesNotice')}
@@ -111,7 +108,7 @@ class ActivityDetailSchedule extends Component {
         >
           {t('activities.schedule.addMilestoneButtonText')}
         </button>
-      </Collapsible>
+      </Subsection>
     );
   }
 }

--- a/web/src/containers/ActivityDetailStandardsAndConditions.js
+++ b/web/src/containers/ActivityDetailStandardsAndConditions.js
@@ -5,7 +5,7 @@ import { STANDARDS } from '../util';
 
 import { t } from '../i18n';
 import { updateActivity as updateActivityAction } from '../actions/activities';
-import Collapsible from '../components/Collapsible';
+import { Subsection } from '../components/Section';
 import { Textarea } from '../components/Inputs';
 
 class ActivityDetailStandardsAndConditions extends Component {
@@ -21,26 +21,25 @@ class ActivityDetailStandardsAndConditions extends Component {
     const { activity } = this.props;
 
     return (
-      <Collapsible title={t('activities.standardsAndConditions.title')}>
-        <p className="bold">
-          {t('activities.standardsAndConditions.subheader')}
-        </p>
+      <Subsection resource="activities.standardsAndConditions">
         {STANDARDS.map(std => (
           <div key={std.id}>
-            <h3>{t([`activities.standardsAndConditions`, std.id, 'title'])}</h3>
+            <h3>
+              {t([`activities.standardsAndConditions`, std.id, 'header'])}
+            </h3>
             <p>
-              {t([`activities.standardsAndConditions`, std.id, 'description'])}
+              {t([`activities.standardsAndConditions`, std.id, 'subheader'])}
             </p>
             <Textarea
               name={`activity-${activity.id}-condition-${std.id}`}
-              label={t([`activities.standardsAndConditions`, std.id, 'prompt'])}
+              label={t([`activities.standardsAndConditions`, std.id, 'title'])}
               rows="3"
               value={activity.standardsAndConditions[std.id]}
               onChange={this.handleChange(std.id)}
             />
           </div>
         ))}
-      </Collapsible>
+      </Subsection>
     );
   }
 }

--- a/web/src/containers/ActivityDetailStatePersonnel.js
+++ b/web/src/containers/ActivityDetailStatePersonnel.js
@@ -7,14 +7,13 @@ import {
   removeActivityStatePerson,
   updateActivity as updateActivityAction
 } from '../actions/activities';
-import Collapsible from '../components/Collapsible';
+import { Subsection } from '../components/Section';
 import {
   Input,
   DollarInput,
   PercentInput,
   Textarea
 } from '../components/Inputs';
-import HelpText from '../components/HelpText';
 import { t } from '../i18n';
 
 class ActivityDetailStatePersonnel extends Component {
@@ -41,9 +40,7 @@ class ActivityDetailStatePersonnel extends Component {
     } = this.props;
 
     return (
-      <Collapsible title={t('activities.statePersonnel.title')}>
-        <p className="bold">{t('activities.statePersonnel.subheader')}</p>
-        <HelpText text="activities.statePersonnel.helpText" />
+      <Subsection resource="activities.statePersonnel">
         <div className="overflow-auto">
           <table
             className="mb2 h5 table table-condensed table-fixed"
@@ -149,7 +146,7 @@ class ActivityDetailStatePersonnel extends Component {
         >
           {t('activities.statePersonnel.addButtonText')}
         </button>
-      </Collapsible>
+      </Subsection>
     );
   }
 }

--- a/web/src/containers/ApdSummary.js
+++ b/web/src/containers/ApdSummary.js
@@ -3,11 +3,8 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { updateApd as updateApdAction } from '../actions/apd';
-import Collapsible from '../components/Collapsible';
 import { RichText } from '../components/Inputs';
-import Section from '../components/Section';
-import SectionDesc from '../components/SectionDesc';
-import SectionTitle from '../components/SectionTitle';
+import { Section, Subsection } from '../components/Section';
 import HelpText from '../components/HelpText';
 import { t } from '../i18n';
 
@@ -40,14 +37,8 @@ class ApdSummary extends Component {
     } = this.props.apd;
 
     return (
-      <Section id="apd-summary">
-        <SectionTitle>{t('apd.sectionTitle')}</SectionTitle>
-        <SectionDesc>{t('apd.helpText')}</SectionDesc>
-        <Collapsible title={t('apd.overview.title')}>
-          <HelpText
-            text="apd.overview.helpText"
-            reminder="apd.overview.reminder"
-          />
+      <Section id="apd-summary" resource="apd">
+        <Subsection resource="apd.overview">
           <div className="mb3">
             <div className="mb-tiny bold">{t('apd.overview.yearsCovered')}</div>
             {YEAR_OPTIONS.map(option => (
@@ -93,7 +84,7 @@ class ApdSummary extends Component {
               onSync={this.syncRichText('mmisNarrative')}
             />
           </div>
-        </Collapsible>
+        </Subsection>
       </Section>
     );
   }

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -21,8 +21,8 @@
   },
 
   "apd": {
-    "sectionTitle": "Program Summary",
-    "helpText":
+    "title": "Program Summary",
+    "helptext":
       "Provide an introduction for your state's program. This should include context for your funding request by providing information such as current size of program, future vision, and how the program is positioned within the state. (Note: This information is similar to the content from the IAPD template executive summary section).",
     "overview": {
       "title": "Overview",
@@ -71,10 +71,14 @@
     "title": "Results of Previous Activities",
     "helpText":
       "Please include a description of the results of previously approved activities. This information is similar to the content from the (IAPD template, results of previous activities)",
-    "sections": {
-      "outline": "Prior Activities Outline",
-      "approvedExpenses": "Approved Expenses",
-      "actualExpenses": "Actual Expenses"
+    "outline": {
+      "title": "Prior Activities Outline"
+    },
+    "approvedExpenses": {
+      "title": "Approved Expenses"
+    },
+    "actualExpenses": {
+      "title": "Actual Expenses"
     }
   },
 
@@ -101,8 +105,7 @@
       "title": "Activity Description",
       "helpText":
         "Describe at a high level the needs of the activity for which requested funding will be used (e.g. administrative, outreach, auditing, public health registry development, etc)",
-      "reminder":
-        "Note: This section is limited to 280 characters or less",
+      "reminder": "Note: This section is limited to 280 characters or less",
       "detailHeader": "Describe the activity in detail",
       "alternativesHeader":
         "State of alternative considerations and supporting justification",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -195,7 +195,8 @@
       "removeLabel": "Remove personnel",
       "addButtonText": "Add personnel"
     },
-    "Non-Personnel Costs": {
+    "expenses": {
+      "title": "Non-Personnel Costs",
       "helpText":
         "Please provide a detailed breakout of any non-personnel and non-contracted costs related to this activity. This should icnlude a brief description of these projected costs.",
       "reminder":
@@ -203,22 +204,20 @@
     },
     "costAllocate": {
       "title": "Cost Allocation and Other Funding Sources",
-      "label": {
-        "costAllocateDesc": "Cost allocation methodology",
-        "otherFundingDesc": "Other funding description",
-        "otherFundingAmt": "Other funding amount"
-      },
-      "help": {
-        "costAllocate":
+      "methodology": {
+        "title": "Cost allocation methodology",
+        "helpText":
           "As specified in OMB Circular A‐87, a cost allocation plan must be included that identifies all participants and their associated cost allocation to depict non‐Medicaid activities and non‐Medicaid FTEs participating in this project, if any.\n\nHITECH cost allocation formulas should be based on the direct benefit to the Medicaid EHR Incentive Program, taking into account State projections of eligible Medicaid provider participation in the incentive program (leveraging actual data/experience as deemed appropriate).\n\nCost allocation must account for other available Federal funding sources, the division of resources and activities across relevant payers, and the relative benefit to the State Medicaid program, among other factors\n\nBe sure that cost allocations involve the timely and insured financial participation of all parties. States should demonstrate that other payers who stand to benefit are contributing their share, ideally from the beginning of the program/activity/service for which funding is being requested.",
-        "otherFunding":
-          "Please account for any and all grant funding that is used to support this activity.\n\nReview the State Medicaid Director Letter 10‐016 for examples of grants that might need to be included as well as other guidance\n\nMake sure that any new grants are included and any expired grants are removed."
+        "reminder":
+          "Do not assume that the absence of other payers is sufficient cause for Medicaid to be the primary payer. Also, limit ambiguity about other potential federal funding sources; for example, if no CHIP funds are being requested, include a statement to that effect in this section."
       },
-      "reminder": {
-        "costAllocate":
-          "Do not assume that the absence of other payers is sufficient cause for Medicaid to be the primary payer. Also, limit ambiguity about other potential federal funding sources; for example, if no CHIP funds are being requested, include a statement to that effect in this section.",
-        "otherFunding":
-          "High level descriptions are appropriate for grant activities"
+      "otherFunding": {
+        "title": "Other funding description",
+        "helpText":
+          "Please account for any and all grant funding that is used to support this activity.\n\nReview the State Medicaid Director Letter 10‐016 for examples of grants that might need to be included as well as other guidance\n\nMake sure that any new grants are included and any expired grants are removed.",
+        "reminder":
+          "High level descriptions are appropriate for grant activities",
+        "amount": "Other funding amount"
       }
     },
     "standardsAndConditions": {
@@ -226,71 +225,71 @@
       "subheader":
         "Please tell us how you'll meet the Medicaid standards and conditions for this activity.",
       "modularity": {
-        "title": "Modularity",
-        "description":
+        "header": "Modularity",
+        "subheader":
           "This condition requires the use of a modular, flexible approach to systems development, including the use of open interfaces and exposed application programming interfaces (API); the separation of business rules from core programming; and the availability of business rules in both human and machine-readable formats. The commitment to formal system development methodology and open, reusable system architecture is extremely important in order to ensure that states can more easily change and maintain systems, as well as integrate and interoperate with a clinical and administrative ecosystem designed to deliver person-centric services and benefits. Modularity is breaking down systems requirements into component parts. Extremely complex systems can be developed as part of a service-oriented architecture (SOA). Modularity also helps address the challenges of customization. Baseline web services and capabilities can be developed for and used by anyone, with exceptions for specific business processes handled by a separate module that interoperates with the baseline modules. With modularity, changes can be made independently to the baseline capabilities without affecting how the extension works. By doing so, the design ensures that future iterations of software can be deployed without breaking custom functionality. A critical element of compliance with this condition is providing CMS with an understanding of where services and code will be tightly coupled, and where the state will pursue a more aggressive decoupling strategy.CMS description text goes here.",
-        "prompt": "Describe how you'll meet the Modularity condition"
+        "title": "Describe how you'll meet the Modularity condition"
       },
       "mita": {
-        "title": "Medicaid Information Technology Architecture (MITA)",
-        "description":
+        "header": "Medicaid Information Technology Architecture (MITA)",
+        "subheader":
           "This condition requires states to align to and advance increasingly in MITA maturity for business, architecture, and data. CMS expects the states to complete and continue to make measurable progress in implementing their MITA roadmaps. Already the MITA investments by federal, state, and private partners have allowed us to make important incremental improvements to share data and reuse business models, applications, and components. CMS strives, however, to build on and accelerate the modernization of the Medicaid enterprise that has thus far been achieved.CMS description text goes here.",
-        "prompt": "Describe how you'll meet the MITA condition"
+        "title": "Describe how you'll meet the MITA condition"
       },
       "industry": {
-        "title": "Industry Standards",
-        "description":
+        "header": "Industry Standards",
+        "subheader":
           "States must ensure alignment with, and incorporation of, industry standards: the Health Insurance Portability and Accountability Act of 1996 (HIPAA) security, privacy and transaction standards; accessibility standards established under section 508 of the Rehabilitation Act, or standards that provide greater accessibility for individuals with disabilities, and compliance with federal civil rights laws; standards adopted by the Secretary under section 1104 of the Affordable Care Act; and standards and protocols adopted by the Secretary under section 1561 of the Affordable Care Act. CMS must ensure that Medicaid infrastructure and information system investments are made with the assurance that timely and reliable adoption of industry standards and productive use of those standards are part of the investments. Industry standards promote reuse, data exchange, and reduction of administrative burden on patients, providers, and applicants.CMS description text goes here.",
-        "prompt": "Describe how you'll meet the Industry Standards condition"
+        "title": "Describe how you'll meet the Industry Standards condition"
       },
       "leverage": {
-        "title": "Leverage",
-        "description":
+        "header": "Leverage",
+        "subheader":
           "State solutions should promote sharing, leverage, and reuse of Medicaid technologies and systems within and among states. States can benefit substantially from the experience and investments of other states through the reuse of components and technologies already developed, consistent with a service-oriented architecture, from publicly available or commercially sold components and products, and from the use of cloud technologies to share infrastructure and applications. CMS commits to work assertively with the states to identify promising state systems that can be leveraged and used by other states. Further, CMS would strongly encourage the states to move to regional or multistate solutions when cost effective, and will seek to support and facilitate such solutions. In addition, CMS will expedite APD approvals for states that are participating in shared development activities with other states, and that are developing components and solutions expressly intended for successful reuse by other states. CMS will also review carefully any proposed investments in sub-state systems when the federal government is asked to share in the costs of updating or maintaining multiple systems performing essentially the same functions within the same state.CMS description text goes here.",
-        "prompt": "Describe how you'll meet the Leverage condition"
+        "title": "Describe how you'll meet the Leverage condition"
       },
       "bizResults": {
-        "title": "Business Results",
-        "description":
+        "header": "Business Results",
+        "subheader":
           "Systems should support accurate and timely processing of claims (including claims of eligibility), adjudications, and effective communications with providers, beneficiaries, and the public. Ultimately, the test of an effective and efficient system is whether it supports and enables an effective and efficient business process, producing and communicating the intended operational results with a high degree of reliability and accuracy. It would be inappropriate to provide enhanced federal funding for systems that are unable to support desired business outcomes. CMS description text goes here.",
-        "prompt": "Describe how you'll meet the Business Results condition"
+        "title": "Describe how you'll meet the Business Results condition"
       },
       "reporting": {
-        "title": "Reporting",
-        "description":
+        "header": "Reporting",
+        "subheader":
           "Solutions should produce transaction data, reports, and performance information that would contribute to program evaluation, continuous improvement in business operations, and transparency and accountability. Systems should be able to produce and to expose electronically the accurate data that are necessary for oversight, administration, evaluation, integrity, and transparency. These reports should be automatically generated through open interfaces to designated federal repositories or data hubs, with appropriate audit trails. MITA 3.0 will provide additional detail about reporting requirements and needs that arise from the Affordable Care Act. Additional details about data definitions, specifications, timing, and routing of information will be supplied later this year. CMS description text goes here.",
-        "prompt": "Describe how you'll meet the Reporting condition"
+        "title": "Describe how you'll meet the Reporting condition"
       },
       "interoperability": {
-        "title": "Interoperability",
-        "description":
+        "header": "Interoperability",
+        "subheader":
           "Systems must ensure seamless coordination and integration with the Exchange (whether run by the state or federal government), and allow interoperability with health information exchanges, public health agencies, human services programs, and community organizations providing outreach and enrollment assistance services. CMS expects that a key outcome of the government’s technology investments will be a much higher degree of interaction and interoperability in order to maximize value and minimize burden and costs on providers, beneficiaries, and other stakeholders. CMS is emphasizing in this standard and condition an expectation that Medicaid agencies work in concert with Exchanges (whether state or federally administered) to share business services and technology investments in order to produce seamless and efficient customer experiences. Systems must also be built with the appropriate architecture and using standardized messaging and communication protocols in order to preserve the ability to efficiently, effectively, and appropriately exchange data with other participants in the health and human services enterprise. As stated in MITA Framework 2.0, each state is “responsible for knowing and understanding its environment (data, applications and infrastructure) in order to map its data to information sharing requirements. The data-sharing architecture also addresses the conceptual and logical mechanisms used for data sharing (i.e., data hubs, repositories, and registries). The data-sharing architecture will also address data semantics, data harmonization strategies, shared-data ownership, security and privacy implications of shared data, and the quality of shared data.CMS description text goes here.",
-        "prompt": "Describe how you'll meet the Interoperability condition"
+        "title": "Describe how you'll meet the Interoperability condition"
       },
       "mitigation": {
-        "title": "Mitigation Strategy",
-        "description":
+        "header": "Mitigation Strategy",
+        "subheader":
           "The condition described at § 433.112(b)(18) requires that states submit mitigation plans addressing strategies to reduce the consequences of failure for all major milestones and functionality. Maintaining a mitigation plan is an industry standard best practice for any major IT build; CMS expects that states will identify potential risks and develop strategies to address those risks throughout the system lifecycle. Mitigation plans for major Medicaid E&E system or MMIS projects should address minimum expected functionality, critical success factors, and risk factors as tied to major milestones identified in the APD. The mitigation plans should also reflect key events and dates that would trigger the mitigation, and projected timeframe for the mitigation sunset. States should consider strategies to address risks for the M&O phase of the project, such as staffing issues and software upgrades. CMS expects states to revise and resubmit their plans to CMS as risks and mitigations change along the system life cycle. States’ proposed mitigations should be commensurate with the nature and scope of the identified risks. We also expect that states will submit their mitigation plans with the APDs to demonstrate compliance with this condition.CMS description text goes here.",
-        "prompt": "Describe how you'll meet the Mitigation Strategy condition"
+        "title": "Describe how you'll meet the Mitigation Strategy condition"
       },
       "keyPersonnel": {
-        "title": "Key Personnel",
-        "description":
+        "header": "Key Personnel",
+        "subheader":
           "The condition described at § 433.112(b)(19) requires that states identify their key state personnel assigned to each major project by name, role, and time commitment. Before we approve a state to launch a major IT initiative, CMS wants to ensure that the state team is adequately resourced. States do not need to provide key vendor personnel for this requirement. As stated in the provision, this information must be included in the APD. For changes to key personnel that occur after an APD is approved, states should notify their CMS points of contact in writing (including by email) and formally reflect the change in the next planned APD update. This condition refines and strengthens the existing APD requirements regarding personnel resource statements as required under 45 CFR 95.610. For Medicaid E&E APDs, states should include this information in the “Medicaid Eligibility and Enrollment (EE) Implementation Advance Planning Document (IAPD) Template” (OMB Approval Number: 0938-1268). Although there is currently no APD template for MMIS APDs, states must include this information in all MMIS APDs for major IT initiatives.CMS description text goes here.",
-        "prompt": "Describe how you'll meet the Key Personnel condition"
+        "title": "Describe how you'll meet the Key Personnel condition"
       },
       "documentation": {
-        "title": "Documentation",
-        "description":
+        "header": "Documentation",
+        "subheader":
           "The condition described at § 433.112(b)(20) requires that states maintain documentation for certain software such that the software could be operated by contractors and other users. This condition is limited to software that is developed using federal funds; it does not apply to Commercial Off-the-Shelf (COTS) software, Software-as-a-Service, or Business-Solutions-as-a-Service. Adequate documentation means that other users could operate the software with reasonable alterations for a specific hardware or operating system. CMS is neutral as to the specific hardware or operating system that the software uses. Documentation must follow industry standards and best practices, and must include components, procedures, layouts, interfaces, inputs, outputs, and other necessary information so that the systems could be installed and operated by a variety of contractors or other users. While the APD should address how the state plans to maintain documentation, such documentation is not required to be submitted along with the APD. It is the state’s responsibility to make the documentation available upon request and to upload documentation to CALT or successor systems as needed for gate reviews or for reuse. Submission to other repositories may be required as CMS explores other options.CMS description text goes here.",
-        "prompt": "Describe how you'll meet the Documentation condition"
+        "title": "Describe how you'll meet the Documentation condition"
       },
       "minimizeCost": {
-        "title":
+        "header":
           "Strategies to Minimize Cost and Difficulty on Alternative Hardware or Operating System",
-        "description":
+        "subheader":
           "The condition described at § 433.112(b)(21) requires that states consider strategies to minimize the costs and difficulty of operating the software on alternate hardware or operating systems. This condition recognizes the significant federal and state investments that are involved with major Medicaid IT projects and requires that states consider options beyond software that will reduce costs or promote reuse. States should describe in the APD the strategies that were considered when deciding which solution was the most economical and efficient. States are not required to adopt a particular strategy, but CMS must have sufficient description to evaluate the extent to which the state looked at other solutions. States should consider, at a minimum, the options that offer more opportunities for reuse, lower development costs, lower long-term operating costs, and shorter development time as well as the extent to which the solutions can be readily implemented with alternate hardware and operating systems. States should consider this new condition in conjunction with existing APD requirements regarding cost benefit analyses required at 45 CFR 95.605 or § 95.610. CMS description text goes here.",
-        "prompt": "Describe how you'll meet the Cost Minimization condition"
+        "title": "Describe how you'll meet the Cost Minimization condition"
       }
     }
   },

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -108,13 +108,21 @@
       "helpText":
         "Describe at a high level the needs of the activity for which requested funding will be used (e.g. administrative, outreach, auditing, public health registry development, etc)",
       "reminder": "Note: This section is limited to 280 characters or less",
-      "detailHeader": "Describe the activity in detail",
-      "alternativesHeader":
-        "State of alternative considerations and supporting justification",
-      "alternativesHelpText":
-        "If no substantive changes have been made to this activity, include a statement that refers back to the Statement of Alternative Considerations contained in previous versions of the IAPD or in the SMHP.\n\nIf substantive changes have been made, include a statement describing the alternatives that the state considered when making the change.",
-      "alternativesHelpReminder":
-        "Remember to update the SMHP as necessary with any substantive changes to the approach for implementing EHR incentives."
+      "summary": {
+        "subheader":
+          "Summarize the activity --- <- not sure what this is supposed to be"
+      },
+      "detail": {
+        "subheader": "Describe the activity in detail"
+      },
+      "alternatives": {
+        "subheader":
+          "State of alternative considerations and supporting justification",
+        "helpText":
+          "If no substantive changes have been made to this activity, include a statement that refers back to the Statement of Alternative Considerations contained in previous versions of the IAPD or in the SMHP.\n\nIf substantive changes have been made, include a statement describing the alternatives that the state considered when making the change.",
+        "reminder":
+          "Remember to update the SMHP as necessary with any substantive changes to the approach for implementing EHR incentives."
+      }
     },
     "goals": {
       "title": "Needs and Objectives",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -88,7 +88,9 @@
       "Please identify individual activities referenced from the overview section. CMS will collect information for each activity. Examples of individual activities include: Auditing, Outreach, Environmental Scans, HIE Registry Development, CQM Database Development, Data and Analytics, HIE Onboarding, etc.",
     "reminder":
       "Note: The first activity in this list is program administration. Program administration information pertains to implementing EHR Incentive program. Examples include: state & contractor costs associated with operating the EHR incentive program and SLR enhancements/upgrades.",
-    "listTitle": "Activity List",
+    "list": {
+      "title": "Activity List"
+    },
     "addActivityButtonText": "Add activity",
     "deleteActivityButtonText": "Remove Activity",
     "noActivityMessage":
@@ -287,21 +289,48 @@
   "proposedBudget": {
     "title": "Proposed Budget",
     "helpText":
-      "Please review the itemized budget, which has summed the funding requested for each activity specified.\n\nIt is broken out by FFY, and shows breakout of Federal Financial Participation (FFP), state match, and Total value (FFP + state match).\n\n We have also included a proposed breakout of this same budget by FFY quarter in the second table."
+      "Please review the itemized budget, which has summed the funding requested for each activity specified.\n\nIt is broken out by FFY, and shows breakout of Federal Financial Participation (FFP), state match, and Total value (FFP + state match).\n\n We have also included a proposed breakout of this same budget by FFY quarter in the second table.",
+    "summaryBudget": {
+      "title": "Short Activity Summary Budget"
+    },
+    "paymentsByFFYQuarter": {
+      "title": "Incentive Payments by FFY Quarter"
+    }
   },
 
   "assurancesAndCompliance": {
     "title": "Assurances and Compliance",
     "helpText":
-      "This section ensures compliance with federal regulations and State Medicaid citations."
+      "This section ensures compliance with federal regulations and State Medicaid citations.",
+    "procurement": {
+      "title": "Procurement Standards"
+    },
+    "recordsAccess": {
+      "title": "Access to Records"
+    },
+    "softwareRights": {
+      "title": "Software Rights"
+    },
+    "security": {
+      "title": "Security"
+    }
   },
   "executiveSummary": {
     "title": "Executive Summary",
     "helpText":
-      "Please see the executive summary that has been generated based upon the activity details provided above.\n\n We have also automatically included the Program Budget tables for your review. If the APD is approved, these program budget tables will be referenced on the CMS approval letter."
+      "Please see the executive summary that has been generated based upon the activity details provided above.\n\n We have also automatically included the Program Budget tables for your review. If the APD is approved, these program budget tables will be referenced on the CMS approval letter.",
+    "summary": {
+      "title": "Executive Summary"
+    },
+    "budgetTable": {
+      "title": "Program Budget Table"
+    }
   },
   "certifyAndSubmit": {
     "title": "Certify and Submit",
-    "helpText": "Certify that the APD is complete and submit your IAPD."
+    "helpText": "Certify that the APD is complete and submit your IAPD.",
+    "certify": {
+      "title": "Certify and Submit"
+    }
   }
 }


### PR DESCRIPTION
Title, subheader, and helptext are looking like they're common parts of our section/subsection structure.  This PR puts those things into the `Section` component and adds a `Subsection` component for the same purpose.

# https://hitech-apd-pr594.app.cloud.gov/

@quarterback: under activities, under the "activity description" subsection, I'm not sure what the label should be for the activity section box.  There wasn't anything in the resource file that clearly mapped to it.

### This pull request changes...
- some minor changes to how the resource file is structured
- every major section supports `title`, `subheader`, and `helpText` resource strings
- every subsection (the collapsable pieces) supports `title`, `subheader`, `helpText`, and `reminder` resource strings 

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author

### This feature is done when...
- [x] Design has approved the experience - @quarterback 
- [ ] Product has approved the experience - @NAretakis 
