### PR TITLE
Set federal share percentage per activity, per FFY quarter

### DIFF
--- a/web/src/actions/apd.js
+++ b/web/src/actions/apd.js
@@ -80,7 +80,6 @@ export const fetchApd = () => dispatch => {
     .then(req => {
       const apd = Array.isArray(req.data) ? req.data : null;
       dispatch(receiveApd(apd));
-      dispatch(updateBudget());
     })
     .catch(error => {
       const reason = error.response ? error.response.data : 'N/A';

--- a/web/src/actions/apd.test.js
+++ b/web/src/actions/apd.test.js
@@ -175,14 +175,13 @@ describe('apd actions', () => {
       fetchMock.reset();
     });
 
-    it('creates GET_APD_SUCCESS and UPDATE_BUDGET after successful APD fetch', () => {
+    it('creates GET_APD_SUCCESS after successful APD fetch', () => {
       const store = mockStore({});
       fetchMock.onGet('/apds').reply(200, [{ foo: 'bar' }]);
 
       const expectedActions = [
         { type: actions.GET_APD_REQUEST },
-        { type: actions.GET_APD_SUCCESS, data: [{ foo: 'bar' }] },
-        { type: actions.UPDATE_BUDGET, state: {} }
+        { type: actions.GET_APD_SUCCESS, data: [{ foo: 'bar' }] }
       ];
 
       return store.dispatch(actions.fetchApd()).then(() => {

--- a/web/src/containers/ActivityDetailCostAllocate.js
+++ b/web/src/containers/ActivityDetailCostAllocate.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import ActivityDetailCostAllocateFFP from './ActivityDetailCostAllocateFFP';
+import ActivityQuarterlyBudgetSummary from './ActivityQuarterlyBudgetSummary';
 import { updateActivity as updateActivityAction } from '../actions/activities';
 import { Subsection } from '../components/Section';
 import { RichText } from '../components/Inputs';
@@ -37,6 +38,18 @@ const ActivityDetailCostAllocate = props => {
         />
       </div>
       <ActivityDetailCostAllocateFFP aId={activity.id} />
+
+      <div className="mb3">
+        <div className="mb-tiny bold">
+          {t('activities.costAllocate.quarterly.title')}
+        </div>
+        <HelpText
+          text="activities.costAllocate.quarterly.helpText"
+          reminder="activities.costAllocate.quarterly.reminder"
+        />
+        <ActivityQuarterlyBudgetSummary aId={activity.id} />
+      </div>
+
       <div className="mb3">
         <div className="mb-tiny bold">
           {t('activities.costAllocate.otherFunding.title')}

--- a/web/src/containers/ActivityDetailCostAllocateFFP.test.js
+++ b/web/src/containers/ActivityDetailCostAllocateFFP.test.js
@@ -52,8 +52,8 @@ describe('the activities cost allocation FFP component', () => {
           statePersonnel: [
             {
               years: {
-                '1066': { amt: 100 },
-                '1067': { amt: 1000 }
+                '1066': { amt: 100, perc: 41 },
+                '1067': { amt: 1000, perc: 63 }
               }
             }
           ],
@@ -138,22 +138,22 @@ describe('the activities cost allocation FFP component', () => {
       byYearData: [
         {
           allocations: [
-            { amount: 261, id: 'federal' },
-            { amount: 29, id: 'state' }
+            { amount: 207.9, id: 'federal' },
+            { amount: 23.1, id: 'state' }
           ],
           ffpSelectVal: '90-10',
-          total: 300,
-          totalNetOther: 290,
+          total: 241,
+          totalNetOther: 231,
           year: '1066'
         },
         {
           allocations: [
-            { amount: 300, id: 'federal' },
-            { amount: 2700, id: 'state' }
+            { amount: 263, id: 'federal' },
+            { amount: 2367, id: 'state' }
           ],
           ffpSelectVal: '10-90',
-          total: 3000,
-          totalNetOther: 3000,
+          total: 2630,
+          totalNetOther: 2630,
           year: '1067'
         }
       ],

--- a/web/src/containers/ActivityQuarterlyBudgetSummary.js
+++ b/web/src/containers/ActivityQuarterlyBudgetSummary.js
@@ -1,0 +1,197 @@
+import PropTypes from 'prop-types';
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
+
+import { updateActivity } from '../actions/activities';
+import { PercentInput } from '../components/Inputs';
+import { t } from '../i18n';
+// import { expenseTypeNames } from '../reducers/budget';
+import { formatMoney, formatPerc } from '../util/formats';
+
+const QUARTERS = [1, 2, 3, 4];
+const COLORS = ['teal', 'green', 'yellow'];
+const EXPENSE_NAME_DISPLAY = {
+  state: t('activities.costAllocate.quarterly.expenseNames.state'),
+  contractors: t('activities.costAllocate.quarterly.expenseNames.contractor'),
+  combined: t('activities.costAllocate.quarterly.expenseNames.combined')
+};
+
+const color = idx => `bg-${COLORS[idx] || 'gray'}`;
+
+class ActivityQuarterlyBudgetSummary extends Component {
+  handleChange = (year, q, name) => e => {
+    // Keep percent as 0-100 here because the activity state
+    // uses Big Percents, and this action updates the
+    // activity state.  The budget state update is triggered
+    // afterwards.
+    const change = {
+      quarterlyFFP: {
+        [year]: { [q]: { [name]: +e.target.value } }
+      }
+    };
+    this.props.update(this.props.aId, change, true);
+  };
+
+  render() {
+    const { quarterlyFFP, years } = this.props;
+
+    // Wait until the budget is ready
+    if (!quarterlyFFP) return null;
+
+    return (
+      <div>
+        <div className="mb3">
+          <div className="overflow-auto">
+            <table className="table-cms table-fixed" style={{ minWidth: 1200 }}>
+              <thead>
+                <tr>
+                  <th style={{ width: 160 }} />
+                  {years.map((year, i) => (
+                    <th key={year} className={`center ${color(i)}`} colSpan="5">
+                      {t('ffy', { year })}
+                    </th>
+                  ))}
+                  <th className="center">{t('table.total')}</th>
+                </tr>
+                <tr>
+                  <th />
+                  {years.map((year, i) => (
+                    <Fragment key={year}>
+                      {QUARTERS.map(q => (
+                        <th key={q} className="center">
+                          {t('table.quarter', { q })}
+                        </th>
+                      ))}
+                      <th className={`right-align ${color(i)}-light`}>
+                        {t('table.subtotal')}
+                      </th>
+                    </Fragment>
+                  ))}
+                  <th className="bg-gray-light" />
+                </tr>
+              </thead>
+              <tbody>
+                {['state', 'contractors'].map(name => (
+                  <Fragment key={name}>
+                    <tr
+                      key={name}
+                      className={`${name === 'combined' ? 'bold' : ''}`}
+                    >
+                      <td rowSpan="2">{EXPENSE_NAME_DISPLAY[name]}</td>
+                      {years.map((year, i) => (
+                        <Fragment key={year}>
+                          {QUARTERS.map(q => (
+                            <td
+                              className={`mono right-align ${
+                                name === 'combined' ? `${color(i)}-light` : ''
+                              }`}
+                              key={q}
+                            >
+                              <PercentInput
+                                name={`ffp-ACTIVITYIDHERE-${year}-${q}-${name}`}
+                                hideLabel
+                                label={`federal share for ffy ${year}, quarter ${q}, ${name}`}
+                                onChange={this.handleChange(year, q, name)}
+                                value={
+                                  quarterlyFFP[year][q][name].percent * 100
+                                }
+                              />
+                            </td>
+                          ))}
+                          <td
+                            className={`bold mono right-align ${color(
+                              i
+                            )}-light`}
+                          >
+                            {formatPerc(
+                              quarterlyFFP[year].subtotal[name].percent
+                            )}
+                          </td>
+                        </Fragment>
+                      ))}
+                      <td
+                        rowSpan="2"
+                        className="bold mono right-align bg-gray-light"
+                      >
+                        {formatMoney(quarterlyFFP.total[name])}
+                      </td>
+                    </tr>
+                    <tr>
+                      {years.map((year, i) => (
+                        <Fragment key={year}>
+                          {QUARTERS.map(q => (
+                            <td
+                              className={`mono right-align ${
+                                name === 'combined' ? `${color(i)}-light` : ''
+                              }`}
+                              key={q}
+                            >
+                              {formatMoney(quarterlyFFP[year][q][name].dollars)}
+                            </td>
+                          ))}
+                          <td
+                            className={`bold mono right-align ${color(
+                              i
+                            )}-light`}
+                          >
+                            {formatMoney(
+                              quarterlyFFP[year].subtotal[name].dollars
+                            )}
+                          </td>
+                        </Fragment>
+                      ))}
+                    </tr>
+                  </Fragment>
+                ))}
+                <tr className="bold">
+                  <td>{EXPENSE_NAME_DISPLAY.combined}</td>
+                  {years.map((year, i) => (
+                    <Fragment key={year}>
+                      {QUARTERS.map(q => (
+                        <td
+                          className={`mono right-align ${color(i)}-light`}
+                          key={q}
+                        >
+                          {formatMoney(quarterlyFFP[year][q].combined.dollars)}
+                        </td>
+                      ))}
+                      <td className={`bold mono right-align ${color(i)}-light`}>
+                        {formatMoney(
+                          quarterlyFFP[year].subtotal.combined.dollars
+                        )}
+                      </td>
+                    </Fragment>
+                  ))}
+                  <td className="bold mono right-align bg-gray-light">
+                    {formatMoney(quarterlyFFP.total.combined)}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+ActivityQuarterlyBudgetSummary.propTypes = {
+  aId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  quarterlyFFP: PropTypes.object.isRequired,
+  years: PropTypes.array.isRequired,
+  update: PropTypes.func.isRequired
+};
+
+const mapStateToProps = ({ apd, budget: { activities } }, { aId }) => {
+  const budget = activities[aId];
+
+  return {
+    quarterlyFFP: budget ? budget.quarterlyFFP : null,
+    years: apd.data.years
+  };
+};
+const mapDispatchToProps = { update: updateActivity };
+
+export default connect(mapStateToProps, mapDispatchToProps)(
+  ActivityQuarterlyBudgetSummary
+);

--- a/web/src/containers/ActivityQuarterlyBudgetSummary.js
+++ b/web/src/containers/ActivityQuarterlyBudgetSummary.js
@@ -5,7 +5,6 @@ import { connect } from 'react-redux';
 import { updateActivity } from '../actions/activities';
 import { PercentInput } from '../components/Inputs';
 import { t } from '../i18n';
-// import { expenseTypeNames } from '../reducers/budget';
 import { formatMoney, formatPerc } from '../util/formats';
 
 const QUARTERS = [1, 2, 3, 4];

--- a/web/src/containers/ActivityQuarterlyBudgetSummary.js
+++ b/web/src/containers/ActivityQuarterlyBudgetSummary.js
@@ -33,7 +33,7 @@ class ActivityQuarterlyBudgetSummary extends Component {
   };
 
   render() {
-    const { quarterlyFFP, years } = this.props;
+    const { aId, quarterlyFFP, years } = this.props;
 
     // Wait until the budget is ready
     if (!quarterlyFFP) return null;
@@ -88,7 +88,7 @@ class ActivityQuarterlyBudgetSummary extends Component {
                               key={q}
                             >
                               <PercentInput
-                                name={`ffp-ACTIVITYIDHERE-${year}-${q}-${name}`}
+                                name={`ffp-${aId}-${year}-${q}-${name}`}
                                 hideLabel
                                 label={`federal share for ffy ${year}, quarter ${q}, ${name}`}
                                 onChange={this.handleChange(year, q, name)}

--- a/web/src/containers/QuarterlyBudgetSummary.js
+++ b/web/src/containers/QuarterlyBudgetSummary.js
@@ -5,7 +5,6 @@ import { connect } from 'react-redux';
 import { updateBudgetQuarterlyShare } from '../actions/apd';
 import { t } from '../i18n';
 import { expenseTypeNames } from '../reducers/budget';
-import { addObjVals } from '../util';
 import { formatMoney } from '../util/formats';
 
 const FUNDING_SOURCES = [['hitAndHie', 'HIT and HIE'], ['mmis', 'MMIS']];
@@ -62,46 +61,18 @@ class QuarterlyBudgetSummary extends Component {
                     </tr>
                     <tr>
                       <th />
-                      {years.map((year, i) => {
-                        const incomplete =
-                          addObjVals(data[year], q => q.percent || 0) !== 100;
-                        return (
-                          <Fragment key={year}>
-                            {QUARTERS.map(q => (
-                              <th key={q} className="center">
-                                <div className="mb-tiny">
-                                  {t('table.quarter', { q })}
-                                </div>
-                                <div className="flex items-center">
-                                  <input
-                                    type="range"
-                                    className="flex-auto input-range"
-                                    min="0"
-                                    max="100"
-                                    step="5"
-                                    value={data[year][q].percent}
-                                    onChange={this.handleChange(
-                                      source,
-                                      year,
-                                      q
-                                    )}
-                                  />
-                                  <div
-                                    className={`ml-tiny flex-none mono right-align ${
-                                      incomplete ? 'red' : ''
-                                    }`}
-                                  >
-                                    {data[year][q].percent}%
-                                  </div>
-                                </div>
-                              </th>
-                            ))}
-                            <th className={`right-align ${color(i)}-light`}>
-                              {t('table.subtotal')}
+                      {years.map((year, i) => (
+                        <Fragment key={year}>
+                          {QUARTERS.map(q => (
+                            <th key={q} className="center">
+                              {t('table.quarter', { q })}
                             </th>
-                          </Fragment>
-                        );
-                      })}
+                          ))}
+                          <th className={`right-align ${color(i)}-light`}>
+                            {t('table.subtotal')}
+                          </th>
+                        </Fragment>
+                      ))}
                       <th className="bg-gray-light" />
                     </tr>
                   </thead>

--- a/web/src/containers/QuarterlyBudgetSummary.js
+++ b/web/src/containers/QuarterlyBudgetSummary.js
@@ -4,18 +4,14 @@ import { connect } from 'react-redux';
 
 import { updateBudgetQuarterlyShare } from '../actions/apd';
 import { t } from '../i18n';
-import { expenseTypeNames } from '../reducers/budget';
 import { formatMoney } from '../util/formats';
 
 const FUNDING_SOURCES = [['hitAndHie', 'HIT and HIE'], ['mmis', 'MMIS']];
 const QUARTERS = [1, 2, 3, 4];
 const COLORS = ['teal', 'green', 'yellow'];
 const EXPENSE_NAME_DISPLAY = {
-  statePersonnel: t(
-    'proposedBudget.quarterlyBudget.expenseNames.statePersonnel'
-  ),
-  expenses: t('proposedBudget.quarterlyBudget.expenseNames.expenses'),
-  contractors: t('proposedBudget.quarterlyBudget.expenseNames.contractors'),
+  state: t('proposedBudget.quarterlyBudget.expenseNames.state'),
+  contractors: t('proposedBudget.quarterlyBudget.expenseNames.contractor'),
   combined: t('proposedBudget.quarterlyBudget.expenseNames.combined')
 };
 
@@ -77,7 +73,7 @@ class QuarterlyBudgetSummary extends Component {
                     </tr>
                   </thead>
                   <tbody>
-                    {expenseTypeNames.map(name => (
+                    {Object.keys(EXPENSE_NAME_DISPLAY).map(name => (
                       <tr
                         key={name}
                         className={`${name === 'combined' ? 'bold' : ''}`}

--- a/web/src/containers/__snapshots__/ActivityDetailCostAllocate.test.js.snap
+++ b/web/src/containers/__snapshots__/ActivityDetailCostAllocate.test.js.snap
@@ -59,12 +59,15 @@ ShallowWrapper {
           <div
             className="mb-tiny bold"
           >
-            bloop
+            moop moop - real text here plz
           </div>
           <HelpText
-            reminder={null}
+            reminder="activities.costAllocate.quarterly.reminder"
+            text="activities.costAllocate.quarterly.helpText"
           />
-          <Connect(QuarterlyBudgetSummary) />
+          <Connect(ActivityQuarterlyBudgetSummary)
+            aId="activity id"
+          />
         </div>,
         <div
           className="mb3"
@@ -174,12 +177,15 @@ ShallowWrapper {
             <div
               className="mb-tiny bold"
             >
-              bloop
+              moop moop - real text here plz
             </div>,
             <HelpText
-              reminder={null}
+              reminder="activities.costAllocate.quarterly.reminder"
+              text="activities.costAllocate.quarterly.helpText"
             />,
-            <Connect(QuarterlyBudgetSummary) />,
+            <Connect(ActivityQuarterlyBudgetSummary)
+              aId="activity id"
+            />,
           ],
           "className": "mb3",
         },
@@ -190,11 +196,11 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "host",
             "props": Object {
-              "children": "bloop",
+              "children": "moop moop - real text here plz",
               "className": "mb-tiny bold",
             },
             "ref": null,
-            "rendered": "bloop",
+            "rendered": "moop moop - real text here plz",
             "type": "div",
           },
           Object {
@@ -202,7 +208,8 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "function",
             "props": Object {
-              "reminder": null,
+              "reminder": "activities.costAllocate.quarterly.reminder",
+              "text": "activities.costAllocate.quarterly.helpText",
             },
             "ref": null,
             "rendered": null,
@@ -212,7 +219,9 @@ ShallowWrapper {
             "instance": null,
             "key": undefined,
             "nodeType": "class",
-            "props": Object {},
+            "props": Object {
+              "aId": "activity id",
+            },
             "ref": null,
             "rendered": null,
             "type": [Function],
@@ -319,12 +328,15 @@ ShallowWrapper {
             <div
               className="mb-tiny bold"
             >
-              bloop
+              moop moop - real text here plz
             </div>
             <HelpText
-              reminder={null}
+              reminder="activities.costAllocate.quarterly.reminder"
+              text="activities.costAllocate.quarterly.helpText"
             />
-            <Connect(QuarterlyBudgetSummary) />
+            <Connect(ActivityQuarterlyBudgetSummary)
+              aId="activity id"
+            />
           </div>,
           <div
             className="mb3"
@@ -434,12 +446,15 @@ ShallowWrapper {
               <div
                 className="mb-tiny bold"
               >
-                bloop
+                moop moop - real text here plz
               </div>,
               <HelpText
-                reminder={null}
+                reminder="activities.costAllocate.quarterly.reminder"
+                text="activities.costAllocate.quarterly.helpText"
               />,
-              <Connect(QuarterlyBudgetSummary) />,
+              <Connect(ActivityQuarterlyBudgetSummary)
+                aId="activity id"
+              />,
             ],
             "className": "mb3",
           },
@@ -450,11 +465,11 @@ ShallowWrapper {
               "key": undefined,
               "nodeType": "host",
               "props": Object {
-                "children": "bloop",
+                "children": "moop moop - real text here plz",
                 "className": "mb-tiny bold",
               },
               "ref": null,
-              "rendered": "bloop",
+              "rendered": "moop moop - real text here plz",
               "type": "div",
             },
             Object {
@@ -462,7 +477,8 @@ ShallowWrapper {
               "key": undefined,
               "nodeType": "function",
               "props": Object {
-                "reminder": null,
+                "reminder": "activities.costAllocate.quarterly.reminder",
+                "text": "activities.costAllocate.quarterly.helpText",
               },
               "ref": null,
               "rendered": null,
@@ -472,7 +488,9 @@ ShallowWrapper {
               "instance": null,
               "key": undefined,
               "nodeType": "class",
-              "props": Object {},
+              "props": Object {
+                "aId": "activity id",
+              },
               "ref": null,
               "rendered": null,
               "type": [Function],

--- a/web/src/containers/__snapshots__/ActivityDetailCostAllocate.test.js.snap
+++ b/web/src/containers/__snapshots__/ActivityDetailCostAllocate.test.js.snap
@@ -59,6 +59,19 @@ ShallowWrapper {
           <div
             className="mb-tiny bold"
           >
+            bloop
+          </div>
+          <HelpText
+            reminder={null}
+          />
+          <Connect(QuarterlyBudgetSummary) />
+        </div>,
+        <div
+          className="mb3"
+        >
+          <div
+            className="mb-tiny bold"
+          >
             Other funding description
           </div>
           <HelpText
@@ -161,6 +174,61 @@ ShallowWrapper {
             <div
               className="mb-tiny bold"
             >
+              bloop
+            </div>,
+            <HelpText
+              reminder={null}
+            />,
+            <Connect(QuarterlyBudgetSummary) />,
+          ],
+          "className": "mb3",
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": "bloop",
+              "className": "mb-tiny bold",
+            },
+            "ref": null,
+            "rendered": "bloop",
+            "type": "div",
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "function",
+            "props": Object {
+              "reminder": null,
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {},
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+        ],
+        "type": "div",
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <div
+              className="mb-tiny bold"
+            >
               Other funding description
             </div>,
             <HelpText
@@ -245,6 +313,19 @@ ShallowWrapper {
           <Connect(ActivityDetailCostAllocateFFP)
             aId="activity id"
           />,
+          <div
+            className="mb3"
+          >
+            <div
+              className="mb-tiny bold"
+            >
+              bloop
+            </div>
+            <HelpText
+              reminder={null}
+            />
+            <Connect(QuarterlyBudgetSummary) />
+          </div>,
           <div
             className="mb3"
           >
@@ -343,6 +424,61 @@ ShallowWrapper {
           "ref": null,
           "rendered": null,
           "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <div
+                className="mb-tiny bold"
+              >
+                bloop
+              </div>,
+              <HelpText
+                reminder={null}
+              />,
+              <Connect(QuarterlyBudgetSummary) />,
+            ],
+            "className": "mb3",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": "bloop",
+                "className": "mb-tiny bold",
+              },
+              "ref": null,
+              "rendered": "bloop",
+              "type": "div",
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "function",
+              "props": Object {
+                "reminder": null,
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {},
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
+          ],
+          "type": "div",
         },
         Object {
           "instance": null,

--- a/web/src/containers/__snapshots__/ActivityDetailCostAllocate.test.js.snap
+++ b/web/src/containers/__snapshots__/ActivityDetailCostAllocate.test.js.snap
@@ -59,7 +59,7 @@ ShallowWrapper {
           <div
             className="mb-tiny bold"
           >
-            moop moop - real text here plz
+            Breakout of federal share by quarter
           </div>
           <HelpText
             reminder="activities.costAllocate.quarterly.reminder"
@@ -177,7 +177,7 @@ ShallowWrapper {
             <div
               className="mb-tiny bold"
             >
-              moop moop - real text here plz
+              Breakout of federal share by quarter
             </div>,
             <HelpText
               reminder="activities.costAllocate.quarterly.reminder"
@@ -196,11 +196,11 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "host",
             "props": Object {
-              "children": "moop moop - real text here plz",
+              "children": "Breakout of federal share by quarter",
               "className": "mb-tiny bold",
             },
             "ref": null,
-            "rendered": "moop moop - real text here plz",
+            "rendered": "Breakout of federal share by quarter",
             "type": "div",
           },
           Object {
@@ -328,7 +328,7 @@ ShallowWrapper {
             <div
               className="mb-tiny bold"
             >
-              moop moop - real text here plz
+              Breakout of federal share by quarter
             </div>
             <HelpText
               reminder="activities.costAllocate.quarterly.reminder"
@@ -446,7 +446,7 @@ ShallowWrapper {
               <div
                 className="mb-tiny bold"
               >
-                moop moop - real text here plz
+                Breakout of federal share by quarter
               </div>,
               <HelpText
                 reminder="activities.costAllocate.quarterly.reminder"
@@ -465,11 +465,11 @@ ShallowWrapper {
               "key": undefined,
               "nodeType": "host",
               "props": Object {
-                "children": "moop moop - real text here plz",
+                "children": "Breakout of federal share by quarter",
                 "className": "mb-tiny bold",
               },
               "ref": null,
-              "rendered": "moop moop - real text here plz",
+              "rendered": "Breakout of federal share by quarter",
               "type": "div",
             },
             Object {

--- a/web/src/i18n/locales/en.yaml
+++ b/web/src/i18n/locales/en.yaml
@@ -20,7 +20,7 @@
     saveApdButtonText: Save APD
   apd: 
     title: "Program Summary"
-    helpText: "Provide an introduction for your state's program. Include context for your funding request by providing information such as current size of program, future vision, and how the program is positioned within the state. This information is similar to the content from the IAPD executive summary template section."
+    helpText: "Provide an introduction for your state's program. clude context for your funding request by providing information such as current size of program, future vision, and how the program is positioned within the state. This information is similar to the content from the IAPD executive summary template section."
     stateProfile:
       title: State Profile Contact Information
       helpText: In this section, provide information about relevant state contacts. You will only need to input this information once. If we have information on record, it will be listed below. Ensure the director's name and office address are listed correctly.
@@ -264,7 +264,7 @@
         reminder:
         expenseNames:
           state: State personnel + non-personnel expenses
-          contractor: Congrator resources
+          contractor: Contractor resources
           combined: Total enhanced FFP
       otherFunding: 
         title: "Other funding description"
@@ -345,7 +345,7 @@
       helpText: ""
       expenseNames:
         state: State personnel + non-personnel expenses
-        contractor: Congrator resources
+        contractor: Contractor resources
         combined: Total enhanced FFP
     paymentsByFFYQuarter: 
       title: Incentive Payments by FFY Quarter

--- a/web/src/i18n/locales/en.yaml
+++ b/web/src/i18n/locales/en.yaml
@@ -259,8 +259,8 @@
         title: "Cost allocation methodology description"
         reminder: "Do not assume the absence of other payers is sufficient cause for Medicaid to be the primary payer. Limit ambiguity about other potential federal funding sources. (For example, if no CHIP funds are being requested, include a statement in this section.)"
       quarterly:
-        title: moop moop - real text here plz
-        helpText: probably ought to describe what this - percent of federal share that the state wants each quarter, right?
+        title: Breakout of federal share by quarter
+        helpText: "In this section, indicate allocations of state personnel & contract resources in the current FFY by quarter."
         reminder:
         expenseNames:
           state: State personnel + non-personnel expenses

--- a/web/src/i18n/locales/en.yaml
+++ b/web/src/i18n/locales/en.yaml
@@ -344,10 +344,9 @@
       title: Federal Share by FFY Quarter
       helpText: ""
       expenseNames:
-          statePersonnel: Project state staff
-          expenses: Non-personnel
-          contractors: Contracted resources
-          combined: Total Enhanced FFP
+        state: State personnel + non-personnel expenses
+        contractor: Congrator resources
+        combined: Total enhanced FFP
     paymentsByFFYQuarter: 
       title: Incentive Payments by FFY Quarter
   assurancesAndCompliance: 

--- a/web/src/i18n/locales/en.yaml
+++ b/web/src/i18n/locales/en.yaml
@@ -20,7 +20,7 @@
     saveApdButtonText: Save APD
   apd: 
     title: "Program Summary"
-    helpText: "Provide an introduction for your state's program. clude context for your funding request by providing information such as current size of program, future vision, and how the program is positioned within the state. This information is similar to the content from the IAPD executive summary template section."
+    helpText: "Provide an introduction for your state's program. Include context for your funding request by providing information such as current size of program, future vision, and how the program is positioned within the state. This information is similar to the content from the IAPD executive summary template section."
     stateProfile:
       title: State Profile Contact Information
       helpText: In this section, provide information about relevant state contacts. You will only need to input this information once. If we have information on record, it will be listed below. Ensure the director's name and office address are listed correctly.

--- a/web/src/i18n/locales/en.yaml
+++ b/web/src/i18n/locales/en.yaml
@@ -258,6 +258,14 @@
       methodology: 
         title: "Cost allocation methodology description"
         reminder: "Do not assume the absence of other payers is sufficient cause for Medicaid to be the primary payer. Limit ambiguity about other potential federal funding sources. (For example, if no CHIP funds are being requested, include a statement in this section.)"
+      quarterly:
+        title: moop moop - real text here plz
+        helpText: probably ought to describe what this - percent of federal share that the state wants each quarter, right?
+        reminder:
+        expenseNames:
+          state: State personnel + non-personnel expenses
+          contractor: Congrator resources
+          combined: Total enhanced FFP
       otherFunding: 
         title: "Other funding description"
         helpText: "Account for any and all grant funding used to support this activity, and review the state Medicaid director Letter 10‐016 for examples of grants needed to be included."

--- a/web/src/i18n/locales/en.yaml
+++ b/web/src/i18n/locales/en.yaml
@@ -245,16 +245,12 @@
       noDataNotice: "It looks like you don’t have any additional costs for this activity."
     costAllocate: 
       title: "Cost Allocation"
-      helpText: "As specified in OMB Circular A‐87, a cost allocation plan must be included identifying all participants and their associated cost allocation to depict non‐Medicaid activities and non‐Medicaid FTEs participating in this project, if any.
+      helpText: "As specified in Office of Management and Budget (OMB) Circular A-87, a cost allocation plan must be included that identifies all participants and their associated cost allocation to depict non-Medicaid activities and non-Medicaid FTEs participating in this project (if any):
       
-      
-      HITECH cost allocation formulas should be based on the direct benefit to the Medicaid EHR Incentive Program, taking into account State projections of eligible Medicaid provider participation in the incentive program (leveraging actual data/experience as deemed appropriate).
-      
-      
-      Cost allocation must account for other available federal funding sources, the division of resources and activities across relevant payers, and the relative benefit to the State Medicaid program, among other factors.
-      
-      
-     Ensure cost allocations involve the timely and insured financial participation of all parties. States should demonstrate that other payers who stand to benefit are contributing their share, ideally from the beginning of the program/activity/service for which funding is being requested."
+      (1) CMS will work with states on an individual basis to determine the most appropriate cost allocation methodology. 
+      (2) HITECH cost allocation formulas should be based on the direct benefit to the Medicaid EHR incentive program, taking into account state projections of eligible Medicaid provider participation in the incentive program,
+      (3) Cost allocation must account for other available federal funding sources, the division of resources and activities across relevant payers, and the relative benefit to the state Medicaid program, among other factors,
+      (4) Cost allocations should be current and ensure financial participation of all parties so Medicaid funds are neither the sole contributor at the onset, nor the primary source of funding. Other payers who may benefit must contribute their share from the outset. The absence of ancillary payers is not sufficient cause for Medicaid to be primary payer."
       methodology: 
         title: "Cost allocation methodology description"
         reminder: "Do not assume the absence of other payers is sufficient cause for Medicaid to be the primary payer. Limit ambiguity about other potential federal funding sources. (For example, if no CHIP funds are being requested, include a statement in this section.)"

--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -498,7 +498,10 @@ export const getCategoryTotals = (entries, iteratee = x => x) => {
 };
 
 export const getActivityCategoryTotals = activity => ({
-  statePersonnel: getCategoryTotals(activity.statePersonnel, d => d.amt),
+  statePersonnel: getCategoryTotals(
+    activity.statePersonnel,
+    d => d.amt * d.perc / 100
+  ),
   contractors: getCategoryTotals(activity.contractorResources),
   expenses: getCategoryTotals(activity.expenses)
 });

--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -61,6 +61,19 @@ const costAllocationEntry = (other = 0, federal = 90, state = 10) => ({
   ffp: { federal, state }
 });
 
+const quarterlyFFPEntry = () =>
+  [1, 2, 3, 4].reduce(
+    (acc, quarter) => ({
+      ...acc,
+      [quarter]: {
+        state: 25,
+        contractors: 25,
+        combined: 25
+      }
+    }),
+    {}
+  );
+
 const newActivity = (
   id,
   { name = '', fundingSource = 'HIT', years = [], ...rest } = {}
@@ -100,6 +113,7 @@ const newActivity = (
     documentation: '',
     minimizeCost: ''
   },
+  quarterlyFFP: arrToObj(years, quarterlyFFPEntry()),
   years,
   meta: {
     expanded: false
@@ -334,7 +348,9 @@ const reducer = (state = initialState, action) => {
             costAllocation: fixupExpenses(
               activity.costAllocation,
               costAllocationEntry
-            )
+            ),
+            quarterlyFFP: () =>
+              fixupYears(activity.quarterlyFFP, quarterlyFFPEntry)
           };
         });
 
@@ -432,6 +448,10 @@ const reducer = (state = initialState, action) => {
             mitigation: a.standardsAndConditions.mitigationStrategy || '',
             reporting: a.standardsAndConditions.reporting || ''
           },
+          quarterlyFFP: {
+            ...arrToObj(action.apd.years, quarterlyFFPEntry())
+          },
+
           meta: {
             expanded: false
           }

--- a/web/src/reducers/activities.test.js
+++ b/web/src/reducers/activities.test.js
@@ -109,6 +109,52 @@ describe('activities reducer', () => {
         id: 3
       }
     ],
+    quarterlyFFP: {
+      '2018': {
+        '1': {
+          combined: 25,
+          contractors: 25,
+          state: 25
+        },
+        '2': {
+          combined: 25,
+          contractors: 25,
+          state: 25
+        },
+        '3': {
+          combined: 25,
+          contractors: 25,
+          state: 25
+        },
+        '4': {
+          combined: 25,
+          contractors: 25,
+          state: 25
+        }
+      },
+      '2019': {
+        '1': {
+          combined: 25,
+          contractors: 25,
+          state: 25
+        },
+        '2': {
+          combined: 25,
+          contractors: 25,
+          state: 25
+        },
+        '3': {
+          combined: 25,
+          contractors: 25,
+          state: 25
+        },
+        '4': {
+          combined: 25,
+          contractors: 25,
+          state: 25
+        }
+      }
+    },
     years: ['2018', '2019']
   };
 
@@ -395,6 +441,31 @@ describe('activities reducer', () => {
                 }
               }
             ],
+            quarterlyFFP: {
+              ...stateWithOne.byId['1'].quarterlyFFP,
+              '2020': {
+                '1': {
+                  combined: 25,
+                  contractors: 25,
+                  state: 25
+                },
+                '2': {
+                  combined: 25,
+                  contractors: 25,
+                  state: 25
+                },
+                '3': {
+                  combined: 25,
+                  contractors: 25,
+                  state: 25
+                },
+                '4': {
+                  combined: 25,
+                  contractors: 25,
+                  state: 25
+                }
+              }
+            },
             years: ['2018', '2019', '2020']
           }
         }
@@ -472,6 +543,10 @@ describe('activities reducer', () => {
                 }
               }
             ],
+            quarterlyFFP: {
+              '2018': stateWithOne.byId['1'].quarterlyFFP['2018'],
+              total: stateWithOne.byId['1'].quarterlyFFP.total
+            },
             years: ['2018']
           }
         }
@@ -736,6 +811,52 @@ describe('activities reducer', () => {
               mitigation: 'run away',
               modularity: 'lego blocks',
               reporting: 'moop moop'
+            },
+            quarterlyFFP: {
+              '2018': {
+                '1': {
+                  combined: 25,
+                  contractors: 25,
+                  state: 25
+                },
+                '2': {
+                  combined: 25,
+                  contractors: 25,
+                  state: 25
+                },
+                '3': {
+                  combined: 25,
+                  contractors: 25,
+                  state: 25
+                },
+                '4': {
+                  combined: 25,
+                  contractors: 25,
+                  state: 25
+                }
+              },
+              '2019': {
+                '1': {
+                  combined: 25,
+                  contractors: 25,
+                  state: 25
+                },
+                '2': {
+                  combined: 25,
+                  contractors: 25,
+                  state: 25
+                },
+                '3': {
+                  combined: 25,
+                  contractors: 25,
+                  state: 25
+                },
+                '4': {
+                  combined: 25,
+                  contractors: 25,
+                  state: 25
+                }
+              }
             },
             meta: { expanded: false }
           }

--- a/web/src/reducers/activities.test.js
+++ b/web/src/reducers/activities.test.js
@@ -898,15 +898,30 @@ describe('activities reducer', () => {
           { years: { '2018': 6, '2019': 60 } }
         ],
         statePersonnel: [
-          { years: { '2018': { amt: 3 }, '2019': { amt: 30 } } },
-          { years: { '2018': { amt: 6 }, '2019': { amt: 60 } } },
-          { years: { '2018': { amt: 9 }, '2019': { amt: 90 } } }
+          {
+            years: {
+              '2018': { amt: 3, perc: 40 },
+              '2019': { amt: 30, perc: 100 }
+            }
+          },
+          {
+            years: {
+              '2018': { amt: 6, perc: 55 },
+              '2019': { amt: 60, perc: 90 }
+            }
+          },
+          {
+            years: {
+              '2018': { amt: 9, perc: 99 },
+              '2019': { amt: 90, perc: 30 }
+            }
+          }
         ]
       })
     ).toEqual({
       contractors: { '2018': 6, '2019': 60 },
       expenses: { '2018': 12, '2019': 120 },
-      statePersonnel: { '2018': 18, '2019': 180 }
+      statePersonnel: { '2018': 13.41, '2019': 111 }
     });
   });
 
@@ -924,12 +939,27 @@ describe('activities reducer', () => {
           { years: { '2018': 6, '2019': 60 } }
         ],
         statePersonnel: [
-          { years: { '2018': { amt: 3 }, '2019': { amt: 30 } } },
-          { years: { '2018': { amt: 6 }, '2019': { amt: 60 } } },
-          { years: { '2018': { amt: 9 }, '2019': { amt: 90 } } }
+          {
+            years: {
+              '2018': { amt: 3, perc: 100 },
+              '2019': { amt: 30, perc: 80 }
+            }
+          },
+          {
+            years: {
+              '2018': { amt: 6, perc: 90 },
+              '2019': { amt: 60, perc: 100 }
+            }
+          },
+          {
+            years: {
+              '2018': { amt: 9, perc: 40 },
+              '2019': { amt: 90, perc: 10 }
+            }
+          }
         ],
         years: ['2018', '2019']
       })
-    ).toEqual({ '2018': 36, '2019': 360 });
+    ).toEqual({ '2018': 30, '2019': 273 });
   });
 });

--- a/web/src/reducers/budget.js
+++ b/web/src/reducers/budget.js
@@ -292,7 +292,7 @@ const buildBudget = wholeState => {
 
     // This is the percent of the federal share per fiscal quarter,
     // by expense type.  This is entered in the
-    // Activi
+    // ActivityQuarterlyBudgetSummary table
     const ffpPercents = activity.quarterlyFFP;
 
     // The grand total of the federal share of this activity's
@@ -385,14 +385,6 @@ const buildBudget = wholeState => {
       });
     });
   });
-
-  // newState.federalShareByFFYQuarter = {
-  //   hitAndHie: getFederalShareByFFYQuarter(
-  //     newState.quarterly.hitAndHie,
-  //     newState.hitAndHie
-  //   ),
-  //   mmis: getFederalShareByFFYQuarter(newState.quarterly.mmis, newState.mmis)
-  // };
 
   return newState;
 };

--- a/web/src/reducers/budget.js
+++ b/web/src/reducers/budget.js
@@ -91,6 +91,7 @@ const initQuarterly = years => ({
 });
 
 const initialState = years => ({
+  activities: {},
   combined: getFundingSourcesByYear(years),
   federalShareByFFYQuarter: {
     hitAndHie: defaultFederalShare(years),
@@ -149,6 +150,7 @@ const collapseAllAmounts = activity => {
   return totals;
 };
 
+// This must be recomputed. Based on federal share by activity per quarter
 const getFederalShareByFFYQuarter = (quartersByFFY, fundingSource) =>
   Object.entries(quartersByFFY).reduce(
     (accum, [ffy, quarters]) => ({
@@ -218,6 +220,7 @@ const getTotalsForActivity = activity => {
       });
 
       return {
+        raw: () => collapsed,
         totals: () => {
           const total = { total: 0, federal: 0, state: 0 };
           Object.values(collapsed).forEach(year => {
@@ -302,6 +305,7 @@ const buildBudget = wholeState => {
   const activityEntries = activities(wholeState);
 
   activityEntries.forEach(activity => {
+    newState.activities[activity.id] = {};
     const totaller = getTotalsForActivity(activity);
 
     budgetInputs.forEach(({ type, value, target }) => {
@@ -310,6 +314,92 @@ const buildBudget = wholeState => {
         .totals()
         .merge(newState, target);
     });
+
+    // Calculate total state expenses for this activity.  That is,
+    // state personnel * FTE% plus non-personnel expenses, per
+    // fiscal year.
+    const stateExpenses = totaller
+      .collapse('statePersonnel', year => +year.amt * +year.perc / 100)
+      .raw();
+    const expenses = totaller.collapse('expenses').raw();
+    Object.entries(stateExpenses).forEach(([year, values]) => {
+      Object.keys(values).forEach(key => {
+        stateExpenses[year][key] += expenses[year][key];
+      });
+    });
+
+    // Same with contractor expenses, but this one is straightforward.
+    const contractorExpenses = totaller.collapse('contractorResources').raw();
+
+    // This is the percent of the federal share per fiscal quarter,
+    // by expense type.  This is entered in the
+    // Activi
+    const ffpPercents = activity.quarterlyFFP;
+
+    // The grand total of the federal share of this activity's
+    // state and contractor expenses, across all quarters
+    // and fiscal years
+    const total = { state: 0, contractors: 0, combined: 0 };
+
+    newState.activities[activity.id].quarterlyFFP = Object.keys(
+      stateExpenses
+    ).reduce(
+      (ffyCumulate, year) => ({
+        ...ffyCumulate,
+        [year]: [1, 2, 3, 4].reduce(
+          (quarterCumulatve, quarter) => {
+            // The federal percent for this FFY, per quarter
+            const ffyQuarterPct = ffpPercents[year][quarter];
+
+            // These are the federal shares of these expenses
+            // for the fiscal quarter.  The budget reducer
+            // stores percentages as 0-1, so we need to
+            // convert those here.
+
+            const statePct = ffyQuarterPct.state / 100;
+            const state = stateExpenses[year].federal * statePct;
+
+            const contractorsPct = ffyQuarterPct.contractors / 100;
+            const contractors =
+              contractorExpenses[year].federal * contractorsPct;
+
+            const combined = state + contractors;
+
+            // Capture this in the grand total...
+            total.state += state;
+            total.contractors += contractors;
+            total.combined += combined;
+
+            // ...and in the FFY subtotal
+            const { subtotal } = quarterCumulatve;
+            subtotal.state.dollars += state;
+            subtotal.state.percent += statePct;
+            subtotal.contractors.dollars += contractors;
+            subtotal.contractors.percent += contractorsPct;
+            subtotal.combined.dollars += combined;
+
+            return {
+              ...quarterCumulatve,
+              [quarter]: {
+                state: { dollars: state, percent: statePct },
+                contractors: { dollars: contractors, percent: contractorsPct },
+                combined: { dollars: combined, percent: 0 }
+              },
+              subtotal
+            };
+          },
+          {
+            subtotal: {
+              state: { dollars: 0, percent: 0 },
+              contractors: { dollars: 0, percent: 0 },
+              combined: { dollars: 0, percent: 0 }
+            }
+          }
+        )
+      }),
+      {}
+    );
+    newState.activities[activity.id].quarterlyFFP.total = total;
   });
 
   getTotalsForFundingSource(newState, 'hie');

--- a/web/src/reducers/budget.test.js
+++ b/web/src/reducers/budget.test.js
@@ -265,196 +265,414 @@ describe('budget reducer', () => {
         }
       })
     ).toEqual({
+      activities: {
+        hieOne: {
+          quarterlyFFP: {
+            '1931': {
+              '1': {
+                state: { dollars: 918, percent: 0.3 },
+                contractors: { dollars: 720, percent: 0.4 },
+                combined: { dollars: 1638, percent: 0 }
+              },
+              '2': {
+                state: { dollars: 612, percent: 0.2 },
+                contractors: { dollars: 360, percent: 0.2 },
+                combined: { dollars: 972, percent: 0 }
+              },
+              '3': {
+                state: { dollars: 1224, percent: 0.4 },
+                contractors: { dollars: 540, percent: 0.3 },
+                combined: { dollars: 1764, percent: 0 }
+              },
+              '4': {
+                state: { dollars: 306, percent: 0.1 },
+                contractors: { dollars: 180, percent: 0.1 },
+                combined: { dollars: 486, percent: 0 }
+              },
+              subtotal: {
+                state: { dollars: 3060, percent: 1 },
+                contractors: { dollars: 1800, percent: 1.0000000000000002 },
+                combined: { dollars: 4860, percent: 0 }
+              }
+            },
+            '1932': {
+              '1': {
+                state: { dollars: 720, percent: 0.25 },
+                contractors: { dollars: 900, percent: 0.5 },
+                combined: { dollars: 1620, percent: 0 }
+              },
+              '2': {
+                state: { dollars: 720, percent: 0.25 },
+                contractors: { dollars: 360, percent: 0.2 },
+                combined: { dollars: 1080, percent: 0 }
+              },
+              '3': {
+                state: { dollars: 720, percent: 0.25 },
+                contractors: { dollars: 360, percent: 0.2 },
+                combined: { dollars: 1080, percent: 0 }
+              },
+              '4': {
+                state: { dollars: 720, percent: 0.25 },
+                contractors: { dollars: 180, percent: 0.1 },
+                combined: { dollars: 900, percent: 0 }
+              },
+              subtotal: {
+                state: { dollars: 2880, percent: 1 },
+                contractors: { dollars: 1800, percent: 0.9999999999999999 },
+                combined: { dollars: 4680, percent: 0 }
+              }
+            },
+            '1933': {
+              '1': {
+                state: { dollars: 243, percent: 0.1 },
+                contractors: { dollars: 720, percent: 0.4 },
+                combined: { dollars: 963, percent: 0 }
+              },
+              '2': {
+                state: { dollars: 486, percent: 0.2 },
+                contractors: { dollars: 540, percent: 0.3 },
+                combined: { dollars: 1026, percent: 0 }
+              },
+              '3': {
+                state: { dollars: 729, percent: 0.3 },
+                contractors: { dollars: 360, percent: 0.2 },
+                combined: { dollars: 1089, percent: 0 }
+              },
+              '4': {
+                state: { dollars: 972, percent: 0.4 },
+                contractors: { dollars: 180, percent: 0.1 },
+                combined: { dollars: 1152, percent: 0 }
+              },
+              subtotal: {
+                state: { dollars: 2430, percent: 1 },
+                contractors: { dollars: 1800, percent: 0.9999999999999999 },
+                combined: { dollars: 4230, percent: 0 }
+              }
+            },
+            total: { state: 8370, contractors: 5400, combined: 13770 }
+          }
+        },
+        hieTwo: {
+          quarterlyFFP: {
+            '1931': {
+              '1': {
+                state: { dollars: 450, percent: 0.25 },
+                contractors: { dollars: 450, percent: 0.5 },
+                combined: { dollars: 900, percent: 0 }
+              },
+              '2': {
+                state: { dollars: 450, percent: 0.25 },
+                contractors: { dollars: 180, percent: 0.2 },
+                combined: { dollars: 630, percent: 0 }
+              },
+              '3': {
+                state: { dollars: 450, percent: 0.25 },
+                contractors: { dollars: 180, percent: 0.2 },
+                combined: { dollars: 630, percent: 0 }
+              },
+              '4': {
+                state: { dollars: 450, percent: 0.25 },
+                contractors: { dollars: 90, percent: 0.1 },
+                combined: { dollars: 540, percent: 0 }
+              },
+              subtotal: {
+                state: { dollars: 1800, percent: 1 },
+                contractors: { dollars: 900, percent: 0.9999999999999999 },
+                combined: { dollars: 2700, percent: 0 }
+              }
+            },
+            '1932': {
+              '1': {
+                state: { dollars: 540, percent: 0.3 },
+                contractors: { dollars: 360, percent: 0.4 },
+                combined: { dollars: 900, percent: 0 }
+              },
+              '2': {
+                state: { dollars: 360, percent: 0.2 },
+                contractors: { dollars: 180, percent: 0.2 },
+                combined: { dollars: 540, percent: 0 }
+              },
+              '3': {
+                state: { dollars: 720, percent: 0.4 },
+                contractors: { dollars: 270, percent: 0.3 },
+                combined: { dollars: 990, percent: 0 }
+              },
+              '4': {
+                state: { dollars: 180, percent: 0.1 },
+                contractors: { dollars: 90, percent: 0.1 },
+                combined: { dollars: 270, percent: 0 }
+              },
+              subtotal: {
+                state: { dollars: 1800, percent: 1 },
+                contractors: { dollars: 900, percent: 1.0000000000000002 },
+                combined: { dollars: 2700, percent: 0 }
+              }
+            },
+            '1933': {
+              '1': {
+                state: { dollars: 180, percent: 0.1 },
+                contractors: { dollars: 360, percent: 0.4 },
+                combined: { dollars: 540, percent: 0 }
+              },
+              '2': {
+                state: { dollars: 360, percent: 0.2 },
+                contractors: { dollars: 270, percent: 0.3 },
+                combined: { dollars: 630, percent: 0 }
+              },
+              '3': {
+                state: { dollars: 540, percent: 0.3 },
+                contractors: { dollars: 180, percent: 0.2 },
+                combined: { dollars: 720, percent: 0 }
+              },
+              '4': {
+                state: { dollars: 720, percent: 0.4 },
+                contractors: { dollars: 90, percent: 0.1 },
+                combined: { dollars: 810, percent: 0 }
+              },
+              subtotal: {
+                state: { dollars: 1800, percent: 1 },
+                contractors: { dollars: 900, percent: 0.9999999999999999 },
+                combined: { dollars: 2700, percent: 0 }
+              }
+            },
+            total: { state: 5400, contractors: 2700, combined: 8100 }
+          }
+        },
+        hitOne: {
+          quarterlyFFP: {
+            '1931': {
+              '1': {
+                state: { dollars: 180, percent: 0.1 },
+                contractors: { dollars: 360, percent: 0.4 },
+                combined: { dollars: 540, percent: 0 }
+              },
+              '2': {
+                state: { dollars: 360, percent: 0.2 },
+                contractors: { dollars: 270, percent: 0.3 },
+                combined: { dollars: 630, percent: 0 }
+              },
+              '3': {
+                state: { dollars: 540, percent: 0.3 },
+                contractors: { dollars: 180, percent: 0.2 },
+                combined: { dollars: 720, percent: 0 }
+              },
+              '4': {
+                state: { dollars: 720, percent: 0.4 },
+                contractors: { dollars: 90, percent: 0.1 },
+                combined: { dollars: 810, percent: 0 }
+              },
+              subtotal: {
+                state: { dollars: 1800, percent: 1 },
+                contractors: { dollars: 900, percent: 0.9999999999999999 },
+                combined: { dollars: 2700, percent: 0 }
+              }
+            },
+            '1932': {
+              '1': {
+                state: { dollars: 450, percent: 0.25 },
+                contractors: { dollars: 450, percent: 0.5 },
+                combined: { dollars: 900, percent: 0 }
+              },
+              '2': {
+                state: { dollars: 450, percent: 0.25 },
+                contractors: { dollars: 180, percent: 0.2 },
+                combined: { dollars: 630, percent: 0 }
+              },
+              '3': {
+                state: { dollars: 450, percent: 0.25 },
+                contractors: { dollars: 180, percent: 0.2 },
+                combined: { dollars: 630, percent: 0 }
+              },
+              '4': {
+                state: { dollars: 450, percent: 0.25 },
+                contractors: { dollars: 90, percent: 0.1 },
+                combined: { dollars: 540, percent: 0 }
+              },
+              subtotal: {
+                state: { dollars: 1800, percent: 1 },
+                contractors: { dollars: 900, percent: 0.9999999999999999 },
+                combined: { dollars: 2700, percent: 0 }
+              }
+            },
+            '1933': {
+              '1': {
+                state: { dollars: 360, percent: 0.3 },
+                contractors: { dollars: 240, percent: 0.4 },
+                combined: { dollars: 600, percent: 0 }
+              },
+              '2': {
+                state: { dollars: 240, percent: 0.2 },
+                contractors: { dollars: 120, percent: 0.2 },
+                combined: { dollars: 360, percent: 0 }
+              },
+              '3': {
+                state: { dollars: 480, percent: 0.4 },
+                contractors: { dollars: 180, percent: 0.3 },
+                combined: { dollars: 660, percent: 0 }
+              },
+              '4': {
+                state: { dollars: 120, percent: 0.1 },
+                contractors: { dollars: 180, percent: 0.3 },
+                combined: { dollars: 300, percent: 0 }
+              },
+              subtotal: {
+                state: { dollars: 1200, percent: 1 },
+                contractors: { dollars: 720, percent: 1.2000000000000002 },
+                combined: { dollars: 1920, percent: 0 }
+              }
+            },
+            total: { state: 4800, contractors: 2520, combined: 7320 }
+          }
+        },
+        mmisOne: {
+          quarterlyFFP: {
+            '1931': {
+              '1': {
+                state: { dollars: 45, percent: 0.1 },
+                contractors: { dollars: 120, percent: 0.4 },
+                combined: { dollars: 165, percent: 0 }
+              },
+              '2': {
+                state: { dollars: 90, percent: 0.2 },
+                contractors: { dollars: 90, percent: 0.3 },
+                combined: { dollars: 180, percent: 0 }
+              },
+              '3': {
+                state: { dollars: 135, percent: 0.3 },
+                contractors: { dollars: 60, percent: 0.2 },
+                combined: { dollars: 195, percent: 0 }
+              },
+              '4': {
+                state: { dollars: 180, percent: 0.4 },
+                contractors: { dollars: 30, percent: 0.1 },
+                combined: { dollars: 210, percent: 0 }
+              },
+              subtotal: {
+                state: { dollars: 450, percent: 1 },
+                contractors: { dollars: 300, percent: 0.9999999999999999 },
+                combined: { dollars: 750, percent: 0 }
+              }
+            },
+            '1932': {
+              '1': {
+                state: { dollars: 300, percent: 0.3 },
+                contractors: { dollars: 200, percent: 0.4 },
+                combined: { dollars: 500, percent: 0 }
+              },
+              '2': {
+                state: { dollars: 200, percent: 0.2 },
+                contractors: { dollars: 100, percent: 0.2 },
+                combined: { dollars: 300, percent: 0 }
+              },
+              '3': {
+                state: { dollars: 400, percent: 0.4 },
+                contractors: { dollars: 150, percent: 0.3 },
+                combined: { dollars: 550, percent: 0 }
+              },
+              '4': {
+                state: { dollars: 100, percent: 0.1 },
+                contractors: { dollars: 150, percent: 0.3 },
+                combined: { dollars: 250, percent: 0 }
+              },
+              subtotal: {
+                state: { dollars: 1000, percent: 1 },
+                contractors: { dollars: 600, percent: 1.2000000000000002 },
+                combined: { dollars: 1600, percent: 0 }
+              }
+            },
+            '1933': {
+              '1': {
+                state: { dollars: 247.5, percent: 0.25 },
+                contractors: { dollars: 450, percent: 0.5 },
+                combined: { dollars: 697.5, percent: 0 }
+              },
+              '2': {
+                state: { dollars: 247.5, percent: 0.25 },
+                contractors: { dollars: 180, percent: 0.2 },
+                combined: { dollars: 427.5, percent: 0 }
+              },
+              '3': {
+                state: { dollars: 247.5, percent: 0.25 },
+                contractors: { dollars: 180, percent: 0.2 },
+                combined: { dollars: 427.5, percent: 0 }
+              },
+              '4': {
+                state: { dollars: 247.5, percent: 0.25 },
+                contractors: { dollars: 90, percent: 0.1 },
+                combined: { dollars: 337.5, percent: 0 }
+              },
+              subtotal: {
+                state: { dollars: 990, percent: 1 },
+                contractors: { dollars: 900, percent: 0.9999999999999999 },
+                combined: { dollars: 1890, percent: 0 }
+              }
+            },
+            total: { state: 2440, contractors: 1800, combined: 4240 }
+          }
+        }
+      },
       combined: {
-        '1931': { federal: 11550, state: 1950, total: 14500 },
-        '1932': { federal: 12300, state: 1700.0100000000002, total: 15000 },
-        '1933': { federal: 11790, state: 1310.01, total: 14100 },
-        total: { federal: 35640, state: 4960.02, total: 43600 }
+        '1931': { federal: 11010, state: 1890, total: 13900 },
+        '1932': { federal: 11580, state: 1620.0100000000002, total: 14200 },
+        '1933': { federal: 10620, state: 1180.0099999999998, total: 12800 },
+        total: { federal: 33210, state: 4690.02, total: 40900 }
       },
       federalShareByFFYQuarter: {
         hitAndHie: {
           '1931': {
-            '1': {
-              contractors: 1530,
-              state: 1548,
-              combined: 3078
-            },
-            '2': {
-              contractors: 810,
-              state: 1422,
-              combined: 2232
-            },
-            '3': {
-              contractors: 900,
-              state: 2214,
-              combined: 3114
-            },
-            '4': {
-              contractors: 360,
-              state: 1476,
-              combined: 1836
-            },
-            subtotal: {
-              contractors: 3600,
-              state: 6660,
-              combined: 10260
-            }
+            '1': { contractors: 1530, state: 1548, combined: 3078 },
+            '2': { contractors: 810, state: 1422, combined: 2232 },
+            '3': { contractors: 900, state: 2214, combined: 3114 },
+            '4': { contractors: 360, state: 1476, combined: 1836 },
+            subtotal: { contractors: 3600, state: 6660, combined: 10260 }
           },
           '1932': {
-            '1': {
-              contractors: 1710,
-              state: 1710,
-              combined: 3420
-            },
-            '2': {
-              contractors: 720,
-              state: 1530,
-              combined: 2250
-            },
-            '3': {
-              contractors: 810,
-              state: 1890,
-              combined: 2700
-            },
-            '4': {
-              contractors: 360,
-              state: 1350,
-              combined: 1710
-            },
-            subtotal: {
-              contractors: 3600,
-              state: 6480,
-              combined: 10080
-            }
+            '1': { contractors: 1710, state: 1710, combined: 3420 },
+            '2': { contractors: 720, state: 1530, combined: 2250 },
+            '3': { contractors: 810, state: 1890, combined: 2700 },
+            '4': { contractors: 360, state: 1350, combined: 1710 },
+            subtotal: { contractors: 3600, state: 6480, combined: 10080 }
           },
           '1933': {
-            '1': {
-              contractors: 900,
-              state: 900,
-              combined: 2700
-            },
-            '2': {
-              contractors: 900,
-              state: 900,
-              combined: 2700
-            },
-            '3': {
-              contractors: 900,
-              state: 900,
-              combined: 2700
-            },
-            '4': {
-              contractors: 900,
-              state: 900,
-              combined: 2700
-            },
-            subtotal: {
-              contractors: 900,
-              state: 900,
-              combined: 2700
-            }
+            '1': { contractors: 1320, state: 783, combined: 2103 },
+            '2': { contractors: 930, state: 1086, combined: 2016 },
+            '3': { contractors: 720, state: 1749, combined: 2469 },
+            '4': { contractors: 450, state: 1812, combined: 2262 },
+            subtotal: { contractors: 3420, state: 5430, combined: 8850 }
           },
-          total: {
-            contractors: 900,
-            state: 900,
-            combined: 2700
-          }
+          total: { contractors: 21240, state: 37140, combined: 58380 }
         },
         mmis: {
           '1931': {
-            '1': {
-              contractors: 900,
-              state: 900,
-              combined: 2700
-            },
-            '2': {
-              contractors: 900,
-              state: 900,
-              combined: 2700
-            },
-            '3': {
-              contractors: 900,
-              state: 900,
-              combined: 2700
-            },
-            '4': {
-              contractors: 900,
-              state: 900,
-              combined: 2700
-            },
-            subtotal: {
-              contractors: 900,
-              state: 900,
-              combined: 2700
-            }
+            '1': { contractors: 120, state: 45, combined: 165 },
+            '2': { contractors: 90, state: 90, combined: 180 },
+            '3': { contractors: 60, state: 135, combined: 195 },
+            '4': { contractors: 30, state: 180, combined: 210 },
+            subtotal: { contractors: 300, state: 450, combined: 750 }
           },
           '1932': {
-            '1': {
-              contractors: 900,
-              state: 900,
-              combined: 2700
-            },
-            '2': {
-              contractors: 900,
-              state: 900,
-              combined: 2700
-            },
-            '3': {
-              contractors: 900,
-              state: 900,
-              combined: 2700
-            },
-            '4': {
-              contractors: 900,
-              state: 900,
-              combined: 2700
-            },
-            subtotal: {
-              contractors: 900,
-              state: 900,
-              combined: 2700
-            }
+            '1': { contractors: 200, state: 300, combined: 500 },
+            '2': { contractors: 100, state: 200, combined: 300 },
+            '3': { contractors: 150, state: 400, combined: 550 },
+            '4': { contractors: 150, state: 100, combined: 250 },
+            subtotal: { contractors: 600, state: 1000, combined: 1600 }
           },
           '1933': {
-            '1': {
-              contractors: 900,
-              state: 900,
-              combined: 2700
-            },
-            '2': {
-              contractors: 900,
-              state: 900,
-              combined: 2700
-            },
-            '3': {
-              contractors: 900,
-              state: 900,
-              combined: 2700
-            },
-            '4': {
-              contractors: 900,
-              state: 900,
-              combined: 2700
-            },
-            subtotal: {
-              contractors: 900,
-              state: 900,
-              combined: 2700
-            }
+            '1': { contractors: 450, state: 247.5, combined: 697.5 },
+            '2': { contractors: 180, state: 247.5, combined: 427.5 },
+            '3': { contractors: 180, state: 247.5, combined: 427.5 },
+            '4': { contractors: 90, state: 247.5, combined: 337.5 },
+            subtotal: { contractors: 900, state: 990, combined: 1890 }
           },
-          total: {
-            contractors: 900,
-            state: 900,
-            combined: 2700
-          }
+          total: { contractors: 3600, state: 4880, combined: 8480 }
         }
       },
       hie: {
         combined: {
-          '1931': { federal: 8100, state: 900, total: 9000 },
-          '1932': { federal: 8100, state: 900, total: 9000 },
-          '1933': { federal: 8100, state: 900, total: 9000 },
-          total: { federal: 24300, state: 2700, total: 27000 }
+          '1931': { federal: 7560, state: 840, total: 8400 },
+          '1932': { federal: 7380, state: 820, total: 8200 },
+          '1933': { federal: 6930, state: 770, total: 7700 },
+          total: { federal: 21870, state: 2430, total: 24300 }
         },
         contractors: {
           '1931': { federal: 2700, state: 300, total: 3000 },
@@ -469,10 +687,10 @@ describe('budget reducer', () => {
           total: { federal: 8100, state: 900, total: 9000 }
         },
         statePersonnel: {
-          '1931': { federal: 2700, state: 300, total: 3000 },
-          '1932': { federal: 2700, state: 300, total: 3000 },
-          '1933': { federal: 2700, state: 300, total: 3000 },
-          total: { federal: 8100, state: 900, total: 9000 }
+          '1931': { federal: 2160, state: 240, total: 2400 },
+          '1932': { federal: 1980, state: 220, total: 2200 },
+          '1933': { federal: 1530, state: 170, total: 1700 },
+          total: { federal: 5670, state: 630, total: 6300 }
         }
       },
       hit: {
@@ -503,10 +721,10 @@ describe('budget reducer', () => {
       },
       hitAndHie: {
         combined: {
-          '1931': { federal: 10800, state: 1200, total: 12000 },
-          '1932': { federal: 10800, state: 1200, total: 12000 },
-          '1933': { federal: 9900, state: 1100.01, total: 12000 },
-          total: { federal: 31500, state: 3500.01, total: 36000 }
+          '1931': { federal: 10260, state: 1140, total: 11400 },
+          '1932': { federal: 10080, state: 1120, total: 11200 },
+          '1933': { federal: 8730, state: 970.01, total: 10700 },
+          total: { federal: 29070, state: 3230.01, total: 33300 }
         },
         contractors: {
           '1931': { federal: 3600, state: 400, total: 4000 },
@@ -521,10 +739,10 @@ describe('budget reducer', () => {
           total: { federal: 10500, state: 1166.67, total: 12000 }
         },
         statePersonnel: {
-          '1931': { federal: 3600, state: 400, total: 4000 },
-          '1932': { federal: 3600, state: 400, total: 4000 },
-          '1933': { federal: 3300, state: 366.67, total: 4000 },
-          total: { federal: 10500, state: 1166.67, total: 12000 }
+          '1931': { federal: 3060, state: 340, total: 3400 },
+          '1932': { federal: 2880, state: 320, total: 3200 },
+          '1933': { federal: 2130, state: 236.67000000000002, total: 2700 },
+          total: { federal: 8070, state: 896.6700000000001, total: 9300 }
         }
       },
       mmis: {

--- a/web/src/reducers/budget.test.js
+++ b/web/src/reducers/budget.test.js
@@ -64,8 +64,6 @@ describe('budget reducer', () => {
   });
 
   it('computes new budget data from state', () => {
-    return;
-
     expect(
       budget(null, {
         type: UPDATE_BUDGET,
@@ -74,6 +72,7 @@ describe('budget reducer', () => {
           activities: {
             byId: {
               hieOne: {
+                id: 'hieOne',
                 fundingSource: 'HIE',
                 years: ['1931', '1932', '1933'],
                 costAllocation: {
@@ -93,20 +92,41 @@ describe('budget reducer', () => {
                   {
                     years: {
                       '1931': { amt: 1000, perc: 100 },
-                      '1932': { amt: 1000, perc: 100 },
-                      '1933': { amt: 1000, perc: 100 }
+                      '1932': { amt: 1000, perc: 70 },
+                      '1933': { amt: 1000, perc: 40 }
                     }
                   },
                   {
                     years: {
-                      '1931': { amt: 1000, perc: 100 },
-                      '1932': { amt: 1000, perc: 100 },
-                      '1933': { amt: 1000, perc: 100 }
+                      '1931': { amt: 1000, perc: 40 },
+                      '1932': { amt: 1000, perc: 50 },
+                      '1933': { amt: 1000, perc: 30 }
                     }
                   }
-                ]
+                ],
+                quarterlyFFP: {
+                  '1931': {
+                    '1': { state: 30, contractors: 40 },
+                    '2': { state: 20, contractors: 20 },
+                    '3': { state: 40, contractors: 30 },
+                    '4': { state: 10, contractors: 10 }
+                  },
+                  '1932': {
+                    '1': { state: 25, contractors: 50 },
+                    '2': { state: 25, contractors: 20 },
+                    '3': { state: 25, contractors: 20 },
+                    '4': { state: 25, contractors: 10 }
+                  },
+                  '1933': {
+                    '1': { state: 10, contractors: 40 },
+                    '2': { state: 20, contractors: 30 },
+                    '3': { state: 30, contractors: 20 },
+                    '4': { state: 40, contractors: 10 }
+                  }
+                }
               },
               hieTwo: {
+                id: 'hieTwo',
                 fundingSource: 'HIE',
                 years: ['1931', '1932', '1933'],
                 costAllocation: {
@@ -128,9 +148,30 @@ describe('budget reducer', () => {
                       '1933': { amt: 1000, perc: 100 }
                     }
                   }
-                ]
+                ],
+                quarterlyFFP: {
+                  '1931': {
+                    '1': { state: 25, contractors: 50 },
+                    '2': { state: 25, contractors: 20 },
+                    '3': { state: 25, contractors: 20 },
+                    '4': { state: 25, contractors: 10 }
+                  },
+                  '1932': {
+                    '1': { state: 30, contractors: 40 },
+                    '2': { state: 20, contractors: 20 },
+                    '3': { state: 40, contractors: 30 },
+                    '4': { state: 10, contractors: 10 }
+                  },
+                  '1933': {
+                    '1': { state: 10, contractors: 40 },
+                    '2': { state: 20, contractors: 30 },
+                    '3': { state: 30, contractors: 20 },
+                    '4': { state: 40, contractors: 10 }
+                  }
+                }
               },
               hitOne: {
+                id: 'hitOne',
                 fundingSource: 'HIT',
                 years: ['1931', '1932', '1933'],
                 costAllocation: {
@@ -152,9 +193,30 @@ describe('budget reducer', () => {
                       '1933': { amt: 1000, perc: 100 }
                     }
                   }
-                ]
+                ],
+                quarterlyFFP: {
+                  '1931': {
+                    '1': { state: 10, contractors: 40 },
+                    '2': { state: 20, contractors: 30 },
+                    '3': { state: 30, contractors: 20 },
+                    '4': { state: 40, contractors: 10 }
+                  },
+                  '1932': {
+                    '1': { state: 25, contractors: 50 },
+                    '2': { state: 25, contractors: 20 },
+                    '3': { state: 25, contractors: 20 },
+                    '4': { state: 25, contractors: 10 }
+                  },
+                  '1933': {
+                    '1': { state: 30, contractors: 40 },
+                    '2': { state: 20, contractors: 20 },
+                    '3': { state: 40, contractors: 30 },
+                    '4': { state: 10, contractors: 30 }
+                  }
+                }
               },
               mmisOne: {
+                id: 'mmisOne',
                 fundingSource: 'MMIS',
                 years: ['1931', '1932', '1933'],
                 costAllocation: {
@@ -176,7 +238,27 @@ describe('budget reducer', () => {
                       '1933': { amt: 1000, perc: 10 }
                     }
                   }
-                ]
+                ],
+                quarterlyFFP: {
+                  '1931': {
+                    '1': { state: 10, contractors: 40 },
+                    '2': { state: 20, contractors: 30 },
+                    '3': { state: 30, contractors: 20 },
+                    '4': { state: 40, contractors: 10 }
+                  },
+                  '1932': {
+                    '1': { state: 30, contractors: 40 },
+                    '2': { state: 20, contractors: 20 },
+                    '3': { state: 40, contractors: 30 },
+                    '4': { state: 10, contractors: 30 }
+                  },
+                  '1933': {
+                    '1': { state: 25, contractors: 50 },
+                    '2': { state: 25, contractors: 20 },
+                    '3': { state: 25, contractors: 20 },
+                    '4': { state: 25, contractors: 10 }
+                  }
+                }
               }
             }
           }
@@ -193,233 +275,177 @@ describe('budget reducer', () => {
         hitAndHie: {
           '1931': {
             '1': {
-              percent: 25,
-              contractors: 900,
-              expenses: 900,
-              statePersonnel: 900,
-              total: 2700
+              contractors: 1530,
+              state: 1548,
+              combined: 3078
             },
             '2': {
-              percent: 25,
-              contractors: 900,
-              expenses: 900,
-              statePersonnel: 900,
-              total: 2700
+              contractors: 810,
+              state: 1422,
+              combined: 2232
             },
             '3': {
-              percent: 25,
               contractors: 900,
-              expenses: 900,
-              statePersonnel: 900,
-              total: 2700
+              state: 2214,
+              combined: 3114
             },
             '4': {
-              percent: 25,
-              contractors: 900,
-              expenses: 900,
-              statePersonnel: 900,
-              total: 2700
+              contractors: 360,
+              state: 1476,
+              combined: 1836
             },
             subtotal: {
               contractors: 3600,
-              expenses: 3600,
-              statePersonnel: 3600,
-              total: 10800
+              state: 6660,
+              combined: 10260
             }
           },
           '1932': {
             '1': {
-              percent: 25,
-              contractors: 900,
-              expenses: 900,
-              statePersonnel: 900,
-              total: 2700
+              contractors: 1710,
+              state: 1710,
+              combined: 3420
             },
             '2': {
-              percent: 25,
-              contractors: 900,
-              expenses: 900,
-              statePersonnel: 900,
-              total: 2700
+              contractors: 720,
+              state: 1530,
+              combined: 2250
             },
             '3': {
-              percent: 25,
-              contractors: 900,
-              expenses: 900,
-              statePersonnel: 900,
-              total: 2700
+              contractors: 810,
+              state: 1890,
+              combined: 2700
             },
             '4': {
-              percent: 25,
-              contractors: 900,
-              expenses: 900,
-              statePersonnel: 900,
-              total: 2700
+              contractors: 360,
+              state: 1350,
+              combined: 1710
             },
             subtotal: {
               contractors: 3600,
-              expenses: 3600,
-              statePersonnel: 3600,
-              total: 10800
+              state: 6480,
+              combined: 10080
             }
           },
           '1933': {
             '1': {
-              percent: 25,
-              contractors: 825,
-              expenses: 825,
-              statePersonnel: 825,
-              total: 2475
+              contractors: 900,
+              state: 900,
+              combined: 2700
             },
             '2': {
-              percent: 25,
-              contractors: 825,
-              expenses: 825,
-              statePersonnel: 825,
-              total: 2475
+              contractors: 900,
+              state: 900,
+              combined: 2700
             },
             '3': {
-              percent: 25,
-              contractors: 825,
-              expenses: 825,
-              statePersonnel: 825,
-              total: 2475
+              contractors: 900,
+              state: 900,
+              combined: 2700
             },
             '4': {
-              percent: 25,
-              contractors: 825,
-              expenses: 825,
-              statePersonnel: 825,
-              total: 2475
+              contractors: 900,
+              state: 900,
+              combined: 2700
             },
             subtotal: {
-              contractors: 3300,
-              expenses: 3300,
-              statePersonnel: 3300,
-              total: 9900
+              contractors: 900,
+              state: 900,
+              combined: 2700
             }
           },
           total: {
-            contractors: 10500,
-            expenses: 10500,
-            statePersonnel: 10500,
-            total: 31500
+            contractors: 900,
+            state: 900,
+            combined: 2700
           }
         },
         mmis: {
           '1931': {
             '1': {
-              percent: 25,
-              contractors: 75,
-              expenses: 75,
-              statePersonnel: 37.5,
-              total: 187.5
+              contractors: 900,
+              state: 900,
+              combined: 2700
             },
             '2': {
-              percent: 25,
-              contractors: 75,
-              expenses: 75,
-              statePersonnel: 37.5,
-              total: 187.5
+              contractors: 900,
+              state: 900,
+              combined: 2700
             },
             '3': {
-              percent: 25,
-              contractors: 75,
-              expenses: 75,
-              statePersonnel: 37.5,
-              total: 187.5
+              contractors: 900,
+              state: 900,
+              combined: 2700
             },
             '4': {
-              percent: 25,
-              contractors: 75,
-              expenses: 75,
-              statePersonnel: 37.5,
-              total: 187.5
+              contractors: 900,
+              state: 900,
+              combined: 2700
             },
             subtotal: {
-              contractors: 300,
-              expenses: 300,
-              statePersonnel: 150,
-              total: 750
+              contractors: 900,
+              state: 900,
+              combined: 2700
             }
           },
           '1932': {
             '1': {
-              percent: 25,
-              contractors: 125,
-              expenses: 125,
-              statePersonnel: 125,
-              total: 375
+              contractors: 900,
+              state: 900,
+              combined: 2700
             },
             '2': {
-              percent: 25,
-              contractors: 125,
-              expenses: 125,
-              statePersonnel: 125,
-              total: 375
+              contractors: 900,
+              state: 900,
+              combined: 2700
             },
             '3': {
-              percent: 25,
-              contractors: 125,
-              expenses: 125,
-              statePersonnel: 125,
-              total: 375
+              contractors: 900,
+              state: 900,
+              combined: 2700
             },
             '4': {
-              percent: 25,
-              contractors: 125,
-              expenses: 125,
-              statePersonnel: 125,
-              total: 375
+              contractors: 900,
+              state: 900,
+              combined: 2700
             },
             subtotal: {
-              contractors: 500,
-              expenses: 500,
-              statePersonnel: 500,
-              total: 1500
+              contractors: 900,
+              state: 900,
+              combined: 2700
             }
           },
           '1933': {
             '1': {
-              percent: 25,
-              contractors: 225,
-              expenses: 225,
-              statePersonnel: 22.5,
-              total: 472.5
+              contractors: 900,
+              state: 900,
+              combined: 2700
             },
             '2': {
-              percent: 25,
-              contractors: 225,
-              expenses: 225,
-              statePersonnel: 22.5,
-              total: 472.5
+              contractors: 900,
+              state: 900,
+              combined: 2700
             },
             '3': {
-              percent: 25,
-              contractors: 225,
-              expenses: 225,
-              statePersonnel: 22.5,
-              total: 472.5
+              contractors: 900,
+              state: 900,
+              combined: 2700
             },
             '4': {
-              percent: 25,
-              contractors: 225,
-              expenses: 225,
-              statePersonnel: 22.5,
-              total: 472.5
+              contractors: 900,
+              state: 900,
+              combined: 2700
             },
             subtotal: {
               contractors: 900,
-              expenses: 900,
-              statePersonnel: 90,
-              total: 1890
+              state: 900,
+              combined: 2700
             }
           },
           total: {
-            contractors: 1700,
-            expenses: 1700,
-            statePersonnel: 740,
-            total: 4140
+            contractors: 900,
+            state: 900,
+            combined: 2700
           }
         }
       },

--- a/web/src/reducers/budget.test.js
+++ b/web/src/reducers/budget.test.js
@@ -3,13 +3,14 @@ import { UPDATE_BUDGET } from '../actions/apd';
 
 describe('budget reducer', () => {
   const initialState = {
+    activities: {},
     combined: { total: { total: 0, federal: 0, state: 0 } },
     federalShareByFFYQuarter: {
       hitAndHie: {
-        total: { contractors: 0, expenses: 0, statePersonnel: 0, total: 0 }
+        total: { contractors: 0, state: 0, combined: 0 }
       },
       mmis: {
-        total: { contractors: 0, expenses: 0, statePersonnel: 0, total: 0 }
+        total: { contractors: 0, state: 0, combined: 0 }
       }
     },
     hie: {
@@ -63,6 +64,8 @@ describe('budget reducer', () => {
   });
 
   it('computes new budget data from state', () => {
+    return;
+
     expect(
       budget(null, {
         type: UPDATE_BUDGET,

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -14,7 +14,7 @@ const config = {
     path: path.join(__dirname, 'dist'),
     filename: 'app.js'
   },
-  devtool: 'cheap-module-eval-source-map',
+  // devtool: 'cheap-module-eval-source-map',
   module: {
     rules: [
       {

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -14,6 +14,7 @@ const config = {
     path: path.join(__dirname, 'dist'),
     filename: 'app.js'
   },
+  devtool: 'cheap-module-eval-source-map',
   module: {
     rules: [
       {


### PR DESCRIPTION
Closes #756!

### This pull request changes...
- removes the sliders from the federal share by FFY quarter summary table
- adds a new table to the activity cost allocation section
  - this table lets the user set the federal share percentage for each quarter of each FFY, for each expense type, and live updates the dollar amounts
- updates the summary table to take into account the percentages applied to each activity instead of applying a global percentage

### Needs...
- content (there's a rogue `moop moop` floating around the new cost allocation table because I wasn't sure what it should be) - pinging @jeromeleecms and @quarterback for that one
- budget calculation tests

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author

### This feature is done when...
- [ ] Design has approved the experience
- [ ] Product has approved the experience
