### PR TITLE
Fix saving cost allocations

### DIFF
--- a/api/db/activity/costAllocation.js
+++ b/api/db/activity/costAllocation.js
@@ -6,6 +6,16 @@ module.exports = {
       return this.belongsTo('apdActivity');
     },
 
+    format(attrs) {
+      return {
+        year: attrs.year,
+        federal_percent: attrs.federalPercent,
+        state_percent: attrs.statePercent,
+        other_amount: attrs.otherAmount,
+        activity_id: attrs.activity_id
+      };
+    },
+
     toJSON() {
       return {
         year: this.get('year'),


### PR DESCRIPTION
Fixes a bug where saving the APD would fail because cost allocation column names didn't match the property names.

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author