### PR TITLE
Save "previous activity" info in the API, and return it when loading an APD [skip deploy]

### DIFF
--- a/api/db/apd.js
+++ b/api/db/apd.js
@@ -10,6 +10,10 @@ module.exports = () => ({
       return this.hasMany('apdKeyPersonnel');
     },
 
+    previousActivityExpenses() {
+      return this.hasMany('apdPreviousActivityExpense');
+    },
+
     state() {
       return this.belongsTo('state');
     },
@@ -21,6 +25,7 @@ module.exports = () => ({
     format(attributes) {
       const out = { ...attributes };
       [
+        ['previousActivitySummary', 'previous_activity_summary'],
         ['programOverview', 'program_overview'],
         ['narrativeHIE', 'narrative_hie'],
         ['narrativeHIT', 'narrative_hit'],
@@ -72,6 +77,10 @@ module.exports = () => ({
         narrativeHIT: this.get('narrative_hit'),
         narrativeMMIS: this.get('narrative_mmis'),
         period: this.get('period'),
+        previousActivityExpenses: this.related(
+          'previousActivityExpenses'
+        ).toJSON(),
+        previousActivitySummary: this.get('previous_activity_summary'),
         programOverview: this.get('program_overview'),
         state: this.get('state_id'),
         stateProfile: {
@@ -97,6 +106,7 @@ module.exports = () => ({
       updateableFields: [
         'status',
         'period',
+        'previousActivitySummary',
         'programOverview',
         'narrativeHIE',
         'narrativeHIT',
@@ -105,7 +115,11 @@ module.exports = () => ({
         'years'
       ],
       foreignKey: 'apd_id',
-      owns: { activities: 'apdActivity', keyPersonnel: 'apdKeyPersonnel' },
+      owns: {
+        activities: 'apdActivity',
+        keyPersonnel: 'apdKeyPersonnel',
+        previousActivityExpenses: 'apdPreviousActivityExpense'
+      },
       withRelated: [
         { activities: query => query.orderBy('id') },
         'activities.contractorResources',
@@ -118,7 +132,8 @@ module.exports = () => ({
         'activities.statePersonnel',
         'activities.statePersonnel.years',
         'keyPersonnel',
-        'keyPersonnel.years'
+        'keyPersonnel.years',
+        'previousActivityExpenses'
       ]
     }
   }

--- a/api/db/apd.test.js
+++ b/api/db/apd.test.js
@@ -16,6 +16,7 @@ tap.test('apd data model', async apdModelTests => {
             updateableFields: [
               'status',
               'period',
+              'previousActivitySummary',
               'programOverview',
               'narrativeHIE',
               'narrativeHIT',
@@ -40,7 +41,8 @@ tap.test('apd data model', async apdModelTests => {
               'activities.statePersonnel',
               'activities.statePersonnel.years',
               'keyPersonnel',
-              'keyPersonnel.years'
+              'keyPersonnel.years',
+              'previousActivityExpenses'
             ]
           }
         }
@@ -58,6 +60,12 @@ tap.test('apd data model', async apdModelTests => {
       apd.apd.keyPersonnel,
       'function',
       'creates a key personnel relationship for the apd model'
+    );
+
+    setupTests.type(
+      apd.apd.previousActivityExpenses,
+      'function',
+      'creates a previous activity expenses relationship for the apd model'
     );
 
     setupTests.type(
@@ -121,6 +129,23 @@ tap.test('apd data model', async apdModelTests => {
   );
 
   apdModelTests.test(
+    'apd model sets up previous activity expenses relationship',
+    async activitiesTests => {
+      const self = {
+        hasMany: sinon.stub().returns('florp')
+      };
+
+      const output = apd.apd.previousActivityExpenses.bind(self)();
+
+      activitiesTests.ok(
+        self.hasMany.calledWith('apdPreviousActivityExpense'),
+        'sets up the relationship mapping to previous activity expenses'
+      );
+      activitiesTests.equal(output, 'florp', 'returns the expected value');
+    }
+  );
+
+  apdModelTests.test(
     'apd model sets up state relationship',
     async stateTests => {
       const self = {
@@ -161,6 +186,7 @@ tap.test('apd data model', async apdModelTests => {
         narrativeHIE: undefined,
         narrativeHIT: null,
         narrativeMMIS: 'also changed',
+        previousActivitySummary: 'blip blop',
         stateProfile: {
           medicaidDirector: {
             name: 'their name'
@@ -182,6 +208,7 @@ tap.test('apd data model', async apdModelTests => {
         {
           fine: 'no change',
           good: 'also no change',
+          previous_activity_summary: 'blip blop',
           program_overview: 'changed over',
           medicaid_director_name: 'their name',
           medicaid_director_email: null,
@@ -216,6 +243,12 @@ tap.test('apd data model', async apdModelTests => {
     self.get.withArgs('state_id').returns('apd-state');
     self.get.withArgs('status').returns('apd-status');
     self.get.withArgs('period').returns('apd-period');
+    self.get
+      .withArgs('previous_activity_summary')
+      .returns('apd-previous-activity-summary');
+    self.related.withArgs('previousActivityExpenses').returns({
+      toJSON: sinon.stub().returns('apd-previous-activity-expenses')
+    });
     self.get.withArgs('program_overview').returns('apd-overview');
     self.get.withArgs('narrative_hie').returns('apd-hie');
     self.get.withArgs('narrative_hit').returns('apd-hit');
@@ -246,6 +279,8 @@ tap.test('apd data model', async apdModelTests => {
         narrativeHIT: 'apd-hit',
         narrativeMMIS: 'apd-mmis',
         period: 'apd-period',
+        previousActivitySummary: 'apd-previous-activity-summary',
+        previousActivityExpenses: 'apd-previous-activity-expenses',
         programOverview: 'apd-overview',
         state: 'apd-state',
         stateProfile: {

--- a/api/db/apdPreviousActivityExpense.js
+++ b/api/db/apdPreviousActivityExpense.js
@@ -1,0 +1,49 @@
+module.exports = () => ({
+  apdPreviousActivityExpense: {
+    tableName: 'apd_previous_activity_expenses',
+
+    apd() {
+      return this.belongsTo('apd');
+    },
+
+    format(attributes) {
+      const out = { year: attributes.year, apd_id: attributes.apd_id };
+      if (attributes.hie) {
+        out.hie_federal_actual = attributes.hie.federalActual || 0;
+        out.hie_federal_approved = attributes.hie.federalApproved || 0;
+        out.hie_state_actual = attributes.hie.stateActual || 0;
+        out.hie_state_approved = attributes.hie.stateApproved || 0;
+      }
+      if (attributes.hit) {
+        out.hit_federal_actual = attributes.hit.federalActual || 0;
+        out.hit_federal_approved = attributes.hit.federalApproved || 0;
+        out.hit_state_actual = attributes.hit.stateActual || 0;
+        out.hit_state_approved = attributes.hit.stateApproved || 0;
+      }
+
+      return out;
+    },
+
+    toJSON() {
+      return {
+        hie: {
+          federalActual: +this.get('hie_federal_actual'),
+          federalApproved: +this.get('hie_federal_approved'),
+          stateActual: +this.get('hie_state_actual'),
+          stateApproved: +this.get('hie_state_approved')
+        },
+        hit: {
+          federalActual: +this.get('hit_federal_actual'),
+          federalApproved: +this.get('hit_federal_approved'),
+          stateActual: +this.get('hit_state_actual'),
+          stateApproved: +this.get('hit_state_approved')
+        },
+        year: `${this.get('year')}`
+      };
+    },
+
+    static: {
+      updateableFields: ['hie', 'hit', 'year']
+    }
+  }
+});

--- a/api/db/apdPreviousActivityExpense.test.js
+++ b/api/db/apdPreviousActivityExpense.test.js
@@ -1,0 +1,105 @@
+const tap = require('tap');
+const sinon = require('sinon');
+
+const {
+  apdPreviousActivityExpense: expense
+} = require('./apdPreviousActivityExpense')();
+
+tap.test('apd previous activity expense data model', async tests => {
+  tests.test('setup', async test => {
+    test.match(
+      expense,
+      {
+        tableName: 'apd_previous_activity_expenses',
+        apd: Function,
+        format: Function,
+        toJSON: Function,
+        static: {
+          updateableFields: ['hie', 'hit', 'year']
+        }
+      },
+      'get the expected model definitions'
+    );
+  });
+
+  tests.test('sets up apd relationship', async test => {
+    const self = {
+      belongsTo: sinon.stub().returns('baz')
+    };
+
+    const output = expense.apd.bind(self)();
+
+    test.ok(
+      self.belongsTo.calledWith('apd'),
+      'sets up the relationship mapping to an apd'
+    );
+    test.equal(output, 'baz', 'returns the expected value');
+  });
+
+  tests.test('formats data into database columns', async test => {
+    const attributes = {
+      year: 1066,
+      apd_id: 'bob',
+      hie: {
+        federalActual: 1,
+        federalApproved: 2,
+        stateActual: 3,
+        stateApproved: 4
+      },
+      hit: {
+        federalActual: 10,
+        federalApproved: 20,
+        stateActual: 30,
+        stateApproved: 40
+      },
+      otherStuff: 'deleted'
+    };
+
+    const output = expense.format(attributes);
+
+    test.same(output, {
+      year: 1066,
+      apd_id: 'bob',
+      hie_federal_actual: 1,
+      hie_federal_approved: 2,
+      hie_state_actual: 3,
+      hie_state_approved: 4,
+      hit_federal_actual: 10,
+      hit_federal_approved: 20,
+      hit_state_actual: 30,
+      hit_state_approved: 40
+    });
+  });
+
+  tests.test('overrides toJSON method', async test => {
+    const self = { get: sinon.stub(), related: sinon.stub() };
+    self.get.returns('--- unknown field ---');
+    self.get.withArgs('hie_federal_actual').returns('100');
+    self.get.withArgs('hie_federal_approved').returns('200');
+    self.get.withArgs('hie_state_actual').returns('300');
+    self.get.withArgs('hie_state_approved').returns('400');
+    self.get.withArgs('hit_federal_actual').returns('1000');
+    self.get.withArgs('hit_federal_approved').returns('2000');
+    self.get.withArgs('hit_state_actual').returns('3000');
+    self.get.withArgs('hit_state_approved').returns('4000');
+    self.get.withArgs('year').returns('year');
+
+    const output = expense.toJSON.bind(self)();
+
+    test.same(output, {
+      hie: {
+        federalActual: 100,
+        federalApproved: 200,
+        stateActual: 300,
+        stateApproved: 400
+      },
+      hit: {
+        federalActual: 1000,
+        federalApproved: 2000,
+        stateActual: 3000,
+        stateApproved: 4000
+      },
+      year: 'year'
+    });
+  });
+});

--- a/api/db/index.js
+++ b/api/db/index.js
@@ -10,6 +10,7 @@ const state = require('./state');
 const apd = require('./apd');
 const apdVersion = require('./apdVersion');
 const keyPersonnel = require('./apdKeyPersonnel');
+const previousActivityExpense = require('./apdPreviousActivityExpense');
 const apdActivity = require('./activity');
 
 const exportedModels = {};
@@ -26,6 +27,7 @@ const setup = (
     apd(),
     apdVersion(),
     keyPersonnel(),
+    previousActivityExpense(),
     apdActivity()
   ]
 ) => {

--- a/api/migrations/20180625174013_apd-previous-activities.js
+++ b/api/migrations/20180625174013_apd-previous-activities.js
@@ -1,0 +1,23 @@
+exports.up = async knex => {
+  await knex.schema.createTable('apd_previous_activity_expenses', table => {
+    table.increments();
+    table.integer('apd_id');
+    table.integer('year');
+    table.decimal('hie_federal_approved', 12, 2);
+    table.decimal('hie_federal_actual', 12, 2);
+    table.decimal('hie_state_approved', 12, 2);
+    table.decimal('hie_state_actual', 12, 2);
+    table.decimal('hit_federal_approved', 12, 2);
+    table.decimal('hit_federal_actual', 12, 2);
+    table.decimal('hit_state_approved', 12, 2);
+    table.decimal('hit_state_actual', 12, 2);
+
+    table.foreign('apd_id').references('apds.id');
+  });
+
+  await knex.schema.alterTable('apds', table => {
+    table.text('previous_activity_summary');
+  });
+};
+
+exports.down = async () => {};

--- a/api/routes/openAPI/index.js
+++ b/api/routes/openAPI/index.js
@@ -244,11 +244,11 @@ module.exports = {
                 type: 'object',
                 properties: {
                   cost: {
-                    type: 'string',
+                    type: 'number',
                     description: `This personnel's cost for the given federal fiscal year`
                   },
                   fte: {
-                    type: 'string',
+                    type: 'number',
                     description:
                       'Percent of time this personnel is dedicating to the activity'
                   },
@@ -273,9 +273,83 @@ module.exports = {
           activities: {
             $ref: '#/components/schemas/activity'
           },
-          narrativeHIE: { type: 'string', description: '' },
-          narrativeHIT: { type: 'string', description: '' },
-          narrativeMMIS: { type: 'string', description: '' },
+          narrativeHIE: {
+            type: 'string',
+            description:
+              'Brief description of HIE-funded activities contained in this APD'
+          },
+          narrativeHIT: {
+            type: 'string',
+            description:
+              'Brief description of HIT-funded activities contained in this APD'
+          },
+          narrativeMMIS: {
+            type: 'string',
+            description:
+              'Brief description of MMIS-funded activities contained in this APD'
+          },
+          previousActivityExpenses: arrayOf({
+            type: 'object',
+            properties: {
+              year: {
+                type: 'string',
+                description: 'Federal fiscal year this information applies to'
+              },
+              hie: {
+                type: 'object',
+                description: 'HIE-funded expenses',
+                properties: {
+                  federalActual: {
+                    type: 'number',
+                    description: 'Total federal share actually spent'
+                  },
+                  federalApproved: {
+                    type: 'number',
+                    description:
+                      'Total federal share approved in the previous APD'
+                  },
+                  stateActual: {
+                    type: 'number',
+                    description: 'Total state share actually spent'
+                  },
+                  stateApproved: {
+                    type: 'number',
+                    description:
+                      'Total state share approved in the previous APD'
+                  }
+                }
+              },
+              hit: {
+                type: 'object',
+                description: 'HIT-funded expenses',
+                properties: {
+                  federalActual: {
+                    type: 'number',
+                    description: 'Total federal share actually spent'
+                  },
+                  federalApproved: {
+                    type: 'number',
+                    description:
+                      'Total federal share approved in the previous APD'
+                  },
+                  stateActual: {
+                    type: 'number',
+                    description: 'Total state share actually spent'
+                  },
+                  stateApproved: {
+                    type: 'number',
+                    description:
+                      'Total state share approved in the previous APD'
+                  }
+                }
+              }
+            }
+          }),
+          previousActivitySummary: {
+            type: 'string',
+            description:
+              'High-level outline of activities approved in previous APD'
+          },
           programOverview: {
             type: 'string',
             description: 'An overview of the overall program'

--- a/web/src/actions/apd.js
+++ b/web/src/actions/apd.js
@@ -108,6 +108,14 @@ export const saveApd = () => (dispatch, state) => {
     narrativeHIE: updatedApd.hieNarrative,
     narrativeHIT: updatedApd.hitNarrative,
     narrativeMMIS: updatedApd.mmisNarrative,
+    previousActivityExpenses: Object.entries(
+      updatedApd.previousActivityExpenses
+    ).map(([year, o]) => ({
+      year,
+      hie: o.hie,
+      hit: o.hit
+    })),
+    previousActivitySummary: updatedApd.previousActivitySummary,
     programOverview: updatedApd.overview,
     stateProfile: updatedApd.stateProfile,
     years: updatedApd.years

--- a/web/src/actions/apd.test.js
+++ b/web/src/actions/apd.test.js
@@ -185,6 +185,13 @@ describe('apd actions', () => {
           hieNarrative: 'HIE narrative text',
           hitNarrative: 'HIT narrative text',
           mmisNarrative: 'MMIS narrative text',
+          previousActivityExpenses: {
+            1066: {
+              hie: 'battle of hastings',
+              hit: 'moop moop'
+            }
+          },
+          previousActivitySummary: 'other activities happened in the past',
           overview: 'APD overview text',
           years: ['1992', '1993'],
           stateProfile: {
@@ -202,6 +209,14 @@ describe('apd actions', () => {
             descLong: 'activity description',
             altApproach: 'alternatives approach',
             costAllocationDesc: 'cost allocation methodology',
+            previousActivitySummary: 'other activities happened in the past',
+            previousActivityExpenses: [
+              {
+                year: 1066,
+                hie: 'battle of hastings',
+                hit: 'moop moop'
+              }
+            ],
             otherFundingDesc: 'other funding sources',
             costAllocation: {
               '1993': { ffp: { federal: 90, state: 10 }, other: 0 },

--- a/web/src/containers/DeleteActivity.js
+++ b/web/src/containers/DeleteActivity.js
@@ -60,7 +60,7 @@ class DeleteActivity extends Component {
 }
 
 DeleteActivity.propTypes = {
-  aId: PropTypes.number.isRequired,
+  aId: PropTypes.string.isRequired,
   removeActivity: PropTypes.func.isRequired
 };
 

--- a/web/src/reducers/apd.js
+++ b/web/src/reducers/apd.js
@@ -92,6 +92,7 @@ const reducer = (state = initialState, action) => {
             narrativeHIT: hitNarrative,
             narrativeHIE: hieNarrative,
             narrativeMMIS: mmisNarrative,
+            previousActivityExpenses,
             previousActivitySummary,
             incentivePayments,
             stateProfile,
@@ -110,13 +111,24 @@ const reducer = (state = initialState, action) => {
               years: (years || defaultAPDYears).map(y => `${y}`),
               yearOptions: defaultAPDYearOptions,
               previousActivitySummary: previousActivitySummary || '',
-              previousActivityExpenses: defaultAPDYearOptions.reduce(
-                (previous, year) => ({
-                  ...previous,
-                  [year - 2]: getPreviousActivityExpense()
-                }),
-                {}
-              ),
+              previousActivityExpenses: previousActivityExpenses
+                ? previousActivityExpenses.reduce(
+                    (previous, year) => ({
+                      ...previous,
+                      [year.year]: {
+                        hie: year.hie,
+                        hit: year.hit
+                      }
+                    }),
+                    {}
+                  )
+                : defaultAPDYearOptions.reduce(
+                    (previous, year) => ({
+                      ...previous,
+                      [year - 2]: getPreviousActivityExpense()
+                    }),
+                    {}
+                  ),
               incentivePayments: incentivePayments || initIncentiveData(),
               stateProfile,
               activities


### PR DESCRIPTION
Closes #694 

### This pull request changes...
- previous activity summary and expenses are saved to the API
- previous activity summary and expense info is loaded when APDs are loaded

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [x] The change has been documented
  - [x] Associated OpenAPI documentation has been updated