### PR TITLE
Use years throughout the app based on the APD summary selection

### DIFF
--- a/web/src/actions/activities.js
+++ b/web/src/actions/activities.js
@@ -1,3 +1,5 @@
+import { updateBudget } from './apd';
+
 export const ADD_ACTIVITY = 'ADD_ACTIVITY';
 export const ADD_ACTIVITY_CONTRACTOR = 'ADD_ACTIVITY_CONTRACTOR';
 export const ADD_ACTIVITY_GOAL = 'ADD_ACTIVITY_GOAL';
@@ -13,28 +15,27 @@ export const REMOVE_ACTIVITY_MILESTONE = 'REMOVE_ACTIVITY_MILESTONE';
 export const REMOVE_ACTIVITY_STATE_PERSON = 'REMOVE_ACTIVITY_STATE_PERSON';
 export const TOGGLE_ACTIVITY_SECTION = 'TOGGLE_ACTIVITY_SECTION';
 export const UPDATE_ACTIVITY = 'UPDATE_ACTIVITY';
-export const UPDATE_BUDGET = 'UPDATE_BUDGET';
 
-export const addActivity = () => ({ type: ADD_ACTIVITY });
+const actionWithYears = (type, other) => (dispatch, getState) =>
+  dispatch({ type, ...other, years: getState().apd.data.years });
 
-export const addActivityContractor = id => ({
-  type: ADD_ACTIVITY_CONTRACTOR,
-  id
-});
+export const addActivity = () => actionWithYears(ADD_ACTIVITY);
+
+export const addActivityContractor = id =>
+  actionWithYears(ADD_ACTIVITY_CONTRACTOR, { id });
 
 export const addActivityGoal = id => ({ type: ADD_ACTIVITY_GOAL, id });
 
-export const addActivityExpense = id => ({ type: ADD_ACTIVITY_EXPENSE, id });
+export const addActivityExpense = id =>
+  actionWithYears(ADD_ACTIVITY_EXPENSE, { id });
 
 export const addActivityMilestone = id => ({
   type: ADD_ACTIVITY_MILESTONE,
   id
 });
 
-export const addActivityStatePerson = id => ({
-  type: ADD_ACTIVITY_STATE_PERSON,
-  id
-});
+export const addActivityStatePerson = id =>
+  actionWithYears(ADD_ACTIVITY_STATE_PERSON, { id });
 
 export const expandActivitySection = id => ({
   type: EXPAND_ACTIVITY_SECTION,
@@ -78,16 +79,13 @@ export const toggleActivitySection = id => ({
   id
 });
 
-export const updateActivity = (id, updates, isExpense = false) => (
-  dispatch,
-  getState
-) => {
+export const updateActivity = (id, updates, isExpense = false) => dispatch => {
   dispatch({
     type: UPDATE_ACTIVITY,
     id,
     updates
   });
   if (isExpense) {
-    dispatch({ type: UPDATE_BUDGET, state: getState() });
+    dispatch(updateBudget());
   }
 };

--- a/web/src/actions/apd.js
+++ b/web/src/actions/apd.js
@@ -9,6 +9,10 @@ export const SAVE_APD_REQUEST = 'SAVE_APD_REQUEST';
 export const SAVE_APD_SUCCESS = 'SAVE_APD_SUCCESS';
 export const SAVE_APD_FAILURE = 'SAVE_APD_FAILURE';
 export const UPDATE_APD = 'UPDATE_APD';
+export const UPDATE_BUDGET = 'UPDATE_BUDGET';
+
+export const updateBudget = () => (dispatch, getState) =>
+  dispatch({ type: UPDATE_BUDGET, state: getState() });
 
 export const requestApd = () => ({ type: GET_APD_REQUEST });
 export const receiveApd = data => ({ type: GET_APD_SUCCESS, data });
@@ -16,7 +20,12 @@ export const failApd = error => ({ type: GET_APD_FAILURE, error });
 
 export const addApdKeyPerson = () => ({ type: ADD_APD_KEY_PERSON });
 export const removeApdKeyPerson = id => ({ type: REMOVE_APD_KEY_PERSON, id });
-export const updateApd = updates => ({ type: UPDATE_APD, updates });
+export const updateApd = updates => dispatch => {
+  dispatch({ type: UPDATE_APD, updates });
+  if (updates.years) {
+    dispatch(updateBudget());
+  }
+};
 
 export const requestSave = () => ({ type: SAVE_APD_REQUEST });
 export const saveSuccess = () => ({ type: SAVE_APD_SUCCESS });
@@ -32,6 +41,7 @@ export const fetchApd = () => dispatch => {
     .then(req => {
       const apd = Array.isArray(req.data) ? req.data[0] : null;
       dispatch(receiveApd(apd));
+      dispatch(updateBudget());
     })
     .catch(error => {
       const reason = error.response ? error.response.data : 'N/A';

--- a/web/src/actions/apd.js
+++ b/web/src/actions/apd.js
@@ -98,7 +98,7 @@ export const saveApd = () => (dispatch, state) => {
       ),
       goals: activity.goals.map(g => ({
         description: g.desc,
-        objectives: [{ description: g.obj }] // TODO - objective should mape 1:1 to goals, instead of being an array (needs backend change first)
+        objective: g.obj
       })),
       schedule: activity.milestones.map(m => ({
         milestone: m.name,

--- a/web/src/actions/apd.test.js
+++ b/web/src/actions/apd.test.js
@@ -33,13 +33,14 @@ describe('state actions', () => {
       fetchMock.reset();
     });
 
-    it('creates GET_APD_SUCCESS after successful APD fetch', () => {
+    it('creates GET_APD_SUCCESS and UPDATE_BUDGET after successful APD fetch', () => {
       const store = mockStore({});
       fetchMock.onGet('/apds').reply(200, [{ foo: 'bar' }]);
 
       const expectedActions = [
         { type: actions.GET_APD_REQUEST },
-        { type: actions.GET_APD_SUCCESS, data: { foo: 'bar' } }
+        { type: actions.GET_APD_SUCCESS, data: { foo: 'bar' } },
+        { type: actions.UPDATE_BUDGET, state: {} }
       ];
 
       return store.dispatch(actions.fetchApd()).then(() => {

--- a/web/src/containers/ActivityDetailAll.js
+++ b/web/src/containers/ActivityDetailAll.js
@@ -54,7 +54,7 @@ class ActivityDetailAll extends Component {
 }
 
 ActivityDetailAll.propTypes = {
-  aId: PropTypes.number.isRequired,
+  aId: PropTypes.string.isRequired,
   expanded: PropTypes.bool.isRequired,
   num: PropTypes.number.isRequired,
   title: PropTypes.string.isRequired,

--- a/web/src/containers/ApdSummary.js
+++ b/web/src/containers/ApdSummary.js
@@ -7,7 +7,6 @@ import { RichText } from '../components/Inputs';
 import { Section, Subsection } from '../components/Section';
 import HelpText from '../components/HelpText';
 import { t } from '../i18n';
-import { YEAR_OPTIONS } from '../util';
 
 class ApdSummary extends Component {
   handleYears = e => {
@@ -29,6 +28,7 @@ class ApdSummary extends Component {
   render() {
     const {
       years,
+      yearOptions,
       overview,
       hitNarrative,
       hieNarrative,
@@ -40,7 +40,7 @@ class ApdSummary extends Component {
         <Subsection resource="apd.overview">
           <div className="mb3">
             <div className="mb-tiny bold">{t('apd.overview.yearsCovered')}</div>
-            {YEAR_OPTIONS.map(option => (
+            {yearOptions.map(option => (
               <label key={option} className="mr1">
                 <input
                   type="checkbox"

--- a/web/src/containers/BudgetSummary.js
+++ b/web/src/containers/BudgetSummary.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 
-import { YEAR_OPTIONS } from '../util';
 import { formatMoney } from '../util/formats';
 
 const categoryLookup = {
@@ -107,7 +106,7 @@ HeaderRow.defaultProps = {
   numberCells: 12
 };
 
-const BudgetSummary = ({ data }) => (
+const BudgetSummary = ({ data, years }) => (
   <div className="py1 overflow-auto">
     <table
       className="h6 table-fixed table-bordered table-budget table-budget-summary"
@@ -116,7 +115,7 @@ const BudgetSummary = ({ data }) => (
       <thead>
         <tr>
           <th style={{ width: 200 }} />
-          {data.years.map(yr => (
+          {years.map(yr => (
             <th key={yr} className="bg-black white center" colSpan="3">
               FFY {yr}
             </th>
@@ -127,7 +126,7 @@ const BudgetSummary = ({ data }) => (
         </tr>
         <tr>
           <th />
-          {[...Array(YEAR_OPTIONS.length + 1)].map((_, i) => (
+          {[...Array(years.length + 1)].map((_, i) => (
             <Fragment key={i}>
               <th className="col-4">Total</th>
               <th className="col-4">Federal share</th>
@@ -137,15 +136,24 @@ const BudgetSummary = ({ data }) => (
         </tr>
       </thead>
       <tbody className="bg-light-blue">
-        <HeaderRow title="HIT activities" />
+        <HeaderRow
+          title="HIT activities"
+          numberCells={(years.length + 1) * 3}
+        />
         <DataRowGroup data={data.hit} />
       </tbody>
       <tbody className="bg-light-yellow">
-        <HeaderRow title="HIE activities" />
+        <HeaderRow
+          title="HIE activities"
+          numberCells={(years.length + 1) * 3}
+        />
         <DataRowGroup data={data.hie} />
       </tbody>
       <tbody className="bg-light-green">
-        <HeaderRow title="MMIS activities" />
+        <HeaderRow
+          title="MMIS activities"
+          numberCells={(years.length + 1) * 3}
+        />
         <DataRowGroup data={data.mmis} />
       </tbody>
       <tbody>
@@ -174,9 +182,13 @@ const BudgetSummary = ({ data }) => (
 );
 
 BudgetSummary.propTypes = {
-  data: PropTypes.object.isRequired
+  data: PropTypes.object.isRequired,
+  years: PropTypes.array.isRequired
 };
 
-const mapStateToProps = ({ budget }) => ({ data: budget });
+const mapStateToProps = ({ apd, budget }) => ({
+  years: apd.data.years,
+  data: budget
+});
 
 export default connect(mapStateToProps)(BudgetSummary);

--- a/web/src/containers/ExecutiveSummary.js
+++ b/web/src/containers/ExecutiveSummary.js
@@ -63,7 +63,7 @@ const mapStateToProps = ({ activities, apd }) => {
     id: 'all',
     name: 'Total Cost',
     descShort: null,
-    totals: aggregateByYear(data.map(d => d.totals))
+    totals: aggregateByYear(data.map(d => d.totals), apd.data.years)
   });
 
   return {

--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -17,38 +17,46 @@ import {
   TOGGLE_ACTIVITY_SECTION,
   UPDATE_ACTIVITY
 } from '../actions/activities';
-import { GET_APD_SUCCESS } from '../actions/apd';
+import { GET_APD_SUCCESS, UPDATE_APD } from '../actions/apd';
 
-import { YEAR_OPTIONS, arrToObj, nextSequence } from '../util';
+import { arrToObj, nextSequence } from '../util';
 
 const newGoal = () => ({ desc: '', obj: '' });
 
 const newMilestone = () => ({ name: '', start: '', end: '' });
 
-const newStatePerson = id => ({
+const statePersonDefaultYear = () => ({ amt: '', perc: '' });
+const newStatePerson = (id, years) => ({
   id,
   title: '',
   desc: '',
-  years: arrToObj(YEAR_OPTIONS, { amt: '', perc: '' })
+  years: arrToObj(years, statePersonDefaultYear())
 });
 
-const newContractor = id => ({
+const contractorDefaultYear = () => 0;
+const newContractor = (id, years) => ({
   id,
   name: '',
   desc: '',
   start: '',
   end: '',
-  years: arrToObj(YEAR_OPTIONS, 0)
+  years: arrToObj(years, contractorDefaultYear())
 });
 
-const newExpense = id => ({
+const expenseDefaultYear = () => 0;
+const newExpense = (id, years) => ({
   id,
   category: 'Hardware, software, and licensing',
   desc: '',
-  years: arrToObj(YEAR_OPTIONS, 100)
+  years: arrToObj(years, expenseDefaultYear())
 });
 
-const newActivity = (id, name = '', fundingSource = 'HIT') => ({
+const costFFPDefaultYear = () => ({ fed: 90, state: 10, other: 0 });
+
+const newActivity = (
+  id,
+  { name = '', fundingSource = 'HIT', years = [] } = {}
+) => ({
   id,
   name,
   fundingSource,
@@ -60,10 +68,18 @@ const newActivity = (id, name = '', fundingSource = 'HIT') => ({
   otherFundingAmt: '',
   goals: [newGoal()],
   milestones: [newMilestone(), newMilestone(), newMilestone()],
-  statePersonnel: [newStatePerson(1), newStatePerson(2), newStatePerson(3)],
-  contractorResources: [newContractor(1), newContractor(2), newContractor(3)],
-  expenses: [newExpense(1), newExpense(2), newExpense(3)],
-  costFFP: arrToObj(YEAR_OPTIONS, { fed: 90, state: 10, other: 0 }),
+  statePersonnel: [
+    newStatePerson(1, years),
+    newStatePerson(2, years),
+    newStatePerson(3, years)
+  ],
+  contractorResources: [
+    newContractor(1, years),
+    newContractor(2, years),
+    newContractor(3, years)
+  ],
+  expenses: [newExpense(1, years), newExpense(2, years), newExpense(3, years)],
+  costFFP: arrToObj(years, { fed: 90, state: 10, other: 0 }),
   standardsAndConditions: {
     modularity: '',
     mita: '',
@@ -77,17 +93,15 @@ const newActivity = (id, name = '', fundingSource = 'HIT') => ({
     documentation: '',
     minimizeCost: ''
   },
+  years,
   meta: {
     expanded: false
   }
 });
 
 const initialState = {
-  byId: {
-    1: newActivity(1, 'Program Administration', 'HIT'),
-    2: newActivity(2, 'Test', 'HIE')
-  },
-  allIds: [1, 2]
+  byId: {},
+  allIds: []
 };
 
 const reducer = (state = initialState, action) => {
@@ -97,7 +111,7 @@ const reducer = (state = initialState, action) => {
       return {
         byId: {
           ...state.byId,
-          [id]: newActivity(id)
+          [id]: newActivity(id, { years: action.years })
         },
         allIds: [...state.allIds, id]
       };
@@ -249,6 +263,67 @@ const reducer = (state = initialState, action) => {
         },
         state
       );
+    case UPDATE_APD:
+      if (action.updates.years) {
+        const { years } = action.updates;
+        const update = { byId: {} };
+
+        const fixupYears = (obj, defaultValue) => {
+          // Can't clone in the typical way because the incoming
+          // object derives from redux state and preventExtensions()
+          // has been called on it.  That means we can't add
+          // years if necessary.  To get around that, stringify
+          // then parse.  It's brute force but it works.
+          const out = JSON.parse(JSON.stringify(obj));
+
+          Object.keys(obj).forEach(year => {
+            if (!years.includes(year)) {
+              delete out[year];
+            }
+          });
+
+          years.forEach(year => {
+            if (!out[year]) {
+              out[year] = defaultValue();
+            }
+          });
+
+          return out;
+        };
+
+        const fixupExpenses = (objects, defaultValue) => () => {
+          // contractorResources, statePersonnel, and expenses
+          // are all arrays with years subproperties
+          if (Array.isArray(objects)) {
+            return objects.map(o => ({
+              ...o,
+              years: fixupYears(o.years, defaultValue)
+            }));
+          }
+          // but costFFP is just an object whose properties
+          // are the years
+          return fixupYears(objects, defaultValue);
+        };
+
+        Object.entries(state.byId).forEach(([id, activity]) => {
+          update.byId[id] = {
+            years,
+            statePersonnel: fixupExpenses(
+              activity.statePersonnel,
+              statePersonDefaultYear
+            ),
+            contractorResources: fixupExpenses(
+              activity.contractorResources,
+              contractorDefaultYear
+            ),
+            expenses: fixupExpenses(activity.expenses, expenseDefaultYear),
+            costFFP: fixupExpenses(activity.costFFP, costFFPDefaultYear)
+          };
+        });
+
+        return u(update, state);
+      }
+      return state;
     case GET_APD_SUCCESS: {
       const byId = {};
       action.data.activities.forEach(a => {
@@ -344,9 +419,17 @@ const reducer = (state = initialState, action) => {
         };
       });
 
+      if (action.data.activities.length === 0) {
+        byId[1] = newActivity(1, {
+          name: 'Program Administration',
+          fundingSource: 'HIT',
+          years: action.data.years
+        });
+      }
+
       return {
         byId,
-        allIds: action.data.activities.map(a => a.id)
+        allIds: Object.keys(byId)
       };
     }
     default:
@@ -358,11 +441,7 @@ export default reducer;
 
 // data munging / aggregation functions
 
-export const aggregateByYear = (
-  dataArray,
-  iteratee = x => x,
-  years = YEAR_OPTIONS
-) =>
+const aggregateByYear = (dataArray, years, iteratee = x => x) =>
   dataArray.reduce((accum, datum) => {
     const totals = accum;
     years.forEach(yr => {
@@ -371,8 +450,13 @@ export const aggregateByYear = (
     return totals;
   }, arrToObj(years, 0));
 
-export const getCategoryTotals = (entries, iteratee = x => x) =>
-  aggregateByYear(entries.map(e => e.years), iteratee);
+export const getCategoryTotals = (entries, iteratee = x => x) => {
+  let years = [];
+  if (entries.length) {
+    years = Object.keys(entries[0].years);
+  }
+  return aggregateByYear(entries.map(e => e.years), years, iteratee);
+};
 
 export const getActivityCategoryTotals = activity => ({
   statePersonnel: getCategoryTotals(activity.statePersonnel, d => d.amt),
@@ -380,18 +464,8 @@ export const getActivityCategoryTotals = activity => ({
   expenses: getCategoryTotals(activity.expenses)
 });
 
-export const getActivitiesCategoryTotals = activities => {
-  const totalsByCat = activities.map(a => getActivityCategoryTotals(a));
-  const catNames = ['statePersonnel', 'contractors', 'expenses'];
-
-  return catNames.reduce((obj, cat) => {
-    obj[cat] = aggregateByYear(totalsByCat.map(t => t[cat])); // eslint-disable-line no-param-reassign
-    return obj;
-  }, {});
-};
-
 export const getActivityTotals = activity =>
-  aggregateByYear(Object.values(getActivityCategoryTotals(activity)));
-
-export const getActivitiesTotals = activities =>
-  aggregateByYear(activities.map(a => getActivityTotals(a)));
+  aggregateByYear(
+    Object.values(getActivityCategoryTotals(activity)),
+    activity.years
+  );

--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -331,6 +331,7 @@ const reducer = (state = initialState, action) => {
           id: a.id,
           name: a.name,
           fundingSource: 'HIT', // TODO
+          years: action.data.years,
           descShort: a.summary,
           descLong: a.description,
           altApproach: a.alternatives,
@@ -441,7 +442,7 @@ export default reducer;
 
 // data munging / aggregation functions
 
-const aggregateByYear = (dataArray, years, iteratee = x => x) =>
+export const aggregateByYear = (dataArray, years, iteratee = x => x) =>
   dataArray.reduce((accum, datum) => {
     const totals = accum;
     years.forEach(yr => {

--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -19,7 +19,7 @@ import {
 } from '../actions/activities';
 import { GET_APD_SUCCESS, UPDATE_APD } from '../actions/apd';
 
-import { arrToObj, nextSequence } from '../util';
+import { arrToObj, defaultAPDYears, nextSequence } from '../util';
 
 const newGoal = () => ({ desc: '', obj: '' });
 
@@ -326,7 +326,7 @@ const reducer = (state = initialState, action) => {
       return state;
     case GET_APD_SUCCESS: {
       const byId = {};
-      action.data.activities.forEach(a => {
+      ((action.data || {}).activities || []).forEach(a => {
         byId[a.id] = {
           id: a.id,
           name: a.name,
@@ -420,11 +420,11 @@ const reducer = (state = initialState, action) => {
         };
       });
 
-      if (action.data.activities.length === 0) {
+      if (Object.keys(byId).length === 0) {
         byId[1] = newActivity(1, {
           name: 'Program Administration',
           fundingSource: 'HIT',
-          years: action.data.years
+          years: defaultAPDYears
         });
       }
 

--- a/web/src/reducers/apd.js
+++ b/web/src/reducers/apd.js
@@ -1,5 +1,6 @@
 import u from 'updeep';
 
+import { defaultAPDYearOptions, defaultAPDYears } from '../util';
 import {
   GET_APD_REQUEST,
   GET_APD_SUCCESS,
@@ -7,29 +8,11 @@ import {
   UPDATE_APD
 } from '../actions/apd';
 
-const thisFFY = (() => {
-  const year = new Date().getFullYear();
-
-  // Federal fiscal year starts October 1,
-  // but Javascript months start with 0 for
-  // some reason, so October is month 9.
-  if (new Date().getMonth() > 8) {
-    return year + 1;
-  }
-  return year;
-})();
-
-// The UI turns the years into strings, so let's
-// just make them strings in the state as well;
-// that simplifies things
-const threeYears = [thisFFY, thisFFY + 1, thisFFY + 2].map(y => `${y}`);
-const firstTwoYears = threeYears.slice(0, 2);
-
 const initialState = {
   data: {
     id: '',
-    years: firstTwoYears,
-    yearOptions: threeYears,
+    years: defaultAPDYears,
+    yearOptions: defaultAPDYearOptions,
     overview: '',
     hitNarrative: '',
     hieNarrative: '',
@@ -54,7 +37,8 @@ const reducer = (state = initialState, action) => {
         narrativeHIE: hieNarrative,
         narrativeMMIS: mmisNarrative,
         previousActivitySummary
-      } = action.data;
+      } =
+        action.data || {};
 
       return {
         ...state,
@@ -66,8 +50,8 @@ const reducer = (state = initialState, action) => {
           hitNarrative,
           hieNarrative,
           mmisNarrative,
-          years: years.map(y => `${y}`) || firstTwoYears,
-          yearOptions: threeYears,
+          years: (years || defaultAPDYears).map(y => `${y}`),
+          yearOptions: defaultAPDYearOptions,
           previousActivitySummary: previousActivitySummary || ''
         }
       };

--- a/web/src/reducers/apd.js
+++ b/web/src/reducers/apd.js
@@ -6,14 +6,30 @@ import {
   GET_APD_FAILURE,
   UPDATE_APD
 } from '../actions/apd';
-import { YEAR_OPTIONS } from '../util';
 
-const firstTwoYears = YEAR_OPTIONS.slice(0, 2);
+const thisFFY = (() => {
+  const year = new Date().getFullYear();
+
+  // Federal fiscal year starts October 1,
+  // but Javascript months start with 0 for
+  // some reason, so October is month 9.
+  if (new Date().getMonth() > 8) {
+    return year + 1;
+  }
+  return year;
+})();
+
+// The UI turns the years into strings, so let's
+// just make them strings in the state as well;
+// that simplifies things
+const threeYears = [thisFFY, thisFFY + 1, thisFFY + 2].map(y => `${y}`);
+const firstTwoYears = threeYears.slice(0, 2);
 
 const initialState = {
   data: {
     id: '',
     years: firstTwoYears,
+    yearOptions: threeYears,
     overview: '',
     hitNarrative: '',
     hieNarrative: '',
@@ -50,7 +66,8 @@ const reducer = (state = initialState, action) => {
           hitNarrative,
           hieNarrative,
           mmisNarrative,
-          years: years || firstTwoYears,
+          years: years.map(y => `${y}`) || firstTwoYears,
+          yearOptions: threeYears,
           previousActivitySummary: previousActivitySummary || ''
         }
       };

--- a/web/src/reducers/apd.test.js
+++ b/web/src/reducers/apd.test.js
@@ -5,6 +5,7 @@ describe('APD reducer', () => {
     data: {
       id: '',
       years: ['2018', '2019'],
+      yearOptions: ['2018', '2019', '2020'],
       overview: '',
       hitNarrative: '',
       hieNarrative: '',
@@ -39,13 +40,17 @@ describe('APD reducer', () => {
           narrativeHIT: 'HIT, but as a play',
           narrativeHIE: 'HIE, but as a novel',
           narrativeMMIS: 'MMIS, but as a script',
-          years: 'the years for the APD'
+          years: []
         }
       })
     ).toEqual({
       data: {
         id: 'apd-id',
-        years: 'the years for the APD',
+        years: [],
+        // TODO: This value is computed based on the current datetime.
+        // Probably ought to mock the time (sinon can do this) so
+        // the test is deterministic.
+        yearOptions: ['2018', '2019', '2020'],
         overview: 'moop moop',
         hitNarrative: 'HIT, but as a play',
         hieNarrative: 'HIE, but as a novel',

--- a/web/src/reducers/budget.js
+++ b/web/src/reducers/budget.js
@@ -1,8 +1,6 @@
-import { UPDATE_BUDGET } from '../actions/activities';
-import { GET_APD_SUCCESS } from '../actions/apd';
-import { YEAR_OPTIONS } from '../util';
+import { UPDATE_BUDGET } from '../actions/apd';
 
-const getFundingSourcesByYear = (years = YEAR_OPTIONS) => ({
+const getFundingSourcesByYear = years => ({
   ...years.reduce(
     (o, year) => ({
       ...o,
@@ -21,19 +19,19 @@ const getFundingSourcesByYear = (years = YEAR_OPTIONS) => ({
   }
 });
 
-const expenseTypes = () => ({
-  statePersonnel: getFundingSourcesByYear(),
-  contractors: getFundingSourcesByYear(),
-  expenses: getFundingSourcesByYear(),
-  combined: getFundingSourcesByYear()
+const expenseTypes = years => ({
+  statePersonnel: getFundingSourcesByYear(years),
+  contractors: getFundingSourcesByYear(years),
+  expenses: getFundingSourcesByYear(years),
+  combined: getFundingSourcesByYear(years)
 });
 
-const initialState = () => ({
-  combined: getFundingSourcesByYear(),
-  hie: expenseTypes(),
-  hit: expenseTypes(),
-  mmis: expenseTypes(),
-  years: YEAR_OPTIONS
+const initialState = years => ({
+  combined: getFundingSourcesByYear(years),
+  hie: expenseTypes(years),
+  hit: expenseTypes(years),
+  mmis: expenseTypes(years),
+  years: []
 });
 
 const activities = src => Object.values(src.activities.byId);
@@ -108,7 +106,7 @@ const getTotalsForFundingSource = (bigState, fundingSource) => {
 };
 
 const buildBudget = wholeState => {
-  const newState = initialState();
+  const newState = initialState(wholeState.apd.data.years);
 
   activities(wholeState).forEach(activity => {
     const totaller = getTotalsForActivity(activity);
@@ -135,11 +133,9 @@ const buildBudget = wholeState => {
   return newState;
 };
 
-const reducer = (state = initialState(), action) => {
+const reducer = (state = initialState([]), action) => {
   switch (action.type) {
     case UPDATE_BUDGET:
-      return buildBudget(action.state);
-    case GET_APD_SUCCESS:
       return buildBudget(action.state);
     default:
       return state;

--- a/web/src/util/index.js
+++ b/web/src/util/index.js
@@ -113,6 +113,26 @@ export const STANDARDS = [
   }
 ];
 
+const thisFFY = (() => {
+  const year = new Date().getFullYear();
+
+  // Federal fiscal year starts October 1,
+  // but Javascript months start with 0 for
+  // some reason, so October is month 9.
+  if (new Date().getMonth() > 8) {
+    return year + 1;
+  }
+  return year;
+})();
+
+// The UI turns the years into strings, so let's
+// just make them strings in the state as well;
+// that simplifies things
+const threeYears = [thisFFY, thisFFY + 1, thisFFY + 2].map(y => `${y}`);
+
+export const defaultAPDYearOptions = threeYears;
+export const defaultAPDYears = threeYears.slice(0, 2);
+
 export const stateLookup = id => STATES.find(s => s.id === id.toLowerCase());
 
 export const getParams = str =>

--- a/web/src/util/index.js
+++ b/web/src/util/index.js
@@ -2,8 +2,6 @@
 
 export const ACTIVITY_FUNDING_SOURCES = ['HIT', 'HIE', 'MMIS'];
 
-export const YEAR_OPTIONS = ['2018', '2019', '2020'];
-
 export const STATES = [
   { id: 'al', name: 'Alabama' },
   { id: 'ak', name: 'Alaska' },


### PR DESCRIPTION
Describe the pull request here, including any supplemental information needed to understand it.

Closes #462
Closes #630
Closes #631
Closes #632
Closes #641

### This pull request changes...
- no hidden 2020 expenses!
- if you DESELECT a year for which data has been entered, that data will be lost
  - need a separate issue to discuss/design the right solution - could just hide that data, or prompt the user to confirm that they want to destroy it
  - if we just hide it, what happens when the APD is saved?

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author

### This feature is done when...
- [ ] Product has approved the experience
