### PR TITLE
Read activity funding source from the API

### DIFF
--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -347,7 +347,7 @@ const reducer = (state = initialState, action) => {
         byId[a.id] = {
           id: a.id,
           name: a.name,
-          fundingSource: 'HIT', // TODO
+          fundingSource: a.fundingSource,
           years: action.apd.years,
           descShort: a.summary || '',
           descLong: a.description || '',

--- a/web/src/reducers/activities.test.js
+++ b/web/src/reducers/activities.test.js
@@ -526,7 +526,7 @@ describe('activities reducer', () => {
                 {
                   id: 998,
                   name: 'activity 998',
-                  // fundingSource TODO:
+                  fundingSource: 'bob',
                   summary: 'summary',
                   description: 'description',
                   alternatives: 'different things',
@@ -654,7 +654,7 @@ describe('activities reducer', () => {
           '998': {
             id: 998,
             name: 'activity 998',
-            fundingSource: 'HIT',
+            fundingSource: 'bob',
             years: ['2018', '2019'],
             descShort: 'summary',
             descLong: 'description',


### PR DESCRIPTION
Despite what #644 says, we were already sending the activity funding source info to the API, storing it, and returning it.  The one thing we weren't doing was reading it from the API and using that to drive the GUI.  That's fixed now.

Closes #644.

### This pull request changes...
- reloading an APD will also restore activities' funding source radio buttons to the right values

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author