### PR TITLE
sortable table

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13312,6 +13312,14 @@
         "prop-types": "15.6.0"
       }
     },
+    "react-table": {
+      "version": "6.8.6",
+      "resolved": "https://registry.npmjs.org/react-table/-/react-table-6.8.6.tgz",
+      "integrity": "sha1-oK2LSDkxkFLVvvwBJgP7Fh5S7eM=",
+      "requires": {
+        "classnames": "2.2.5"
+      }
+    },
     "react-test-renderer": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.2.0.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -64,6 +64,7 @@
     "react-redux": "^5.0.7",
     "react-router-dom": "^4.2.2",
     "react-router-redux": "^5.0.0-alpha.9",
+    "react-table": "^6.8.6",
     "react-text-mask": "^5.4.1",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",

--- a/web/src/containers/ScheduleSummary.js
+++ b/web/src/containers/ScheduleSummary.js
@@ -1,62 +1,71 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
+import ReactTable from 'react-table';
 
 import { t } from '../i18n';
 import { Section, Subsection } from '../components/Section';
 
-const ScheduleSummary = ({ milestones }) => (
+const ScheduleSummary = ({ tableData }) => (
   <Section id="schedule-summary" resource="scheduleSummary">
-    <Subsection resource="scheduleSummary.main">
-      {milestones.length > 0 && (
-        <div className="overflow-auto">
-          <table className="h6 table-bordered table-striped">
-            <thead>
-              <tr>
-                <th>{t('scheduleSummary.main.table.activity')}</th>
-                <th>{t('scheduleSummary.main.table.milestone')}</th>
-                <th>{t('scheduleSummary.main.table.start')}</th>
-                <th>{t('scheduleSummary.main.table.end')}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {milestones.map(m => (
-                <tr key={m.id}>
-                  <td>{m.activityName}</td>
-                  <td>{m.name || 'N/A'}</td>
-                  <td>{m.start || 'N/A'}</td>
-                  <td>{m.end || 'N/A'}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+    <Subsection resource="scheduleSummary.main" open>
+      {tableData.data.length > 0 && (
+        <ReactTable
+          showPagination={false}
+          resizable={false}
+          minRows={0}
+          className="mb3 h6 -striped"
+          {...tableData}
+        />
       )}
     </Subsection>
   </Section>
 );
 
 ScheduleSummary.propTypes = {
-  milestones: PropTypes.array.isRequired
+  tableData: PropTypes.shape({
+    data: PropTypes.array,
+    columns: PropTypes.array,
+    defaultSorted: PropTypes.array
+  }).isRequired
 };
 
+const Cell = row => row.value || 'N/A';
+
 const mapStateToProps = ({ activities }) => {
-  const milestones = [];
+  const data = [];
 
   Object.values(activities.byId).forEach(activity => {
-    activity.milestones.forEach((milestone, i) => {
-      milestones.push({
-        ...milestone,
-        id: `${activity.id}-${i + 1}`,
-        activityId: activity.id,
-        activityName: activity.name
-      });
+    activity.milestones.forEach(milestone => {
+      data.push({ ...milestone, activityName: activity.name });
     });
   });
 
-  milestones.sort((a, b) => a.start - b.start);
+  const columns = [
+    {
+      accessor: 'activityName',
+      Header: t('scheduleSummary.main.table.activity')
+    },
+    {
+      accessor: 'name',
+      Header: t('scheduleSummary.main.table.milestone'),
+      Cell
+    },
+    {
+      accessor: 'start',
+      Header: t('scheduleSummary.main.table.start'),
+      Cell
+    },
+    {
+      accessor: 'end',
+      Header: t('scheduleSummary.main.table.end'),
+      Cell
+    }
+  ];
 
-  return { milestones };
+  const defaultSorted = [{ id: 'start', desc: false }];
+
+  return { tableData: { data, columns, defaultSorted } };
 };
 
 export default connect(mapStateToProps)(ScheduleSummary);

--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -23,7 +23,11 @@ import { arrToObj, defaultAPDYears, nextSequence } from '../util';
 
 const newGoal = () => ({ desc: '', obj: '' });
 
-const newMilestone = () => ({ name: '', start: '', end: '' });
+const newMilestone = (name = '', start = '', end = '') => ({
+  name,
+  start,
+  end
+});
 
 const statePersonDefaultYear = () => ({ amt: '', perc: '' });
 const newStatePerson = (id, years) => ({

--- a/web/src/styles/app/table.css
+++ b/web/src/styles/app/table.css
@@ -1,3 +1,32 @@
+@import 'react-table/react-table.css';
+
+/* react-table overrides */
+
+.ReactTable .rt-thead.-header {
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.15);
+}
+
+.ReactTable .rt-thead .rt-tr {
+  font-weight: bold;
+  text-align: left;
+}
+
+.ReactTable .rt-thead .rt-td,
+.ReactTable .rt-thead .rt-th {
+  padding: 0.5rem 1rem;
+}
+
+.ReactTable .rt-thead .rt-th:focus {
+  outline: none;
+}
+
+.ReactTable .rt-td,
+.ReactTable .rt-th {
+  padding: 0.5rem 1rem;
+}
+
+/* additional styles */
+
 .table th,
 .table td {
   border-top: 1px solid #e7e7e7;


### PR DESCRIPTION
Adds `react-table` and makes apd schedule summary table sortable (resolves https://github.com/18F/cms-hitech-apd/issues/688)

And I think we can utilize more of the features of `react-table` over time (filtering, editable text, etc).

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This feature is done when...
- [ ] Product has approved the experience
