### PR TITLE
Collapsible sidebar links

### DIFF
--- a/web/src/actions/sidebar.js
+++ b/web/src/actions/sidebar.js
@@ -1,0 +1,2 @@
+export const SIDEBAR_TOGGLE_EXPAND = 'SIDEBAR_TOGGLE_EXPAND';
+export const toggleExpand = id => ({ type: SIDEBAR_TOGGLE_EXPAND, id });

--- a/web/src/actions/sidebar.test.js
+++ b/web/src/actions/sidebar.test.js
@@ -1,0 +1,10 @@
+import * as actions from './sidebar';
+
+describe('sidebar actions actions', () => {
+  it('toggleExpand should create SIDEBAR_TOGGLE_EXPAND action', () => {
+    expect(actions.toggleExpand('my id')).toEqual({
+      type: actions.SIDEBAR_TOGGLE_EXPAND,
+      id: 'my id'
+    });
+  });
+});

--- a/web/src/components/SidebarLink.js
+++ b/web/src/components/SidebarLink.js
@@ -1,9 +1,36 @@
 import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
+import Icon from '@fortawesome/react-fontawesome';
+
+import { faChevronDown, faChevronUp } from './Icons';
 
 const addIf = (condit, yes, no = '') => (condit ? yes : no);
 
-const SidebarLink = ({ anchor, children, depth, hash, sub, ...rest }) => (
+const icon = (expanded, handler) => {
+  if (expanded === true || expanded === false) {
+    return (
+      <button className="btn block right white" onClick={handler}>
+        {expanded ? (
+          <Icon icon={faChevronUp} size="sm" />
+        ) : (
+          <Icon icon={faChevronDown} size="sm" />
+        )}
+      </button>
+    );
+  }
+  return null;
+};
+
+const SidebarLink = ({
+  anchor,
+  children,
+  depth,
+  expanded,
+  hash,
+  sub,
+  toggleExpand,
+  ...rest
+}) => (
   <Fragment>
     <li
       className={`mb1 relative sb-item ${addIf(depth, 'pl2')} ${addIf(
@@ -13,17 +40,19 @@ const SidebarLink = ({ anchor, children, depth, hash, sub, ...rest }) => (
     >
       <a
         href={`#${anchor || '!'}`}
-        className="block white text-decoration-none truncate"
+        className="white text-decoration-none truncate"
         {...rest}
       >
         {children}
       </a>
+      {icon(expanded, toggleExpand)}
     </li>
-    {sub.map(l => (
-      <SidebarLink key={l.id} anchor={l.id} hash={hash} depth={depth + 1}>
-        {l.name}
-      </SidebarLink>
-    ))}
+    {expanded &&
+      sub.map(l => (
+        <SidebarLink key={l.id} anchor={l.id} hash={hash} depth={depth + 1}>
+          {l.name}
+        </SidebarLink>
+      ))}
   </Fragment>
 );
 
@@ -31,15 +60,19 @@ SidebarLink.propTypes = {
   anchor: PropTypes.string,
   children: PropTypes.node.isRequired,
   depth: PropTypes.number,
+  expanded: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
   hash: PropTypes.string,
-  sub: PropTypes.array
+  sub: PropTypes.array,
+  toggleExpand: PropTypes.func
 };
 
 SidebarLink.defaultProps = {
   anchor: null,
   depth: 0,
+  expanded: null,
   hash: null,
-  sub: []
+  sub: [],
+  toggleExpand: () => {}
 };
 
 export default SidebarLink;

--- a/web/src/components/SidebarLink.test.js
+++ b/web/src/components/SidebarLink.test.js
@@ -24,4 +24,29 @@ describe('SidebarLink component', () => {
     );
     expect(component).toMatchSnapshot();
   });
+
+  test('renders correctly if link has sub-links', () => {
+    const component = shallow(
+      <SidebarLink sub={[{ id: 1, name: 'child' }]}>link text</SidebarLink>
+    );
+    expect(component).toMatchSnapshot();
+  });
+
+  test('renders correctly if link is collapsed', () => {
+    const component = shallow(
+      <SidebarLink expanded={false} sub={[{ id: 1, name: 'child' }]}>
+        link text
+      </SidebarLink>
+    );
+    expect(component).toMatchSnapshot();
+  });
+
+  test('renders correctly if link is expanded', () => {
+    const component = shallow(
+      <SidebarLink expanded sub={[{ id: 1, name: 'child' }]}>
+        link text
+      </SidebarLink>
+    );
+    expect(component).toMatchSnapshot();
+  });
 });

--- a/web/src/components/__snapshots__/SidebarLink.test.js.snap
+++ b/web/src/components/__snapshots__/SidebarLink.test.js.snap
@@ -7,8 +7,10 @@ ShallowWrapper {
   Symbol(enzyme.__unrendered__): <SidebarLink
     anchor="moop"
     depth={0}
+    expanded={null}
     hash="moop"
     sub={Array []}
+    toggleExpand={[Function]}
   >
     link text
   </SidebarLink>,
@@ -29,13 +31,13 @@ ShallowWrapper {
           className="mb1 relative sb-item  sb-item-active"
         >
           <a
-            className="block white text-decoration-none truncate"
+            className="white text-decoration-none truncate"
             href="#moop"
           >
             link text
           </a>
         </li>,
-        Array [],
+        null,
       ],
     },
     "ref": null,
@@ -45,30 +47,37 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "host",
         "props": Object {
-          "children": <a
-            className="block white text-decoration-none truncate"
-            href="#moop"
-          >
-            link text
-          </a>,
+          "children": Array [
+            <a
+              className="white text-decoration-none truncate"
+              href="#moop"
+            >
+              link text
+            </a>,
+            null,
+          ],
           "className": "mb1 relative sb-item  sb-item-active",
         },
         "ref": null,
-        "rendered": Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "host",
-          "props": Object {
-            "children": "link text",
-            "className": "block white text-decoration-none truncate",
-            "href": "#moop",
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": "link text",
+              "className": "white text-decoration-none truncate",
+              "href": "#moop",
+            },
+            "ref": null,
+            "rendered": "link text",
+            "type": "a",
           },
-          "ref": null,
-          "rendered": "link text",
-          "type": "a",
-        },
+          null,
+        ],
         "type": "li",
       },
+      null,
     ],
     "type": Symbol(react.fragment),
   },
@@ -83,13 +92,13 @@ ShallowWrapper {
             className="mb1 relative sb-item  sb-item-active"
           >
             <a
-              className="block white text-decoration-none truncate"
+              className="white text-decoration-none truncate"
               href="#moop"
             >
               link text
             </a>
           </li>,
-          Array [],
+          null,
         ],
       },
       "ref": null,
@@ -99,30 +108,37 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "host",
           "props": Object {
-            "children": <a
-              className="block white text-decoration-none truncate"
-              href="#moop"
-            >
-              link text
-            </a>,
+            "children": Array [
+              <a
+                className="white text-decoration-none truncate"
+                href="#moop"
+              >
+                link text
+              </a>,
+              null,
+            ],
             "className": "mb1 relative sb-item  sb-item-active",
           },
           "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "host",
-            "props": Object {
-              "children": "link text",
-              "className": "block white text-decoration-none truncate",
-              "href": "#moop",
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": "link text",
+                "className": "white text-decoration-none truncate",
+                "href": "#moop",
+              },
+              "ref": null,
+              "rendered": "link text",
+              "type": "a",
             },
-            "ref": null,
-            "rendered": "link text",
-            "type": "a",
-          },
+            null,
+          ],
           "type": "li",
         },
+        null,
       ],
       "type": Symbol(react.fragment),
     },
@@ -144,8 +160,10 @@ ShallowWrapper {
   Symbol(enzyme.__unrendered__): <SidebarLink
     anchor={null}
     depth={0}
+    expanded={null}
     hash={null}
     sub={Array []}
+    toggleExpand={[Function]}
   >
     link text
   </SidebarLink>,
@@ -166,13 +184,13 @@ ShallowWrapper {
           className="mb1 relative sb-item  sb-item-active"
         >
           <a
-            className="block white text-decoration-none truncate"
+            className="white text-decoration-none truncate"
             href="#!"
           >
             link text
           </a>
         </li>,
-        Array [],
+        null,
       ],
     },
     "ref": null,
@@ -182,30 +200,37 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "host",
         "props": Object {
-          "children": <a
-            className="block white text-decoration-none truncate"
-            href="#!"
-          >
-            link text
-          </a>,
+          "children": Array [
+            <a
+              className="white text-decoration-none truncate"
+              href="#!"
+            >
+              link text
+            </a>,
+            null,
+          ],
           "className": "mb1 relative sb-item  sb-item-active",
         },
         "ref": null,
-        "rendered": Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "host",
-          "props": Object {
-            "children": "link text",
-            "className": "block white text-decoration-none truncate",
-            "href": "#!",
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": "link text",
+              "className": "white text-decoration-none truncate",
+              "href": "#!",
+            },
+            "ref": null,
+            "rendered": "link text",
+            "type": "a",
           },
-          "ref": null,
-          "rendered": "link text",
-          "type": "a",
-        },
+          null,
+        ],
         "type": "li",
       },
+      null,
     ],
     "type": Symbol(react.fragment),
   },
@@ -220,13 +245,13 @@ ShallowWrapper {
             className="mb1 relative sb-item  sb-item-active"
           >
             <a
-              className="block white text-decoration-none truncate"
+              className="white text-decoration-none truncate"
               href="#!"
             >
               link text
             </a>
           </li>,
-          Array [],
+          null,
         ],
       },
       "ref": null,
@@ -236,30 +261,37 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "host",
           "props": Object {
-            "children": <a
-              className="block white text-decoration-none truncate"
-              href="#!"
-            >
-              link text
-            </a>,
+            "children": Array [
+              <a
+                className="white text-decoration-none truncate"
+                href="#!"
+              >
+                link text
+              </a>,
+              null,
+            ],
             "className": "mb1 relative sb-item  sb-item-active",
           },
           "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "host",
-            "props": Object {
-              "children": "link text",
-              "className": "block white text-decoration-none truncate",
-              "href": "#!",
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": "link text",
+                "className": "white text-decoration-none truncate",
+                "href": "#!",
+              },
+              "ref": null,
+              "rendered": "link text",
+              "type": "a",
             },
-            "ref": null,
-            "rendered": "link text",
-            "type": "a",
-          },
+            null,
+          ],
           "type": "li",
         },
+        null,
       ],
       "type": Symbol(react.fragment),
     },
@@ -281,8 +313,10 @@ ShallowWrapper {
   Symbol(enzyme.__unrendered__): <SidebarLink
     anchor="moop"
     depth={0}
+    expanded={null}
     hash={null}
     sub={Array []}
+    toggleExpand={[Function]}
   >
     link text
   </SidebarLink>,
@@ -303,13 +337,13 @@ ShallowWrapper {
           className="mb1 relative sb-item  "
         >
           <a
-            className="block white text-decoration-none truncate"
+            className="white text-decoration-none truncate"
             href="#moop"
           >
             link text
           </a>
         </li>,
-        Array [],
+        null,
       ],
     },
     "ref": null,
@@ -319,30 +353,37 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "host",
         "props": Object {
-          "children": <a
-            className="block white text-decoration-none truncate"
-            href="#moop"
-          >
-            link text
-          </a>,
+          "children": Array [
+            <a
+              className="white text-decoration-none truncate"
+              href="#moop"
+            >
+              link text
+            </a>,
+            null,
+          ],
           "className": "mb1 relative sb-item  ",
         },
         "ref": null,
-        "rendered": Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "host",
-          "props": Object {
-            "children": "link text",
-            "className": "block white text-decoration-none truncate",
-            "href": "#moop",
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": "link text",
+              "className": "white text-decoration-none truncate",
+              "href": "#moop",
+            },
+            "ref": null,
+            "rendered": "link text",
+            "type": "a",
           },
-          "ref": null,
-          "rendered": "link text",
-          "type": "a",
-        },
+          null,
+        ],
         "type": "li",
       },
+      null,
     ],
     "type": Symbol(react.fragment),
   },
@@ -357,13 +398,13 @@ ShallowWrapper {
             className="mb1 relative sb-item  "
           >
             <a
-              className="block white text-decoration-none truncate"
+              className="white text-decoration-none truncate"
               href="#moop"
             >
               link text
             </a>
           </li>,
-          Array [],
+          null,
         ],
       },
       "ref": null,
@@ -373,30 +414,37 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "host",
           "props": Object {
-            "children": <a
-              className="block white text-decoration-none truncate"
-              href="#moop"
-            >
-              link text
-            </a>,
+            "children": Array [
+              <a
+                className="white text-decoration-none truncate"
+                href="#moop"
+              >
+                link text
+              </a>,
+              null,
+            ],
             "className": "mb1 relative sb-item  ",
           },
           "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "host",
-            "props": Object {
-              "children": "link text",
-              "className": "block white text-decoration-none truncate",
-              "href": "#moop",
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": "link text",
+                "className": "white text-decoration-none truncate",
+                "href": "#moop",
+              },
+              "ref": null,
+              "rendered": "link text",
+              "type": "a",
             },
-            "ref": null,
-            "rendered": "link text",
-            "type": "a",
-          },
+            null,
+          ],
           "type": "li",
         },
+        null,
       ],
       "type": Symbol(react.fragment),
     },

--- a/web/src/components/__snapshots__/SidebarLink.test.js.snap
+++ b/web/src/components/__snapshots__/SidebarLink.test.js.snap
@@ -1,5 +1,165 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SidebarLink component renders correctly if link has sub-links 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <SidebarLink
+    anchor={null}
+    depth={0}
+    expanded={null}
+    hash={null}
+    sub={
+      Array [
+        Object {
+          "id": 1,
+          "name": "child",
+        },
+      ]
+    }
+    toggleExpand={[Function]}
+  >
+    link text
+  </SidebarLink>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "function",
+    "props": Object {
+      "children": Array [
+        <li
+          className="mb1 relative sb-item  sb-item-active"
+        >
+          <a
+            className="white text-decoration-none truncate"
+            href="#!"
+          >
+            link text
+          </a>
+        </li>,
+        null,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <a
+              className="white text-decoration-none truncate"
+              href="#!"
+            >
+              link text
+            </a>,
+            null,
+          ],
+          "className": "mb1 relative sb-item  sb-item-active",
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": "link text",
+              "className": "white text-decoration-none truncate",
+              "href": "#!",
+            },
+            "ref": null,
+            "rendered": "link text",
+            "type": "a",
+          },
+          null,
+        ],
+        "type": "li",
+      },
+      null,
+    ],
+    "type": Symbol(react.fragment),
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "function",
+      "props": Object {
+        "children": Array [
+          <li
+            className="mb1 relative sb-item  sb-item-active"
+          >
+            <a
+              className="white text-decoration-none truncate"
+              href="#!"
+            >
+              link text
+            </a>
+          </li>,
+          null,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <a
+                className="white text-decoration-none truncate"
+                href="#!"
+              >
+                link text
+              </a>,
+              null,
+            ],
+            "className": "mb1 relative sb-item  sb-item-active",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": "link text",
+                "className": "white text-decoration-none truncate",
+                "href": "#!",
+              },
+              "ref": null,
+              "rendered": "link text",
+              "type": "a",
+            },
+            null,
+          ],
+          "type": "li",
+        },
+        null,
+      ],
+      "type": Symbol(react.fragment),
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
 exports[`SidebarLink component renders correctly if link is active 1`] = `
 ShallowWrapper {
   "length": 1,
@@ -139,6 +299,944 @@ ShallowWrapper {
           "type": "li",
         },
         null,
+      ],
+      "type": Symbol(react.fragment),
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`SidebarLink component renders correctly if link is collapsed 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <SidebarLink
+    anchor={null}
+    depth={0}
+    expanded={false}
+    hash={null}
+    sub={
+      Array [
+        Object {
+          "id": 1,
+          "name": "child",
+        },
+      ]
+    }
+    toggleExpand={[Function]}
+  >
+    link text
+  </SidebarLink>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "function",
+    "props": Object {
+      "children": Array [
+        <li
+          className="mb1 relative sb-item  sb-item-active"
+        >
+          <a
+            className="white text-decoration-none truncate"
+            href="#!"
+          >
+            link text
+          </a>
+          <button
+            className="btn block right white"
+            onClick={[Function]}
+          >
+            <FontAwesomeIcon$1
+              border={false}
+              className=""
+              fixedWidth={false}
+              flip={null}
+              icon={
+                Object {
+                  "icon": Array [
+                    448,
+                    512,
+                    Array [],
+                    "f078",
+                    "M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z",
+                  ],
+                  "iconName": "chevron-down",
+                  "prefix": "fas",
+                }
+              }
+              listItem={false}
+              mask={null}
+              name=""
+              pull={null}
+              pulse={false}
+              rotation={null}
+              size="sm"
+              spin={false}
+              symbol={false}
+              transform={null}
+            />
+          </button>
+        </li>,
+        false,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <a
+              className="white text-decoration-none truncate"
+              href="#!"
+            >
+              link text
+            </a>,
+            <button
+              className="btn block right white"
+              onClick={[Function]}
+            >
+              <FontAwesomeIcon$1
+                border={false}
+                className=""
+                fixedWidth={false}
+                flip={null}
+                icon={
+                  Object {
+                    "icon": Array [
+                      448,
+                      512,
+                      Array [],
+                      "f078",
+                      "M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z",
+                    ],
+                    "iconName": "chevron-down",
+                    "prefix": "fas",
+                  }
+                }
+                listItem={false}
+                mask={null}
+                name=""
+                pull={null}
+                pulse={false}
+                rotation={null}
+                size="sm"
+                spin={false}
+                symbol={false}
+                transform={null}
+              />
+            </button>,
+          ],
+          "className": "mb1 relative sb-item  sb-item-active",
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": "link text",
+              "className": "white text-decoration-none truncate",
+              "href": "#!",
+            },
+            "ref": null,
+            "rendered": "link text",
+            "type": "a",
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": <FontAwesomeIcon$1
+                border={false}
+                className=""
+                fixedWidth={false}
+                flip={null}
+                icon={
+                  Object {
+                    "icon": Array [
+                      448,
+                      512,
+                      Array [],
+                      "f078",
+                      "M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z",
+                    ],
+                    "iconName": "chevron-down",
+                    "prefix": "fas",
+                  }
+                }
+                listItem={false}
+                mask={null}
+                name=""
+                pull={null}
+                pulse={false}
+                rotation={null}
+                size="sm"
+                spin={false}
+                symbol={false}
+                transform={null}
+              />,
+              "className": "btn block right white",
+              "onClick": [Function],
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "border": false,
+                "className": "",
+                "fixedWidth": false,
+                "flip": null,
+                "icon": Object {
+                  "icon": Array [
+                    448,
+                    512,
+                    Array [],
+                    "f078",
+                    "M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z",
+                  ],
+                  "iconName": "chevron-down",
+                  "prefix": "fas",
+                },
+                "listItem": false,
+                "mask": null,
+                "name": "",
+                "pull": null,
+                "pulse": false,
+                "rotation": null,
+                "size": "sm",
+                "spin": false,
+                "symbol": false,
+                "transform": null,
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            "type": "button",
+          },
+        ],
+        "type": "li",
+      },
+      false,
+    ],
+    "type": Symbol(react.fragment),
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "function",
+      "props": Object {
+        "children": Array [
+          <li
+            className="mb1 relative sb-item  sb-item-active"
+          >
+            <a
+              className="white text-decoration-none truncate"
+              href="#!"
+            >
+              link text
+            </a>
+            <button
+              className="btn block right white"
+              onClick={[Function]}
+            >
+              <FontAwesomeIcon$1
+                border={false}
+                className=""
+                fixedWidth={false}
+                flip={null}
+                icon={
+                  Object {
+                    "icon": Array [
+                      448,
+                      512,
+                      Array [],
+                      "f078",
+                      "M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z",
+                    ],
+                    "iconName": "chevron-down",
+                    "prefix": "fas",
+                  }
+                }
+                listItem={false}
+                mask={null}
+                name=""
+                pull={null}
+                pulse={false}
+                rotation={null}
+                size="sm"
+                spin={false}
+                symbol={false}
+                transform={null}
+              />
+            </button>
+          </li>,
+          false,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <a
+                className="white text-decoration-none truncate"
+                href="#!"
+              >
+                link text
+              </a>,
+              <button
+                className="btn block right white"
+                onClick={[Function]}
+              >
+                <FontAwesomeIcon$1
+                  border={false}
+                  className=""
+                  fixedWidth={false}
+                  flip={null}
+                  icon={
+                    Object {
+                      "icon": Array [
+                        448,
+                        512,
+                        Array [],
+                        "f078",
+                        "M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z",
+                      ],
+                      "iconName": "chevron-down",
+                      "prefix": "fas",
+                    }
+                  }
+                  listItem={false}
+                  mask={null}
+                  name=""
+                  pull={null}
+                  pulse={false}
+                  rotation={null}
+                  size="sm"
+                  spin={false}
+                  symbol={false}
+                  transform={null}
+                />
+              </button>,
+            ],
+            "className": "mb1 relative sb-item  sb-item-active",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": "link text",
+                "className": "white text-decoration-none truncate",
+                "href": "#!",
+              },
+              "ref": null,
+              "rendered": "link text",
+              "type": "a",
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": <FontAwesomeIcon$1
+                  border={false}
+                  className=""
+                  fixedWidth={false}
+                  flip={null}
+                  icon={
+                    Object {
+                      "icon": Array [
+                        448,
+                        512,
+                        Array [],
+                        "f078",
+                        "M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z",
+                      ],
+                      "iconName": "chevron-down",
+                      "prefix": "fas",
+                    }
+                  }
+                  listItem={false}
+                  mask={null}
+                  name=""
+                  pull={null}
+                  pulse={false}
+                  rotation={null}
+                  size="sm"
+                  spin={false}
+                  symbol={false}
+                  transform={null}
+                />,
+                "className": "btn block right white",
+                "onClick": [Function],
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "function",
+                "props": Object {
+                  "border": false,
+                  "className": "",
+                  "fixedWidth": false,
+                  "flip": null,
+                  "icon": Object {
+                    "icon": Array [
+                      448,
+                      512,
+                      Array [],
+                      "f078",
+                      "M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z",
+                    ],
+                    "iconName": "chevron-down",
+                    "prefix": "fas",
+                  },
+                  "listItem": false,
+                  "mask": null,
+                  "name": "",
+                  "pull": null,
+                  "pulse": false,
+                  "rotation": null,
+                  "size": "sm",
+                  "spin": false,
+                  "symbol": false,
+                  "transform": null,
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
+              },
+              "type": "button",
+            },
+          ],
+          "type": "li",
+        },
+        false,
+      ],
+      "type": Symbol(react.fragment),
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`SidebarLink component renders correctly if link is expanded 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <SidebarLink
+    anchor={null}
+    depth={0}
+    expanded={true}
+    hash={null}
+    sub={
+      Array [
+        Object {
+          "id": 1,
+          "name": "child",
+        },
+      ]
+    }
+    toggleExpand={[Function]}
+  >
+    link text
+  </SidebarLink>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "function",
+    "props": Object {
+      "children": Array [
+        <li
+          className="mb1 relative sb-item  sb-item-active"
+        >
+          <a
+            className="white text-decoration-none truncate"
+            href="#!"
+          >
+            link text
+          </a>
+          <button
+            className="btn block right white"
+            onClick={[Function]}
+          >
+            <FontAwesomeIcon$1
+              border={false}
+              className=""
+              fixedWidth={false}
+              flip={null}
+              icon={
+                Object {
+                  "icon": Array [
+                    448,
+                    512,
+                    Array [],
+                    "f077",
+                    "M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z",
+                  ],
+                  "iconName": "chevron-up",
+                  "prefix": "fas",
+                }
+              }
+              listItem={false}
+              mask={null}
+              name=""
+              pull={null}
+              pulse={false}
+              rotation={null}
+              size="sm"
+              spin={false}
+              symbol={false}
+              transform={null}
+            />
+          </button>
+        </li>,
+        Array [
+          <SidebarLink
+            anchor={1}
+            depth={1}
+            expanded={null}
+            hash={null}
+            sub={Array []}
+            toggleExpand={[Function]}
+          >
+            child
+          </SidebarLink>,
+        ],
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <a
+              className="white text-decoration-none truncate"
+              href="#!"
+            >
+              link text
+            </a>,
+            <button
+              className="btn block right white"
+              onClick={[Function]}
+            >
+              <FontAwesomeIcon$1
+                border={false}
+                className=""
+                fixedWidth={false}
+                flip={null}
+                icon={
+                  Object {
+                    "icon": Array [
+                      448,
+                      512,
+                      Array [],
+                      "f077",
+                      "M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z",
+                    ],
+                    "iconName": "chevron-up",
+                    "prefix": "fas",
+                  }
+                }
+                listItem={false}
+                mask={null}
+                name=""
+                pull={null}
+                pulse={false}
+                rotation={null}
+                size="sm"
+                spin={false}
+                symbol={false}
+                transform={null}
+              />
+            </button>,
+          ],
+          "className": "mb1 relative sb-item  sb-item-active",
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": "link text",
+              "className": "white text-decoration-none truncate",
+              "href": "#!",
+            },
+            "ref": null,
+            "rendered": "link text",
+            "type": "a",
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": <FontAwesomeIcon$1
+                border={false}
+                className=""
+                fixedWidth={false}
+                flip={null}
+                icon={
+                  Object {
+                    "icon": Array [
+                      448,
+                      512,
+                      Array [],
+                      "f077",
+                      "M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z",
+                    ],
+                    "iconName": "chevron-up",
+                    "prefix": "fas",
+                  }
+                }
+                listItem={false}
+                mask={null}
+                name=""
+                pull={null}
+                pulse={false}
+                rotation={null}
+                size="sm"
+                spin={false}
+                symbol={false}
+                transform={null}
+              />,
+              "className": "btn block right white",
+              "onClick": [Function],
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "border": false,
+                "className": "",
+                "fixedWidth": false,
+                "flip": null,
+                "icon": Object {
+                  "icon": Array [
+                    448,
+                    512,
+                    Array [],
+                    "f077",
+                    "M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z",
+                  ],
+                  "iconName": "chevron-up",
+                  "prefix": "fas",
+                },
+                "listItem": false,
+                "mask": null,
+                "name": "",
+                "pull": null,
+                "pulse": false,
+                "rotation": null,
+                "size": "sm",
+                "spin": false,
+                "symbol": false,
+                "transform": null,
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            "type": "button",
+          },
+        ],
+        "type": "li",
+      },
+      Object {
+        "instance": null,
+        "key": "1",
+        "nodeType": "function",
+        "props": Object {
+          "anchor": 1,
+          "children": "child",
+          "depth": 1,
+          "expanded": null,
+          "hash": null,
+          "sub": Array [],
+          "toggleExpand": [Function],
+        },
+        "ref": null,
+        "rendered": "child",
+        "type": [Function],
+      },
+    ],
+    "type": Symbol(react.fragment),
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "function",
+      "props": Object {
+        "children": Array [
+          <li
+            className="mb1 relative sb-item  sb-item-active"
+          >
+            <a
+              className="white text-decoration-none truncate"
+              href="#!"
+            >
+              link text
+            </a>
+            <button
+              className="btn block right white"
+              onClick={[Function]}
+            >
+              <FontAwesomeIcon$1
+                border={false}
+                className=""
+                fixedWidth={false}
+                flip={null}
+                icon={
+                  Object {
+                    "icon": Array [
+                      448,
+                      512,
+                      Array [],
+                      "f077",
+                      "M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z",
+                    ],
+                    "iconName": "chevron-up",
+                    "prefix": "fas",
+                  }
+                }
+                listItem={false}
+                mask={null}
+                name=""
+                pull={null}
+                pulse={false}
+                rotation={null}
+                size="sm"
+                spin={false}
+                symbol={false}
+                transform={null}
+              />
+            </button>
+          </li>,
+          Array [
+            <SidebarLink
+              anchor={1}
+              depth={1}
+              expanded={null}
+              hash={null}
+              sub={Array []}
+              toggleExpand={[Function]}
+            >
+              child
+            </SidebarLink>,
+          ],
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <a
+                className="white text-decoration-none truncate"
+                href="#!"
+              >
+                link text
+              </a>,
+              <button
+                className="btn block right white"
+                onClick={[Function]}
+              >
+                <FontAwesomeIcon$1
+                  border={false}
+                  className=""
+                  fixedWidth={false}
+                  flip={null}
+                  icon={
+                    Object {
+                      "icon": Array [
+                        448,
+                        512,
+                        Array [],
+                        "f077",
+                        "M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z",
+                      ],
+                      "iconName": "chevron-up",
+                      "prefix": "fas",
+                    }
+                  }
+                  listItem={false}
+                  mask={null}
+                  name=""
+                  pull={null}
+                  pulse={false}
+                  rotation={null}
+                  size="sm"
+                  spin={false}
+                  symbol={false}
+                  transform={null}
+                />
+              </button>,
+            ],
+            "className": "mb1 relative sb-item  sb-item-active",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": "link text",
+                "className": "white text-decoration-none truncate",
+                "href": "#!",
+              },
+              "ref": null,
+              "rendered": "link text",
+              "type": "a",
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": <FontAwesomeIcon$1
+                  border={false}
+                  className=""
+                  fixedWidth={false}
+                  flip={null}
+                  icon={
+                    Object {
+                      "icon": Array [
+                        448,
+                        512,
+                        Array [],
+                        "f077",
+                        "M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z",
+                      ],
+                      "iconName": "chevron-up",
+                      "prefix": "fas",
+                    }
+                  }
+                  listItem={false}
+                  mask={null}
+                  name=""
+                  pull={null}
+                  pulse={false}
+                  rotation={null}
+                  size="sm"
+                  spin={false}
+                  symbol={false}
+                  transform={null}
+                />,
+                "className": "btn block right white",
+                "onClick": [Function],
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "function",
+                "props": Object {
+                  "border": false,
+                  "className": "",
+                  "fixedWidth": false,
+                  "flip": null,
+                  "icon": Object {
+                    "icon": Array [
+                      448,
+                      512,
+                      Array [],
+                      "f077",
+                      "M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z",
+                    ],
+                    "iconName": "chevron-up",
+                    "prefix": "fas",
+                  },
+                  "listItem": false,
+                  "mask": null,
+                  "name": "",
+                  "pull": null,
+                  "pulse": false,
+                  "rotation": null,
+                  "size": "sm",
+                  "spin": false,
+                  "symbol": false,
+                  "transform": null,
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
+              },
+              "type": "button",
+            },
+          ],
+          "type": "li",
+        },
+        Object {
+          "instance": null,
+          "key": "1",
+          "nodeType": "function",
+          "props": Object {
+            "anchor": 1,
+            "children": "child",
+            "depth": 1,
+            "expanded": null,
+            "hash": null,
+            "sub": Array [],
+            "toggleExpand": [Function],
+          },
+          "ref": null,
+          "rendered": "child",
+          "type": [Function],
+        },
       ],
       "type": Symbol(react.fragment),
     },

--- a/web/src/containers/Sidebar.js
+++ b/web/src/containers/Sidebar.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { t } from '../i18n';
 import { expandActivitySection } from '../actions/activities';
 import { saveApd } from '../actions/apd';
+import { toggleExpand as toggleExpandAction } from '../actions/sidebar';
 import SidebarLink from '../components/SidebarLink';
 
 const linkGroup1 = [
@@ -107,7 +108,15 @@ const linkGroup2 = [
   }
 ];
 
-const Sidebar = ({ activities, place, hash, expandSection, saveApdToAPI }) => (
+const Sidebar = ({
+  activities,
+  place,
+  hash,
+  expanded,
+  expandSection,
+  saveApdToAPI,
+  toggleExpand
+}) => (
   <div className="site-sidebar bg-teal relative">
     <div className="xs-hide sm-hide">
       <div className="px2 py3 lg-px3 lg-py4 bg-white flex items-center">
@@ -126,28 +135,44 @@ const Sidebar = ({ activities, place, hash, expandSection, saveApdToAPI }) => (
       <div className="p2 lg-p3">
         <ul className="list-reset">
           {linkGroup1.map(d => (
-            <SidebarLink key={d.id} anchor={d.id} hash={hash} sub={d.sub}>
+            <SidebarLink
+              key={d.id}
+              anchor={d.id}
+              expanded={expanded[d.id]}
+              hash={hash}
+              sub={d.sub}
+              toggleExpand={() => toggleExpand(d.id)}
+            >
               {d.name}
             </SidebarLink>
           ))}
-          <ul className="mb0 list-reset">
-            {activities.map((a, i) => (
-              <SidebarLink
-                key={a.id}
-                anchor={a.anchor}
-                depth={1}
-                hash={hash}
-                onClick={() => expandSection(a.id)}
-              >
-                {t(`sidebar.titles.activity-${a.name ? 'set' : 'unset'}`, {
-                  number: i + 1,
-                  name: a.name
-                })}
-              </SidebarLink>
-            ))}
-          </ul>
+          {expanded.activities && (
+            <ul className="mb0 list-reset">
+              {activities.map((a, i) => (
+                <SidebarLink
+                  key={a.id}
+                  anchor={a.anchor}
+                  depth={1}
+                  hash={hash}
+                  onClick={() => expandSection(a.id)}
+                >
+                  {t(`sidebar.titles.activity-${a.name ? 'set' : 'unset'}`, {
+                    number: i + 1,
+                    name: a.name
+                  })}
+                </SidebarLink>
+              ))}
+            </ul>
+          )}
           {linkGroup2.map(d => (
-            <SidebarLink key={d.id} anchor={d.id} hash={hash} sub={d.sub}>
+            <SidebarLink
+              key={d.id}
+              anchor={d.id}
+              expanded={expanded[d.id]}
+              hash={hash}
+              sub={d.sub}
+              toggleExpand={() => toggleExpand(d.id)}
+            >
               {d.name}
             </SidebarLink>
           ))}
@@ -173,22 +198,30 @@ Sidebar.propTypes = {
   activities: PropTypes.array.isRequired,
   place: PropTypes.object.isRequired,
   hash: PropTypes.string.isRequired,
+  expanded: PropTypes.object.isRequired,
   expandSection: PropTypes.func.isRequired,
-  saveApdToAPI: PropTypes.func.isRequired
+  saveApdToAPI: PropTypes.func.isRequired,
+  toggleExpand: PropTypes.func.isRequired
 };
 
-const mapStateToProps = ({ activities: { byId, allIds }, router }) => ({
+const mapStateToProps = ({
+  activities: { byId, allIds },
+  sidebar,
+  router
+}) => ({
   activities: allIds.map(id => ({
     id,
     anchor: `activity-${id}`,
     name: byId[id].name
   })),
+  expanded: sidebar.expanded,
   hash: router.location.hash.slice(1) || ''
 });
 
 const mapDispatchToProps = {
   expandSection: expandActivitySection,
-  saveApdToAPI: saveApd
+  saveApdToAPI: saveApd,
+  toggleExpand: toggleExpandAction
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Sidebar);

--- a/web/src/reducers/index.js
+++ b/web/src/reducers/index.js
@@ -6,6 +6,7 @@ import apd from './apd';
 import auth from './auth';
 import budget from './budget';
 import notification from './notification';
+import sidebar from './sidebar';
 import state from './state';
 import user from './user';
 
@@ -15,6 +16,7 @@ const rootReducer = combineReducers({
   auth,
   budget,
   notification,
+  sidebar,
   state,
   user,
   router: routerReducer

--- a/web/src/reducers/index.test.js
+++ b/web/src/reducers/index.test.js
@@ -9,6 +9,7 @@ describe('root reducer', () => {
       'auth',
       'budget',
       'notification',
+      'sidebar',
       'state',
       'user',
       'router'

--- a/web/src/reducers/sidebar.js
+++ b/web/src/reducers/sidebar.js
@@ -1,0 +1,32 @@
+import u from 'updeep';
+import { SIDEBAR_TOGGLE_EXPAND } from '../actions/sidebar';
+
+const initialState = {
+  expanded: {
+    'apd-summary': false,
+    'prev-activities': false,
+    activities: false,
+    'schedule-summary': false,
+    budget: false,
+    'assurances-compliance': false,
+    'executive-summary': false,
+    'certify-submit': false
+  }
+};
+
+const sidebar = (state = initialState, action) => {
+  switch (action.type) {
+    case SIDEBAR_TOGGLE_EXPAND:
+      return {
+        ...state,
+        expanded: {
+          ...state.expanded,
+          [action.id]: !state.expanded[action.id]
+        }
+      };
+    default:
+      return state;
+  }
+};
+
+export default sidebar;

--- a/web/src/reducers/sidebar.js
+++ b/web/src/reducers/sidebar.js
@@ -1,4 +1,3 @@
-import u from 'updeep';
 import { SIDEBAR_TOGGLE_EXPAND } from '../actions/sidebar';
 
 const initialState = {

--- a/web/src/reducers/sidebar.test.js
+++ b/web/src/reducers/sidebar.test.js
@@ -1,0 +1,55 @@
+import sidebar from './sidebar';
+import { SIDEBAR_TOGGLE_EXPAND } from '../actions/sidebar';
+
+describe('sidebar reducer', () => {
+  const initialState = {
+    expanded: {
+      'apd-summary': false,
+      'prev-activities': false,
+      activities: false,
+      'schedule-summary': false,
+      budget: false,
+      'assurances-compliance': false,
+      'executive-summary': false,
+      'certify-submit': false
+    }
+  };
+
+  it('should handle initial state', () => {
+    expect(sidebar(undefined, {})).toEqual(initialState);
+  });
+
+  it('should handle SIDEBAR_TOGGLE_EXPAND', () => {
+    const toggle = sidebar(initialState, {
+      type: SIDEBAR_TOGGLE_EXPAND,
+      id: 'budget'
+    });
+    expect(toggle).toEqual({
+      expanded: {
+        'apd-summary': false,
+        'prev-activities': false,
+        activities: false,
+        'schedule-summary': false,
+        budget: true,
+        'assurances-compliance': false,
+        'executive-summary': false,
+        'certify-submit': false
+      }
+    });
+
+    expect(
+      sidebar(toggle, { type: SIDEBAR_TOGGLE_EXPAND, id: 'budget' })
+    ).toEqual({
+      expanded: {
+        'apd-summary': false,
+        'prev-activities': false,
+        activities: false,
+        'schedule-summary': false,
+        budget: false,
+        'assurances-compliance': false,
+        'executive-summary': false,
+        'certify-submit': false
+      }
+    });
+  });
+});


### PR DESCRIPTION
Starts the sidebar with major sections collapsed and makes them expandable.

@lauraponce When you click on a section in the sidebar, should that section expand as well as navigate the page?  (from https://github.com/18F/cms-hitech-apd/issues/781#issuecomment-403986690)

Closes #781

### Still needs:
- reducer and action tests

### This pull request changes...
- the major sections in the sidebar are collapsed by default
- clicking the up/down arrows will expand/collapse the link section without navigating the page

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This feature is done when...
- [x] Design has approved the experience
- [ ] Product has approved the experience
