### PR TITLE
fix rich editor copy and paste

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -4518,14 +4518,14 @@
       }
     },
     "draftjs-to-html": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/draftjs-to-html/-/draftjs-to-html-0.8.3.tgz",
-      "integrity": "sha1-DKPCc+gC7Ts7vxLjkA67cP2VUX8="
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/draftjs-to-html/-/draftjs-to-html-0.8.4.tgz",
+      "integrity": "sha512-+4hekxc8dTJvKk6usiEsFX9O1uOD9vLZZOs9ZI3RhTe89yNmtazYII/ILDXfbMPfzNaYfX7Gf3zjRm6UUFxqyg=="
     },
     "draftjs-utils": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/draftjs-utils/-/draftjs-utils-0.9.3.tgz",
-      "integrity": "sha1-eBJUkIvrfKnv9tpjvH2WTd0D7CI="
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/draftjs-utils/-/draftjs-utils-0.8.8.tgz",
+      "integrity": "sha1-WDXa7ZX1nT7h+W/cu7mAl3LIZJA="
     },
     "duplexify": {
       "version": "3.5.4",
@@ -7316,9 +7316,9 @@
       "dev": true
     },
     "html-to-draftjs": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/html-to-draftjs/-/html-to-draftjs-1.3.0.tgz",
-      "integrity": "sha512-JC4cM6X7jZwIHlVRK8RinJMUBbHV+duA3zNrXAPDAA4YlTPo8lcsPWPA/cSclm+Uq2moRfUmXfkoop5n877vAQ=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/html-to-draftjs/-/html-to-draftjs-1.4.0.tgz",
+      "integrity": "sha1-ijy7ultJ1QvozoXMCLES1b8A/B0="
     },
     "html-webpack-plugin": {
       "version": "2.30.1",
@@ -13386,14 +13386,12 @@
       }
     },
     "react-draft-wysiwyg": {
-      "version": "1.12.11",
-      "resolved": "https://registry.npmjs.org/react-draft-wysiwyg/-/react-draft-wysiwyg-1.12.11.tgz",
-      "integrity": "sha512-qYxBQ+TawA+Qe3whptKaEBkn/fmxZ8pCOgQu/0CKL7hres4XtV1RR4ubav+dVsFl6sUM7FEJBGM4LpzLPx3P5g==",
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/react-draft-wysiwyg/-/react-draft-wysiwyg-1.10.7.tgz",
+      "integrity": "sha1-TJrPlRWxJa9rC/qiLXuSgA0ipBg=",
       "requires": {
         "classnames": "2.2.5",
-        "draftjs-utils": "0.9.3",
-        "html-to-draftjs": "1.3.0",
-        "linkify-it": "2.0.3",
+        "draftjs-utils": "0.8.8",
         "prop-types": "15.6.0"
       }
     },

--- a/web/package.json
+++ b/web/package.json
@@ -35,7 +35,7 @@
     "Nikki Lee",
     "Laura Poncé",
     "Brendan Sudol",
-    "Greg Walker" 
+    "Greg Walker"
   ],
   "license": "CC0-1.0",
   "bugs": {
@@ -57,9 +57,9 @@
     "d3-transition": "^1.1.1",
     "deline": "^1.0.4",
     "draft-js": "^0.10.5",
-    "draftjs-to-html": "^0.8.3",
+    "draftjs-to-html": "^0.8.4",
     "history": "^4.7.2",
-    "html-to-draftjs": "^1.3.0",
+    "html-to-draftjs": "^1.4.0",
     "i18n-js": "^3.0.3",
     "lodash.kebabcase": "^4.1.1",
     "markdown-it": "^8.4.1",
@@ -67,7 +67,7 @@
     "prop-types": "^15.6.0",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
-    "react-draft-wysiwyg": "^1.12.11",
+    "react-draft-wysiwyg": "^1.10.7",
     "react-redux": "^5.0.7",
     "react-router-dom": "^4.2.2",
     "react-router-redux": "^5.0.0-alpha.9",

--- a/web/src/components/temp/MiscPage.js
+++ b/web/src/components/temp/MiscPage.js
@@ -1,13 +1,13 @@
 import React from 'react';
 
 import Container from '../Container';
-import ExecutiveSummaryBudget from '../../containers/ApdStateProfilePointsOfContact';
+import { RichText } from '../Inputs';
 
 const MiscPage = () => (
   <Container>
     <h1 className="h2">Misc Components (for testing purposes)</h1>
-    <div className="p3 bg-white overflow-auto">
-      <ExecutiveSummaryBudget />
+    <div className="p2 bg-white">
+      <RichText />
     </div>
   </Container>
 );

--- a/web/src/styles/app/editor.css
+++ b/web/src/styles/app/editor.css
@@ -43,9 +43,18 @@
   box-shadow: 0 0 0 2px rgba(0, 116, 217, 0.5);
 }
 
+.public-DraftStyleDefault-ol,
+.public-DraftStyleDefault-ul {
+  margin: 0.5rem 0;
+}
+
 .public-DraftStyleDefault-block {
-  line-height: 1.75;
+  line-height: 1.25;
   margin: 0;
+}
+
+.public-DraftStyleDefault-unorderedListItem {
+  line-height: 1;
 }
 
 .rdw-dropdown-wrapper a {


### PR DESCRIPTION
Now, we can copy and paste in sentences with bold and italics and yes, even lists, from Word or Google Docs into our rich text editors and it should now work. 🤞 

This was tricky to track down because the library we were using (https://github.com/jpuri/react-draft-wysiwyg) allows for this functionality and it works great on their demo page but it wasn't working for us. The reason: we were using the latest version of this package and they recently made some changes to fix other things that in turn broke this copy/pasting (and their demo page kept working fine because it never upgraded to the latest version). So all I had to do was revert to the version that's being used on their demo page and all is now good :)

Preview:
https://cl.ly/t0Lj

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author

### This feature is done when...
- [ ] Product has approved the experience
