### PR TITLE
Move quarterly budget table text into resource file

### DIFF
--- a/web/src/containers/QuarterlyBudgetSummary.js
+++ b/web/src/containers/QuarterlyBudgetSummary.js
@@ -12,10 +12,12 @@ const FUNDING_SOURCES = [['hitAndHie', 'HIT and HIE'], ['mmis', 'MMIS']];
 const QUARTERS = [1, 2, 3, 4];
 const COLORS = ['teal', 'green', 'yellow'];
 const EXPENSE_NAME_DISPLAY = {
-  statePersonnel: 'Project state staff',
-  expenses: 'Non-personnel',
-  contractors: 'Contracted resources',
-  combined: 'Total Enhanced FFP'
+  statePersonnel: t(
+    'proposedBudget.quarterlyBudget.expenseNames.statePersonnel'
+  ),
+  expenses: t('proposedBudget.quarterlyBudget.expenseNames.expenses'),
+  contractors: t('proposedBudget.quarterlyBudget.expenseNames.contractors'),
+  combined: t('proposedBudget.quarterlyBudget.expenseNames.combined')
 };
 
 const color = idx => `bg-${COLORS[idx] || 'gray'}`;

--- a/web/src/i18n/locales/en.yaml
+++ b/web/src/i18n/locales/en.yaml
@@ -259,6 +259,11 @@
       title: Summary Budget Table
     quarterlyBudget: 
       title: Federal Share by FFY Quarter
+      expenseNames:
+          statePersonnel: Project state staff
+          expenses: Non-personnel
+          contractors: Contracted resources
+          combined: Total Enhanced FFP
     paymentsByFFYQuarter: 
       title: Incentive Payments by FFY Quarter
   assurancesAndCompliance: 


### PR DESCRIPTION
Takes user-facing text out of the code and puts it in the resource file.  Closes #678.

### This pull request changes...
- text is in the resource file

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author

### This feature is done when...
- [x] Product has approved the experience
