### PR TITLE
Fix: Adjust personnel costs according to FTE%

### DIFF
--- a/api/db/activity/statePersonnel.js
+++ b/api/db/activity/statePersonnel.js
@@ -34,7 +34,7 @@ module.exports = {
     },
 
     async validate() {
-      if (this.attributes.fte < 0 || this.attributes.fte > 1) {
+      if (this.attributes.fte < 0) {
         throw new Error('fte-out-of-range');
       }
       if (this.attributes.year < 2010 || this.attributes.year > 3000) {

--- a/api/db/activity/statePersonnel.test.js
+++ b/api/db/activity/statePersonnel.test.js
@@ -129,17 +129,11 @@ tap.test(
         }
       );
 
-      validationTests.test(
-        'fails if FTE is too small or too large',
-        async test => {
-          self.attributes.year = 2019;
-          self.attributes.fte = -0.3;
-          test.rejects(cost.validate.bind(self), 'rejects if fte is negative');
-
-          self.attributes.fte = 1.3;
-          test.rejects(cost.validate.bind(self), 'rejects if fte is over 100%');
-        }
-      );
+      validationTests.test('fails if FTE is too small', async test => {
+        self.attributes.year = 2019;
+        self.attributes.fte = -0.3;
+        test.rejects(cost.validate.bind(self), 'rejects if fte is negative');
+      });
 
       validationTests.test('succeeds if data is valid', async test => {
         self.attributes.year = 2019;

--- a/web/src/actions/apd.js
+++ b/web/src/actions/apd.js
@@ -110,7 +110,7 @@ export const saveApd = () => (dispatch, state) => {
         description: s.desc,
         years: Object.keys(s.years).map(year => ({
           cost: +s.years[year].amt,
-          fte: +s.years[year].perc,
+          fte: +s.years[year].perc / 100,
           year
         }))
       })),

--- a/web/src/containers/ActivityDetailStatePersonnel.js
+++ b/web/src/containers/ActivityDetailStatePersonnel.js
@@ -31,7 +31,7 @@ class ActivityDetailStatePersonnel extends Component {
       {
         statePersonnel: { [idx]: toUpdate }
       },
-      key === 'amt'
+      key === 'amt' || key === 'perc'
     );
   };
 

--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -368,7 +368,7 @@ const reducer = (state = initialState, action) => {
                 ...years,
                 [y.year]: {
                   amt: y.cost,
-                  perc: y.fte
+                  perc: y.fte * 100
                 }
               }),
               {}

--- a/web/src/reducers/budget.js
+++ b/web/src/reducers/budget.js
@@ -111,7 +111,7 @@ const buildBudget = wholeState => {
   activities(wholeState).forEach(activity => {
     const totaller = getTotalsForActivity(activity);
     totaller
-      .collapse('statePersonnel', year => +year.amt)
+      .collapse('statePersonnel', year => +year.amt * +year.perc / 100)
       .totals()
       .merge(newState);
 


### PR DESCRIPTION
Closes #651

### This pull request changes...
- adjusts the state personnel costs in the budget table according to the FTE% assigned to the row
- FTE% is not limited to 100%; however, the database currently caps it at 999.99% - we can remove/raise that cap in a separate pull request (it requires a migration and I'm not 100% sure how to do it without destroying data)
- the budget table updates when the FTE% is modified

### This pull request is ready to merge when...
- [ ] This code has been reviewed by someone other than the original author

### This feature is done when...
- [ ] Product has approved the experience
