### PR TITLE
add funding source, drop types

### DIFF
--- a/api/db/activity/activity.js
+++ b/api/db/activity/activity.js
@@ -46,11 +46,11 @@ module.exports = {
             out.other_funding_sources_description = value.otherSources;
           }
         } else if (
-          // stringify the types and standardsAndConditions fields,
-          // but only if they're not null; if they are null, stringify
+          // stringify the standardsAndConditions field,
+          // but only if it's not null; if null, stringify
           // returns the string 'null', which is invalid JSON and will
           // cause Postgres to throw
-          (field === 'types' || field === 'standardsAndConditions') &&
+          field === 'standardsAndConditions' &&
           value
         ) {
           out[outField] = JSON.stringify(value);
@@ -68,8 +68,8 @@ module.exports = {
         'description',
         'alternatives',
         'costAllocationNarrative',
-        'types',
-        'standardsAndConditions'
+        'standardsAndConditions',
+        'fundingSource'
       ],
       owns: {
         goals: 'apdActivityGoal',
@@ -116,7 +116,6 @@ module.exports = {
       return {
         id: this.get('id'),
         name: this.get('name'),
-        types: this.get('types'),
         summary: this.get('summary'),
         description: this.get('description'),
         alternatives: this.get('alternatives'),
@@ -130,7 +129,8 @@ module.exports = {
           otherSources: this.get('other_funding_sources_description')
         },
         costAllocation: this.related('costAllocation'),
-        standardsAndConditions: this.get('standards_and_conditions')
+        standardsAndConditions: this.get('standards_and_conditions'),
+        fundingSource: this.get('funding_source')
       };
     }
   }

--- a/api/db/activity/activity.test.js
+++ b/api/db/activity/activity.test.js
@@ -27,8 +27,8 @@ tap.test('activity data model', async activityModelTests => {
               'description',
               'alternatives',
               'costAllocationNarrative',
-              'types',
-              'standardsAndConditions'
+              'standardsAndConditions',
+              'fundingSource'
             ],
             owns: {
               goals: 'apdActivityGoal',
@@ -305,7 +305,7 @@ tap.test('activity data model', async activityModelTests => {
       self.get
         .withArgs('other_funding_sources_description')
         .returns('panhandling, funny videos online');
-      self.get.withArgs('types').returns('on a typewriter');
+      self.get.withArgs('funding_source').returns('bitcoin');
       self.get
         .withArgs('standards_and_conditions')
         .returns('nobody reads them');
@@ -331,8 +331,8 @@ tap.test('activity data model', async activityModelTests => {
           },
           costAllocation: 'cost allocation by year',
           goals: 'goooooaaaaals',
-          types: 'on a typewriter',
-          standardsAndConditions: 'nobody reads them'
+          standardsAndConditions: 'nobody reads them',
+          fundingSource: 'bitcoin'
         },
         'gives us back the right JSON-ified object'
       );

--- a/api/endpoint-tests/activities/put.js
+++ b/api/endpoint-tests/activities/put.js
@@ -143,7 +143,7 @@ tap.test(
               schedule: [],
               standardsAndConditions: null,
               summary: null,
-              types: null,
+              fundingSource: null,
               statePersonnel: []
             },
             'sends back the updated activity object'

--- a/api/migrations/20180607102756_activity-funding-source.js
+++ b/api/migrations/20180607102756_activity-funding-source.js
@@ -1,0 +1,8 @@
+exports.up = async knex => {
+  await knex.schema.alterTable('activities', table => {
+    table.string('funding_source', 32);
+    table.dropColumn('types');
+  });
+};
+
+exports.down = async () => {};

--- a/api/routes/openAPI/index.js
+++ b/api/routes/openAPI/index.js
@@ -48,11 +48,10 @@ module.exports = {
             type: 'string',
             description: 'Activity name, unique within an APD'
           },
-          types: arrayOf({
+          fundingSource: {
             type: 'string',
-            description:
-              'List of federal funding sources that apply to this activity'
-          }),
+            description: 'Federal funding source that applies to this activity'
+          },
           summary: {
             type: 'string',
             description: 'Short summary of the activity'


### PR DESCRIPTION
Adds `funding_source` to activities table and drops `types`

addresses https://github.com/18F/cms-hitech-apd/pull/625#pullrequestreview-124898885 and resolves https://github.com/18F/cms-hitech-apd/issues/624

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
