### PR TITLE
Conditional "Add Contact" button text

### DIFF
--- a/web/src/actions/apd.js
+++ b/web/src/actions/apd.js
@@ -13,6 +13,7 @@ export const GET_APD_REQUEST = 'GET_APD_REQUEST';
 export const GET_APD_SUCCESS = 'GET_APD_SUCCESS';
 export const GET_APD_FAILURE = 'GET_APD_FAILURE';
 export const REMOVE_APD_KEY_PERSON = 'REMOVE_APD_KEY_PERSON';
+export const REMOVE_APD_POC = 'REMOVE_APD_POC';
 export const SAVE_APD_REQUEST = 'SAVE_APD_REQUEST';
 export const SAVE_APD_SUCCESS = 'SAVE_APD_SUCCESS';
 export const SAVE_APD_FAILURE = 'SAVE_APD_FAILURE';
@@ -25,6 +26,7 @@ export const UPDATE_BUDGET = 'UPDATE_BUDGET';
 export const UPDATE_BUDGET_QUARTERLY_SHARE = 'UPDATE_BUDGET_QUARTERLY_SHARE';
 
 export const addPointOfContact = () => ({ type: ADD_APD_POC });
+export const removePointOfContact = index => ({ type: REMOVE_APD_POC, index });
 
 export const updateBudget = () => (dispatch, getState) =>
   dispatch({ type: UPDATE_BUDGET, state: getState() });

--- a/web/src/components/DeleteConfirm.js
+++ b/web/src/components/DeleteConfirm.js
@@ -1,15 +1,13 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 
 import { t } from '../i18n';
-import { removeActivity as removeActivityAction } from '../actions/activities';
 import { confirmAlert } from '../components/ConfirmAlert';
 
-const DeleteConfirm = ({ onClose, onConfirm }) => (
+const DeleteConfirm = ({ onClose, onConfirm, resource }) => (
   <div className="p2 sm-p3 bg-white rounded confirm-body">
-    <h2 className="mt0">{t('activities.delete.header')}</h2>
-    <p>{t('activities.delete.body')}</p>
+    <h2 className="mt0">{t(`${resource}.confirm.header`)}</h2>
+    <p>{t(`${resource}.confirm.body`)}</p>
     <button
       className="btn btn-small btn-primary bg-black h6"
       onClick={() => {
@@ -17,34 +15,41 @@ const DeleteConfirm = ({ onClose, onConfirm }) => (
         onClose();
       }}
     >
-      {t('activities.delete._yes')}
+      {t(`${resource}.confirm._yes`)}
     </button>{' '}
     <button className="btn btn-small btn-outline h6" onClick={onClose}>
-      {t('activities.delete._no')}
+      {t(`${resource}.confirm._no`)}
     </button>
   </div>
 );
 
 DeleteConfirm.propTypes = {
   onClose: PropTypes.func.isRequired,
-  onConfirm: PropTypes.func.isRequired
+  onConfirm: PropTypes.func.isRequired,
+  resource: PropTypes.string.isRequired
 };
 
-class DeleteActivity extends Component {
+class DeleteButton extends Component {
   handleClick = () => {
+    const { resource } = this.props;
     confirmAlert({
       customUI: ({ onClose }) => (
-        <DeleteConfirm onClose={onClose} onConfirm={this.handleConfirm} />
+        <DeleteConfirm
+          onClose={onClose}
+          onConfirm={this.handleConfirm}
+          resource={resource}
+        />
       )
     });
   };
 
   handleConfirm = () => {
-    const { aId, removeActivity } = this.props;
-    removeActivity(aId);
+    const { remove } = this.props;
+    remove();
   };
 
   render() {
+    const { resource } = this.props;
     return (
       <div>
         <button
@@ -52,20 +57,16 @@ class DeleteActivity extends Component {
           className="btn btn-small btn-primary bg-black h6"
           onClick={this.handleClick}
         >
-          {t('activities.deleteActivityButtonText')}
+          {t(`${resource}.text`)}
         </button>
       </div>
     );
   }
 }
 
-DeleteActivity.propTypes = {
-  aId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-  removeActivity: PropTypes.func.isRequired
+DeleteButton.propTypes = {
+  resource: PropTypes.string.isRequired,
+  remove: PropTypes.func.isRequired
 };
 
-const mapDispatchToProps = {
-  removeActivity: removeActivityAction
-};
-
-export default connect(null, mapDispatchToProps)(DeleteActivity);
+export default DeleteButton;

--- a/web/src/components/DeleteConfirm.js
+++ b/web/src/components/DeleteConfirm.js
@@ -49,12 +49,12 @@ class DeleteButton extends Component {
   };
 
   render() {
-    const { resource } = this.props;
+    const { className, resource } = this.props;
     return (
       <div>
         <button
           type="button"
-          className="btn btn-small btn-primary bg-black h6"
+          className={className || 'btn btn-small btn-primary bg-black h6'}
           onClick={this.handleClick}
         >
           {t(`${resource}.text`)}
@@ -65,8 +65,12 @@ class DeleteButton extends Component {
 }
 
 DeleteButton.propTypes = {
+  className: PropTypes.string,
   resource: PropTypes.string.isRequired,
   remove: PropTypes.func.isRequired
+};
+DeleteButton.defaultProps = {
+  className: null
 };
 
 export default DeleteButton;

--- a/web/src/containers/ActivityDetailAll.js
+++ b/web/src/containers/ActivityDetailAll.js
@@ -10,9 +10,12 @@ import ActivityDetailSchedule from './ActivityDetailSchedule';
 import ActivityDetailExpenses from './ActivityDetailExpenses';
 import ActivityDetailStandardsAndConditions from './ActivityDetailStandardsAndConditions';
 import ActivityDetailStatePersonnel from './ActivityDetailStatePersonnel';
-import DeleteActivity from './DeleteActivity';
-import { toggleActivitySection } from '../actions/activities';
+import {
+  removeActivity as removeActivityAction,
+  toggleActivitySection
+} from '../actions/activities';
 import Collapsible from '../components/Collapsible';
+import DeleteButton from '../components/DeleteConfirm';
 import { t } from '../i18n';
 
 const activityTitle = (a, i) => {
@@ -39,7 +42,7 @@ class ActivityDetailAll extends Component {
   };
 
   render() {
-    const { aId, expanded, num, title } = this.props;
+    const { aId, expanded, num, removeActivity, title } = this.props;
 
     return (
       <Collapsible
@@ -53,7 +56,12 @@ class ActivityDetailAll extends Component {
         {activityComponents.map((ActivityComponent, i) => (
           <ActivityComponent key={i} aId={aId} />
         ))}
-        {num > 1 && <DeleteActivity aId={aId} />}
+        {num > 1 && (
+          <DeleteButton
+            remove={() => removeActivity(aId)}
+            resource="activities.delete"
+          />
+        )}
       </Collapsible>
     );
   }
@@ -63,6 +71,7 @@ ActivityDetailAll.propTypes = {
   aId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   expanded: PropTypes.bool.isRequired,
   num: PropTypes.number.isRequired,
+  removeActivity: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
   toggleSection: PropTypes.func.isRequired
 };
@@ -76,6 +85,7 @@ export const mapStateToProps = ({ activities: { byId } }, { aId, num }) => {
 };
 
 export const mapDispatchToProps = {
+  removeActivity: removeActivityAction,
   toggleSection: toggleActivitySection
 };
 

--- a/web/src/containers/ActivityDetailAll.test.js
+++ b/web/src/containers/ActivityDetailAll.test.js
@@ -15,6 +15,7 @@ describe('the Activities details container component', () => {
     aId: 'activity-id',
     expanded: false,
     num: 3,
+    removeActivity: sinon.stub(),
     title: 'Activity title',
     toggleSection: sinon.stub()
   };

--- a/web/src/containers/ActivityDetailAll.test.js
+++ b/web/src/containers/ActivityDetailAll.test.js
@@ -2,7 +2,7 @@ import { shallow } from 'enzyme';
 import sinon from 'sinon';
 import React from 'react';
 
-import { toggleActivitySection } from '../actions/activities';
+import { removeActivity, toggleActivitySection } from '../actions/activities';
 
 import {
   raw as ActivityDetailAll,
@@ -62,6 +62,7 @@ describe('the Activities details container component', () => {
 
   test('maps dispatch actions to props', () => {
     expect(mapDispatchToProps).toEqual({
+      removeActivity,
       toggleSection: toggleActivitySection
     });
   });

--- a/web/src/containers/ActivityListEntry.js
+++ b/web/src/containers/ActivityListEntry.js
@@ -2,8 +2,11 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
-import DeleteActivity from './DeleteActivity';
-import { updateActivity as updateActivityAction } from '../actions/activities';
+import {
+  removeActivity as removeActivityAction,
+  updateActivity as updateActivityAction
+} from '../actions/activities';
+import DeleteButton from '../components/DeleteConfirm';
 import { ACTIVITY_FUNDING_SOURCES } from '../util';
 
 class ActivityListEntry extends Component {
@@ -17,7 +20,7 @@ class ActivityListEntry extends Component {
   };
 
   render() {
-    const { activity, num } = this.props;
+    const { activity, num, removeActivity } = this.props;
     const { id, name, fundingSource } = activity;
 
     return (
@@ -46,7 +49,12 @@ class ActivityListEntry extends Component {
             </label>
           ))}
         </div>
-        {num > 1 && <DeleteActivity aId={id} />}
+        {num > 1 && (
+          <DeleteButton
+            remove={() => removeActivity(id)}
+            resource="activities.delete"
+          />
+        )}
       </div>
     );
   }
@@ -55,6 +63,7 @@ class ActivityListEntry extends Component {
 ActivityListEntry.propTypes = {
   activity: PropTypes.object.isRequired,
   num: PropTypes.number.isRequired,
+  removeActivity: PropTypes.func.isRequired,
   updateActivity: PropTypes.func.isRequired
 };
 
@@ -63,7 +72,8 @@ const mapStateToProps = ({ activities: { byId } }, props) => ({
 });
 
 const mapDispatchToProps = {
-  updateActivity: updateActivityAction
+  updateActivity: updateActivityAction,
+  removeActivity: removeActivityAction
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(ActivityListEntry);

--- a/web/src/containers/ApdStateProfilePointsOfContact.js
+++ b/web/src/containers/ApdStateProfilePointsOfContact.js
@@ -51,6 +51,7 @@ class ApdStateProfile extends Component {
               onChange={this.handleChange('email', i)}
             />
             <DeleteButton
+              className="btn btn-small btn-outline bg-white blue h5"
               remove={() => removePoc(i)}
               resource={`${tRoot}.delete`}
             />

--- a/web/src/containers/ApdStateProfilePointsOfContact.js
+++ b/web/src/containers/ApdStateProfilePointsOfContact.js
@@ -3,9 +3,11 @@ import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 
 import {
-  updateApd as updateApdAction,
-  addPointOfContact
+  addPointOfContact,
+  removePointOfContact,
+  updateApd as updateApdAction
 } from '../actions/apd';
+import DeleteButton from '../components/DeleteConfirm';
 import { Input } from '../components/Inputs';
 import { t } from '../i18n';
 
@@ -18,7 +20,11 @@ class ApdStateProfile extends Component {
   };
 
   render() {
-    const { addPointOfContact: addPoc, poc } = this.props;
+    const {
+      addPointOfContact: addPoc,
+      poc,
+      removePointOfContact: removePoc
+    } = this.props;
     const tRoot = 'apd.stateProfile.pointsOfContact';
 
     return (
@@ -44,6 +50,10 @@ class ApdStateProfile extends Component {
               value={person.email}
               onChange={this.handleChange('email', i)}
             />
+            <DeleteButton
+              remove={() => removePoc(i)}
+              resource={`${tRoot}.delete`}
+            />
           </div>
         ))}
         <button type="button" className="btn btn-primary" onClick={addPoc}>
@@ -59,12 +69,17 @@ class ApdStateProfile extends Component {
 ApdStateProfile.propTypes = {
   addPointOfContact: PropTypes.func.isRequired,
   poc: PropTypes.array.isRequired,
+  removePointOfContact: PropTypes.func.isRequired,
   updateApd: PropTypes.func.isRequired
 };
 
 const mapStateToProps = ({ apd: { data: { pointsOfContact } } }) => ({
   poc: pointsOfContact
 });
-const mapDispatchToProps = { updateApd: updateApdAction, addPointOfContact };
+const mapDispatchToProps = {
+  addPointOfContact,
+  updateApd: updateApdAction,
+  removePointOfContact
+};
 
 export default connect(mapStateToProps, mapDispatchToProps)(ApdStateProfile);

--- a/web/src/containers/ApdStateProfilePointsOfContact.js
+++ b/web/src/containers/ApdStateProfilePointsOfContact.js
@@ -47,7 +47,9 @@ class ApdStateProfile extends Component {
           </div>
         ))}
         <button type="button" className="btn btn-primary" onClick={addPoc}>
-          {t('apd.stateProfile.pointsOfContact.labels.addButton')}
+          {t('apd.stateProfile.pointsOfContact.labels.addButton', {
+            count: poc.length
+          })}
         </button>
       </Fragment>
     );

--- a/web/src/containers/__snapshots__/ActivityDetailAll.test.js.snap
+++ b/web/src/containers/__snapshots__/ActivityDetailAll.test.js.snap
@@ -51,8 +51,9 @@ ShallowWrapper {
             aId="activity-id"
           />,
         ],
-        <Connect(DeleteActivity)
-          aId="activity-id"
+        <DeleteButton
+          remove={[Function]}
+          resource="activities.delete"
         />,
       ],
       "id": "activity-activity-id",
@@ -156,7 +157,8 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "class",
         "props": Object {
-          "aId": "activity-id",
+          "remove": [Function],
+          "resource": "activities.delete",
         },
         "ref": null,
         "rendered": null,
@@ -199,8 +201,9 @@ ShallowWrapper {
               aId="activity-id"
             />,
           ],
-          <Connect(DeleteActivity)
-            aId="activity-id"
+          <DeleteButton
+            remove={[Function]}
+            resource="activities.delete"
           />,
         ],
         "id": "activity-activity-id",
@@ -304,7 +307,8 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "class",
           "props": Object {
-            "aId": "activity-id",
+            "remove": [Function],
+            "resource": "activities.delete",
           },
           "ref": null,
           "rendered": null,

--- a/web/src/containers/__snapshots__/ActivityDetailAll.test.js.snap
+++ b/web/src/containers/__snapshots__/ActivityDetailAll.test.js.snap
@@ -8,6 +8,7 @@ ShallowWrapper {
     aId="activity-id"
     expanded={false}
     num={3}
+    removeActivity={[Function]}
     title="Activity title"
     toggleSection={[Function]}
   />,
@@ -52,6 +53,7 @@ ShallowWrapper {
           />,
         ],
         <DeleteButton
+          className={null}
           remove={[Function]}
           resource="activities.delete"
         />,
@@ -157,6 +159,7 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "class",
         "props": Object {
+          "className": null,
           "remove": [Function],
           "resource": "activities.delete",
         },
@@ -202,6 +205,7 @@ ShallowWrapper {
             />,
           ],
           <DeleteButton
+            className={null}
             remove={[Function]}
             resource="activities.delete"
           />,
@@ -307,6 +311,7 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "class",
           "props": Object {
+            "className": null,
             "remove": [Function],
             "resource": "activities.delete",
           },

--- a/web/src/i18n/locales/en.yaml
+++ b/web/src/i18n/locales/en.yaml
@@ -52,7 +52,10 @@
           name: Name
           position: Position
           email: Email address
-          addButton: Add point-of-contact
+          addButton: 
+            zero: Add point-of-contact
+            one: Add another contact
+            other: Add another contact
     overview: 
       title: "Program Overview"
       helpText: "Provide a high level summary of your state's program, history, and future vision."

--- a/web/src/i18n/locales/en.yaml
+++ b/web/src/i18n/locales/en.yaml
@@ -56,6 +56,13 @@
             zero: Add point-of-contact
             one: Add another contact
             other: Add another contact
+        delete:
+          text: Remove contact
+          confirm:
+            header: Confirm
+            body: Are you sure you’d like to remove this contact?
+            _yes: "Yes"
+            _no: "No"
     overview: 
       title: "Program Overview"
       helpText: "Provide a high level summary of your state's program, history, and future vision."
@@ -134,13 +141,14 @@
       helpText: "Examples of individual activities include: Auditing, Outreach, Environmental Scans, HIE Registry Development, CQM Database Development, Data and Analytics, HIE Onboarding, etc."
       reminder: "The first activity in this list is Program Administration. Program Administration is where you should include information that pertains to implementing the EHR Incentive program. Examples of information that belongs within this activity includes: State and Contractor costs associated with operating the EHR incentive program and SLR Enhancements/Upgrades."
     addActivityButtonText: "Add activity"
-    deleteActivityButtonText: "Remove Activity"
     noActivityMessage: "It looks like you don’t have any activities. Add one below."
-    delete: 
-      header: "Confirm"
-      body: "Are you sure you’d like to remove this activity?"
-      _yes: "Yes"
-      _no: "No"
+    delete:
+      text: Remove Activity
+      confirm:
+        header: Confirm
+        body: Are you sure you’d like to remove this activity?
+        _yes: "Yes"
+        _no: "No"
     header: "Program Activities"
     namePrefix: "Activity"
     namePrefixAndNum: "Core Activity {{number}}"

--- a/web/src/reducers/apd.js
+++ b/web/src/reducers/apd.js
@@ -5,6 +5,7 @@ import {
   GET_APD_REQUEST,
   GET_APD_SUCCESS,
   GET_APD_FAILURE,
+  REMOVE_APD_POC,
   SELECT_APD,
   UPDATE_APD
 } from '../actions/apd';
@@ -215,6 +216,15 @@ const reducer = (state = initialState, action) => {
     }
     case GET_APD_FAILURE:
       return { ...state, fetching: false, error: action.error };
+    case REMOVE_APD_POC:
+      return u(
+        {
+          data: {
+            pointsOfContact: pocs => pocs.filter((_, i) => i !== action.index)
+          }
+        },
+        state
+      );
     case SELECT_APD:
       return { ...state, data: { ...action.apd } };
     case UPDATE_APD:


### PR DESCRIPTION
From @lauraponce's comment at https://github.com/18F/cms-hitech-apd/pull/767#issuecomment-402811352, this PR modifies the add contact button text to support different text for the case where there are currently 0 contacts, currently 1 contact, and currently more than 1 contact.

No contacts yet:
![screen shot 2018-07-05 at 1 40 36 pm](https://user-images.githubusercontent.com/1775733/42341549-0bad32ba-8059-11e8-91a0-dba33fb9cf0f.png)

One or more contacts already:
![screen shot 2018-07-05 at 1 40 44 pm](https://user-images.githubusercontent.com/1775733/42341560-17142532-8059-11e8-803d-a51d6884c234.png)

Modifies the `DeleteActivity` component to be generic so we can reuse it, and then promptly reuses it.

### This pull request changes...
- "add contact" button text changes to be more useful
- add "remove" button for contacts

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author

### This feature is done when...
- [ ] Design has approved the experience