### PR TITLE
Update the deploy bot's message when it redeploys a PR app

### DIFF
--- a/bin/cleanup-pr-deploys.sh
+++ b/bin/cleanup-pr-deploys.sh
@@ -32,7 +32,7 @@ while read -r app; do
       COMMENTS=$(curl -s -u "$GH_BOT_USER:$GH_BOT_PASSWORD" https://api.github.com/repos/18f/cms-hitech-apd/issues/$PULL/comments | jq -c -r '.[] | {id:.id,user:.user.login}' | grep "$GH_BOT_USER" || true)
       if [ "$COMMENTS" ]; then
         ID=$(echo "$COMMENTS" | jq -c -r .id)
-          curl -s -u "$GH_BOT_USER:$GH_BOT_PASSWORD" -d '{"body":"This deploy was cleaned up."}' -H "Content-Type: application/json" -X PATCH "https://api.github.com/repos/18f/cms-hitech-apd/issues/comments/$ID"
+        curl -s -u "$GH_BOT_USER:$GH_BOT_PASSWORD" -d '{"body":"This deploy was cleaned up."}' -H "Content-Type: application/json" -X PATCH "https://api.github.com/repos/18f/cms-hitech-apd/issues/comments/$ID"
       fi
     fi
   fi

--- a/bin/deploy-pr.sh
+++ b/bin/deploy-pr.sh
@@ -34,12 +34,17 @@ if [ -n "$CI_PULL_REQUESTS" ] && [ "$WEBCHANGES" -ne 0 ]; then
   # Push
   cf push "hitech-apd-frontend-pr$PRNUM" -n "hitech-apd-pr$PRNUM" -b https://github.com/cloudfoundry/staticfile-buildpack.git -m 64M --no-manifest -p web/dist
 
-  # Add a comment on Github, if there's not one already
+  # Delete comment on Github, if there's one already
   COMMENTS=$(curl -s -u "$GH_BOT_USER:$GH_BOT_PASSWORD" https://api.github.com/repos/18f/cms-hitech-apd/issues/$PRNUM/comments | jq -c -r '.[] | {id:.id,user:.user.login}' | grep "$GH_BOT_USER" || true)
-  if ! [ "$COMMENTS" ]; then
-    URL="https://hitech-apd-pr$PRNUM.app.cloud.gov/"
-    curl -s -u "$GH_BOT_USER:$GH_BOT_PASSWORD" -d '{"body":"See this pull request in action: '"$URL"'"}' -H "Content-Type: application/json" -X POST "https://api.github.com/repos/18f/cms-hitech-apd/issues/$PRNUM/comments"
+  if [ "$COMMENTS" ]; then
+    ID=$(echo "$COMMENTS" | jq -c -r .id)
+    curl -s -u "$GH_BOT_USER:$GH_BOT_PASSWORD" -X DELETE "https://api.github.com/repos/18f/cms-hitech-apd/issues/comments/$ID"
   fi
+
+  # Post again.  This way we'll know the bot updated the thing.
+  URL="https://hitech-apd-pr$PRNUM.app.cloud.gov/"
+  curl -s -u "$GH_BOT_USER:$GH_BOT_PASSWORD" -d '{"body":"See this pull request in action: '"$URL"'"}' -H "Content-Type: application/json" -X POST "https://api.github.com/repos/18f/cms-hitech-apd/issues/$PRNUM/comments"
+
 
 elif [ "$WEBCHANGES" -eq 0 ]; then
   echo "No changes to /web"


### PR DESCRIPTION
Currently, once the bot has commented on a PR, it doesn't comment again.  This will change the bot's behavior so that it will delete its old comment and create a new one every time it deploys the app.  That way its comment will always be at the bottom and we'll know that it updated.

### This pull request changes...
- The PR bot message will be the most recent comment after it finishes a deploy, so we can tell when it redeploys after changes are made

@jeromeleecms Feel free to just close this if you don't want the change in behavior, I won't mind.  😉