### PR TITLE
Initiate APD with state profile from state model, update state model when APD is saved with state profile

### DIFF
--- a/api/db/apd.js
+++ b/api/db/apd.js
@@ -104,8 +104,6 @@ module.exports = () => ({
 
     static: {
       updateableFields: [
-        'status',
-        'period',
         'previousActivitySummary',
         'programOverview',
         'narrativeHIE',

--- a/api/db/apd.test.js
+++ b/api/db/apd.test.js
@@ -14,8 +14,6 @@ tap.test('apd data model', async apdModelTests => {
           toJSON: Function,
           static: {
             updateableFields: [
-              'status',
-              'period',
               'previousActivitySummary',
               'programOverview',
               'narrativeHIE',

--- a/api/db/state.js
+++ b/api/db/state.js
@@ -2,6 +2,17 @@ module.exports = () => ({
   state: {
     tableName: 'states',
 
+    format(attributes) {
+      const out = { ...attributes };
+
+      // Stringify.  If undefined, set that instead.  These
+      // must be set to something or else bookshelf will throw
+      out.medicaid_office = JSON.stringify(out.medicaid_office);
+      out.state_pocs = JSON.stringify(out.state_pocs);
+
+      return out;
+    },
+
     apds() {
       return this.hasMany('apd');
     }

--- a/api/endpoint-tests/apds/put.js
+++ b/api/endpoint-tests/apds/put.js
@@ -51,8 +51,7 @@ tap.test('APD endpoint | PUT /apds/:id', async putAPDTest => {
         const { response, body } = await request.put(url(4000), {
           jar: cookies,
           json: {
-            status: 'new status',
-            period: 'new period'
+            programOverview: 'new overview'
           }
         });
 
@@ -61,8 +60,7 @@ tap.test('APD endpoint | PUT /apds/:id', async putAPDTest => {
           body,
           {
             id: 4000,
-            period: 'new period',
-            status: 'new status',
+            programOverview: 'new overview',
             state: 'mn'
           },
           'sends back the updated APD object'

--- a/api/middleware/synchronize.js
+++ b/api/middleware/synchronize.js
@@ -79,12 +79,15 @@ const synchronizeAll = getSpecifics =>
  * @param {SyncEventHandler} events.beforeSync Called before the model is
  *    synced.  A good opportunity to massage the request object.
  */
-const synchronizeSpecific = (getModelToSync, events = {}) =>
+const synchronizeSpecific = (getModelToSync, { afterSync, beforeSync } = {}) =>
   cache(
-    ['sync-one', modelIndex(getModelToSync), modelIndex(events)],
+    [
+      'sync-one',
+      modelIndex(getModelToSync),
+      modelIndex(afterSync),
+      modelIndex(beforeSync)
+    ],
     () => async (req, res, next) => {
-      const { afterSync, beforeSync } = events;
-
       let action;
       try {
         if (typeof beforeSync === 'function') {

--- a/api/middleware/synchronize.test.js
+++ b/api/middleware/synchronize.test.js
@@ -13,6 +13,9 @@ tap.test('Data model synchronization middleware', async middlewareTests => {
     status: sandbox.stub()
   };
 
+  const beforeSync = sandbox.stub();
+  const afterSync = sandbox.stub();
+
   const getDetails = sandbox.stub();
 
   middlewareTests.beforeEach(async () => {
@@ -21,6 +24,9 @@ tap.test('Data model synchronization middleware', async middlewareTests => {
 
     res.send.returns(res);
     res.status.returns(res);
+
+    beforeSync.resolves();
+    afterSync.resolves();
   });
 
   middlewareTests.test(
@@ -165,8 +171,13 @@ tap.test('Data model synchronization middleware', async middlewareTests => {
 
           const body = {};
 
-          await middleware.synchronizeSpecific(getDetails)({ body }, res, next);
+          await middleware.synchronizeSpecific(getDetails, {
+            beforeSync,
+            afterSync
+          })({ body }, res, next);
 
+          test.ok(beforeSync.calledOnce, 'event is called before syncing');
+          test.ok(afterSync.notCalled, 'event is NOT called after syncing');
           test.ok(model.synchronize.calledWith(body), 'model is synchronized');
           test.ok(next.notCalled, 'the middleware chain is broken');
           test.ok(
@@ -199,8 +210,13 @@ tap.test('Data model synchronization middleware', async middlewareTests => {
 
           const body = {};
 
-          await middleware.synchronizeSpecific(getDetails)({ body }, res, next);
+          await middleware.synchronizeSpecific(getDetails, {
+            beforeSync,
+            afterSync
+          })({ body }, res, next);
 
+          test.ok(beforeSync.calledOnce, 'event is called before syncing');
+          test.ok(afterSync.calledOnce, 'event is called after syncing');
           test.ok(model.synchronize.calledWith(body), 'model is synchronized');
           test.ok(
             model.fetch.calledWith({ withRelated: 'list of relationships' }),

--- a/api/routes/apds/openAPI.js
+++ b/api/routes/apds/openAPI.js
@@ -35,7 +35,7 @@ const openAPI = {
     put: {
       tags: ['APDs'],
       summary: 'Update a specific APD',
-      description: 'Update an apd in the system',
+      description: `Update an APD in the system.  If state profile information is included, the profile information is also updated for the user's state.`,
       parameters: [
         {
           name: 'id',

--- a/api/routes/apds/post.js
+++ b/api/routes/apds/post.js
@@ -1,8 +1,15 @@
 const logger = require('../../logger')('apds route post');
-const { apd: defaultApdModel } = require('../../db').models;
+const {
+  apd: defaultApdModel,
+  state: defaultStateModel
+} = require('../../db').models;
 const { can } = require('../../middleware');
 
-module.exports = (app, ApdModel = defaultApdModel) => {
+module.exports = (
+  app,
+  ApdModel = defaultApdModel,
+  StateModel = defaultStateModel
+) => {
   logger.silly('setting up POST /apds/ route');
   app.post('/apds', can('edit-document'), async (req, res) => {
     logger.silly(req, 'handling POST /apds route');
@@ -12,6 +19,12 @@ module.exports = (app, ApdModel = defaultApdModel) => {
         state_id: req.user.state,
         status: 'draft'
       });
+
+      const state = await StateModel.where({ id: req.user.state }).fetch();
+      if (state.get('medicaid_office')) {
+        newApd.set({ stateProfile: state.get('medicaid_office') });
+      }
+
       await newApd.save();
 
       const apd = await ApdModel.where({ id: newApd.get('id') }).fetch({

--- a/api/routes/apds/post.test.js
+++ b/api/routes/apds/post.test.js
@@ -13,8 +13,13 @@ tap.test('apds POST endpoint', async endpointTest => {
     where: sandbox.stub()
   };
 
+  const StateModel = {
+    where: sandbox.stub(),
+    fetch: sandbox.stub()
+  };
+
   endpointTest.test('setup', async test => {
-    postEndpoint(app, ApdModel);
+    postEndpoint(app, ApdModel, StateModel);
 
     test.ok(
       app.post.calledWith('/apds', can('edit-document'), sinon.match.func),
@@ -33,8 +38,9 @@ tap.test('apds POST endpoint', async endpointTest => {
       end: sandbox.stub()
     };
 
+    const set = sinon.stub();
+
     tests.beforeEach(async () => {
-      console.log('tests beforeEach');
       sandbox.resetBehavior();
       sandbox.resetHistory();
 
@@ -47,13 +53,17 @@ tap.test('apds POST endpoint', async endpointTest => {
           .stub()
           .withArgs('id')
           .returns('new-apd-id'),
+        set,
         save: sandbox.stub().resolves()
       });
+
       ApdModel.where.returns({
         fetch: sandbox.stub().resolves('this is the new APD')
       });
 
-      postEndpoint(app, ApdModel);
+      StateModel.where.returns(StateModel);
+
+      postEndpoint(app, ApdModel, StateModel);
       handler = app.post.args[0].slice(-1).pop();
     });
 
@@ -66,9 +76,52 @@ tap.test('apds POST endpoint', async endpointTest => {
     });
 
     tests.test('sends back the new APD if everything works', async test => {
+      StateModel.fetch.resolves({
+        get: sinon
+          .stub()
+          .withArgs('medicaid_office')
+          .returns({
+            medicaidDirector: {
+              name: 'Abraham Lincoln',
+              email: 'honestabe@presidents.gov',
+              phone: '555-ABE-LNCN'
+            },
+            medicaidOffice: {
+              address1: '1600 Pennsylvania Ave',
+              address2: 'c/o 1865',
+              city: 'Washington',
+              state: 'DC',
+              zip: '20500'
+            }
+          })
+      });
+
       await handler(req, res);
 
-      test.ok(ApdModel.forge.calledWith({ state_id: 'st', status: 'draft' }));
+      test.ok(
+        ApdModel.forge.calledWith({
+          state_id: 'st',
+          status: 'draft'
+        })
+      );
+      test.ok(
+        set.calledWith({
+          stateProfile: {
+            medicaidDirector: {
+              name: 'Abraham Lincoln',
+              email: 'honestabe@presidents.gov',
+              phone: '555-ABE-LNCN'
+            },
+            medicaidOffice: {
+              address1: '1600 Pennsylvania Ave',
+              address2: 'c/o 1865',
+              city: 'Washington',
+              state: 'DC',
+              zip: '20500'
+            }
+          }
+        })
+      );
       test.ok(
         res.send.calledWith('this is the new APD'),
         'sends back the new APD'

--- a/api/routes/apds/put.js
+++ b/api/routes/apds/put.js
@@ -1,5 +1,8 @@
 const logger = require('../../logger')('apds route put');
-const { apd: defaultApdModel } = require('../../db').models;
+const {
+  apd: defaultApdModel,
+  state: defaultStateModel
+} = require('../../db').models;
 const {
   can,
   synchronizeSpecific,
@@ -12,13 +15,22 @@ const syncResponder = (ApdModel = defaultApdModel) => req => ({
   action: 'update-apd'
 });
 
+const updateStateProfile = (StateModel = defaultStateModel) => async req => {
+  const profile = req.body.stateProfile;
+  const state = await StateModel.where({ id: req.user.state }).fetch();
+  state.set('medicaid_office', JSON.stringify(profile));
+  await state.save();
+};
+
 module.exports = app => {
   logger.silly('setting up PUT /apds/:id route');
   app.put(
     '/apds/:id',
     can('edit-document'),
     userCanEditAPD(),
-    synchronizeSpecific(syncResponder())
+    synchronizeSpecific(syncResponder(), {
+      afterSync: updateStateProfile()
+    })
   );
 };
 

--- a/api/routes/apds/put.js
+++ b/api/routes/apds/put.js
@@ -35,3 +35,4 @@ module.exports = app => {
 };
 
 module.exports.syncResponder = syncResponder;
+module.exports.updateStateProfile = updateStateProfile;

--- a/api/routes/apds/put.js
+++ b/api/routes/apds/put.js
@@ -17,9 +17,11 @@ const syncResponder = (ApdModel = defaultApdModel) => req => ({
 
 const updateStateProfile = (StateModel = defaultStateModel) => async req => {
   const profile = req.body.stateProfile;
-  const state = await StateModel.where({ id: req.user.state }).fetch();
-  state.set('medicaid_office', JSON.stringify(profile));
-  await state.save();
+  if (profile) {
+    const state = await StateModel.where({ id: req.user.state }).fetch();
+    state.set('medicaid_office', profile);
+    await state.save();
+  }
 };
 
 module.exports = app => {

--- a/api/routes/apds/put.test.js
+++ b/api/routes/apds/put.test.js
@@ -1,7 +1,11 @@
 const tap = require('tap');
 const sinon = require('sinon');
 
-const { can, userCanEditAPD } = require('../../middleware');
+const {
+  can,
+  userCanEditAPD,
+  synchronizeSpecific
+} = require('../../middleware');
 const putEndpoint = require('./put');
 
 tap.test('apds PUT endpoint', async endpointTest => {
@@ -36,6 +40,40 @@ tap.test('apds PUT endpoint', async endpointTest => {
         out,
         { model, modelClass, action: 'update-apd' },
         'returns the specific model to synchronize'
+      );
+    }
+  );
+
+  endpointTest.test(
+    'afterSync event handler updates state profile',
+    async test => {
+      const StateModel = {
+        where: sinon.stub(),
+        fetch: sinon.stub()
+      };
+      StateModel.where.returns(StateModel);
+
+      const state = {
+        set: sinon.stub(),
+        save: sinon.stub().resolves()
+      };
+      StateModel.fetch.resolves(state);
+
+      await putEndpoint.updateStateProfile(StateModel)({
+        user: { state: 'zz' },
+        body: { stateProfile: { info: 'goes here', toBe: 'saved' } }
+      });
+
+      test.ok(
+        StateModel.where.calledWith({ id: 'zz' }),
+        'fetches the associated state'
+      );
+      test.ok(
+        state.set.calledWith(
+          'medicaid_office',
+          '{"info":"goes here","toBe":"saved"}'
+        ),
+        'updates the state with profile info from the request body'
       );
     }
   );

--- a/api/routes/apds/put.test.js
+++ b/api/routes/apds/put.test.js
@@ -1,11 +1,7 @@
 const tap = require('tap');
 const sinon = require('sinon');
 
-const {
-  can,
-  userCanEditAPD,
-  synchronizeSpecific
-} = require('../../middleware');
+const { can, userCanEditAPD } = require('../../middleware');
 const putEndpoint = require('./put');
 
 tap.test('apds PUT endpoint', async endpointTest => {

--- a/api/routes/apds/put.test.js
+++ b/api/routes/apds/put.test.js
@@ -69,10 +69,10 @@ tap.test('apds PUT endpoint', async endpointTest => {
         'fetches the associated state'
       );
       test.ok(
-        state.set.calledWith(
-          'medicaid_office',
-          '{"info":"goes here","toBe":"saved"}'
-        ),
+        state.set.calledWith('medicaid_office', {
+          info: 'goes here',
+          toBe: 'saved'
+        }),
         'updates the state with profile info from the request body'
       );
     }

--- a/api/routes/states/put.js
+++ b/api/routes/states/put.js
@@ -108,15 +108,7 @@ module.exports = (app, dataHelper = defaultDataHelper) => {
           .end();
       }
 
-      state.set({
-        ...newData,
-        // These fields have to be stringified, which is kind of unexpected
-        // since bookshelf converts them into objects when we read them...
-        // They also must be present, even if undefined, or bookshelf throws
-        // an error.
-        medicaid_office: JSON.stringify(newData.medicaid_office),
-        state_pocs: JSON.stringify(newData.state_pocs)
-      });
+      state.set(newData);
       await state.save();
 
       // Overwrite the old data with the new, and we will have what now

--- a/api/routes/states/put.test.js
+++ b/api/routes/states/put.test.js
@@ -173,14 +173,9 @@ tap.test('states PUT endpoints', async endpointTest => {
             await handler(req, res);
 
             validTest.ok(
-              // Medicaid office and state POCs are always set - if they
-              // are not passed as arguments, they are set to undefined.
-              // If they're not set, bookshelf throws an error.
               stateModel.set.calledWith({
                 program_benefits: 'new benefits goes here',
-                program_vision: '',
-                medicaid_office: undefined,
-                state_pocs: undefined
+                program_vision: ''
               }),
               'updates the model with only supported fields'
             );


### PR DESCRIPTION
Modifies the API behavior in two ways:
- when a new APD is created, if the state already has a profile configured, the profile is copied into the APD
- when an APD is saved, if it has state profile information, the state model's profile info is updated with the info from the APD

Closes #700
Closes #701

### This pull request changes...
- new APDs will have state profile information, if any is defined

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [x] The change has been documented
  - [x] Associated OpenAPI documentation has been updated