### PR TITLE
Save state profile with APD [skip deploy]

### DIFF
--- a/api/db/apd.js
+++ b/api/db/apd.js
@@ -36,6 +36,30 @@ module.exports = () => ({
         out.years = JSON.stringify(attributes.years);
       }
 
+      if (attributes.stateProfile) {
+        if (attributes.stateProfile.medicaidDirector) {
+          out.medicaid_director_name =
+            attributes.stateProfile.medicaidDirector.name || null;
+          out.medicaid_director_email =
+            attributes.stateProfile.medicaidDirector.email || null;
+          out.medicaid_director_phone =
+            attributes.stateProfile.medicaidDirector.phone || null;
+        }
+        if (attributes.stateProfile.medicaidOffice) {
+          out.medicaid_office_address1 =
+            attributes.stateProfile.medicaidOffice.address1 || null;
+          out.medicaid_office_address2 =
+            attributes.stateProfile.medicaidOffice.address2 || null;
+          out.medicaid_office_city =
+            attributes.stateProfile.medicaidOffice.city || null;
+          out.medicaid_office_state =
+            attributes.stateProfile.medicaidOffice.state || null;
+          out.medicaid_office_zip =
+            attributes.stateProfile.medicaidOffice.zip || null;
+        }
+        delete out.stateProfile;
+      }
+
       return out;
     },
 
@@ -50,6 +74,20 @@ module.exports = () => ({
         period: this.get('period'),
         programOverview: this.get('program_overview'),
         state: this.get('state_id'),
+        stateProfile: {
+          medicaidDirector: {
+            name: this.get('medicaid_director_name'),
+            email: this.get('medicaid_director_email'),
+            phone: this.get('medicaid_director_phone')
+          },
+          medicaidOffice: {
+            address1: this.get('medicaid_office_address1'),
+            address2: this.get('medicaid_office_address2'),
+            city: this.get('medicaid_office_city'),
+            state: this.get('medicaid_office_state'),
+            zip: this.get('medicaid_office_zip')
+          }
+        },
         status: this.get('status'),
         years: this.get('years')
       };
@@ -63,6 +101,7 @@ module.exports = () => ({
         'narrativeHIE',
         'narrativeHIT',
         'narrativeMMIS',
+        'stateProfile',
         'years'
       ],
       foreignKey: 'apd_id',

--- a/api/db/apd.test.js
+++ b/api/db/apd.test.js
@@ -20,6 +20,7 @@ tap.test('apd data model', async apdModelTests => {
               'narrativeHIE',
               'narrativeHIT',
               'narrativeMMIS',
+              'stateProfile',
               'years'
             ],
             foreignKey: 'apd_id',
@@ -160,6 +161,17 @@ tap.test('apd data model', async apdModelTests => {
         narrativeHIE: undefined,
         narrativeHIT: null,
         narrativeMMIS: 'also changed',
+        stateProfile: {
+          medicaidDirector: {
+            name: 'their name'
+          },
+          medicaidOffice: {
+            address2: 'skip address 1',
+            city: 'city',
+            state: 'somewhere',
+            zip: 'hello'
+          }
+        },
         years: { key: 'value' }
       };
 
@@ -171,6 +183,14 @@ tap.test('apd data model', async apdModelTests => {
           fine: 'no change',
           good: 'also no change',
           program_overview: 'changed over',
+          medicaid_director_name: 'their name',
+          medicaid_director_email: null,
+          medicaid_director_phone: null,
+          medicaid_office_address1: null,
+          medicaid_office_address2: 'skip address 1',
+          medicaid_office_city: 'city',
+          medicaid_office_state: 'somewhere',
+          medicaid_office_zip: 'hello',
           narrative_hit: null,
           narrative_mmis: 'also changed',
           years: '{"key":"value"}'
@@ -201,6 +221,18 @@ tap.test('apd data model', async apdModelTests => {
     self.get.withArgs('narrative_hit').returns('apd-hit');
     self.get.withArgs('narrative_mmis').returns('apd-mmis');
     self.get.withArgs('years').returns('apd-years');
+    self.get.withArgs('medicaid_director_name').returns('Carrie Feher');
+    self.get.withArgs('medicaid_director_email').returns('em@il');
+    self.get.withArgs('medicaid_director_phone').returns('☎️');
+    self.get.withArgs('medicaid_office_address1').returns('place for street');
+    self.get
+      .withArgs('medicaid_office_address2')
+      .returns('office, po box, whatever');
+    self.get.withArgs('medicaid_office_city').returns('a place within a state');
+    self.get.withArgs('medicaid_office_state').returns('a state');
+    self.get
+      .withArgs('medicaid_office_zip')
+      .returns('a code to help the USPS get stuff there');
 
     const output = apd.apd.toJSON.bind(self)();
 
@@ -216,6 +248,20 @@ tap.test('apd data model', async apdModelTests => {
         period: 'apd-period',
         programOverview: 'apd-overview',
         state: 'apd-state',
+        stateProfile: {
+          medicaidDirector: {
+            name: 'Carrie Feher',
+            email: 'em@il',
+            phone: '☎️'
+          },
+          medicaidOffice: {
+            address1: 'place for street',
+            address2: 'office, po box, whatever',
+            city: 'a place within a state',
+            state: 'a state',
+            zip: 'a code to help the USPS get stuff there'
+          }
+        },
         status: 'apd-status',
         years: 'apd-years'
       },

--- a/api/migrations/20180625133221_apd-specific-state-info.js
+++ b/api/migrations/20180625133221_apd-specific-state-info.js
@@ -1,0 +1,12 @@
+exports.up = async knex =>
+  knex.schema.alterTable('apds', table => {
+    table.text('medicaid_director_name');
+    table.text('medicaid_director_email');
+    table.text('medicaid_director_phone');
+    table.text('medicaid_office_address1');
+    table.text('medicaid_office_address2');
+    table.text('medicaid_office_city');
+    table.text('medicaid_office_state');
+    table.text('medicaid_office_zip');
+  });
+exports.down = async () => {};

--- a/api/routes/apds/openAPI.js
+++ b/api/routes/apds/openAPI.js
@@ -50,19 +50,7 @@ const openAPI = {
       requestBody: {
         description: 'The new values for the apd.  All fields are optional.',
         required: true,
-        content: jsonResponse({
-          type: 'object',
-          properties: {
-            status: {
-              description: 'The new status for the apd.',
-              type: 'string'
-            },
-            period: {
-              description: 'The new period for the apd.',
-              type: 'string'
-            }
-          }
-        })
+        content: jsonResponse({ $ref: '#/components/schemas/apd' })
       },
       responses: {
         200: {

--- a/api/routes/openAPI/index.js
+++ b/api/routes/openAPI/index.js
@@ -280,6 +280,54 @@ module.exports = {
             type: 'string',
             description: 'An overview of the overall program'
           },
+          stateProfile: {
+            type: 'object',
+            description: 'The state profile for this specific APD',
+            properties: {
+              medicaidDirector: {
+                type: 'object',
+                properties: {
+                  name: {
+                    type: 'string',
+                    description: `State Medicaid director's name`
+                  },
+                  email: {
+                    type: 'string',
+                    description: `State Medicaid director's email address`
+                  },
+                  phone: {
+                    type: 'string',
+                    description: `State Medicaid director's phone number`
+                  }
+                }
+              },
+              medicaidOffice: {
+                type: 'object',
+                properties: {
+                  address1: {
+                    type: 'string',
+                    description: 'State Medicaid office address'
+                  },
+                  address2: {
+                    type: 'string',
+                    description: 'State Medicaid office address'
+                  },
+                  city: {
+                    type: 'string',
+                    description: 'State Medicaid office address city'
+                  },
+                  state: {
+                    type: 'string',
+                    description: 'State Medicaid office address state'
+                  },
+                  zip: {
+                    type: 'string',
+                    description: 'State Medicaid office address ZIP code'
+                  }
+                }
+              }
+            }
+          },
           status: {
             type: 'string',
             description: 'Status'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,9 @@ services:
     environment:
       - POSTGRES_DB=hitech_apd
       - POSTGRES_PASSWORD=cms
+      - PGDATA=/pgdata
+    volumes:
+      - ./pgdata:/pgdata
     expose:
       - 5432
     ports:

--- a/web/src/actions/apd.js
+++ b/web/src/actions/apd.js
@@ -107,7 +107,7 @@ export const saveApd = () => (dispatch, state) => {
     narrativeHIT: updatedApd.hitNarrative,
     narrativeMMIS: updatedApd.mmisNarrative,
     programOverview: updatedApd.overview,
-    state: updatedApd.state,
+    stateProfile: updatedApd.stateProfile,
     years: updatedApd.years
   };
 

--- a/web/src/actions/apd.test.js
+++ b/web/src/actions/apd.test.js
@@ -185,8 +185,7 @@ describe('apd actions', () => {
           mmisNarrative: 'MMIS narrative text',
           overview: 'APD overview text',
           years: ['1992', '1993'],
-          state: {
-            id: 'state-id',
+          stateProfile: {
             medicaidDirector: 'an object goes here',
             medicaidOffice: 'an object goes here'
           }

--- a/web/src/containers/ApdStateProfile.js
+++ b/web/src/containers/ApdStateProfile.js
@@ -10,11 +10,11 @@ import { t } from '../i18n';
 class ApdStateProfile extends Component {
   handleChange = (area, field) => e => {
     const { updateApd } = this.props;
-    updateApd({ state: { [area]: { [field]: e.target.value } } });
+    updateApd({ stateProfile: { [area]: { [field]: e.target.value } } });
   };
 
   render() {
-    const { medicaidDirector, medicaidOffice } = this.props.stateInfo;
+    const { medicaidDirector, medicaidOffice } = this.props.stateProfile;
     const dirTRoot = 'apd.stateProfile.directorAndAddress.director';
     const offTRoot = 'apd.stateProfile.directorAndAddress.address';
 
@@ -91,12 +91,12 @@ class ApdStateProfile extends Component {
 }
 
 ApdStateProfile.propTypes = {
-  stateInfo: PropTypes.object.isRequired,
+  stateProfile: PropTypes.object.isRequired,
   updateApd: PropTypes.func.isRequired
 };
 
-const mapStateToProps = ({ apd: { data: { state } } }) => ({
-  stateInfo: state
+const mapStateToProps = ({ apd: { data: { stateProfile } } }) => ({
+  stateProfile
 });
 const mapDispatchToProps = { updateApd: updateApdAction };
 

--- a/web/src/reducers/apd.js
+++ b/web/src/reducers/apd.js
@@ -53,8 +53,7 @@ const initialState = {
       {}
     ),
     incentivePayments: initIncentiveData(),
-    state: {
-      id: '--',
+    stateProfile: {
       medicaidDirector: {
         name: '',
         email: '',
@@ -95,6 +94,7 @@ const reducer = (state = initialState, action) => {
             narrativeMMIS: mmisNarrative,
             previousActivitySummary,
             incentivePayments,
+            stateProfile,
             activities
           } =
             apd || {};
@@ -118,7 +118,7 @@ const reducer = (state = initialState, action) => {
                 {}
               ),
               incentivePayments: incentivePayments || initIncentiveData(),
-              state: { ...initialState.data.state }, // TODO: get from API
+              stateProfile,
               activities
             }
           };

--- a/web/src/reducers/apd.test.js
+++ b/web/src/reducers/apd.test.js
@@ -19,8 +19,7 @@ describe('APD reducer', () => {
         2018: getPreviousActivityExpense()
       },
       incentivePayments,
-      state: {
-        id: '--',
+      stateProfile: {
         medicaidDirector: {
           name: '',
           email: '',
@@ -82,6 +81,7 @@ describe('APD reducer', () => {
             narrativeHIT: 'HIT, but as a play',
             narrativeHIE: 'HIE, but as a novel',
             narrativeMMIS: 'MMIS, but as a script',
+            stateProfile: 'this is the state profile as a string',
             years: [2013, 2014]
           }
         ]
@@ -107,22 +107,7 @@ describe('APD reducer', () => {
             2018: getPreviousActivityExpense()
           },
           incentivePayments,
-          state: {
-            // TODO: Update this when we actually get data from the API
-            id: '--',
-            medicaidDirector: {
-              name: '',
-              email: '',
-              phone: ''
-            },
-            medicaidOffice: {
-              address1: '',
-              address2: '',
-              city: '',
-              state: '',
-              zip: ''
-            }
-          }
+          stateProfile: 'this is the state profile as a string'
         }
       },
       data: {
@@ -138,9 +123,7 @@ describe('APD reducer', () => {
           2018: getPreviousActivityExpense()
         },
         incentivePayments,
-        state: {
-          // TODO: Update this when we actually get data from the API
-          id: '--',
+        stateProfile: {
           medicaidDirector: {
             name: '',
             email: '',


### PR DESCRIPTION
Adds state profile information to the APD data model and updates the code to read/write that information, as expected.  Polishes up the data handling on the frontend to hook them up.

Addresses part of #700.

### This pull request changes...
- saving an APD will also save state profile information
- loading an APD will also load that APD's state profile information

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [x] The change has been documented
  - [x] Associated OpenAPI documentation has been updated