### PR TITLE
Set default previous activity expenses if none provided by the API

### DIFF
--- a/web/src/reducers/apd.js
+++ b/web/src/reducers/apd.js
@@ -99,7 +99,6 @@ const reducer = (state = initialState, action) => {
         fetching: false,
         loaded: true,
         byId: action.data.reduce((acc, apd) => {
-          // TODO: capture previous activity expenses when it's returned by the API
           const {
             id,
             activities,
@@ -127,24 +126,25 @@ const reducer = (state = initialState, action) => {
               hitNarrative,
               mmisNarrative,
               overview,
-              previousActivityExpenses: previousActivityExpenses
-                ? previousActivityExpenses.reduce(
-                    (previous, year) => ({
-                      ...previous,
-                      [year.year]: {
-                        hie: year.hie,
-                        hit: year.hit
-                      }
-                    }),
-                    {}
-                  )
-                : defaultAPDYearOptions.reduce(
-                    (previous, year) => ({
-                      ...previous,
-                      [year - 2]: getPreviousActivityExpense()
-                    }),
-                    {}
-                  ),
+              previousActivityExpenses:
+                previousActivityExpenses && previousActivityExpenses.length
+                  ? previousActivityExpenses.reduce(
+                      (previous, year) => ({
+                        ...previous,
+                        [year.year]: {
+                          hie: year.hie,
+                          hit: year.hit
+                        }
+                      }),
+                      {}
+                    )
+                  : defaultAPDYearOptions.reduce(
+                      (previous, year) => ({
+                        ...previous,
+                        [year - 2]: getPreviousActivityExpense()
+                      }),
+                      {}
+                    ),
               previousActivitySummary: previousActivitySummary || '',
               stateProfile,
               years: (years || defaultAPDYears).map(y => `${y}`),

--- a/web/src/reducers/apd.test.js
+++ b/web/src/reducers/apd.test.js
@@ -75,40 +75,56 @@ describe('APD reducer', () => {
     });
   });
 
-  it('should handle a successful APD get', () => {
-    expect(
-      apd(initialState, {
-        type: 'GET_APD_SUCCESS',
-        data: [
-          {
+  describe('should handle a successful APD get', () => {
+    let data;
+    let expected;
+
+    beforeEach(() => {
+      data = {
+        id: 'apd-id',
+        federalCitations:
+          'The Third Sentence of the Ninth Paragraph of the Three Hundred and Twenty-First Section of the Ninety-Fifth Part of the Forty-Fifth Title of the Federal Code of Regulations',
+        programOverview: 'moop moop',
+        narrativeHIT: 'HIT, but as a play',
+        narrativeHIE: 'HIE, but as a novel',
+        narrativeMMIS: 'MMIS, but as a script',
+        stateProfile: 'this is the state profile as a string',
+        years: [2013, 2014]
+      };
+
+      expected = {
+        byId: {
+          'apd-id': {
+            activities: undefined,
             id: 'apd-id',
-            federalCitations:
+            assurancesAndCompliance:
               'The Third Sentence of the Ninth Paragraph of the Three Hundred and Twenty-First Section of the Ninety-Fifth Part of the Forty-Fifth Title of the Federal Code of Regulations',
-            programOverview: 'moop moop',
-            narrativeHIT: 'HIT, but as a play',
-            narrativeHIE: 'HIE, but as a novel',
-            narrativeMMIS: 'MMIS, but as a script',
-            stateProfile: 'this is the state profile as a string',
-            years: [2013, 2014]
+            years: ['2013', '2014'],
+            // TODO: This value is computed based on the current datetime.
+            // Probably ought to mock the time (sinon can do this) so
+            // the test is deterministic.
+            yearOptions: ['2018', '2019', '2020'],
+            overview: 'moop moop',
+            hitNarrative: 'HIT, but as a play',
+            hieNarrative: 'HIE, but as a novel',
+            mmisNarrative: 'MMIS, but as a script',
+            previousActivitySummary: '',
+            previousActivityExpenses: {
+              2016: getPreviousActivityExpense(),
+              2017: getPreviousActivityExpense(),
+              2018: getPreviousActivityExpense()
+            },
+            incentivePayments,
+            stateProfile: 'this is the state profile as a string'
           }
-        ]
-      })
-    ).toEqual({
-      byId: {
-        'apd-id': {
-          activities: undefined,
-          id: 'apd-id',
-          years: ['2013', '2014'],
-          // TODO: This value is computed based on the current datetime.
-          // Probably ought to mock the time (sinon can do this) so
-          // the test is deterministic.
-          yearOptions: ['2018', '2019', '2020'],
-          overview: 'moop moop',
-          hitNarrative: 'HIT, but as a play',
-          hieNarrative: 'HIE, but as a novel',
-          mmisNarrative: 'MMIS, but as a script',
-          assurancesAndCompliance:
-            'The Third Sentence of the Ninth Paragraph of the Three Hundred and Twenty-First Section of the Ninety-Fifth Part of the Forty-Fifth Title of the Federal Code of Regulations',
+        },
+        data: {
+          id: '',
+          overview: '',
+          hitNarrative: '',
+          hieNarrative: '',
+          mmisNarrative: '',
+          assurancesAndCompliance: initialAssurances,
           previousActivitySummary: '',
           previousActivityExpenses: {
             2016: getPreviousActivityExpense(),
@@ -116,46 +132,93 @@ describe('APD reducer', () => {
             2018: getPreviousActivityExpense()
           },
           incentivePayments,
-          stateProfile: 'this is the state profile as a string'
-        }
-      },
-      data: {
-        id: '',
-        overview: '',
-        hitNarrative: '',
-        hieNarrative: '',
-        mmisNarrative: '',
-        assurancesAndCompliance: initialAssurances,
-        previousActivitySummary: '',
-        previousActivityExpenses: {
-          2016: getPreviousActivityExpense(),
-          2017: getPreviousActivityExpense(),
-          2018: getPreviousActivityExpense()
-        },
-        incentivePayments,
-        stateProfile: {
-          medicaidDirector: {
-            name: '',
-            email: '',
-            phone: ''
+          stateProfile: {
+            medicaidDirector: {
+              name: '',
+              email: '',
+              phone: ''
+            },
+            medicaidOffice: {
+              address1: '',
+              address2: '',
+              city: '',
+              state: '',
+              zip: ''
+            }
           },
-          medicaidOffice: {
-            address1: '',
-            address2: '',
-            city: '',
-            state: '',
-            zip: ''
-          }
+          // TODO: This value is computed based on the current datetime.
+          // Probably ought to mock the time (sinon can do this) so
+          // the test is deterministic.
+          years: ['2018', '2019'],
+          yearOptions: ['2018', '2019', '2020']
         },
-        // TODO: This value is computed based on the current datetime.
-        // Probably ought to mock the time (sinon can do this) so
-        // the test is deterministic.
-        years: ['2018', '2019'],
-        yearOptions: ['2018', '2019', '2020']
-      },
-      fetching: false,
-      loaded: true,
-      error: ''
+        fetching: false,
+        loaded: true,
+        error: ''
+      };
+    });
+
+    it('handles the previous activity expenses being an empty array', () => {
+      data.previousActivityExpenses = [];
+      expect(
+        apd(initialState, {
+          type: 'GET_APD_SUCCESS',
+          data: [data]
+        })
+      ).toEqual(expected);
+    });
+
+    it('handles the previous activity expenses being set', () => {
+      data.previousActivityExpenses = [
+        {
+          hie: {
+            federalActual: 10,
+            federalApproved: 20,
+            stateActual: 30,
+            stateApproved: 40
+          },
+          hit: {
+            federalActual: 100,
+            federalApproved: 200,
+            stateActual: 300,
+            stateApproved: 400
+          },
+          year: 1776
+        }
+      ];
+
+      expected.byId['apd-id'].previousActivityExpenses = {
+        1776: {
+          hie: {
+            federalActual: 10,
+            federalApproved: 20,
+            stateActual: 30,
+            stateApproved: 40
+          },
+          hit: {
+            federalActual: 100,
+            federalApproved: 200,
+            stateActual: 300,
+            stateApproved: 400
+          }
+        }
+      };
+
+      expect(
+        apd(initialState, {
+          type: 'GET_APD_SUCCESS',
+          data: [data]
+        })
+      ).toEqual(expected);
+    });
+
+    it('sets values from the API, and defaults otherwise', () => {
+      expect(
+        apd(initialState, {
+          type: 'GET_APD_SUCCESS',
+          data: [data]
+        })
+      ).toEqual(expected);
     });
   });
 


### PR DESCRIPTION
Fixes #731 

### This pull request changes...
- when you load an existing API, the previous activity expenses table will show up

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author