### PR TITLE
rework cost allocation

### DIFF
--- a/web/src/actions/apd.js
+++ b/web/src/actions/apd.js
@@ -119,14 +119,14 @@ export const saveApd = () => (dispatch, state) => {
       description: activity.descLong,
       alternatives: activity.altApproach,
       costAllocationNarrative: {
-        methodology: activity.costAllocateDesc,
+        methodology: activity.costAllocationDesc,
         otherSources: activity.otherFundingDesc
       },
-      costAllocation: Object.entries(activity.costFFP).map(
+      costAllocation: Object.entries(activity.costAllocation).map(
         ([year, allocation]) => ({
-          federal: +allocation.fed / 100,
-          state: +allocation.state / 100,
-          other: +allocation.other / 100,
+          federal: +allocation.ffp.federal / 100,
+          state: +allocation.ffp.state / 100,
+          other: +allocation.other,
           year
         })
       ),

--- a/web/src/actions/apd.test.js
+++ b/web/src/actions/apd.test.js
@@ -195,11 +195,11 @@ describe('apd actions', () => {
             descShort: 'activity summary',
             descLong: 'activity description',
             altApproach: 'alternatives approach',
-            costAllocateDesc: 'cost allocation methodology',
+            costAllocationDesc: 'cost allocation methodology',
             otherFundingDesc: 'other funding sources',
-            costFFP: {
-              '1993': { fed: 90, state: 10, other: 0 },
-              '1994': { fed: 70, state: 20, other: 10 }
+            costAllocation: {
+              '1993': { ffp: { federal: 90, state: 10 }, other: 0 },
+              '1994': { ffp: { federal: 70, state: 20 }, other: 10 }
             },
             goals: [
               { desc: 'goal 1 description', obj: 'objective 1' },

--- a/web/src/components/temp/MiscPage.js
+++ b/web/src/components/temp/MiscPage.js
@@ -1,11 +1,11 @@
 import React from 'react';
 
 import Container from '../Container';
-import QuarterlyBudgetSummary from '../../containers/QuarterlyBudgetSummary';
+import ActivityDetailCostAllocateFFP from '../../containers/ActivityDetailCostAllocateFFP';
 
 const MiscPage = () => (
   <Container>
-    <QuarterlyBudgetSummary />
+    <ActivityDetailCostAllocateFFP aId={1} />
   </Container>
 );
 

--- a/web/src/components/temp/MiscPage.js
+++ b/web/src/components/temp/MiscPage.js
@@ -1,11 +1,10 @@
 import React from 'react';
 
 import Container from '../Container';
-import ActivityDetailCostAllocateFFP from '../../containers/ActivityDetailCostAllocateFFP';
 
 const MiscPage = () => (
   <Container>
-    <ActivityDetailCostAllocateFFP aId={1} />
+    <h1 className="h2">Misc Components (for testing purposes)</h1>
   </Container>
 );
 

--- a/web/src/containers/ActivityDetailCostAllocate.js
+++ b/web/src/containers/ActivityDetailCostAllocate.js
@@ -11,7 +11,7 @@ import { t } from '../i18n';
 
 const ActivityDetailCostAllocate = props => {
   const { activity, updateActivity } = props;
-  const { costAllocateDesc, otherFundingDesc } = activity;
+  const { costAllocationDesc, otherFundingDesc } = activity;
 
   const sync = name => html => {
     updateActivity(activity.id, { [name]: html });
@@ -28,8 +28,8 @@ const ActivityDetailCostAllocate = props => {
           reminder="activities.costAllocate.methodology.reminder"
         />
         <RichText
-          content={costAllocateDesc}
-          onSync={sync('costAllocateDesc')}
+          content={costAllocationDesc}
+          onSync={sync('costAllocationDesc')}
         />
       </div>
       <ActivityDetailCostAllocateFFP aId={activity.id} />

--- a/web/src/containers/ActivityDetailCostAllocate.js
+++ b/web/src/containers/ActivityDetailCostAllocate.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import ActivityDetailCostAllocateFFP from './ActivityDetailCostAllocateFFP';
 import { updateActivity as updateActivityAction } from '../actions/activities';
 import { Subsection } from '../components/Section';
-import { DollarInput, RichText } from '../components/Inputs';
+import { RichText } from '../components/Inputs';
 import HelpText from '../components/HelpText';
 import { t } from '../i18n';
 
@@ -46,15 +46,6 @@ const ActivityDetailCostAllocate = props => {
           onSync={sync('otherFundingDesc')}
         />
       </div>
-      <DollarInput
-        name="other-funding-amt"
-        label={t('activities.costAllocate.otherFunding.amount')}
-        wrapperClass="mb2 sm-col-4"
-        value={activity.otherFundingAmt}
-        onChange={e =>
-          updateActivity(activity.id, { otherFundingAmt: e.target.value })
-        }
-      />
     </Subsection>
   );
 };

--- a/web/src/containers/ActivityDetailCostAllocateFFP.js
+++ b/web/src/containers/ActivityDetailCostAllocateFFP.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { updateActivity as updateActivityAction } from '../actions/activities';
 import { DollarInput } from '../components/Inputs';
 import Select from '../components/Select';
+import { t } from '../i18n';
 import { getActivityTotals } from '../reducers/activities';
 import { titleCase } from '../util';
 import { formatMoney } from '../util/formats';
@@ -32,9 +33,9 @@ class ActivityDetailCostAllocateFFP extends Component {
 
     return (
       <div className="mb3">
-        <h4>Federal Financial Partipation (FFP) and Cost Allocation</h4>
+        <h4>{t('activities.costAllocate.ffp.title')}</h4>
         <div className="clearfix mxn1">
-          {byYearData.map(({ year, total, allocations }) => (
+          {byYearData.map(({ year, total, totalNetOther, allocations }) => (
             <div key={year} className="col col-12 sm-col-4 px1">
               <div className="p2 bg-darken-1">
                 <div>{year}</div>
@@ -42,23 +43,24 @@ class ActivityDetailCostAllocateFFP extends Component {
                 <hr />
                 <DollarInput
                   name={`cost-allocate-other-${year}`}
-                  label="Other (amount)"
+                  label={t('activities.costAllocate.ffp.labels.other')}
                   value={costAllocation[year].other}
                   onChange={this.handleOther(year)}
                 />
+                <div>{t('activities.costAllocate.ffp.totalNetOther')}</div>
+                <div className="h3 bold mono">{formatMoney(totalNetOther)}</div>
                 <hr />
                 <Select
                   name={`ffp-${year}`}
-                  label="Federal / State (percent)"
+                  label={t('activities.costAllocate.ffp.labels.fedStateSplit')}
                   options={['90-10', '75-25', '50-50']}
                   onChange={this.handleFFP(year)}
                 />
-                <hr />
                 <div className="flex mxn-tiny">
                   {allocations.map(({ id, amount }) => (
                     <div key={id} className="col-12">
                       <div>{titleCase(id)}</div>
-                      <div className="bold mono">{formatMoney(amount)}</div>
+                      <div className="h3 bold mono">{formatMoney(amount)}</div>
                     </div>
                   ))}
                 </div>
@@ -89,14 +91,12 @@ const mapStateToProps = ({ activities: { byId } }, { aId }) => {
     const { ffp, other } = costAllocation[year];
     const totalNetOther = total - other;
 
-    const allocations = Object.keys(ffp)
-      .map(id => ({
-        id,
-        amount: totalNetOther * ffp[id] / 100
-      }))
-      .concat({ id: 'other', amount: other });
+    const allocations = Object.keys(ffp).map(id => ({
+      id,
+      amount: totalNetOther * ffp[id] / 100
+    }));
 
-    return { year, total, allocations };
+    return { year, total, totalNetOther, allocations };
   });
 
   return { byYearData, costAllocation };

--- a/web/src/containers/ActivityDetailCostAllocateFFP.js
+++ b/web/src/containers/ActivityDetailCostAllocateFFP.js
@@ -35,38 +35,47 @@ class ActivityDetailCostAllocateFFP extends Component {
       <div className="mb3">
         <h4>{t('activities.costAllocate.ffp.title')}</h4>
         <div className="clearfix mxn1">
-          {byYearData.map(({ year, total, totalNetOther, allocations }) => (
-            <div key={year} className="col col-12 sm-col-4 px1">
-              <div className="p2 bg-darken-1">
-                <div>{year}</div>
-                <div className="h3 bold mono">{formatMoney(total)}</div>
-                <hr />
-                <DollarInput
-                  name={`cost-allocate-other-${year}`}
-                  label={t('activities.costAllocate.ffp.labels.other')}
-                  value={costAllocation[year].other}
-                  onChange={this.handleOther(year)}
-                />
-                <div>{t('activities.costAllocate.ffp.totalNetOther')}</div>
-                <div className="h3 bold mono">{formatMoney(totalNetOther)}</div>
-                <hr />
-                <Select
-                  name={`ffp-${year}`}
-                  label={t('activities.costAllocate.ffp.labels.fedStateSplit')}
-                  options={['90-10', '75-25', '50-50']}
-                  onChange={this.handleFFP(year)}
-                />
-                <div className="flex mxn-tiny">
-                  {allocations.map(({ id, amount }) => (
-                    <div key={id} className="col-12">
-                      <div>{titleCase(id)}</div>
-                      <div className="h3 bold mono">{formatMoney(amount)}</div>
-                    </div>
-                  ))}
+          {byYearData.map(
+            ({ year, total, totalNetOther, ffpSelectVal, allocations }) => (
+              <div key={year} className="col col-12 sm-col-4 px1">
+                <div className="p2 bg-darken-1">
+                  <div>{year}</div>
+                  <div className="h3 bold mono">{formatMoney(total)}</div>
+                  <hr />
+                  <DollarInput
+                    name={`cost-allocate-other-${year}`}
+                    label={t('activities.costAllocate.ffp.labels.other')}
+                    value={costAllocation[year].other}
+                    onChange={this.handleOther(year)}
+                  />
+                  <div>{t('activities.costAllocate.ffp.totalNetOther')}</div>
+                  <div className="h3 bold mono">
+                    {formatMoney(totalNetOther)}
+                  </div>
+                  <hr />
+                  <Select
+                    name={`ffp-${year}`}
+                    label={t(
+                      'activities.costAllocate.ffp.labels.fedStateSplit'
+                    )}
+                    options={['90-10', '75-25', '50-50']}
+                    value={ffpSelectVal}
+                    onChange={this.handleFFP(year)}
+                  />
+                  <div className="flex mxn-tiny">
+                    {allocations.map(({ id, amount }) => (
+                      <div key={id} className="col-12">
+                        <div>{titleCase(id)}</div>
+                        <div className="h3 bold mono">
+                          {formatMoney(amount)}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
                 </div>
               </div>
-            </div>
-          ))}
+            )
+          )}
         </div>
       </div>
     );
@@ -90,13 +99,13 @@ const mapStateToProps = ({ activities: { byId } }, { aId }) => {
     const total = totals[year];
     const { ffp, other } = costAllocation[year];
     const totalNetOther = total - other;
-
+    const ffpSelectVal = `${ffp.federal}-${ffp.state}`;
     const allocations = Object.keys(ffp).map(id => ({
       id,
       amount: totalNetOther * ffp[id] / 100
     }));
 
-    return { year, total, totalNetOther, allocations };
+    return { year, total, totalNetOther, ffpSelectVal, allocations };
   });
 
   return { byYearData, costAllocation };

--- a/web/src/containers/ActivityDetailCostAllocateFFP.js
+++ b/web/src/containers/ActivityDetailCostAllocateFFP.js
@@ -1,96 +1,109 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { updateActivity as updateActivityAction } from '../actions/activities';
-import { PercentInput } from '../components/Inputs';
+import { DollarInput } from '../components/Inputs';
+import Select from '../components/Select';
 import { getActivityTotals } from '../reducers/activities';
 import { formatMoney } from '../util/formats';
 
 const ffpDisplay = {
   fed: 'Fed',
   state: 'State',
-  other: 'Other'
+  otherAmt: 'Other'
 };
 
-const ActivityDetailCostAllocateFFP = ({ aId, byYearData, updateActivity }) => (
-  <div className="mb3">
-    <h4>Federal Financial Partipation (FFP) and Cost Allocation</h4>
-    <div className="clearfix mxn1">
-      {byYearData.map(({ year, total, ffpLeft, ffpData }) => (
-        <div key={year} className="col col-12 sm-col-4 px1">
-          <div className="p2 bg-darken-1">
-            <div>{year}</div>
-            <div className="h3 bold mono">{formatMoney(total)}</div>
-            <hr />
-            <div className="flex mxn-tiny">
-              {ffpData.map(({ id, percent }) => (
-                <PercentInput
-                  key={id}
-                  name={`ffp-fed-${year}`}
-                  label={ffpDisplay[id]}
-                  wrapperClass="px-tiny"
-                  value={percent}
-                  onChange={e =>
-                    updateActivity(
-                      aId,
-                      {
-                        costFFP: { [year]: { [id]: e.target.value } }
-                      },
-                      true
-                    )
-                  }
+class ActivityDetailCostAllocateFFP extends Component {
+  handleOtherChange = year => e => {
+    const { aId, updateActivity } = this.props;
+    const { value } = e.target;
+    const updates = { costFFP: { [year]: { otherAmt: +value } } };
+
+    updateActivity(aId, updates, true);
+  };
+
+  handleFfpChange = year => e => {
+    const { aId, updateActivity } = this.props;
+    const { value } = e.target;
+    const [fed, state] = value.split('-').map(Number);
+    const updates = { costFFP: { [year]: { fed, state } } };
+
+    updateActivity(aId, updates, true);
+  };
+
+  render() {
+    const { byYearData, costFFP } = this.props;
+
+    return (
+      <div className="mb3">
+        <h4>Federal Financial Partipation (FFP) and Cost Allocation</h4>
+        <div className="clearfix mxn1">
+          {byYearData.map(({ year, total, allocations }) => (
+            <div key={year} className="col col-12 sm-col-4 px1">
+              <div className="p2 bg-darken-1">
+                <div>{year}</div>
+                <div className="h3 bold mono">{formatMoney(total)}</div>
+                <hr />
+                <DollarInput
+                  name={`cost-allocate-other-${year}`}
+                  label="Other (amount)"
+                  value={costFFP[year].otherAmt}
+                  onChange={this.handleOtherChange(year)}
                 />
-              ))}
-            </div>
-            {ffpLeft !== 0 && (
-              <div className="mt2 p1 h6 alert alert-error">
-                {ffpLeft < 0
-                  ? `You're over by ${Math.abs(ffpLeft)}%`
-                  : `Please allocate an additional ${ffpLeft}%`}
-              </div>
-            )}
-            <hr />
-            <div className="flex mxn-tiny">
-              {ffpData.map(({ id, amount }) => (
-                <div key={id} className="col-12">
-                  <div>{ffpDisplay[id]}</div>
-                  <div className="bold mono">{formatMoney(amount)}</div>
+                <hr />
+                <Select
+                  name={`ffp-${year}`}
+                  label="Federal / State (percent)"
+                  options={['90-10', '75-25', '50-50']}
+                  onChange={this.handleFfpChange(year)}
+                />
+                <hr />
+                <div className="flex mxn-tiny">
+                  {allocations.map(({ id, amount }) => (
+                    <div key={id} className="col-12">
+                      <div>{ffpDisplay[id]}</div>
+                      <div className="bold mono">{formatMoney(amount)}</div>
+                    </div>
+                  ))}
                 </div>
-              ))}
+              </div>
             </div>
-          </div>
+          ))}
         </div>
-      ))}
-    </div>
-  </div>
-);
+      </div>
+    );
+  }
+}
 
 ActivityDetailCostAllocateFFP.propTypes = {
   aId: PropTypes.number.isRequired,
   byYearData: PropTypes.array.isRequired,
+  costFFP: PropTypes.object.isRequired,
   updateActivity: PropTypes.func.isRequired
 };
 
 const mapStateToProps = ({ activities: { byId } }, { aId }) => {
   const activity = byId[aId];
+  const { costFFP } = activity;
   const totals = getActivityTotals(activity);
 
   const byYearData = Object.keys(totals).map(year => {
     const total = totals[year];
-    const ffp = activity.costFFP[year];
+    const ffp = costFFP[year];
+    const totalLessOther = total - ffp.otherAmt;
 
-    const ffpLeft = 100 - Object.values(ffp).reduce((a, b) => a + b, 0);
-    const ffpData = Object.entries(ffp).map(([id, percent]) => ({
-      id,
-      percent,
-      amount: total * percent / 100
-    }));
+    const allocations = ['fed', 'state']
+      .map(id => ({
+        id,
+        amount: totalLessOther * ffp[id] / 100
+      }))
+      .concat({ id: 'otherAmt', amount: ffp.otherAmt });
 
-    return { year, total, ffpLeft, ffpData };
+    return { year, total, totalLessOther, allocations };
   });
 
-  return { byYearData };
+  return { byYearData, costFFP };
 };
 
 const mapDispatchToProps = {

--- a/web/src/i18n/locales/en.yaml
+++ b/web/src/i18n/locales/en.yaml
@@ -189,7 +189,13 @@
         title: "Other funding description"
         helpText: "Account for any and all grant funding used to support this activity, and review the state Medicaid director Letter 10‐016 for examples of grants needed to be included."
         reminder: "High level descriptions are appropriate for grant activities. Ensure any new grants are included and any expired grants are removed."
-        amount: "Other funding amount"
+      ffp:
+        title: Federal Financial Partipation (FFP) and Cost Allocation
+        totalNetOther: Medicaid Share
+        labels:
+          other: Other Funding Amount
+          fedStateSplit: Federal-State Split
+
     standardsAndConditions: 
       title: "Key Standards & Conditions"
       subheader: "Describe us how you'll meet the Medicaid standards and conditions for this activity."

--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -44,7 +44,6 @@ const newContractor = (id, years) => ({
 });
 
 const expenseDefaultYear = () => 0;
-// const expenseDefaultYear = () => 100;
 
 const newExpense = (id, years) => ({
   id,
@@ -53,7 +52,10 @@ const newExpense = (id, years) => ({
   years: arrToObj(years, expenseDefaultYear())
 });
 
-const costFFPDefaultYear = () => ({ fed: 90, state: 10, otherAmt: 0 });
+const costAllocationDefaultYear = () => ({
+  other: 0,
+  ffp: { federal: 90, state: 10 }
+});
 
 const newActivity = (
   id,
@@ -65,7 +67,7 @@ const newActivity = (
   descShort: '',
   descLong: '',
   altApproach: '',
-  costAllocateDesc: '',
+  costAllocationDesc: '',
   otherFundingDesc: '',
   goals: [newGoal()],
   milestones: [newMilestone(), newMilestone(), newMilestone()],
@@ -80,7 +82,7 @@ const newActivity = (
     newContractor(3, years)
   ],
   expenses: [newExpense(1, years), newExpense(2, years), newExpense(3, years)],
-  costFFP: arrToObj(years, costFFPDefaultYear()),
+  costAllocation: arrToObj(years, costAllocationDefaultYear()),
   standardsAndConditions: {
     modularity: '',
     mita: '',
@@ -104,11 +106,6 @@ const initialState = {
   byId: {},
   allIds: []
 };
-
-// const initialState = {
-//   byId: { 1: newActivity(1, { years: ['2018', '2019'] }) },
-//   allIds: [1]
-// };
 
 const reducer = (state = initialState, action) => {
   switch (action.type) {
@@ -312,7 +309,7 @@ const reducer = (state = initialState, action) => {
               years: fixupYears(o.years, defaultValue)
             }));
           }
-          // but costFFP is just an object whose properties
+          // but costAllocation is just an object whose properties
           // are the years
           return fixupYears(objects, defaultValue);
         };
@@ -329,7 +326,10 @@ const reducer = (state = initialState, action) => {
               contractorDefaultYear
             ),
             expenses: fixupExpenses(activity.expenses, expenseDefaultYear),
-            costFFP: fixupExpenses(activity.costFFP, costFFPDefaultYear)
+            costAllocation: fixupExpenses(
+              activity.costAllocation,
+              costAllocationDefaultYear
+            )
           };
         });
 
@@ -347,15 +347,17 @@ const reducer = (state = initialState, action) => {
           descShort: a.summary || '',
           descLong: a.description || '',
           altApproach: a.alternatives || '',
-          costAllocateDesc: a.costAllocationNarrative.methodology || '',
+          costAllocationDesc: a.costAllocationNarrative.methodology || '',
           otherFundingDesc: a.costAllocationNarrative.otherSources || '',
-          costFFP: a.costAllocation.reduce(
+          costAllocation: a.costAllocation.reduce(
             (all, ffp) => ({
               ...all,
               [ffp.year]: {
-                fed: ffp.federal * 100,
-                state: ffp.state * 100,
-                otherAmt: ffp.other * 100
+                other: ffp.other || 0,
+                ffp: {
+                  federal: ffp.federal * 100,
+                  state: ffp.state * 100
+                }
               }
             }),
             {}

--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -43,7 +43,9 @@ const newContractor = (id, years) => ({
   years: arrToObj(years, contractorDefaultYear())
 });
 
-const expenseDefaultYear = () => 100;
+const expenseDefaultYear = () => 0;
+// const expenseDefaultYear = () => 100;
+
 const newExpense = (id, years) => ({
   id,
   category: 'Hardware, software, and licensing',
@@ -99,9 +101,14 @@ const newActivity = (
 });
 
 const initialState = {
-  byId: { 1: newActivity(1, { years: ['2018', '2019'] }) },
-  allIds: [1]
+  byId: {},
+  allIds: []
 };
+
+// const initialState = {
+//   byId: { 1: newActivity(1, { years: ['2018', '2019'] }) },
+//   allIds: [1]
+// };
 
 const reducer = (state = initialState, action) => {
   switch (action.type) {

--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -43,7 +43,7 @@ const newContractor = (id, years) => ({
   years: arrToObj(years, contractorDefaultYear())
 });
 
-const expenseDefaultYear = () => 0;
+const expenseDefaultYear = () => 100;
 const newExpense = (id, years) => ({
   id,
   category: 'Hardware, software, and licensing',
@@ -51,7 +51,7 @@ const newExpense = (id, years) => ({
   years: arrToObj(years, expenseDefaultYear())
 });
 
-const costFFPDefaultYear = () => ({ fed: 90, state: 10, other: 0 });
+const costFFPDefaultYear = () => ({ fed: 90, state: 10, otherAmt: 0 });
 
 const newActivity = (
   id,
@@ -65,7 +65,6 @@ const newActivity = (
   altApproach: '',
   costAllocateDesc: '',
   otherFundingDesc: '',
-  otherFundingAmt: '',
   goals: [newGoal()],
   milestones: [newMilestone(), newMilestone(), newMilestone()],
   statePersonnel: [
@@ -79,7 +78,7 @@ const newActivity = (
     newContractor(3, years)
   ],
   expenses: [newExpense(1, years), newExpense(2, years), newExpense(3, years)],
-  costFFP: arrToObj(years, { fed: 90, state: 10, other: 0 }),
+  costFFP: arrToObj(years, costFFPDefaultYear()),
   standardsAndConditions: {
     modularity: '',
     mita: '',
@@ -100,8 +99,8 @@ const newActivity = (
 });
 
 const initialState = {
-  byId: {},
-  allIds: []
+  byId: { 1: newActivity(1, { years: ['2018', '2019'] }) },
+  allIds: [1]
 };
 
 const reducer = (state = initialState, action) => {
@@ -343,14 +342,13 @@ const reducer = (state = initialState, action) => {
           altApproach: a.alternatives || '',
           costAllocateDesc: a.costAllocationNarrative.methodology || '',
           otherFundingDesc: a.costAllocationNarrative.otherSources || '',
-          otherFundingAmt: 0,
           costFFP: a.costAllocation.reduce(
             (all, ffp) => ({
               ...all,
               [ffp.year]: {
                 fed: ffp.federal * 100,
                 state: ffp.state * 100,
-                other: ffp.other * 100
+                otherAmt: ffp.other * 100
               }
             }),
             {}

--- a/web/src/reducers/activities.test.js
+++ b/web/src/reducers/activities.test.js
@@ -57,8 +57,8 @@ describe('activities reducer', () => {
     ],
     costAllocateDesc: '',
     costFFP: {
-      '2018': { fed: 90, other: 0, state: 10 },
-      '2019': { fed: 90, other: 0, state: 10 }
+      '2018': { fed: 90, state: 10, otherAmt: 0 },
+      '2019': { fed: 90, state: 10, otherAmt: 0 }
     },
     descLong: '',
     descShort: '',
@@ -81,7 +81,6 @@ describe('activities reducer', () => {
     meta: { expanded: false },
     milestones: [{ ...newMilestone }, { ...newMilestone }, { ...newMilestone }],
     name: '',
-    otherFundingAmt: '',
     otherFundingDesc: '',
     standardsAndConditions: {
       bizResults: '',
@@ -348,7 +347,7 @@ describe('activities reducer', () => {
             ],
             costFFP: {
               ...stateWithOne.byId['1'].costFFP,
-              '2020': { fed: 90, other: 0, state: 10 }
+              '2020': { fed: 90, state: 10, otherAmt: 0 }
             },
             expenses: [
               {
@@ -431,7 +430,7 @@ describe('activities reducer', () => {
               }
             ],
             costFFP: {
-              '2018': { fed: 90, other: 0, state: 10 }
+              '2018': { fed: 90, state: 10, otherAmt: 0 }
             },
             expenses: [
               {
@@ -652,10 +651,9 @@ describe('activities reducer', () => {
             altApproach: 'different things',
             costAllocateDesc: 'how',
             otherFundingDesc: 'which',
-            otherFundingAmt: 0,
             costFFP: {
-              2018: { fed: 80, state: 15, other: 5 },
-              2019: { fed: 60, state: 20, other: 20 }
+              2018: { fed: 80, state: 15, otherAmt: 5 },
+              2019: { fed: 60, state: 20, otherAmt: 20 }
             },
             goals: [
               { desc: 'goal 1 description', obj: 'goal 1 objective' },

--- a/web/src/reducers/activities.test.js
+++ b/web/src/reducers/activities.test.js
@@ -55,10 +55,10 @@ describe('activities reducer', () => {
         id: 3
       }
     ],
-    costAllocateDesc: '',
-    costFFP: {
-      '2018': { fed: 90, state: 10, otherAmt: 0 },
-      '2019': { fed: 90, state: 10, otherAmt: 0 }
+    costAllocationDesc: '',
+    costAllocation: {
+      '2018': { ffp: { federal: 90, state: 10 }, other: 0 },
+      '2019': { ffp: { federal: 90, state: 10 }, other: 0 }
     },
     descLong: '',
     descShort: '',
@@ -345,9 +345,9 @@ describe('activities reducer', () => {
                 }
               }
             ],
-            costFFP: {
-              ...stateWithOne.byId['1'].costFFP,
-              '2020': { fed: 90, state: 10, otherAmt: 0 }
+            costAllocation: {
+              ...stateWithOne.byId['1'].costAllocation,
+              '2020': { ffp: { federal: 90, state: 10 }, other: 0 }
             },
             expenses: [
               {
@@ -429,8 +429,8 @@ describe('activities reducer', () => {
                 }
               }
             ],
-            costFFP: {
-              '2018': { fed: 90, state: 10, otherAmt: 0 }
+            costAllocation: {
+              '2018': { ffp: { federal: 90, state: 10 }, other: 0 }
             },
             expenses: [
               {
@@ -535,8 +535,8 @@ describe('activities reducer', () => {
                     otherSources: 'which'
                   },
                   costAllocation: [
-                    { year: 2018, federal: 0.8, state: 0.15, other: 0.05 },
-                    { year: 2019, federal: 0.6, state: 0.2, other: 0.2 }
+                    { year: 2018, federal: 0.8, state: 0.15, other: 100 },
+                    { year: 2019, federal: 0.6, state: 0.2, other: 200 }
                   ],
                   goals: [
                     {
@@ -649,11 +649,11 @@ describe('activities reducer', () => {
             descShort: 'summary',
             descLong: 'description',
             altApproach: 'different things',
-            costAllocateDesc: 'how',
+            costAllocationDesc: 'how',
             otherFundingDesc: 'which',
-            costFFP: {
-              2018: { fed: 80, state: 15, otherAmt: 5 },
-              2019: { fed: 60, state: 20, otherAmt: 20 }
+            costAllocation: {
+              2018: { ffp: { federal: 80, state: 15 }, other: 100 },
+              2019: { ffp: { federal: 60, state: 20 }, other: 200 }
             },
             goals: [
               { desc: 'goal 1 description', obj: 'goal 1 objective' },

--- a/web/src/reducers/budget.js
+++ b/web/src/reducers/budget.js
@@ -63,10 +63,10 @@ const initialState = years => ({
   years
 });
 
-const budgetInput = (id, value = v => +v, target = null) => ({
-  id,
+const budgetInput = (type, value = v => +v, target = null) => ({
+  type,
   value,
-  target: target || id
+  target: target || type
 });
 
 const budgetInputs = [
@@ -88,16 +88,30 @@ const addBudgetBlocks = (into, from = { total: 0, federal: 0, state: 0 }) => {
   out.state += from.state;
 };
 
+const collapseAllAmounts = activity => {
+  const totals = arrToObj(activity.years);
+
+  budgetInputs.forEach(({ type, value }) => {
+    activity[type].forEach(entry => {
+      Object.keys(entry.years).forEach(year => {
+        totals[year] += value(entry.years[year]);
+      });
+    });
+  });
+
+  return totals;
+};
+
 const getTotalsForActivity = activity => {
   const fundingSource = activity.fundingSource.toLowerCase();
-  const ffp = activity.costFFP;
+  const allocate = activity.costAllocation;
+  const totalByYear = collapseAllAmounts(activity);
 
-  // get overall activity total by year
-  // (state personnel + contractors + expenses)
-  // this is needed to compute the amount of money
-  // to not count towards the fed/state allocation
-  const activityTotalByYear = arrToObj(activity.years);
-  console.log(activityTotalByYear);
+  const netOtherPercent = year => {
+    const { other } = allocate[year];
+    const total = totalByYear[year];
+    return total ? 1 - other / total : 1;
+  };
 
   return {
     collapse: (type, value = v => +v) => {
@@ -107,11 +121,15 @@ const getTotalsForActivity = activity => {
           if (!collapsed[year]) {
             collapsed[year] = { total: 0, federal: 0, state: 0 };
           }
-          const v = value(expense.years[year]);
+
+          const total = value(expense.years[year]);
+          const totalNetOther = total * netOtherPercent(year);
+          const { federal, state } = allocate[year].ffp;
+
           addBudgetBlocks(collapsed[year], {
-            total: v,
-            federal: v * ffp[year].fed / 100,
-            state: v * ffp[year].state / 100
+            total,
+            federal: totalNetOther * federal / 100,
+            state: totalNetOther * state / 100
           });
         });
       });
@@ -174,9 +192,9 @@ const buildBudget = wholeState => {
   activities(wholeState).forEach(activity => {
     const totaller = getTotalsForActivity(activity);
 
-    budgetInputs.forEach(({ id, value, target }) => {
+    budgetInputs.forEach(({ type, value, target }) => {
       totaller
-        .collapse(id, value)
+        .collapse(type, value)
         .totals()
         .merge(newState, target);
     });

--- a/web/src/reducers/budget.test.js
+++ b/web/src/reducers/budget.test.js
@@ -167,20 +167,26 @@ describe('budget reducer', () => {
             byId: {
               hieOne: {
                 fundingSource: 'HIE',
-                costFFP: {
+                costAllocation: {
                   '1931': {
-                    fed: 50,
-                    state: 50,
+                    ffp: {
+                      federal: 50,
+                      state: 50
+                    },
                     other: 0
                   },
                   '1932': {
-                    fed: 10,
-                    state: 10,
+                    ffp: {
+                      federal: 10,
+                      state: 10
+                    },
                     other: 80
                   },
                   '1933': {
-                    fed: 99,
-                    state: 0,
+                    ffp: {
+                      federal: 99,
+                      state: 0
+                    },
                     other: 1
                   }
                 },
@@ -242,20 +248,26 @@ describe('budget reducer', () => {
               },
               hieTwo: {
                 fundingSource: 'HIE',
-                costFFP: {
+                costAllocation: {
                   '1931': {
-                    fed: 1,
-                    state: 1,
+                    ffp: {
+                      federal: 1,
+                      state: 1
+                    },
                     other: 98
                   },
                   '1932': {
-                    fed: 13,
-                    state: 31,
+                    ffp: {
+                      federal: 13,
+                      state: 31
+                    },
                     other: 56
                   },
                   '1933': {
-                    fed: 74,
-                    state: 19,
+                    ffp: {
+                      federal: 74,
+                      state: 19
+                    },
                     other: 7
                   }
                 },
@@ -289,20 +301,26 @@ describe('budget reducer', () => {
               },
               hitOne: {
                 fundingSource: 'HIT',
-                costFFP: {
+                costAllocation: {
                   '1931': {
-                    fed: 3,
-                    state: 5,
+                    ffp: {
+                      federal: 3,
+                      state: 5
+                    },
                     other: 92
                   },
                   '1932': {
-                    fed: 12,
-                    state: 37,
+                    ffp: {
+                      federal: 12,
+                      state: 37
+                    },
                     other: 51
                   },
                   '1933': {
-                    fed: 78,
-                    state: 14,
+                    ffp: {
+                      federal: 78,
+                      state: 14
+                    },
                     other: 8
                   }
                 },
@@ -336,20 +354,26 @@ describe('budget reducer', () => {
               },
               mmisOne: {
                 fundingSource: 'MMIS',
-                costFFP: {
+                costAllocation: {
                   '1931': {
-                    fed: 1,
-                    state: 1,
+                    ffp: {
+                      federal: 1,
+                      state: 1
+                    },
                     other: 98
                   },
                   '1932': {
-                    fed: 13,
-                    state: 31,
+                    ffp: {
+                      federal: 13,
+                      state: 31
+                    },
                     other: 56
                   },
                   '1933': {
-                    fed: 74,
-                    state: 19,
+                    ffp: {
+                      federal: 74,
+                      state: 19
+                    },
                     other: 7
                   }
                 },

--- a/web/src/util/index.js
+++ b/web/src/util/index.js
@@ -159,3 +159,5 @@ export const arrToObj = (array = [], initialValue = 0) =>
   Object.assign({}, ...array.map(a => ({ [a]: initialValue })));
 
 export const addObjVals = obj => Object.values(obj).reduce((a, b) => a + b, 0);
+
+export const titleCase = str => str.replace(/\b\S/g, t => t.toUpperCase());

--- a/web/src/util/index.js
+++ b/web/src/util/index.js
@@ -155,7 +155,7 @@ export const getParams = str =>
 
 export const nextSequence = arrOfNums => Math.max(...arrOfNums, 0) + 1;
 
-export const arrToObj = (array, initialValue = 0) =>
+export const arrToObj = (array = [], initialValue = 0) =>
   Object.assign({}, ...array.map(a => ({ [a]: initialValue })));
 
 export const addObjVals = obj => Object.values(obj).reduce((a, b) => a + b, 0);

--- a/web/src/util/index.test.js
+++ b/web/src/util/index.test.js
@@ -42,7 +42,14 @@ describe('provides default years based on now', () => {
 });
 
 describe('utility functions', () => {
-  const { addObjVals, arrToObj, getParams, nextSequence, stateLookup } = load();
+  const {
+    addObjVals,
+    arrToObj,
+    getParams,
+    nextSequence,
+    stateLookup,
+    titleCase
+  } = load();
 
   test('finds a state by two-letter code', () => {
     expect(stateLookup('Mo')).toEqual({ id: 'mo', name: 'Missouri' });
@@ -78,5 +85,10 @@ describe('utility functions', () => {
   test('sums up the object values for a given object', () => {
     expect(addObjVals({ foo: 1, bar: 2 })).toEqual(3);
     expect(addObjVals({ a: 1, b: 2, c: -3 })).toEqual(0);
+  });
+
+  test('title cases a given string', () => {
+    expect(titleCase('foo')).toEqual('Foo');
+    expect(titleCase('foo bar')).toEqual('Foo Bar');
   });
 });


### PR DESCRIPTION
This PR reworks the cost allocation as per https://github.com/18F/cms-hitech-apd/issues/685.

In summary
* one can specify a per-activity other amount, which comes off the top before computing the federal and state amounts
* the federal / state percentages can now we only 1 of 3 things (90/10, 75/25, 50/50)

The budget summary data munging methods are adjusted to reflect this new math/logic. 

preview:
https://cl.ly/sKrg

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author

### This feature is done when...
- [ ] Product has approved the experience
