### PR TITLE
add z-index to sticky class

### DIFF
--- a/web/src/styles/app/layout.css
+++ b/web/src/styles/app/layout.css
@@ -57,4 +57,5 @@ footer {
 .sticky-top {
   position: sticky;
   top: 0;
+  z-index: 1;
 }


### PR DESCRIPTION
### This pull request...
- fixes a small bug where certain buttons on the rich text editor were appearing in front of our sticky activity header when scrolling; adding a smidge of z-index fixes it :)

### This pull request is ready to merge when...
- [ ] This code has been reviewed by someone other than the original author