### PR TITLE
bug fix (null inputs)

### DIFF
--- a/web/src/reducers/apd.js
+++ b/web/src/reducers/apd.js
@@ -13,7 +13,8 @@ import {
   INCENTIVE_ENTRIES,
   arrToObj,
   defaultAPDYearOptions,
-  defaultAPDYears
+  defaultAPDYears,
+  replaceNulls
 } from '../util';
 
 import assurancesList from '../data/assurancesAndCompliance.yaml';
@@ -220,7 +221,7 @@ const reducer = (state = initialState, action) => {
                     ),
               previousActivitySummary: previousActivitySummary || '',
 
-              stateProfile,
+              stateProfile: replaceNulls(stateProfile),
               years: (years || defaultAPDYears).map(y => `${y}`),
               yearOptions: defaultAPDYearOptions
             }

--- a/web/src/util/index.js
+++ b/web/src/util/index.js
@@ -165,3 +165,17 @@ export const titleCase = str => str.replace(/\b\S/g, t => t.toUpperCase());
 
 export const isProgamAdmin = activity =>
   activity.name === 'Program Administration' || activity.id === 1;
+
+export const replaceNulls = (obj, newValue = '') => {
+  const replace = o => {
+    Object.keys(o).forEach(k => {
+      // eslint-disable-next-line no-param-reassign
+      if (o[k] === null) o[k] = newValue;
+      else if (typeof o[k] === 'object') replace(o[k]);
+    });
+  };
+
+  const objNew = JSON.parse(JSON.stringify(obj));
+  replace(objNew);
+  return objNew;
+};

--- a/web/src/util/index.test.js
+++ b/web/src/util/index.test.js
@@ -47,9 +47,24 @@ describe('utility functions', () => {
     arrToObj,
     getParams,
     nextSequence,
+    replaceNulls,
     stateLookup,
     titleCase
   } = load();
+
+  test('replace nulls with empty strings in an object', () => {
+    expect(replaceNulls({ foo: null, bar: 123 })).toEqual({
+      foo: '',
+      bar: 123
+    });
+
+    expect(replaceNulls({ foo: { bar: null, baz: 'abc' }, foo2: 123 })).toEqual(
+      {
+        foo: { bar: '', baz: 'abc' },
+        foo2: 123
+      }
+    );
+  });
 
   test('finds a state by two-letter code', () => {
     expect(stateLookup('Mo')).toEqual({ id: 'mo', name: 'Missouri' });


### PR DESCRIPTION
this fixes a bug where we were getting console errors because controlled inputs had a value of `null` (which React doesn't like) in the State Profile section; the fix was to create a helper function that converts nulls to empty strings for objects received from API.

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author