### PR TITLE
Sets default of 1 milestone for activities

### DIFF
--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -74,7 +74,7 @@ const newActivity = (
   costAllocationDesc: '',
   otherFundingDesc: '',
   goals: [newGoal()],
-  milestones: [newMilestone(), newMilestone(), newMilestone()],
+  milestones: [newMilestone()],
   statePersonnel: [
     newStatePerson(1, years),
     newStatePerson(2, years),

--- a/web/src/reducers/activities.test.js
+++ b/web/src/reducers/activities.test.js
@@ -79,7 +79,7 @@ describe('activities reducer', () => {
     fundingSource: 'HIT',
     goals: [{ ...newGoal }],
     meta: { expanded: false },
-    milestones: [{ ...newMilestone }, { ...newMilestone }, { ...newMilestone }],
+    milestones: [{ ...newMilestone }],
     name: '',
     otherFundingDesc: '',
     standardsAndConditions: {


### PR DESCRIPTION
Activities will start with 1 milestone each, instead of 3. However users will have the ability to add new milestones as needed.

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author

