### PR TITLE
no table data UI

### DIFF
--- a/web/src/components/NoDataMsg.js
+++ b/web/src/components/NoDataMsg.js
@@ -1,0 +1,12 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const NoDataMsg = ({ children }) => (
+  <div className="mb2 p1 h6 alert alert-error">{children}</div>
+);
+
+NoDataMsg.propTypes = {
+  children: PropTypes.node.isRequired
+};
+
+export default NoDataMsg;

--- a/web/src/containers/ActivityDetailContractorResources.js
+++ b/web/src/containers/ActivityDetailContractorResources.js
@@ -2,14 +2,15 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
-import { t } from '../i18n';
 import {
   addActivityContractor,
   removeActivityContractor,
   updateActivity as updateActivityAction
 } from '../actions/activities';
-import { Subsection } from '../components/Section';
+import NoDataMsg from '../components/NoDataMsg';
 import { Input, DollarInput, Textarea } from '../components/Inputs';
+import { Subsection } from '../components/Section';
+import { t } from '../i18n';
 import { isProgamAdmin } from '../util';
 
 class ActivityDetailContractorExpenses extends Component {
@@ -40,11 +41,15 @@ class ActivityDetailContractorExpenses extends Component {
         resource="activities.contractorResources"
         isKey={isProgamAdmin(activity)}
       >
-        <div>
+        {contractorResources.length === 0 ? (
+          <NoDataMsg>
+            {t('activities.contractorResources.noDataNotice')}
+          </NoDataMsg>
+        ) : (
           <div className="overflow-auto">
             <table
               className="mb2 h5 table table-condensed table-fixed"
-              style={{ minWidth: 700 }}
+              style={{ minWidth: 800 }}
             >
               <thead>
                 <tr>
@@ -165,7 +170,7 @@ class ActivityDetailContractorExpenses extends Component {
               </tbody>
             </table>
           </div>
-        </div>
+        )}
         <button
           type="button"
           className="btn btn-primary bg-black"

--- a/web/src/containers/ActivityDetailExpenses.js
+++ b/web/src/containers/ActivityDetailExpenses.js
@@ -7,9 +7,11 @@ import {
   removeActivityExpense,
   updateActivity as updateActivityAction
 } from '../actions/activities';
-import { Subsection } from '../components/Section';
+import NoDataMsg from '../components/NoDataMsg';
 import { DollarInput, Textarea } from '../components/Inputs';
+import { Subsection } from '../components/Section';
 import Select from '../components/Select';
+import { t } from '../i18n';
 import { isProgamAdmin } from '../util';
 
 class ActivityDetailExpenses extends Component {
@@ -38,81 +40,82 @@ class ActivityDetailExpenses extends Component {
         resource="activities.expenses"
         isKey={isProgamAdmin(activity)}
       >
-        <div className="overflow-auto">
-          <table
-            className="mb2 h5 table table-condensed table-fixed"
-            style={{ minWidth: 700 }}
-          >
-            <thead>
-              <tr>
-                <th className="col-1">#</th>
-                <th className="col-3">Category</th>
-                <th className="col-4">Description</th>
-                {years.map(year => (
-                  <th key={year} className="col-2">
-                    {year} Cost
-                  </th>
-                ))}
-                <th className="col-1" />
-              </tr>
-            </thead>
-            <tbody>
-              {expenses.map((expense, i) => (
-                <tr key={expense.id}>
-                  <td className="mono">{i + 1}.</td>
-                  <td>
-                    <Select
-                      name={`expense-${i}-desc`}
-                      options={[
-                        'Hardware, software, and licensing',
-                        'Equipment and supplies',
-                        'Training and outreach',
-                        'Travel',
-                        'Administrative operations',
-                        'Miscellaneous expenses for the project'
-                      ]}
-                      label="Expense category"
-                      hideLabel
-                      value={expense.category}
-                      onChange={this.handleChange(i, 'category')}
-                    />
-                  </td>
-                  <td>
-                    <Textarea
-                      name={`expense-${i}-desc`}
-                      label="Describe the expense"
-                      hideLabel
-                      rows="3"
-                      value={expense.desc}
-                      onChange={this.handleChange(i, 'desc')}
-                    />
-                  </td>
+        {expenses.length === 0 ? (
+          <NoDataMsg>{t('activities.expenses.noDataNotice')}</NoDataMsg>
+        ) : (
+          <div className="overflow-auto">
+            <table className="mb2 h5 table table-condensed table-fixed">
+              <thead>
+                <tr>
+                  <th className="col-1">#</th>
+                  <th className="col-3">Category</th>
+                  <th className="col-4">Description</th>
                   {years.map(year => (
-                    <td key={year}>
-                      <DollarInput
-                        name={`expense-${i}-${year}-cost`}
-                        label={`Cost for ${year}`}
+                    <th key={year} className="col-2">
+                      {year} Cost
+                    </th>
+                  ))}
+                  <th className="col-1" />
+                </tr>
+              </thead>
+              <tbody>
+                {expenses.map((expense, i) => (
+                  <tr key={expense.id}>
+                    <td className="mono">{i + 1}.</td>
+                    <td>
+                      <Select
+                        name={`expense-${i}-desc`}
+                        options={[
+                          'Hardware, software, and licensing',
+                          'Equipment and supplies',
+                          'Training and outreach',
+                          'Travel',
+                          'Administrative operations',
+                          'Miscellaneous expenses for the project'
+                        ]}
+                        label="Expense category"
                         hideLabel
-                        value={expense.years[year]}
-                        onChange={this.handleYearChange(i, year)}
+                        value={expense.category}
+                        onChange={this.handleChange(i, 'category')}
                       />
                     </td>
-                  ))}
-                  <td className="center">
-                    <button
-                      type="button"
-                      className="btn btn-outline border-silver px1 py-tiny mt-tiny"
-                      title="Remove Expense"
-                      onClick={() => removeExpense(activityID, expense.id)}
-                    >
-                      ✗
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+                    <td>
+                      <Textarea
+                        name={`expense-${i}-desc`}
+                        label="Describe the expense"
+                        hideLabel
+                        rows="3"
+                        value={expense.desc}
+                        onChange={this.handleChange(i, 'desc')}
+                      />
+                    </td>
+                    {years.map(year => (
+                      <td key={year}>
+                        <DollarInput
+                          name={`expense-${i}-${year}-cost`}
+                          label={`Cost for ${year}`}
+                          hideLabel
+                          value={expense.years[year]}
+                          onChange={this.handleYearChange(i, year)}
+                        />
+                      </td>
+                    ))}
+                    <td className="center">
+                      <button
+                        type="button"
+                        className="btn btn-outline border-silver px1 py-tiny mt-tiny"
+                        title="Remove Expense"
+                        onClick={() => removeExpense(activityID, expense.id)}
+                      >
+                        ✗
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
         <button
           type="button"
           className="btn btn-primary bg-black"

--- a/web/src/containers/ActivityDetailSchedule.js
+++ b/web/src/containers/ActivityDetailSchedule.js
@@ -2,14 +2,15 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
-import { t } from '../i18n';
 import {
   addActivityMilestone as addActivityMilestoneAction,
   removeActivityMilestone as removeActivityMilestoneAction,
   updateActivity as updateActivityAction
 } from '../actions/activities';
+import NoDataMsg from '../components/NoDataMsg';
 import { Subsection } from '../components/Section';
 import { Input } from '../components/Inputs';
+import { t } from '../i18n';
 import { isProgamAdmin } from '../util';
 
 class ActivityDetailSchedule extends Component {
@@ -34,9 +35,7 @@ class ActivityDetailSchedule extends Component {
         isKey={isProgamAdmin(activity)}
       >
         {activity.milestones.length === 0 ? (
-          <div className="mb2 p1 h6 alert">
-            {t('activities.schedule.noMilestonesNotice')}
-          </div>
+          <NoDataMsg>{t('activities.schedule.noMilestonesNotice')}</NoDataMsg>
         ) : (
           <div className="mb3 overflow-auto">
             <table className="h5 table table-fixed" style={{ minWidth: 500 }}>

--- a/web/src/containers/ActivityDetailStatePersonnel.js
+++ b/web/src/containers/ActivityDetailStatePersonnel.js
@@ -7,13 +7,14 @@ import {
   removeActivityStatePerson,
   updateActivity as updateActivityAction
 } from '../actions/activities';
-import { Subsection } from '../components/Section';
+import NoDataMsg from '../components/NoDataMsg';
 import {
   Input,
   DollarInput,
   PercentInput,
   Textarea
 } from '../components/Inputs';
+import { Subsection } from '../components/Section';
 import { t } from '../i18n';
 import { isProgamAdmin } from '../util';
 
@@ -45,104 +46,112 @@ class ActivityDetailStatePersonnel extends Component {
         resource="activities.statePersonnel"
         isKey={isProgamAdmin(activity)}
       >
-        <div className="overflow-auto">
-          <table
-            className="mb2 h5 table table-condensed table-fixed"
-            style={{ minWidth: 700 }}
-          >
-            <thead>
-              <tr>
-                <th className="col-1" />
-                <th className="col-4" />
-                <th className="col-5" />
-                {years.map(year => (
-                  <th key={year} className="col-4" colSpan="2">
-                    {t('activities.statePersonnel.labels.yearCost', {
-                      year
-                    })}
+        {statePersonnel.length === 0 ? (
+          <NoDataMsg>{t('activities.statePersonnel.noDataNotice')}</NoDataMsg>
+        ) : (
+          <div className="overflow-auto">
+            <table
+              className="mb2 h5 table table-condensed table-fixed"
+              style={{ minWidth: 800 }}
+            >
+              <thead>
+                <tr>
+                  <th className="col-1" />
+                  <th className="col-4" />
+                  <th className="col-5" />
+                  {years.map(year => (
+                    <th key={year} className="col-4" colSpan="2">
+                      {t('activities.statePersonnel.labels.yearCost', {
+                        year
+                      })}
+                    </th>
+                  ))}
+                  <th className="col-1" />
+                </tr>
+                <tr>
+                  <th className="col-1">
+                    {t('activities.statePersonnel.labels.entryNum')}
                   </th>
-                ))}
-                <th className="col-1" />
-              </tr>
-              <tr>
-                <th className="col-1">
-                  {t('activities.statePersonnel.labels.entryNum')}
-                </th>
-                <th className="col-4">
-                  {t('activities.statePersonnel.labels.title')}
-                </th>
-                <th className="col-5">
-                  {t('activities.statePersonnel.labels.desc')}
-                </th>
-                {years.map(year => (
-                  <Fragment key={year}>
-                    <th>{t('activities.statePersonnel.labels.costAmt')}</th>
-                    <th>{t('activities.statePersonnel.labels.costPerc')}</th>
-                  </Fragment>
-                ))}
-                <th className="col-1" />
-              </tr>
-            </thead>
-            <tbody>
-              {statePersonnel.map((d, i) => (
-                <tr key={d.id}>
-                  <td className="mono">{i + 1}.</td>
-                  <td>
-                    <Input
-                      name={`state-person-${d.id}-title`}
-                      label={t('activities.statePersonnel.labels.title')}
-                      hideLabel
-                      value={d.title}
-                      onChange={this.handleChange(i, 'title')}
-                    />
-                  </td>
-                  <td>
-                    <Textarea
-                      name={`state-person-${d.id}-desc`}
-                      label={t('activities.statePersonnel.labels.desc')}
-                      hideLabel
-                      rows="3"
-                      value={d.desc}
-                      onChange={this.handleChange(i, 'desc')}
-                    />
-                  </td>
+                  <th className="col-4">
+                    {t('activities.statePersonnel.labels.title')}
+                  </th>
+                  <th className="col-5">
+                    {t('activities.statePersonnel.labels.desc')}
+                  </th>
                   {years.map(year => (
                     <Fragment key={year}>
-                      <td>
-                        <DollarInput
-                          name={`state-person-${d.id}-${year}-amt`}
-                          label={t('activities.statePersonnel.labels.costAmt')}
-                          hideLabel
-                          value={d.years[year].amt}
-                          onChange={this.handleChange(i, 'amt', year)}
-                        />
-                      </td>
-                      <td>
-                        <PercentInput
-                          name={`state-person-${d.id}-${year}-perc`}
-                          label={t('activities.statePersonnel.labels.costPerc')}
-                          hideLabel
-                          value={d.years[year].perc}
-                          onChange={this.handleChange(i, 'perc', year)}
-                        />
-                      </td>
+                      <th>{t('activities.statePersonnel.labels.costAmt')}</th>
+                      <th>{t('activities.statePersonnel.labels.costPerc')}</th>
                     </Fragment>
                   ))}
-                  <td className="center">
-                    <button
-                      type="button"
-                      className="btn btn-outline border-silver px1 py-tiny mt-tiny"
-                      title={t('activities.statePersonnel.removeLabel')}
-                      onClick={() => removePerson(activityID, d.id)}
-                    >
-                      ✗
-                    </button>
-                  </td>
+                  <th className="col-1" />
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody>
+                {statePersonnel.map((d, i) => (
+                  <tr key={d.id}>
+                    <td className="mono">{i + 1}.</td>
+                    <td>
+                      <Input
+                        name={`state-person-${d.id}-title`}
+                        label={t('activities.statePersonnel.labels.title')}
+                        hideLabel
+                        value={d.title}
+                        onChange={this.handleChange(i, 'title')}
+                      />
+                    </td>
+                    <td>
+                      <Textarea
+                        name={`state-person-${d.id}-desc`}
+                        label={t('activities.statePersonnel.labels.desc')}
+                        hideLabel
+                        rows="3"
+                        value={d.desc}
+                        onChange={this.handleChange(i, 'desc')}
+                      />
+                    </td>
+                    {years.map(year => (
+                      <Fragment key={year}>
+                        <td>
+                          <DollarInput
+                            name={`state-person-${d.id}-${year}-amt`}
+                            label={t(
+                              'activities.statePersonnel.labels.costAmt'
+                            )}
+                            hideLabel
+                            value={d.years[year].amt}
+                            onChange={this.handleChange(i, 'amt', year)}
+                          />
+                        </td>
+                        <td>
+                          <PercentInput
+                            name={`state-person-${d.id}-${year}-perc`}
+                            label={t(
+                              'activities.statePersonnel.labels.costPerc'
+                            )}
+                            hideLabel
+                            value={d.years[year].perc}
+                            onChange={this.handleChange(i, 'perc', year)}
+                          />
+                        </td>
+                      </Fragment>
+                    ))}
+                    <td className="center">
+                      <button
+                        type="button"
+                        className="btn btn-outline border-silver px1 py-tiny mt-tiny"
+                        title={t('activities.statePersonnel.removeLabel')}
+                        onClick={() => removePerson(activityID, d.id)}
+                      >
+                        ✗
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
         <button
           type="button"
           className="btn btn-primary bg-black"

--- a/web/src/containers/__snapshots__/ActivityDetailContractorResources.test.js.snap
+++ b/web/src/containers/__snapshots__/ActivityDetailContractorResources.test.js.snap
@@ -46,18 +46,345 @@ ShallowWrapper {
     "nodeType": "function",
     "props": Object {
       "children": Array [
-        <div>
-          <div
-            className="overflow-auto"
-          >
-            <table
-              className="mb2 h5 table table-condensed table-fixed"
-              style={
-                Object {
-                  "minWidth": 700,
-                }
+        <div
+          className="overflow-auto"
+        >
+          <table
+            className="mb2 h5 table table-condensed table-fixed"
+            style={
+              Object {
+                "minWidth": 800,
               }
-            >
+            }
+          >
+            <thead>
+              <tr>
+                <th
+                  className="col-1"
+                >
+                  #
+                </th>
+                <th
+                  className="col-4"
+                >
+                  Contractor Name
+                </th>
+                <th
+                  className="col-5"
+                >
+                  Description of Services
+                </th>
+                <th
+                  className="col-4"
+                >
+                  Term Period
+                </th>
+                <th
+                  className="col-2"
+                >
+                  1066 Cost
+                </th>
+                <th
+                  className="col-2"
+                >
+                  1067 Cost
+                </th>
+                <th
+                  className="col-1"
+                />
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td
+                  className="mono"
+                >
+                  1
+                  .
+                </td>
+                <td>
+                  <InputHolder
+                    hideLabel={true}
+                    label="Contractor name"
+                    name="contractor-0-name"
+                    onChange={[Function]}
+                    type="text"
+                    value="contractor name"
+                    wrapperClass=""
+                  />
+                </td>
+                <td>
+                  <InputHolder
+                    hideLabel={true}
+                    id="contractor-0-desc"
+                    label="Describe the services the contractor will provide"
+                    name="contractor-0-desc"
+                    onChange={[Function]}
+                    rows="3"
+                    spellCheck="true"
+                    type="text"
+                    value="contractor description"
+                    wrapperClass=""
+                  />
+                </td>
+                <td>
+                  <div
+                    className="mb1 flex items-baseline h6"
+                  >
+                    <span
+                      className="mr-tiny w-3 right-align"
+                    >
+                      Start:
+                    </span>
+                    <InputHolder
+                      hideLabel={true}
+                      label="Contractor term start"
+                      name="contractor-0-start"
+                      onChange={[Function]}
+                      type="date"
+                      value="start date"
+                      wrapperClass="mb1 flex-auto"
+                    />
+                  </div>
+                  <div
+                    className="mb1 flex items-baseline h6"
+                  >
+                    <span
+                      className="mr-tiny w-3 right-align"
+                    >
+                      End:
+                    </span>
+                    <InputHolder
+                      hideLabel={true}
+                      label="Contractor term end"
+                      name="contractor-0-end"
+                      onChange={[Function]}
+                      type="date"
+                      value="end date"
+                      wrapperClass="mb1 flex-auto"
+                    />
+                  </div>
+                </td>
+                <td>
+                  <InputHolder
+                    hideLabel={true}
+                    label="Contractor cost for 1066"
+                    name="contractor-0-cost-1066"
+                    onChange={[Function]}
+                    type="text"
+                    value={100}
+                    wrapperClass=""
+                  />
+                </td>
+                <td>
+                  <InputHolder
+                    hideLabel={true}
+                    label="Contractor cost for 1067"
+                    name="contractor-0-cost-1067"
+                    onChange={[Function]}
+                    type="text"
+                    value={200}
+                    wrapperClass=""
+                  />
+                </td>
+                <td
+                  className="center"
+                >
+                  <button
+                    className="btn btn-outline border-silver px1 py-tiny mt-tiny"
+                    onClick={[Function]}
+                    title="Remove resource"
+                    type="button"
+                  >
+                    ✗
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>,
+        <button
+          className="btn btn-primary bg-black"
+          onClick={[Function]}
+          type="button"
+        >
+          Add resource
+        </button>,
+      ],
+      "id": null,
+      "isKey": false,
+      "open": false,
+      "resource": "activities.contractorResources",
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": <table
+            className="mb2 h5 table table-condensed table-fixed"
+            style={
+              Object {
+                "minWidth": 800,
+              }
+            }
+          >
+            <thead>
+              <tr>
+                <th
+                  className="col-1"
+                >
+                  #
+                </th>
+                <th
+                  className="col-4"
+                >
+                  Contractor Name
+                </th>
+                <th
+                  className="col-5"
+                >
+                  Description of Services
+                </th>
+                <th
+                  className="col-4"
+                >
+                  Term Period
+                </th>
+                <th
+                  className="col-2"
+                >
+                  1066 Cost
+                </th>
+                <th
+                  className="col-2"
+                >
+                  1067 Cost
+                </th>
+                <th
+                  className="col-1"
+                />
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td
+                  className="mono"
+                >
+                  1
+                  .
+                </td>
+                <td>
+                  <InputHolder
+                    hideLabel={true}
+                    label="Contractor name"
+                    name="contractor-0-name"
+                    onChange={[Function]}
+                    type="text"
+                    value="contractor name"
+                    wrapperClass=""
+                  />
+                </td>
+                <td>
+                  <InputHolder
+                    hideLabel={true}
+                    id="contractor-0-desc"
+                    label="Describe the services the contractor will provide"
+                    name="contractor-0-desc"
+                    onChange={[Function]}
+                    rows="3"
+                    spellCheck="true"
+                    type="text"
+                    value="contractor description"
+                    wrapperClass=""
+                  />
+                </td>
+                <td>
+                  <div
+                    className="mb1 flex items-baseline h6"
+                  >
+                    <span
+                      className="mr-tiny w-3 right-align"
+                    >
+                      Start:
+                    </span>
+                    <InputHolder
+                      hideLabel={true}
+                      label="Contractor term start"
+                      name="contractor-0-start"
+                      onChange={[Function]}
+                      type="date"
+                      value="start date"
+                      wrapperClass="mb1 flex-auto"
+                    />
+                  </div>
+                  <div
+                    className="mb1 flex items-baseline h6"
+                  >
+                    <span
+                      className="mr-tiny w-3 right-align"
+                    >
+                      End:
+                    </span>
+                    <InputHolder
+                      hideLabel={true}
+                      label="Contractor term end"
+                      name="contractor-0-end"
+                      onChange={[Function]}
+                      type="date"
+                      value="end date"
+                      wrapperClass="mb1 flex-auto"
+                    />
+                  </div>
+                </td>
+                <td>
+                  <InputHolder
+                    hideLabel={true}
+                    label="Contractor cost for 1066"
+                    name="contractor-0-cost-1066"
+                    onChange={[Function]}
+                    type="text"
+                    value={100}
+                    wrapperClass=""
+                  />
+                </td>
+                <td>
+                  <InputHolder
+                    hideLabel={true}
+                    label="Contractor cost for 1067"
+                    name="contractor-0-cost-1067"
+                    onChange={[Function]}
+                    type="text"
+                    value={200}
+                    wrapperClass=""
+                  />
+                </td>
+                <td
+                  className="center"
+                >
+                  <button
+                    className="btn btn-outline border-silver px1 py-tiny mt-tiny"
+                    onClick={[Function]}
+                    title="Remove resource"
+                    type="button"
+                  >
+                    ✗
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>,
+          "className": "overflow-auto",
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
               <thead>
                 <tr>
                   <th
@@ -94,7 +421,7 @@ ShallowWrapper {
                     className="col-1"
                   />
                 </tr>
-              </thead>
+              </thead>,
               <tbody>
                 <tr>
                   <td
@@ -201,38 +528,823 @@ ShallowWrapper {
                     </button>
                   </td>
                 </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>,
-        <button
-          className="btn btn-primary bg-black"
-          onClick={[Function]}
-          type="button"
-        >
-          Add resource
-        </button>,
-      ],
-      "id": null,
-      "isKey": false,
-      "open": false,
-      "resource": "activities.contractorResources",
-    },
-    "ref": null,
-    "rendered": Array [
+              </tbody>,
+            ],
+            "className": "mb2 h5 table table-condensed table-fixed",
+            "style": Object {
+              "minWidth": 800,
+            },
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": <tr>
+                  <th
+                    className="col-1"
+                  >
+                    #
+                  </th>
+                  <th
+                    className="col-4"
+                  >
+                    Contractor Name
+                  </th>
+                  <th
+                    className="col-5"
+                  >
+                    Description of Services
+                  </th>
+                  <th
+                    className="col-4"
+                  >
+                    Term Period
+                  </th>
+                  <th
+                    className="col-2"
+                  >
+                    1066 Cost
+                  </th>
+                  <th
+                    className="col-2"
+                  >
+                    1067 Cost
+                  </th>
+                  <th
+                    className="col-1"
+                  />
+                </tr>,
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": Array [
+                    <th
+                      className="col-1"
+                    >
+                      #
+                    </th>,
+                    <th
+                      className="col-4"
+                    >
+                      Contractor Name
+                    </th>,
+                    <th
+                      className="col-5"
+                    >
+                      Description of Services
+                    </th>,
+                    <th
+                      className="col-4"
+                    >
+                      Term Period
+                    </th>,
+                    Array [
+                      <th
+                        className="col-2"
+                      >
+                        1066 Cost
+                      </th>,
+                      <th
+                        className="col-2"
+                      >
+                        1067 Cost
+                      </th>,
+                    ],
+                    <th
+                      className="col-1"
+                    />,
+                  ],
+                },
+                "ref": null,
+                "rendered": Array [
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": "#",
+                      "className": "col-1",
+                    },
+                    "ref": null,
+                    "rendered": "#",
+                    "type": "th",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": "Contractor Name",
+                      "className": "col-4",
+                    },
+                    "ref": null,
+                    "rendered": "Contractor Name",
+                    "type": "th",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": "Description of Services",
+                      "className": "col-5",
+                    },
+                    "ref": null,
+                    "rendered": "Description of Services",
+                    "type": "th",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": "Term Period",
+                      "className": "col-4",
+                    },
+                    "ref": null,
+                    "rendered": "Term Period",
+                    "type": "th",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": "1066",
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": "1066 Cost",
+                      "className": "col-2",
+                    },
+                    "ref": null,
+                    "rendered": "1066 Cost",
+                    "type": "th",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": "1067",
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": "1067 Cost",
+                      "className": "col-2",
+                    },
+                    "ref": null,
+                    "rendered": "1067 Cost",
+                    "type": "th",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "className": "col-1",
+                    },
+                    "ref": null,
+                    "rendered": null,
+                    "type": "th",
+                  },
+                ],
+                "type": "tr",
+              },
+              "type": "thead",
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  <tr>
+                    <td
+                      className="mono"
+                    >
+                      1
+                      .
+                    </td>
+                    <td>
+                      <InputHolder
+                        hideLabel={true}
+                        label="Contractor name"
+                        name="contractor-0-name"
+                        onChange={[Function]}
+                        type="text"
+                        value="contractor name"
+                        wrapperClass=""
+                      />
+                    </td>
+                    <td>
+                      <InputHolder
+                        hideLabel={true}
+                        id="contractor-0-desc"
+                        label="Describe the services the contractor will provide"
+                        name="contractor-0-desc"
+                        onChange={[Function]}
+                        rows="3"
+                        spellCheck="true"
+                        type="text"
+                        value="contractor description"
+                        wrapperClass=""
+                      />
+                    </td>
+                    <td>
+                      <div
+                        className="mb1 flex items-baseline h6"
+                      >
+                        <span
+                          className="mr-tiny w-3 right-align"
+                        >
+                          Start:
+                        </span>
+                        <InputHolder
+                          hideLabel={true}
+                          label="Contractor term start"
+                          name="contractor-0-start"
+                          onChange={[Function]}
+                          type="date"
+                          value="start date"
+                          wrapperClass="mb1 flex-auto"
+                        />
+                      </div>
+                      <div
+                        className="mb1 flex items-baseline h6"
+                      >
+                        <span
+                          className="mr-tiny w-3 right-align"
+                        >
+                          End:
+                        </span>
+                        <InputHolder
+                          hideLabel={true}
+                          label="Contractor term end"
+                          name="contractor-0-end"
+                          onChange={[Function]}
+                          type="date"
+                          value="end date"
+                          wrapperClass="mb1 flex-auto"
+                        />
+                      </div>
+                    </td>
+                    <td>
+                      <InputHolder
+                        hideLabel={true}
+                        label="Contractor cost for 1066"
+                        name="contractor-0-cost-1066"
+                        onChange={[Function]}
+                        type="text"
+                        value={100}
+                        wrapperClass=""
+                      />
+                    </td>
+                    <td>
+                      <InputHolder
+                        hideLabel={true}
+                        label="Contractor cost for 1067"
+                        name="contractor-0-cost-1067"
+                        onChange={[Function]}
+                        type="text"
+                        value={200}
+                        wrapperClass=""
+                      />
+                    </td>
+                    <td
+                      className="center"
+                    >
+                      <button
+                        className="btn btn-outline border-silver px1 py-tiny mt-tiny"
+                        onClick={[Function]}
+                        title="Remove resource"
+                        type="button"
+                      >
+                        ✗
+                      </button>
+                    </td>
+                  </tr>,
+                ],
+              },
+              "ref": null,
+              "rendered": Array [
+                Object {
+                  "instance": null,
+                  "key": "contractor id",
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      <td
+                        className="mono"
+                      >
+                        1
+                        .
+                      </td>,
+                      <td>
+                        <InputHolder
+                          hideLabel={true}
+                          label="Contractor name"
+                          name="contractor-0-name"
+                          onChange={[Function]}
+                          type="text"
+                          value="contractor name"
+                          wrapperClass=""
+                        />
+                      </td>,
+                      <td>
+                        <InputHolder
+                          hideLabel={true}
+                          id="contractor-0-desc"
+                          label="Describe the services the contractor will provide"
+                          name="contractor-0-desc"
+                          onChange={[Function]}
+                          rows="3"
+                          spellCheck="true"
+                          type="text"
+                          value="contractor description"
+                          wrapperClass=""
+                        />
+                      </td>,
+                      <td>
+                        <div
+                          className="mb1 flex items-baseline h6"
+                        >
+                          <span
+                            className="mr-tiny w-3 right-align"
+                          >
+                            Start:
+                          </span>
+                          <InputHolder
+                            hideLabel={true}
+                            label="Contractor term start"
+                            name="contractor-0-start"
+                            onChange={[Function]}
+                            type="date"
+                            value="start date"
+                            wrapperClass="mb1 flex-auto"
+                          />
+                        </div>
+                        <div
+                          className="mb1 flex items-baseline h6"
+                        >
+                          <span
+                            className="mr-tiny w-3 right-align"
+                          >
+                            End:
+                          </span>
+                          <InputHolder
+                            hideLabel={true}
+                            label="Contractor term end"
+                            name="contractor-0-end"
+                            onChange={[Function]}
+                            type="date"
+                            value="end date"
+                            wrapperClass="mb1 flex-auto"
+                          />
+                        </div>
+                      </td>,
+                      Array [
+                        <td>
+                          <InputHolder
+                            hideLabel={true}
+                            label="Contractor cost for 1066"
+                            name="contractor-0-cost-1066"
+                            onChange={[Function]}
+                            type="text"
+                            value={100}
+                            wrapperClass=""
+                          />
+                        </td>,
+                        <td>
+                          <InputHolder
+                            hideLabel={true}
+                            label="Contractor cost for 1067"
+                            name="contractor-0-cost-1067"
+                            onChange={[Function]}
+                            type="text"
+                            value={200}
+                            wrapperClass=""
+                          />
+                        </td>,
+                      ],
+                      <td
+                        className="center"
+                      >
+                        <button
+                          className="btn btn-outline border-silver px1 py-tiny mt-tiny"
+                          onClick={[Function]}
+                          title="Remove resource"
+                          type="button"
+                        >
+                          ✗
+                        </button>
+                      </td>,
+                    ],
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": Array [
+                          1,
+                          ".",
+                        ],
+                        "className": "mono",
+                      },
+                      "ref": null,
+                      "rendered": Array [
+                        1,
+                        ".",
+                      ],
+                      "type": "td",
+                    },
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": <InputHolder
+                          hideLabel={true}
+                          label="Contractor name"
+                          name="contractor-0-name"
+                          onChange={[Function]}
+                          type="text"
+                          value="contractor name"
+                          wrapperClass=""
+                        />,
+                      },
+                      "ref": null,
+                      "rendered": Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "function",
+                        "props": Object {
+                          "hideLabel": true,
+                          "label": "Contractor name",
+                          "name": "contractor-0-name",
+                          "onChange": [Function],
+                          "type": "text",
+                          "value": "contractor name",
+                          "wrapperClass": "",
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": [Function],
+                      },
+                      "type": "td",
+                    },
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": <InputHolder
+                          hideLabel={true}
+                          id="contractor-0-desc"
+                          label="Describe the services the contractor will provide"
+                          name="contractor-0-desc"
+                          onChange={[Function]}
+                          rows="3"
+                          spellCheck="true"
+                          type="text"
+                          value="contractor description"
+                          wrapperClass=""
+                        />,
+                      },
+                      "ref": null,
+                      "rendered": Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "function",
+                        "props": Object {
+                          "hideLabel": true,
+                          "id": "contractor-0-desc",
+                          "label": "Describe the services the contractor will provide",
+                          "name": "contractor-0-desc",
+                          "onChange": [Function],
+                          "rows": "3",
+                          "spellCheck": "true",
+                          "type": "text",
+                          "value": "contractor description",
+                          "wrapperClass": "",
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": [Function],
+                      },
+                      "type": "td",
+                    },
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": Array [
+                          <div
+                            className="mb1 flex items-baseline h6"
+                          >
+                            <span
+                              className="mr-tiny w-3 right-align"
+                            >
+                              Start:
+                            </span>
+                            <InputHolder
+                              hideLabel={true}
+                              label="Contractor term start"
+                              name="contractor-0-start"
+                              onChange={[Function]}
+                              type="date"
+                              value="start date"
+                              wrapperClass="mb1 flex-auto"
+                            />
+                          </div>,
+                          <div
+                            className="mb1 flex items-baseline h6"
+                          >
+                            <span
+                              className="mr-tiny w-3 right-align"
+                            >
+                              End:
+                            </span>
+                            <InputHolder
+                              hideLabel={true}
+                              label="Contractor term end"
+                              name="contractor-0-end"
+                              onChange={[Function]}
+                              type="date"
+                              value="end date"
+                              wrapperClass="mb1 flex-auto"
+                            />
+                          </div>,
+                        ],
+                      },
+                      "ref": null,
+                      "rendered": Array [
+                        Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": Array [
+                              <span
+                                className="mr-tiny w-3 right-align"
+                              >
+                                Start:
+                              </span>,
+                              <InputHolder
+                                hideLabel={true}
+                                label="Contractor term start"
+                                name="contractor-0-start"
+                                onChange={[Function]}
+                                type="date"
+                                value="start date"
+                                wrapperClass="mb1 flex-auto"
+                              />,
+                            ],
+                            "className": "mb1 flex items-baseline h6",
+                          },
+                          "ref": null,
+                          "rendered": Array [
+                            Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": "Start:",
+                                "className": "mr-tiny w-3 right-align",
+                              },
+                              "ref": null,
+                              "rendered": "Start:",
+                              "type": "span",
+                            },
+                            Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "function",
+                              "props": Object {
+                                "hideLabel": true,
+                                "label": "Contractor term start",
+                                "name": "contractor-0-start",
+                                "onChange": [Function],
+                                "type": "date",
+                                "value": "start date",
+                                "wrapperClass": "mb1 flex-auto",
+                              },
+                              "ref": null,
+                              "rendered": null,
+                              "type": [Function],
+                            },
+                          ],
+                          "type": "div",
+                        },
+                        Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": Array [
+                              <span
+                                className="mr-tiny w-3 right-align"
+                              >
+                                End:
+                              </span>,
+                              <InputHolder
+                                hideLabel={true}
+                                label="Contractor term end"
+                                name="contractor-0-end"
+                                onChange={[Function]}
+                                type="date"
+                                value="end date"
+                                wrapperClass="mb1 flex-auto"
+                              />,
+                            ],
+                            "className": "mb1 flex items-baseline h6",
+                          },
+                          "ref": null,
+                          "rendered": Array [
+                            Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": "End:",
+                                "className": "mr-tiny w-3 right-align",
+                              },
+                              "ref": null,
+                              "rendered": "End:",
+                              "type": "span",
+                            },
+                            Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "function",
+                              "props": Object {
+                                "hideLabel": true,
+                                "label": "Contractor term end",
+                                "name": "contractor-0-end",
+                                "onChange": [Function],
+                                "type": "date",
+                                "value": "end date",
+                                "wrapperClass": "mb1 flex-auto",
+                              },
+                              "ref": null,
+                              "rendered": null,
+                              "type": [Function],
+                            },
+                          ],
+                          "type": "div",
+                        },
+                      ],
+                      "type": "td",
+                    },
+                    Object {
+                      "instance": null,
+                      "key": "1066",
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": <InputHolder
+                          hideLabel={true}
+                          label="Contractor cost for 1066"
+                          name="contractor-0-cost-1066"
+                          onChange={[Function]}
+                          type="text"
+                          value={100}
+                          wrapperClass=""
+                        />,
+                      },
+                      "ref": null,
+                      "rendered": Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "function",
+                        "props": Object {
+                          "hideLabel": true,
+                          "label": "Contractor cost for 1066",
+                          "name": "contractor-0-cost-1066",
+                          "onChange": [Function],
+                          "type": "text",
+                          "value": 100,
+                          "wrapperClass": "",
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": [Function],
+                      },
+                      "type": "td",
+                    },
+                    Object {
+                      "instance": null,
+                      "key": "1067",
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": <InputHolder
+                          hideLabel={true}
+                          label="Contractor cost for 1067"
+                          name="contractor-0-cost-1067"
+                          onChange={[Function]}
+                          type="text"
+                          value={200}
+                          wrapperClass=""
+                        />,
+                      },
+                      "ref": null,
+                      "rendered": Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "function",
+                        "props": Object {
+                          "hideLabel": true,
+                          "label": "Contractor cost for 1067",
+                          "name": "contractor-0-cost-1067",
+                          "onChange": [Function],
+                          "type": "text",
+                          "value": 200,
+                          "wrapperClass": "",
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": [Function],
+                      },
+                      "type": "td",
+                    },
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": <button
+                          className="btn btn-outline border-silver px1 py-tiny mt-tiny"
+                          onClick={[Function]}
+                          title="Remove resource"
+                          type="button"
+                        >
+                          ✗
+                        </button>,
+                        "className": "center",
+                      },
+                      "ref": null,
+                      "rendered": Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": "✗",
+                          "className": "btn btn-outline border-silver px1 py-tiny mt-tiny",
+                          "onClick": [Function],
+                          "title": "Remove resource",
+                          "type": "button",
+                        },
+                        "ref": null,
+                        "rendered": "✗",
+                        "type": "button",
+                      },
+                      "type": "td",
+                    },
+                  ],
+                  "type": "tr",
+                },
+              ],
+              "type": "tbody",
+            },
+          ],
+          "type": "table",
+        },
+        "type": "div",
+      },
       Object {
         "instance": null,
         "key": undefined,
         "nodeType": "host",
         "props": Object {
-          "children": <div
+          "children": "Add resource",
+          "className": "btn btn-primary bg-black",
+          "onClick": [Function],
+          "type": "button",
+        },
+        "ref": null,
+        "rendered": "Add resource",
+        "type": "button",
+      },
+    ],
+    "type": [Function],
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "function",
+      "props": Object {
+        "children": Array [
+          <div
             className="overflow-auto"
           >
             <table
               className="mb2 h5 table table-condensed table-fixed"
               style={
                 Object {
-                  "minWidth": 700,
+                  "minWidth": 800,
                 }
               }
             >
@@ -382,9 +1494,22 @@ ShallowWrapper {
               </tbody>
             </table>
           </div>,
-        },
-        "ref": null,
-        "rendered": Object {
+          <button
+            className="btn btn-primary bg-black"
+            onClick={[Function]}
+            type="button"
+          >
+            Add resource
+          </button>,
+        ],
+        "id": null,
+        "isKey": false,
+        "open": false,
+        "resource": "activities.contractorResources",
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
           "instance": null,
           "key": undefined,
           "nodeType": "host",
@@ -393,7 +1518,7 @@ ShallowWrapper {
               className="mb2 h5 table table-condensed table-fixed"
               style={
                 Object {
-                  "minWidth": 700,
+                  "minWidth": 800,
                 }
               }
             >
@@ -698,7 +1823,7 @@ ShallowWrapper {
               ],
               "className": "mb2 h5 table table-condensed table-fixed",
               "style": Object {
-                "minWidth": 700,
+                "minWidth": 800,
               },
             },
             "ref": null,
@@ -1476,1467 +2601,6 @@ ShallowWrapper {
               },
             ],
             "type": "table",
-          },
-          "type": "div",
-        },
-        "type": "div",
-      },
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "host",
-        "props": Object {
-          "children": "Add resource",
-          "className": "btn btn-primary bg-black",
-          "onClick": [Function],
-          "type": "button",
-        },
-        "ref": null,
-        "rendered": "Add resource",
-        "type": "button",
-      },
-    ],
-    "type": [Function],
-  },
-  Symbol(enzyme.__nodes__): Array [
-    Object {
-      "instance": null,
-      "key": undefined,
-      "nodeType": "function",
-      "props": Object {
-        "children": Array [
-          <div>
-            <div
-              className="overflow-auto"
-            >
-              <table
-                className="mb2 h5 table table-condensed table-fixed"
-                style={
-                  Object {
-                    "minWidth": 700,
-                  }
-                }
-              >
-                <thead>
-                  <tr>
-                    <th
-                      className="col-1"
-                    >
-                      #
-                    </th>
-                    <th
-                      className="col-4"
-                    >
-                      Contractor Name
-                    </th>
-                    <th
-                      className="col-5"
-                    >
-                      Description of Services
-                    </th>
-                    <th
-                      className="col-4"
-                    >
-                      Term Period
-                    </th>
-                    <th
-                      className="col-2"
-                    >
-                      1066 Cost
-                    </th>
-                    <th
-                      className="col-2"
-                    >
-                      1067 Cost
-                    </th>
-                    <th
-                      className="col-1"
-                    />
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td
-                      className="mono"
-                    >
-                      1
-                      .
-                    </td>
-                    <td>
-                      <InputHolder
-                        hideLabel={true}
-                        label="Contractor name"
-                        name="contractor-0-name"
-                        onChange={[Function]}
-                        type="text"
-                        value="contractor name"
-                        wrapperClass=""
-                      />
-                    </td>
-                    <td>
-                      <InputHolder
-                        hideLabel={true}
-                        id="contractor-0-desc"
-                        label="Describe the services the contractor will provide"
-                        name="contractor-0-desc"
-                        onChange={[Function]}
-                        rows="3"
-                        spellCheck="true"
-                        type="text"
-                        value="contractor description"
-                        wrapperClass=""
-                      />
-                    </td>
-                    <td>
-                      <div
-                        className="mb1 flex items-baseline h6"
-                      >
-                        <span
-                          className="mr-tiny w-3 right-align"
-                        >
-                          Start:
-                        </span>
-                        <InputHolder
-                          hideLabel={true}
-                          label="Contractor term start"
-                          name="contractor-0-start"
-                          onChange={[Function]}
-                          type="date"
-                          value="start date"
-                          wrapperClass="mb1 flex-auto"
-                        />
-                      </div>
-                      <div
-                        className="mb1 flex items-baseline h6"
-                      >
-                        <span
-                          className="mr-tiny w-3 right-align"
-                        >
-                          End:
-                        </span>
-                        <InputHolder
-                          hideLabel={true}
-                          label="Contractor term end"
-                          name="contractor-0-end"
-                          onChange={[Function]}
-                          type="date"
-                          value="end date"
-                          wrapperClass="mb1 flex-auto"
-                        />
-                      </div>
-                    </td>
-                    <td>
-                      <InputHolder
-                        hideLabel={true}
-                        label="Contractor cost for 1066"
-                        name="contractor-0-cost-1066"
-                        onChange={[Function]}
-                        type="text"
-                        value={100}
-                        wrapperClass=""
-                      />
-                    </td>
-                    <td>
-                      <InputHolder
-                        hideLabel={true}
-                        label="Contractor cost for 1067"
-                        name="contractor-0-cost-1067"
-                        onChange={[Function]}
-                        type="text"
-                        value={200}
-                        wrapperClass=""
-                      />
-                    </td>
-                    <td
-                      className="center"
-                    >
-                      <button
-                        className="btn btn-outline border-silver px1 py-tiny mt-tiny"
-                        onClick={[Function]}
-                        title="Remove resource"
-                        type="button"
-                      >
-                        ✗
-                      </button>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>,
-          <button
-            className="btn btn-primary bg-black"
-            onClick={[Function]}
-            type="button"
-          >
-            Add resource
-          </button>,
-        ],
-        "id": null,
-        "isKey": false,
-        "open": false,
-        "resource": "activities.contractorResources",
-      },
-      "ref": null,
-      "rendered": Array [
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "host",
-          "props": Object {
-            "children": <div
-              className="overflow-auto"
-            >
-              <table
-                className="mb2 h5 table table-condensed table-fixed"
-                style={
-                  Object {
-                    "minWidth": 700,
-                  }
-                }
-              >
-                <thead>
-                  <tr>
-                    <th
-                      className="col-1"
-                    >
-                      #
-                    </th>
-                    <th
-                      className="col-4"
-                    >
-                      Contractor Name
-                    </th>
-                    <th
-                      className="col-5"
-                    >
-                      Description of Services
-                    </th>
-                    <th
-                      className="col-4"
-                    >
-                      Term Period
-                    </th>
-                    <th
-                      className="col-2"
-                    >
-                      1066 Cost
-                    </th>
-                    <th
-                      className="col-2"
-                    >
-                      1067 Cost
-                    </th>
-                    <th
-                      className="col-1"
-                    />
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td
-                      className="mono"
-                    >
-                      1
-                      .
-                    </td>
-                    <td>
-                      <InputHolder
-                        hideLabel={true}
-                        label="Contractor name"
-                        name="contractor-0-name"
-                        onChange={[Function]}
-                        type="text"
-                        value="contractor name"
-                        wrapperClass=""
-                      />
-                    </td>
-                    <td>
-                      <InputHolder
-                        hideLabel={true}
-                        id="contractor-0-desc"
-                        label="Describe the services the contractor will provide"
-                        name="contractor-0-desc"
-                        onChange={[Function]}
-                        rows="3"
-                        spellCheck="true"
-                        type="text"
-                        value="contractor description"
-                        wrapperClass=""
-                      />
-                    </td>
-                    <td>
-                      <div
-                        className="mb1 flex items-baseline h6"
-                      >
-                        <span
-                          className="mr-tiny w-3 right-align"
-                        >
-                          Start:
-                        </span>
-                        <InputHolder
-                          hideLabel={true}
-                          label="Contractor term start"
-                          name="contractor-0-start"
-                          onChange={[Function]}
-                          type="date"
-                          value="start date"
-                          wrapperClass="mb1 flex-auto"
-                        />
-                      </div>
-                      <div
-                        className="mb1 flex items-baseline h6"
-                      >
-                        <span
-                          className="mr-tiny w-3 right-align"
-                        >
-                          End:
-                        </span>
-                        <InputHolder
-                          hideLabel={true}
-                          label="Contractor term end"
-                          name="contractor-0-end"
-                          onChange={[Function]}
-                          type="date"
-                          value="end date"
-                          wrapperClass="mb1 flex-auto"
-                        />
-                      </div>
-                    </td>
-                    <td>
-                      <InputHolder
-                        hideLabel={true}
-                        label="Contractor cost for 1066"
-                        name="contractor-0-cost-1066"
-                        onChange={[Function]}
-                        type="text"
-                        value={100}
-                        wrapperClass=""
-                      />
-                    </td>
-                    <td>
-                      <InputHolder
-                        hideLabel={true}
-                        label="Contractor cost for 1067"
-                        name="contractor-0-cost-1067"
-                        onChange={[Function]}
-                        type="text"
-                        value={200}
-                        wrapperClass=""
-                      />
-                    </td>
-                    <td
-                      className="center"
-                    >
-                      <button
-                        className="btn btn-outline border-silver px1 py-tiny mt-tiny"
-                        onClick={[Function]}
-                        title="Remove resource"
-                        type="button"
-                      >
-                        ✗
-                      </button>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>,
-          },
-          "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "host",
-            "props": Object {
-              "children": <table
-                className="mb2 h5 table table-condensed table-fixed"
-                style={
-                  Object {
-                    "minWidth": 700,
-                  }
-                }
-              >
-                <thead>
-                  <tr>
-                    <th
-                      className="col-1"
-                    >
-                      #
-                    </th>
-                    <th
-                      className="col-4"
-                    >
-                      Contractor Name
-                    </th>
-                    <th
-                      className="col-5"
-                    >
-                      Description of Services
-                    </th>
-                    <th
-                      className="col-4"
-                    >
-                      Term Period
-                    </th>
-                    <th
-                      className="col-2"
-                    >
-                      1066 Cost
-                    </th>
-                    <th
-                      className="col-2"
-                    >
-                      1067 Cost
-                    </th>
-                    <th
-                      className="col-1"
-                    />
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td
-                      className="mono"
-                    >
-                      1
-                      .
-                    </td>
-                    <td>
-                      <InputHolder
-                        hideLabel={true}
-                        label="Contractor name"
-                        name="contractor-0-name"
-                        onChange={[Function]}
-                        type="text"
-                        value="contractor name"
-                        wrapperClass=""
-                      />
-                    </td>
-                    <td>
-                      <InputHolder
-                        hideLabel={true}
-                        id="contractor-0-desc"
-                        label="Describe the services the contractor will provide"
-                        name="contractor-0-desc"
-                        onChange={[Function]}
-                        rows="3"
-                        spellCheck="true"
-                        type="text"
-                        value="contractor description"
-                        wrapperClass=""
-                      />
-                    </td>
-                    <td>
-                      <div
-                        className="mb1 flex items-baseline h6"
-                      >
-                        <span
-                          className="mr-tiny w-3 right-align"
-                        >
-                          Start:
-                        </span>
-                        <InputHolder
-                          hideLabel={true}
-                          label="Contractor term start"
-                          name="contractor-0-start"
-                          onChange={[Function]}
-                          type="date"
-                          value="start date"
-                          wrapperClass="mb1 flex-auto"
-                        />
-                      </div>
-                      <div
-                        className="mb1 flex items-baseline h6"
-                      >
-                        <span
-                          className="mr-tiny w-3 right-align"
-                        >
-                          End:
-                        </span>
-                        <InputHolder
-                          hideLabel={true}
-                          label="Contractor term end"
-                          name="contractor-0-end"
-                          onChange={[Function]}
-                          type="date"
-                          value="end date"
-                          wrapperClass="mb1 flex-auto"
-                        />
-                      </div>
-                    </td>
-                    <td>
-                      <InputHolder
-                        hideLabel={true}
-                        label="Contractor cost for 1066"
-                        name="contractor-0-cost-1066"
-                        onChange={[Function]}
-                        type="text"
-                        value={100}
-                        wrapperClass=""
-                      />
-                    </td>
-                    <td>
-                      <InputHolder
-                        hideLabel={true}
-                        label="Contractor cost for 1067"
-                        name="contractor-0-cost-1067"
-                        onChange={[Function]}
-                        type="text"
-                        value={200}
-                        wrapperClass=""
-                      />
-                    </td>
-                    <td
-                      className="center"
-                    >
-                      <button
-                        className="btn btn-outline border-silver px1 py-tiny mt-tiny"
-                        onClick={[Function]}
-                        title="Remove resource"
-                        type="button"
-                      >
-                        ✗
-                      </button>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>,
-              "className": "overflow-auto",
-            },
-            "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "host",
-              "props": Object {
-                "children": Array [
-                  <thead>
-                    <tr>
-                      <th
-                        className="col-1"
-                      >
-                        #
-                      </th>
-                      <th
-                        className="col-4"
-                      >
-                        Contractor Name
-                      </th>
-                      <th
-                        className="col-5"
-                      >
-                        Description of Services
-                      </th>
-                      <th
-                        className="col-4"
-                      >
-                        Term Period
-                      </th>
-                      <th
-                        className="col-2"
-                      >
-                        1066 Cost
-                      </th>
-                      <th
-                        className="col-2"
-                      >
-                        1067 Cost
-                      </th>
-                      <th
-                        className="col-1"
-                      />
-                    </tr>
-                  </thead>,
-                  <tbody>
-                    <tr>
-                      <td
-                        className="mono"
-                      >
-                        1
-                        .
-                      </td>
-                      <td>
-                        <InputHolder
-                          hideLabel={true}
-                          label="Contractor name"
-                          name="contractor-0-name"
-                          onChange={[Function]}
-                          type="text"
-                          value="contractor name"
-                          wrapperClass=""
-                        />
-                      </td>
-                      <td>
-                        <InputHolder
-                          hideLabel={true}
-                          id="contractor-0-desc"
-                          label="Describe the services the contractor will provide"
-                          name="contractor-0-desc"
-                          onChange={[Function]}
-                          rows="3"
-                          spellCheck="true"
-                          type="text"
-                          value="contractor description"
-                          wrapperClass=""
-                        />
-                      </td>
-                      <td>
-                        <div
-                          className="mb1 flex items-baseline h6"
-                        >
-                          <span
-                            className="mr-tiny w-3 right-align"
-                          >
-                            Start:
-                          </span>
-                          <InputHolder
-                            hideLabel={true}
-                            label="Contractor term start"
-                            name="contractor-0-start"
-                            onChange={[Function]}
-                            type="date"
-                            value="start date"
-                            wrapperClass="mb1 flex-auto"
-                          />
-                        </div>
-                        <div
-                          className="mb1 flex items-baseline h6"
-                        >
-                          <span
-                            className="mr-tiny w-3 right-align"
-                          >
-                            End:
-                          </span>
-                          <InputHolder
-                            hideLabel={true}
-                            label="Contractor term end"
-                            name="contractor-0-end"
-                            onChange={[Function]}
-                            type="date"
-                            value="end date"
-                            wrapperClass="mb1 flex-auto"
-                          />
-                        </div>
-                      </td>
-                      <td>
-                        <InputHolder
-                          hideLabel={true}
-                          label="Contractor cost for 1066"
-                          name="contractor-0-cost-1066"
-                          onChange={[Function]}
-                          type="text"
-                          value={100}
-                          wrapperClass=""
-                        />
-                      </td>
-                      <td>
-                        <InputHolder
-                          hideLabel={true}
-                          label="Contractor cost for 1067"
-                          name="contractor-0-cost-1067"
-                          onChange={[Function]}
-                          type="text"
-                          value={200}
-                          wrapperClass=""
-                        />
-                      </td>
-                      <td
-                        className="center"
-                      >
-                        <button
-                          className="btn btn-outline border-silver px1 py-tiny mt-tiny"
-                          onClick={[Function]}
-                          title="Remove resource"
-                          type="button"
-                        >
-                          ✗
-                        </button>
-                      </td>
-                    </tr>
-                  </tbody>,
-                ],
-                "className": "mb2 h5 table table-condensed table-fixed",
-                "style": Object {
-                  "minWidth": 700,
-                },
-              },
-              "ref": null,
-              "rendered": Array [
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": <tr>
-                      <th
-                        className="col-1"
-                      >
-                        #
-                      </th>
-                      <th
-                        className="col-4"
-                      >
-                        Contractor Name
-                      </th>
-                      <th
-                        className="col-5"
-                      >
-                        Description of Services
-                      </th>
-                      <th
-                        className="col-4"
-                      >
-                        Term Period
-                      </th>
-                      <th
-                        className="col-2"
-                      >
-                        1066 Cost
-                      </th>
-                      <th
-                        className="col-2"
-                      >
-                        1067 Cost
-                      </th>
-                      <th
-                        className="col-1"
-                      />
-                    </tr>,
-                  },
-                  "ref": null,
-                  "rendered": Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "host",
-                    "props": Object {
-                      "children": Array [
-                        <th
-                          className="col-1"
-                        >
-                          #
-                        </th>,
-                        <th
-                          className="col-4"
-                        >
-                          Contractor Name
-                        </th>,
-                        <th
-                          className="col-5"
-                        >
-                          Description of Services
-                        </th>,
-                        <th
-                          className="col-4"
-                        >
-                          Term Period
-                        </th>,
-                        Array [
-                          <th
-                            className="col-2"
-                          >
-                            1066 Cost
-                          </th>,
-                          <th
-                            className="col-2"
-                          >
-                            1067 Cost
-                          </th>,
-                        ],
-                        <th
-                          className="col-1"
-                        />,
-                      ],
-                    },
-                    "ref": null,
-                    "rendered": Array [
-                      Object {
-                        "instance": null,
-                        "key": undefined,
-                        "nodeType": "host",
-                        "props": Object {
-                          "children": "#",
-                          "className": "col-1",
-                        },
-                        "ref": null,
-                        "rendered": "#",
-                        "type": "th",
-                      },
-                      Object {
-                        "instance": null,
-                        "key": undefined,
-                        "nodeType": "host",
-                        "props": Object {
-                          "children": "Contractor Name",
-                          "className": "col-4",
-                        },
-                        "ref": null,
-                        "rendered": "Contractor Name",
-                        "type": "th",
-                      },
-                      Object {
-                        "instance": null,
-                        "key": undefined,
-                        "nodeType": "host",
-                        "props": Object {
-                          "children": "Description of Services",
-                          "className": "col-5",
-                        },
-                        "ref": null,
-                        "rendered": "Description of Services",
-                        "type": "th",
-                      },
-                      Object {
-                        "instance": null,
-                        "key": undefined,
-                        "nodeType": "host",
-                        "props": Object {
-                          "children": "Term Period",
-                          "className": "col-4",
-                        },
-                        "ref": null,
-                        "rendered": "Term Period",
-                        "type": "th",
-                      },
-                      Object {
-                        "instance": null,
-                        "key": "1066",
-                        "nodeType": "host",
-                        "props": Object {
-                          "children": "1066 Cost",
-                          "className": "col-2",
-                        },
-                        "ref": null,
-                        "rendered": "1066 Cost",
-                        "type": "th",
-                      },
-                      Object {
-                        "instance": null,
-                        "key": "1067",
-                        "nodeType": "host",
-                        "props": Object {
-                          "children": "1067 Cost",
-                          "className": "col-2",
-                        },
-                        "ref": null,
-                        "rendered": "1067 Cost",
-                        "type": "th",
-                      },
-                      Object {
-                        "instance": null,
-                        "key": undefined,
-                        "nodeType": "host",
-                        "props": Object {
-                          "className": "col-1",
-                        },
-                        "ref": null,
-                        "rendered": null,
-                        "type": "th",
-                      },
-                    ],
-                    "type": "tr",
-                  },
-                  "type": "thead",
-                },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": Array [
-                      <tr>
-                        <td
-                          className="mono"
-                        >
-                          1
-                          .
-                        </td>
-                        <td>
-                          <InputHolder
-                            hideLabel={true}
-                            label="Contractor name"
-                            name="contractor-0-name"
-                            onChange={[Function]}
-                            type="text"
-                            value="contractor name"
-                            wrapperClass=""
-                          />
-                        </td>
-                        <td>
-                          <InputHolder
-                            hideLabel={true}
-                            id="contractor-0-desc"
-                            label="Describe the services the contractor will provide"
-                            name="contractor-0-desc"
-                            onChange={[Function]}
-                            rows="3"
-                            spellCheck="true"
-                            type="text"
-                            value="contractor description"
-                            wrapperClass=""
-                          />
-                        </td>
-                        <td>
-                          <div
-                            className="mb1 flex items-baseline h6"
-                          >
-                            <span
-                              className="mr-tiny w-3 right-align"
-                            >
-                              Start:
-                            </span>
-                            <InputHolder
-                              hideLabel={true}
-                              label="Contractor term start"
-                              name="contractor-0-start"
-                              onChange={[Function]}
-                              type="date"
-                              value="start date"
-                              wrapperClass="mb1 flex-auto"
-                            />
-                          </div>
-                          <div
-                            className="mb1 flex items-baseline h6"
-                          >
-                            <span
-                              className="mr-tiny w-3 right-align"
-                            >
-                              End:
-                            </span>
-                            <InputHolder
-                              hideLabel={true}
-                              label="Contractor term end"
-                              name="contractor-0-end"
-                              onChange={[Function]}
-                              type="date"
-                              value="end date"
-                              wrapperClass="mb1 flex-auto"
-                            />
-                          </div>
-                        </td>
-                        <td>
-                          <InputHolder
-                            hideLabel={true}
-                            label="Contractor cost for 1066"
-                            name="contractor-0-cost-1066"
-                            onChange={[Function]}
-                            type="text"
-                            value={100}
-                            wrapperClass=""
-                          />
-                        </td>
-                        <td>
-                          <InputHolder
-                            hideLabel={true}
-                            label="Contractor cost for 1067"
-                            name="contractor-0-cost-1067"
-                            onChange={[Function]}
-                            type="text"
-                            value={200}
-                            wrapperClass=""
-                          />
-                        </td>
-                        <td
-                          className="center"
-                        >
-                          <button
-                            className="btn btn-outline border-silver px1 py-tiny mt-tiny"
-                            onClick={[Function]}
-                            title="Remove resource"
-                            type="button"
-                          >
-                            ✗
-                          </button>
-                        </td>
-                      </tr>,
-                    ],
-                  },
-                  "ref": null,
-                  "rendered": Array [
-                    Object {
-                      "instance": null,
-                      "key": "contractor id",
-                      "nodeType": "host",
-                      "props": Object {
-                        "children": Array [
-                          <td
-                            className="mono"
-                          >
-                            1
-                            .
-                          </td>,
-                          <td>
-                            <InputHolder
-                              hideLabel={true}
-                              label="Contractor name"
-                              name="contractor-0-name"
-                              onChange={[Function]}
-                              type="text"
-                              value="contractor name"
-                              wrapperClass=""
-                            />
-                          </td>,
-                          <td>
-                            <InputHolder
-                              hideLabel={true}
-                              id="contractor-0-desc"
-                              label="Describe the services the contractor will provide"
-                              name="contractor-0-desc"
-                              onChange={[Function]}
-                              rows="3"
-                              spellCheck="true"
-                              type="text"
-                              value="contractor description"
-                              wrapperClass=""
-                            />
-                          </td>,
-                          <td>
-                            <div
-                              className="mb1 flex items-baseline h6"
-                            >
-                              <span
-                                className="mr-tiny w-3 right-align"
-                              >
-                                Start:
-                              </span>
-                              <InputHolder
-                                hideLabel={true}
-                                label="Contractor term start"
-                                name="contractor-0-start"
-                                onChange={[Function]}
-                                type="date"
-                                value="start date"
-                                wrapperClass="mb1 flex-auto"
-                              />
-                            </div>
-                            <div
-                              className="mb1 flex items-baseline h6"
-                            >
-                              <span
-                                className="mr-tiny w-3 right-align"
-                              >
-                                End:
-                              </span>
-                              <InputHolder
-                                hideLabel={true}
-                                label="Contractor term end"
-                                name="contractor-0-end"
-                                onChange={[Function]}
-                                type="date"
-                                value="end date"
-                                wrapperClass="mb1 flex-auto"
-                              />
-                            </div>
-                          </td>,
-                          Array [
-                            <td>
-                              <InputHolder
-                                hideLabel={true}
-                                label="Contractor cost for 1066"
-                                name="contractor-0-cost-1066"
-                                onChange={[Function]}
-                                type="text"
-                                value={100}
-                                wrapperClass=""
-                              />
-                            </td>,
-                            <td>
-                              <InputHolder
-                                hideLabel={true}
-                                label="Contractor cost for 1067"
-                                name="contractor-0-cost-1067"
-                                onChange={[Function]}
-                                type="text"
-                                value={200}
-                                wrapperClass=""
-                              />
-                            </td>,
-                          ],
-                          <td
-                            className="center"
-                          >
-                            <button
-                              className="btn btn-outline border-silver px1 py-tiny mt-tiny"
-                              onClick={[Function]}
-                              title="Remove resource"
-                              type="button"
-                            >
-                              ✗
-                            </button>
-                          </td>,
-                        ],
-                      },
-                      "ref": null,
-                      "rendered": Array [
-                        Object {
-                          "instance": null,
-                          "key": undefined,
-                          "nodeType": "host",
-                          "props": Object {
-                            "children": Array [
-                              1,
-                              ".",
-                            ],
-                            "className": "mono",
-                          },
-                          "ref": null,
-                          "rendered": Array [
-                            1,
-                            ".",
-                          ],
-                          "type": "td",
-                        },
-                        Object {
-                          "instance": null,
-                          "key": undefined,
-                          "nodeType": "host",
-                          "props": Object {
-                            "children": <InputHolder
-                              hideLabel={true}
-                              label="Contractor name"
-                              name="contractor-0-name"
-                              onChange={[Function]}
-                              type="text"
-                              value="contractor name"
-                              wrapperClass=""
-                            />,
-                          },
-                          "ref": null,
-                          "rendered": Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "function",
-                            "props": Object {
-                              "hideLabel": true,
-                              "label": "Contractor name",
-                              "name": "contractor-0-name",
-                              "onChange": [Function],
-                              "type": "text",
-                              "value": "contractor name",
-                              "wrapperClass": "",
-                            },
-                            "ref": null,
-                            "rendered": null,
-                            "type": [Function],
-                          },
-                          "type": "td",
-                        },
-                        Object {
-                          "instance": null,
-                          "key": undefined,
-                          "nodeType": "host",
-                          "props": Object {
-                            "children": <InputHolder
-                              hideLabel={true}
-                              id="contractor-0-desc"
-                              label="Describe the services the contractor will provide"
-                              name="contractor-0-desc"
-                              onChange={[Function]}
-                              rows="3"
-                              spellCheck="true"
-                              type="text"
-                              value="contractor description"
-                              wrapperClass=""
-                            />,
-                          },
-                          "ref": null,
-                          "rendered": Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "function",
-                            "props": Object {
-                              "hideLabel": true,
-                              "id": "contractor-0-desc",
-                              "label": "Describe the services the contractor will provide",
-                              "name": "contractor-0-desc",
-                              "onChange": [Function],
-                              "rows": "3",
-                              "spellCheck": "true",
-                              "type": "text",
-                              "value": "contractor description",
-                              "wrapperClass": "",
-                            },
-                            "ref": null,
-                            "rendered": null,
-                            "type": [Function],
-                          },
-                          "type": "td",
-                        },
-                        Object {
-                          "instance": null,
-                          "key": undefined,
-                          "nodeType": "host",
-                          "props": Object {
-                            "children": Array [
-                              <div
-                                className="mb1 flex items-baseline h6"
-                              >
-                                <span
-                                  className="mr-tiny w-3 right-align"
-                                >
-                                  Start:
-                                </span>
-                                <InputHolder
-                                  hideLabel={true}
-                                  label="Contractor term start"
-                                  name="contractor-0-start"
-                                  onChange={[Function]}
-                                  type="date"
-                                  value="start date"
-                                  wrapperClass="mb1 flex-auto"
-                                />
-                              </div>,
-                              <div
-                                className="mb1 flex items-baseline h6"
-                              >
-                                <span
-                                  className="mr-tiny w-3 right-align"
-                                >
-                                  End:
-                                </span>
-                                <InputHolder
-                                  hideLabel={true}
-                                  label="Contractor term end"
-                                  name="contractor-0-end"
-                                  onChange={[Function]}
-                                  type="date"
-                                  value="end date"
-                                  wrapperClass="mb1 flex-auto"
-                                />
-                              </div>,
-                            ],
-                          },
-                          "ref": null,
-                          "rendered": Array [
-                            Object {
-                              "instance": null,
-                              "key": undefined,
-                              "nodeType": "host",
-                              "props": Object {
-                                "children": Array [
-                                  <span
-                                    className="mr-tiny w-3 right-align"
-                                  >
-                                    Start:
-                                  </span>,
-                                  <InputHolder
-                                    hideLabel={true}
-                                    label="Contractor term start"
-                                    name="contractor-0-start"
-                                    onChange={[Function]}
-                                    type="date"
-                                    value="start date"
-                                    wrapperClass="mb1 flex-auto"
-                                  />,
-                                ],
-                                "className": "mb1 flex items-baseline h6",
-                              },
-                              "ref": null,
-                              "rendered": Array [
-                                Object {
-                                  "instance": null,
-                                  "key": undefined,
-                                  "nodeType": "host",
-                                  "props": Object {
-                                    "children": "Start:",
-                                    "className": "mr-tiny w-3 right-align",
-                                  },
-                                  "ref": null,
-                                  "rendered": "Start:",
-                                  "type": "span",
-                                },
-                                Object {
-                                  "instance": null,
-                                  "key": undefined,
-                                  "nodeType": "function",
-                                  "props": Object {
-                                    "hideLabel": true,
-                                    "label": "Contractor term start",
-                                    "name": "contractor-0-start",
-                                    "onChange": [Function],
-                                    "type": "date",
-                                    "value": "start date",
-                                    "wrapperClass": "mb1 flex-auto",
-                                  },
-                                  "ref": null,
-                                  "rendered": null,
-                                  "type": [Function],
-                                },
-                              ],
-                              "type": "div",
-                            },
-                            Object {
-                              "instance": null,
-                              "key": undefined,
-                              "nodeType": "host",
-                              "props": Object {
-                                "children": Array [
-                                  <span
-                                    className="mr-tiny w-3 right-align"
-                                  >
-                                    End:
-                                  </span>,
-                                  <InputHolder
-                                    hideLabel={true}
-                                    label="Contractor term end"
-                                    name="contractor-0-end"
-                                    onChange={[Function]}
-                                    type="date"
-                                    value="end date"
-                                    wrapperClass="mb1 flex-auto"
-                                  />,
-                                ],
-                                "className": "mb1 flex items-baseline h6",
-                              },
-                              "ref": null,
-                              "rendered": Array [
-                                Object {
-                                  "instance": null,
-                                  "key": undefined,
-                                  "nodeType": "host",
-                                  "props": Object {
-                                    "children": "End:",
-                                    "className": "mr-tiny w-3 right-align",
-                                  },
-                                  "ref": null,
-                                  "rendered": "End:",
-                                  "type": "span",
-                                },
-                                Object {
-                                  "instance": null,
-                                  "key": undefined,
-                                  "nodeType": "function",
-                                  "props": Object {
-                                    "hideLabel": true,
-                                    "label": "Contractor term end",
-                                    "name": "contractor-0-end",
-                                    "onChange": [Function],
-                                    "type": "date",
-                                    "value": "end date",
-                                    "wrapperClass": "mb1 flex-auto",
-                                  },
-                                  "ref": null,
-                                  "rendered": null,
-                                  "type": [Function],
-                                },
-                              ],
-                              "type": "div",
-                            },
-                          ],
-                          "type": "td",
-                        },
-                        Object {
-                          "instance": null,
-                          "key": "1066",
-                          "nodeType": "host",
-                          "props": Object {
-                            "children": <InputHolder
-                              hideLabel={true}
-                              label="Contractor cost for 1066"
-                              name="contractor-0-cost-1066"
-                              onChange={[Function]}
-                              type="text"
-                              value={100}
-                              wrapperClass=""
-                            />,
-                          },
-                          "ref": null,
-                          "rendered": Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "function",
-                            "props": Object {
-                              "hideLabel": true,
-                              "label": "Contractor cost for 1066",
-                              "name": "contractor-0-cost-1066",
-                              "onChange": [Function],
-                              "type": "text",
-                              "value": 100,
-                              "wrapperClass": "",
-                            },
-                            "ref": null,
-                            "rendered": null,
-                            "type": [Function],
-                          },
-                          "type": "td",
-                        },
-                        Object {
-                          "instance": null,
-                          "key": "1067",
-                          "nodeType": "host",
-                          "props": Object {
-                            "children": <InputHolder
-                              hideLabel={true}
-                              label="Contractor cost for 1067"
-                              name="contractor-0-cost-1067"
-                              onChange={[Function]}
-                              type="text"
-                              value={200}
-                              wrapperClass=""
-                            />,
-                          },
-                          "ref": null,
-                          "rendered": Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "function",
-                            "props": Object {
-                              "hideLabel": true,
-                              "label": "Contractor cost for 1067",
-                              "name": "contractor-0-cost-1067",
-                              "onChange": [Function],
-                              "type": "text",
-                              "value": 200,
-                              "wrapperClass": "",
-                            },
-                            "ref": null,
-                            "rendered": null,
-                            "type": [Function],
-                          },
-                          "type": "td",
-                        },
-                        Object {
-                          "instance": null,
-                          "key": undefined,
-                          "nodeType": "host",
-                          "props": Object {
-                            "children": <button
-                              className="btn btn-outline border-silver px1 py-tiny mt-tiny"
-                              onClick={[Function]}
-                              title="Remove resource"
-                              type="button"
-                            >
-                              ✗
-                            </button>,
-                            "className": "center",
-                          },
-                          "ref": null,
-                          "rendered": Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "host",
-                            "props": Object {
-                              "children": "✗",
-                              "className": "btn btn-outline border-silver px1 py-tiny mt-tiny",
-                              "onClick": [Function],
-                              "title": "Remove resource",
-                              "type": "button",
-                            },
-                            "ref": null,
-                            "rendered": "✗",
-                            "type": "button",
-                          },
-                          "type": "td",
-                        },
-                      ],
-                      "type": "tr",
-                    },
-                  ],
-                  "type": "tbody",
-                },
-              ],
-              "type": "table",
-            },
-            "type": "div",
           },
           "type": "div",
         },

--- a/web/src/i18n/locales/en.yaml
+++ b/web/src/i18n/locales/en.yaml
@@ -207,6 +207,7 @@
       title: "Contract Resources"
       subheader: "Do you have contracting resources? In this section, outline contracts by vendor name or contract. Mirror your existing IAPD template structure for this section."
       reminder: "Contracts and projected contracts must be itemized, with estimated costs per contract including FFY costs. It is not necessary to know exact names of all contractors at this stage. "
+      noDataNotice: "It looks like you don’t have any contracting resources for this activity."
       labels: 
         entryNumber: "#"
         contractorName: "Contractor Name"
@@ -227,6 +228,7 @@
       title: "Personnel"
       subheader: "Outline the personnel resources for this section. This includes anyone funded as a part of this activity. This does not include personnel listed in the contract section."
       helpText: "Personnel costs for this section includes combined salary and benefits. Salary amount is the yearly cost of the individual personnel listed and personnel only need to be listed once. FTE% is the percentage attributable to the activity. Personnel costs are automatically calculated from the %FTE provided. "
+      noDataNotice: "It looks like you don’t have any personnel resources for this activity."
       labels: 
         entryNum: "#"
         title: "Title"
@@ -240,6 +242,7 @@
       title: "Non-Personnel Costs"
       helpText: "Provide a detailed breakout of any non-personnel and non-contracted costs related to this activity. This should include a brief description of these projected costs."
       reminder: "“Miscellaneous expenses” from the drop down, includes materials and supplies, communications‐related expenses, printing costs and facilities expenses."
+      noDataNotice: "It looks like you don’t have any additional costs for this activity."
     costAllocate: 
       title: "Cost Allocation"
       helpText: "As specified in OMB Circular A‐87, a cost allocation plan must be included identifying all participants and their associated cost allocation to depict non‐Medicaid activities and non‐Medicaid FTEs participating in this project, if any.

--- a/web/src/styles/app/table.css
+++ b/web/src/styles/app/table.css
@@ -27,9 +27,18 @@
 
 /* additional styles */
 
-.align-middle > th,
-.align-middle > td {
-  vertical-align: middle;
+.table th,
+.table td {
+  border-top: 1px solid #e7e7e7;
+}
+
+.table-fixed {
+  table-layout: fixed;
+}
+
+.table-condensed th,
+.table-condensed td {
+  padding: 0.25rem 0.375rem;
 }
 
 .table-cms {
@@ -56,11 +65,7 @@
   border-left: none;
 }
 
-.table-fixed {
-  table-layout: fixed;
-}
-
-.table-condensed th,
-.table-condensed td {
-  padding: 0.25rem 0.375rem;
+.align-middle > th,
+.align-middle > td {
+  vertical-align: middle;
 }


### PR DESCRIPTION
adds a tasteful 'no rows/data' message if you remove all the entries from the state personnel / contractor / expenses sections (instead of showing an ugly table with just columns and no rows)

preview:
![image](https://user-images.githubusercontent.com/1060893/42566951-46d8526c-84d6-11e8-8c41-89eaa56e7b26.png)

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
