### PR TITLE
Fix: Deleting personnel, contractor, or expense rows triggers a budget table update

### DIFF
--- a/web/src/actions/activities.js
+++ b/web/src/actions/activities.js
@@ -42,7 +42,10 @@ export const expandActivitySection = id => ({
   id
 });
 
-export const removeActivity = id => ({ type: REMOVE_ACTIVITY, id });
+export const removeActivity = id => dispatch => {
+  dispatch({ type: REMOVE_ACTIVITY, id });
+  dispatch(updateBudget());
+};
 
 export const removeActivityContractor = (id, contractorId) => dispatch => {
   dispatch({

--- a/web/src/actions/activities.js
+++ b/web/src/actions/activities.js
@@ -44,11 +44,14 @@ export const expandActivitySection = id => ({
 
 export const removeActivity = id => ({ type: REMOVE_ACTIVITY, id });
 
-export const removeActivityContractor = (id, contractorId) => ({
-  type: REMOVE_ACTIVITY_CONTRACTOR,
-  id,
-  contractorId
-});
+export const removeActivityContractor = (id, contractorId) => dispatch => {
+  dispatch({
+    type: REMOVE_ACTIVITY_CONTRACTOR,
+    id,
+    contractorId
+  });
+  dispatch(updateBudget());
+};
 
 export const removeActivityGoal = (id, goalIdx) => ({
   type: REMOVE_ACTIVITY_GOAL,
@@ -56,11 +59,14 @@ export const removeActivityGoal = (id, goalIdx) => ({
   goalIdx
 });
 
-export const removeActivityExpense = (id, expenseId) => ({
-  type: REMOVE_ACTIVITY_EXPENSE,
-  id,
-  expenseId
-});
+export const removeActivityExpense = (id, expenseId) => dispatch => {
+  dispatch({
+    type: REMOVE_ACTIVITY_EXPENSE,
+    id,
+    expenseId
+  });
+  dispatch(updateBudget());
+};
 
 export const removeActivityMilestone = (id, milestoneIdx) => ({
   type: REMOVE_ACTIVITY_MILESTONE,
@@ -68,11 +74,14 @@ export const removeActivityMilestone = (id, milestoneIdx) => ({
   milestoneIdx
 });
 
-export const removeActivityStatePerson = (id, personId) => ({
-  type: REMOVE_ACTIVITY_STATE_PERSON,
-  id,
-  personId
-});
+export const removeActivityStatePerson = (id, personId) => dispatch => {
+  dispatch({
+    type: REMOVE_ACTIVITY_STATE_PERSON,
+    id,
+    personId
+  });
+  dispatch(updateBudget());
+};
 
 export const toggleActivitySection = id => ({
   type: TOGGLE_ACTIVITY_SECTION,

--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -131,7 +131,10 @@ const reducer = (state = initialState, action) => {
             [action.id]: {
               contractorResources: contractors => [
                 ...contractors,
-                newContractor(nextSequence(contractors.map(c => c.id)))
+                newContractor(
+                  nextSequence(contractors.map(c => c.id)),
+                  action.years
+                )
               ]
             }
           }
@@ -157,7 +160,10 @@ const reducer = (state = initialState, action) => {
             [action.id]: {
               statePersonnel: people => [
                 ...people,
-                newStatePerson(nextSequence(people.map(p => p.id)))
+                newStatePerson(
+                  nextSequence(people.map(p => p.id)),
+                  action.years
+                )
               ]
             }
           }
@@ -205,7 +211,7 @@ const reducer = (state = initialState, action) => {
             [action.id]: {
               expenses: expenses => [
                 ...expenses,
-                newExpense(nextSequence(expenses.map(e => e.id)))
+                newExpense(nextSequence(expenses.map(e => e.id)), action.years)
               ]
             }
           }

--- a/web/src/reducers/budget.js
+++ b/web/src/reducers/budget.js
@@ -36,6 +36,10 @@ const initialState = years => ({
 
 const activities = src => Object.values(src.activities.byId);
 
+// The default for from is to handle the case where an expense
+// block doesn't have any rows.  In that case, from is never
+// populated.  But that block doesn't conribute to the budget,
+// either, so easiest thing to do is just zero it out.
 const addBudgetBlocks = (into, from = { total: 0, federal: 0, state: 0 }) => {
   const out = into;
   out.total += from.total;

--- a/web/src/reducers/budget.js
+++ b/web/src/reducers/budget.js
@@ -36,7 +36,7 @@ const initialState = years => ({
 
 const activities = src => Object.values(src.activities.byId);
 
-const addBudgetBlocks = (into, from) => {
+const addBudgetBlocks = (into, from = { total: 0, federal: 0, state: 0 }) => {
   const out = into;
   out.total += from.total;
   out.federal += from.federal;


### PR DESCRIPTION
Also fixes a bug where you couldn't add new personnel, contractor, or expense rows.  😬

Closes #645

### This pull request changes...
- deleting any of those kinds of rows will update the budget table
- deleting an activity will update the budget table
- you can add more of those kinds of rows

### This pull request is ready to merge when...
- ~Tests have been updated (and all tests are passing)~ Big tests overhaul coming soon, this will get wrapped up into that
- [ ] This code has been reviewed by someone other than the original author

### This feature is done when...
- [ ] Product has approved the experience
