### PR TITLE
cross browser sidebar

### DIFF
--- a/web/src/components/ApdApplication.js
+++ b/web/src/components/ApdApplication.js
@@ -18,7 +18,7 @@ const PLACE = { id: 'tx', name: 'Texas' };
 const ApdApplication = () => (
   <div className="site-body">
     <Sidebar place={PLACE} />
-    <div className="p2 sm-p4 md-px0 mx-auto col-12 md-col-7">
+    <div className="site-main p2 sm-p4 md-px0">
       <TopBtns />
       <StateProfile />
       <ApdSummary />

--- a/web/src/components/Container.js
+++ b/web/src/components/Container.js
@@ -6,7 +6,7 @@ import TopNav from '../containers/TopNav';
 const Container = ({ children }) => (
   <Fragment>
     <TopNav />
-    <div className="site-main">
+    <div className="flex-none">
       <div className="container p2">{children}</div>
     </div>
   </Fragment>

--- a/web/src/components/__snapshots__/ApdApplication.test.js.snap
+++ b/web/src/components/__snapshots__/ApdApplication.test.js.snap
@@ -27,7 +27,7 @@ ShallowWrapper {
           }
         />,
         <div
-          className="p2 sm-p4 md-px0 mx-auto col-12 md-col-7"
+          className="site-main p2 sm-p4 md-px0"
         >
           <Connect(TopBtns) />
           <ApdStateProfile />
@@ -76,7 +76,7 @@ ShallowWrapper {
             <Connect(ExecutiveSummary) />,
             <Connect(CertifyAndSubmit) />,
           ],
-          "className": "p2 sm-p4 md-px0 mx-auto col-12 md-col-7",
+          "className": "site-main p2 sm-p4 md-px0",
         },
         "ref": null,
         "rendered": Array [
@@ -192,7 +192,7 @@ ShallowWrapper {
             }
           />,
           <div
-            className="p2 sm-p4 md-px0 mx-auto col-12 md-col-7"
+            className="site-main p2 sm-p4 md-px0"
           >
             <Connect(TopBtns) />
             <ApdStateProfile />
@@ -241,7 +241,7 @@ ShallowWrapper {
               <Connect(ExecutiveSummary) />,
               <Connect(CertifyAndSubmit) />,
             ],
-            "className": "p2 sm-p4 md-px0 mx-auto col-12 md-col-7",
+            "className": "site-main p2 sm-p4 md-px0",
           },
           "ref": null,
           "rendered": Array [

--- a/web/src/components/__snapshots__/Container.test.js.snap
+++ b/web/src/components/__snapshots__/Container.test.js.snap
@@ -24,7 +24,7 @@ ShallowWrapper {
       "children": Array [
         <Connect(TopNav) />,
         <div
-          className="site-main"
+          className="flex-none"
         >
           <div
             className="container p2"
@@ -59,7 +59,7 @@ ShallowWrapper {
               className="test child"
             />
           </div>,
-          "className": "site-main",
+          "className": "flex-none",
         },
         "ref": null,
         "rendered": Object {
@@ -100,7 +100,7 @@ ShallowWrapper {
         "children": Array [
           <Connect(TopNav) />,
           <div
-            className="site-main"
+            className="flex-none"
           >
             <div
               className="container p2"
@@ -135,7 +135,7 @@ ShallowWrapper {
                 className="test child"
               />
             </div>,
-            "className": "site-main",
+            "className": "flex-none",
           },
           "ref": null,
           "rendered": Object {

--- a/web/src/styles/app/layout.css
+++ b/web/src/styles/app/layout.css
@@ -33,13 +33,19 @@ footer {
   }
 
   .site-sidebar {
+    bottom: 0;
     flex: 0 0 auto;
     max-height: 100vh;
-    min-width: 16rem;
     overflow-y: auto;
-    position: sticky;
-    top: 0px;
-    width: 25%;
+    position: fixed;
+    top: 0;
+    width: var(--col-3);
+  }
+
+  .site-main {
+    margin-left: var(--col-4);
+    margin-right: var(--col-1);
+    width: var(--col-7);
   }
 }
 

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -50,6 +50,19 @@
 
   --button-font-weight: normal;
 
+  --col-1: calc(1/12 * 100%);
+  --col-2: calc(2/12 * 100%);
+  --col-3: calc(3/12 * 100%);
+  --col-4: calc(4/12 * 100%);
+  --col-5: calc(5/12 * 100%);
+  --col-6: calc(6/12 * 100%);
+  --col-7: calc(7/12 * 100%);
+  --col-8: calc(8/12 * 100%);
+  --col-9: calc(9/12 * 100%);
+  --col-10: calc(10/12 * 100%);
+  --col-11: calc(11/12 * 100%);
+  --col-12: calc(12/12 * 100%);
+
   /* ace color overrides */
 
   --gray: #ccc;


### PR DESCRIPTION
moves away from `position:sticky` ([not supported in IE](https://developer.mozilla.org/en-US/docs/Web/CSS/position#Browser_compatibility)) to `position:fixed` which should look the same as before and now work in IE :) 

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
