### PR TITLE
Move quarterly federal share calculations into reducer [skip deploy]

### DIFF
--- a/web/src/actions/apd.js
+++ b/web/src/actions/apd.js
@@ -262,50 +262,6 @@ export const submitAPD = (save = saveApd) => (dispatch, getState) =>
       dispatch({ type: SUBMIT_APD_REQUEST });
 
       const { apd: { data: { id: apdID } }, budget } = getState();
-      const getFederalShareByFFYQuarter = fundingSource =>
-        Object.entries(budget.quarterly[fundingSource]).reduce(
-          (accum, [ffy, quarters]) => ({
-            ...accum,
-            [ffy]: Object.entries(quarters).reduce(
-              (qAccum, [quarter, percent]) => ({
-                ...qAccum,
-                [quarter]: {
-                  percent,
-                  contractors:
-                    budget[fundingSource].contractors[ffy].federal *
-                    percent /
-                    100,
-                  expenses:
-                    budget[fundingSource].expenses[ffy].federal * percent / 100,
-                  statePersonnel:
-                    budget[fundingSource].statePersonnel[ffy].federal *
-                    percent /
-                    100,
-                  total:
-                    budget[fundingSource].combined[ffy].federal * percent / 100
-                }
-              }),
-              {
-                subtotal: {
-                  contractors: budget[fundingSource].contractors[ffy].federal,
-                  expenses: budget[fundingSource].expenses[ffy].federal,
-                  statePersonnel:
-                    budget[fundingSource].statePersonnel[ffy].federal,
-                  total: budget[fundingSource].combined[ffy].federal
-                }
-              }
-            )
-          }),
-          {
-            total: {
-              contractors: budget[fundingSource].contractors.total.federal,
-              expenses: budget[fundingSource].expenses.total.federal,
-              statePersonnel:
-                budget[fundingSource].statePersonnel.total.federal,
-              total: budget[fundingSource].combined.total.federal
-            }
-          }
-        );
 
       const tables = {
         summaryBudgetTable: {
@@ -314,10 +270,7 @@ export const submitAPD = (save = saveApd) => (dispatch, getState) =>
           mmis: budget.mmis,
           total: budget.combined
         },
-        federalShareByFFYQuarter: {
-          hitAndHie: getFederalShareByFFYQuarter('hitAndHie'),
-          mmis: getFederalShareByFFYQuarter('mmis')
-        },
+        federalShareByFFYQuarter: budget.federalShareByFFYQuarter,
         programBudgetTable: {
           hitAndHie: {
             hit: budget.hit.combined,

--- a/web/src/containers/QuarterlyBudgetSummary.js
+++ b/web/src/containers/QuarterlyBudgetSummary.js
@@ -29,8 +29,7 @@ class QuarterlyBudgetSummary extends Component {
   };
 
   render() {
-    const { budget } = this.props;
-    const { quarterly, years } = budget;
+    const { budget, years } = this.props;
 
     // wait until budget is loaded
     if (!years.length) return null;
@@ -65,7 +64,7 @@ class QuarterlyBudgetSummary extends Component {
                       <th />
                       {years.map((year, i) => {
                         const incomplete =
-                          addObjVals(quarterly[source][year]) !== 100;
+                          addObjVals(data[year], q => q.percent || 0) !== 100;
                         return (
                           <Fragment key={year}>
                             {QUARTERS.map(q => (
@@ -80,7 +79,7 @@ class QuarterlyBudgetSummary extends Component {
                                     min="0"
                                     max="100"
                                     step="5"
-                                    value={quarterly[source][year][q]}
+                                    value={data[year][q].percent}
                                     onChange={this.handleChange(
                                       source,
                                       year,
@@ -92,7 +91,7 @@ class QuarterlyBudgetSummary extends Component {
                                       incomplete ? 'red' : ''
                                     }`}
                                   >
-                                    {quarterly[source][year][q]}%
+                                    {data[year][q].percent}%
                                   </div>
                                 </div>
                               </th>
@@ -122,11 +121,7 @@ class QuarterlyBudgetSummary extends Component {
                                 }`}
                                 key={q}
                               >
-                                {formatMoney(
-                                  quarterly[source][year][q] *
-                                    data[name][year].federal /
-                                    100
-                                )}
+                                {formatMoney(data[year][q][name])}
                               </td>
                             ))}
                             <td
@@ -134,12 +129,12 @@ class QuarterlyBudgetSummary extends Component {
                                 i
                               )}-light`}
                             >
-                              {formatMoney(data[name][year].federal)}
+                              {formatMoney(data[year].subtotal[name])}
                             </td>
                           </Fragment>
                         ))}
                         <td className="bold mono right-align bg-gray-light">
-                          {formatMoney(data[name].total.federal)}
+                          {formatMoney(data.total[name])}
                         </td>
                       </tr>
                     ))}
@@ -156,10 +151,14 @@ class QuarterlyBudgetSummary extends Component {
 
 QuarterlyBudgetSummary.propTypes = {
   budget: PropTypes.object.isRequired,
+  years: PropTypes.array.isRequired,
   update: PropTypes.func.isRequired
 };
 
-const mapStateToProps = ({ budget }) => ({ budget });
+const mapStateToProps = ({ budget, apd }) => ({
+  budget: budget.federalShareByFFYQuarter,
+  years: apd.data.years
+});
 const mapDispatchToProps = { update: updateBudgetQuarterlyShare };
 
 export default connect(mapStateToProps, mapDispatchToProps)(

--- a/web/src/reducers/budget.test.js
+++ b/web/src/reducers/budget.test.js
@@ -4,6 +4,14 @@ import { UPDATE_BUDGET } from '../actions/apd';
 describe('budget reducer', () => {
   const initialState = {
     combined: { total: { total: 0, federal: 0, state: 0 } },
+    federalShareByFFYQuarter: {
+      hitAndHie: {
+        total: { contractors: 0, expenses: 0, statePersonnel: 0, total: 0 }
+      },
+      mmis: {
+        total: { contractors: 0, expenses: 0, statePersonnel: 0, total: 0 }
+      }
+    },
     hie: {
       combined: { total: { total: 0, federal: 0, state: 0 } },
       contractors: { total: { total: 0, federal: 0, state: 0 } },
@@ -177,6 +185,240 @@ describe('budget reducer', () => {
         '1932': { federal: 12300, state: 1700.0100000000002, total: 15000 },
         '1933': { federal: 11790, state: 1310.01, total: 14100 },
         total: { federal: 35640, state: 4960.02, total: 43600 }
+      },
+      federalShareByFFYQuarter: {
+        hitAndHie: {
+          '1931': {
+            '1': {
+              percent: 25,
+              contractors: 900,
+              expenses: 900,
+              statePersonnel: 900,
+              total: 2700
+            },
+            '2': {
+              percent: 25,
+              contractors: 900,
+              expenses: 900,
+              statePersonnel: 900,
+              total: 2700
+            },
+            '3': {
+              percent: 25,
+              contractors: 900,
+              expenses: 900,
+              statePersonnel: 900,
+              total: 2700
+            },
+            '4': {
+              percent: 25,
+              contractors: 900,
+              expenses: 900,
+              statePersonnel: 900,
+              total: 2700
+            },
+            subtotal: {
+              contractors: 3600,
+              expenses: 3600,
+              statePersonnel: 3600,
+              total: 10800
+            }
+          },
+          '1932': {
+            '1': {
+              percent: 25,
+              contractors: 900,
+              expenses: 900,
+              statePersonnel: 900,
+              total: 2700
+            },
+            '2': {
+              percent: 25,
+              contractors: 900,
+              expenses: 900,
+              statePersonnel: 900,
+              total: 2700
+            },
+            '3': {
+              percent: 25,
+              contractors: 900,
+              expenses: 900,
+              statePersonnel: 900,
+              total: 2700
+            },
+            '4': {
+              percent: 25,
+              contractors: 900,
+              expenses: 900,
+              statePersonnel: 900,
+              total: 2700
+            },
+            subtotal: {
+              contractors: 3600,
+              expenses: 3600,
+              statePersonnel: 3600,
+              total: 10800
+            }
+          },
+          '1933': {
+            '1': {
+              percent: 25,
+              contractors: 825,
+              expenses: 825,
+              statePersonnel: 825,
+              total: 2475
+            },
+            '2': {
+              percent: 25,
+              contractors: 825,
+              expenses: 825,
+              statePersonnel: 825,
+              total: 2475
+            },
+            '3': {
+              percent: 25,
+              contractors: 825,
+              expenses: 825,
+              statePersonnel: 825,
+              total: 2475
+            },
+            '4': {
+              percent: 25,
+              contractors: 825,
+              expenses: 825,
+              statePersonnel: 825,
+              total: 2475
+            },
+            subtotal: {
+              contractors: 3300,
+              expenses: 3300,
+              statePersonnel: 3300,
+              total: 9900
+            }
+          },
+          total: {
+            contractors: 10500,
+            expenses: 10500,
+            statePersonnel: 10500,
+            total: 31500
+          }
+        },
+        mmis: {
+          '1931': {
+            '1': {
+              percent: 25,
+              contractors: 75,
+              expenses: 75,
+              statePersonnel: 37.5,
+              total: 187.5
+            },
+            '2': {
+              percent: 25,
+              contractors: 75,
+              expenses: 75,
+              statePersonnel: 37.5,
+              total: 187.5
+            },
+            '3': {
+              percent: 25,
+              contractors: 75,
+              expenses: 75,
+              statePersonnel: 37.5,
+              total: 187.5
+            },
+            '4': {
+              percent: 25,
+              contractors: 75,
+              expenses: 75,
+              statePersonnel: 37.5,
+              total: 187.5
+            },
+            subtotal: {
+              contractors: 300,
+              expenses: 300,
+              statePersonnel: 150,
+              total: 750
+            }
+          },
+          '1932': {
+            '1': {
+              percent: 25,
+              contractors: 125,
+              expenses: 125,
+              statePersonnel: 125,
+              total: 375
+            },
+            '2': {
+              percent: 25,
+              contractors: 125,
+              expenses: 125,
+              statePersonnel: 125,
+              total: 375
+            },
+            '3': {
+              percent: 25,
+              contractors: 125,
+              expenses: 125,
+              statePersonnel: 125,
+              total: 375
+            },
+            '4': {
+              percent: 25,
+              contractors: 125,
+              expenses: 125,
+              statePersonnel: 125,
+              total: 375
+            },
+            subtotal: {
+              contractors: 500,
+              expenses: 500,
+              statePersonnel: 500,
+              total: 1500
+            }
+          },
+          '1933': {
+            '1': {
+              percent: 25,
+              contractors: 225,
+              expenses: 225,
+              statePersonnel: 22.5,
+              total: 472.5
+            },
+            '2': {
+              percent: 25,
+              contractors: 225,
+              expenses: 225,
+              statePersonnel: 22.5,
+              total: 472.5
+            },
+            '3': {
+              percent: 25,
+              contractors: 225,
+              expenses: 225,
+              statePersonnel: 22.5,
+              total: 472.5
+            },
+            '4': {
+              percent: 25,
+              contractors: 225,
+              expenses: 225,
+              statePersonnel: 22.5,
+              total: 472.5
+            },
+            subtotal: {
+              contractors: 900,
+              expenses: 900,
+              statePersonnel: 90,
+              total: 1890
+            }
+          },
+          total: {
+            contractors: 1700,
+            expenses: 1700,
+            statePersonnel: 740,
+            total: 4140
+          }
+        }
       },
       hie: {
         combined: {

--- a/web/src/util/index.js
+++ b/web/src/util/index.js
@@ -158,7 +158,8 @@ export const nextSequence = arrOfNums => Math.max(...arrOfNums, 0) + 1;
 export const arrToObj = (array = [], initialValue = 0) =>
   Object.assign({}, ...array.map(a => ({ [a]: initialValue })));
 
-export const addObjVals = obj => Object.values(obj).reduce((a, b) => a + b, 0);
+export const addObjVals = (obj, getVal = a => a) =>
+  Object.values(obj).reduce((a, b) => a + getVal(b), 0);
 
 export const titleCase = str => str.replace(/\b\S/g, t => t.toUpperCase());
 


### PR DESCRIPTION
Instead of calculating the federal share in the UI component and in the APD submission process, we now calculate it along with all the other budget data in the application state reducer.  One place!

Most of the code change addition is updating the reducer tests...  :)

Closes #762

### This pull request changes...
- no visible changes

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author