### PR TITLE
Flesh out OpenAPI with more metadata to make it more navigable

### DIFF
--- a/api/routes/apds/activities/openAPI.js
+++ b/api/routes/apds/activities/openAPI.js
@@ -15,6 +15,8 @@ const activitySubParts = [
 const openAPI = {
   '/apds/{id}/activities': {
     post: {
+      tags: ['APD activities'],
+      summary: 'Add a new activity to an APD',
       description: 'Add a new activity to the specified APD',
       parameters: [
         {
@@ -53,6 +55,8 @@ const openAPI = {
 
   '/activities/{id}': {
     put: {
+      tags: ['APD activities'],
+      summary: 'Update a specific activity',
       description: 'Update an APD activity in the system',
       parameters: [
         {
@@ -93,6 +97,8 @@ const openAPI = {
 activitySubParts.forEach(sub => {
   openAPI[`/activities/{id}/${sub}`] = {
     put: {
+      tags: ['APD activities'],
+      summary: `Set the ${sub} for a specific activity`,
       description: `Set the ${sub} for a specific activity`,
       parameters: [
         {

--- a/api/routes/apds/openAPI.js
+++ b/api/routes/apds/openAPI.js
@@ -8,6 +8,8 @@ const activities = require('./activities/openAPI');
 const openAPI = {
   '/apds': {
     get: {
+      tags: ['APDs'],
+      summary: 'Get all of the APDs available to the user',
       description: 'Get a list of all apds associated with requesting user',
       responses: {
         200: {
@@ -17,6 +19,8 @@ const openAPI = {
       }
     },
     post: {
+      tags: ['APDs'],
+      summary: `Create a new draft APD associated with the user's state`,
       description: `Create a new draft APD for the current user's state`,
       responses: {
         200: {
@@ -29,6 +33,8 @@ const openAPI = {
 
   '/apds/{id}': {
     put: {
+      tags: ['APDs'],
+      summary: 'Update a specific APD',
       description: 'Update an apd in the system',
       parameters: [
         {
@@ -72,7 +78,10 @@ const openAPI = {
 
   '/apds/{id}/versions': {
     post: {
-      description: 'Create a new saved version of an APD',
+      tags: ['APDs'],
+      summary: 'Save a submitted version of a specific APD',
+      description:
+        'Create a new saved version of an APD and makes the APD non-draft so it cannot be edited',
       parameters: [
         {
           name: 'id',

--- a/api/routes/auth/activities/openAPI.js
+++ b/api/routes/auth/activities/openAPI.js
@@ -6,6 +6,8 @@ const {
 const openAPI = {
   '/auth/activities': {
     get: {
+      tags: ['Authentication and authorization'],
+      summary: 'Gets the list of all activities',
       description: 'Get a list of all activities in the system',
       responses: {
         200: {

--- a/api/routes/auth/roles/openAPI.js
+++ b/api/routes/auth/roles/openAPI.js
@@ -24,6 +24,8 @@ const roleObjectSchema = {
 const openAPI = {
   '/auth/roles': {
     get: {
+      tags: ['Authentication and authorization'],
+      summary: 'Gets the list of all roles',
       description: 'Get a list of all roles in the system',
       responses: {
         200: {
@@ -33,6 +35,8 @@ const openAPI = {
       }
     },
     post: {
+      tags: ['Authentication and authorization'],
+      summary: 'Creates a new role',
       description: 'Create a new role',
       requestBody: {
         description: 'The new values for the new role',
@@ -70,6 +74,8 @@ const openAPI = {
   },
   '/auth/roles/{id}': {
     put: {
+      tags: ['Authentication and authorization'],
+      summary: 'Sets the activities for a role',
       description:
         'Change which activities an existing role is associated with',
       parameters: [
@@ -115,6 +121,8 @@ const openAPI = {
       }
     },
     delete: {
+      tags: ['Authentication and authorization'],
+      summary: 'Deletes a role',
       description:
         'Remove the associations between a role and activities, and delete the role',
       parameters: [

--- a/api/routes/me/openAPI.js
+++ b/api/routes/me/openAPI.js
@@ -6,7 +6,9 @@ const {
 const openAPI = {
   '/me': {
     get: {
-      description: `Get information about the current users`,
+      tags: ['Users'],
+      summary: `Gets the current user's information`,
+      description: `Get information about the current user`,
       responses: {
         200: {
           description: 'The current user',

--- a/api/routes/openAPI/auth.js
+++ b/api/routes/openAPI/auth.js
@@ -3,6 +3,8 @@ const { schema: { jsonResponse } } = require('./helpers');
 module.exports = {
   '/auth/login': {
     post: {
+      tags: ['Authentication and authorization'],
+      summary: 'Logs a user in',
       description: 'Authenticate a user against the local database',
       requestBody: {
         required: true,
@@ -42,6 +44,8 @@ module.exports = {
   },
   '/auth/logout': {
     get: {
+      tags: ['Authentication and authorization'],
+      summary: 'Logs the current user out',
       description: 'Logs the user out by invalidating the session cookie',
       responses: {
         200: {

--- a/api/routes/openAPI/index.js
+++ b/api/routes/openAPI/index.js
@@ -26,6 +26,8 @@ module.exports = {
     ...states,
     '/open-api': {
       get: {
+        tags: ['Metadata'],
+        summary: 'Gets this document',
         description: 'Returns this document',
         responses: {
           200: {

--- a/api/routes/states/openAPI.js
+++ b/api/routes/states/openAPI.js
@@ -6,6 +6,8 @@ const {
 const openAPI = {
   '/states': {
     get: {
+      tags: ['States, territories, and districts'],
+      summary: `Gets information about the current user's state/territory/district`,
       description: `Get information about the users's state, territory, or district`,
       responses: {
         200: {
@@ -19,6 +21,8 @@ const openAPI = {
       }
     },
     put: {
+      tags: ['States, territories, and districts'],
+      summary: `Sets information about the current user's state/territory/district`,
       description: `Update information about the users's state, territory, or district`,
       requestBody: {
         description:
@@ -44,6 +48,8 @@ const openAPI = {
   },
   '/states/{id}': {
     get: {
+      tags: ['States, territories, and districts'],
+      summary: 'Gets information about a specific state/territory/district',
       description:
         'Get information about a specific state, territory, or district',
       parameters: [

--- a/api/routes/users/openAPI.js
+++ b/api/routes/users/openAPI.js
@@ -21,6 +21,8 @@ const userObjectSchema = {
 const openAPI = {
   '/users': {
     get: {
+      tags: ['Users'],
+      summary: 'Gets a list of all users',
       description: 'Get a list of all users in the system',
       responses: {
         200: {
@@ -30,6 +32,8 @@ const openAPI = {
       }
     },
     post: {
+      tags: ['Users'],
+      summary: 'Adds a new user',
       description: 'Add a new user to the system',
       requestBody: {
         content: jsonResponse({
@@ -62,6 +66,8 @@ const openAPI = {
   },
   '/users/{id}': {
     delete: {
+      tags: ['Users'],
+      summary: 'Removes a user',
       description: 'Delete a user from the system',
       parameters: [
         {
@@ -87,6 +93,8 @@ const openAPI = {
       }
     },
     get: {
+      tags: ['Users'],
+      summary: 'Gets the information for a specific user',
       description: 'Get a specific user in the system',
       parameters: [
         {


### PR DESCRIPTION
This might be helpful for @NAretakis and @jeromeleecms with respect to "poking" the API.  Will follow-up in Slack with info about how this is useful after it's merged.

The short version is the API documentation is now sectioned off, and each endpoint has a nice little piece of text showing you what it is before you expand it:

![screen shot 2018-06-14 at 2 14 49 pm](https://user-images.githubusercontent.com/1775733/41433021-52baa6e2-6fdd-11e8-869d-b8dd3520fd9a.png)

### This pull request changes...
- nothing visible

### This pull request is ready to merge when...
- [ ] This code has been reviewed by someone other than the original author
- [x] The change has been documented
  - [x] Associated OpenAPI documentation has been updated