### PR TITLE
Save activity quarterly FFP in the API

### DIFF
--- a/api/db/activity/activity.js
+++ b/api/db/activity/activity.js
@@ -32,6 +32,10 @@ module.exports = {
       return this.hasMany('apdActivityCostAllocation');
     },
 
+    quarterlyFFP() {
+      return this.hasMany('apdActivityQuarterlyFFP');
+    },
+
     format: attr =>
       Object.keys(attr).reduce((builtUp, field) => {
         const out = { ...builtUp };
@@ -77,7 +81,8 @@ module.exports = {
         expenses: 'apdActivityExpense',
         schedule: 'apdActivitySchedule',
         statePersonnel: 'apdActivityStatePersonnel',
-        costAllocation: 'apdActivityCostAllocation'
+        costAllocation: 'apdActivityCostAllocation',
+        quarterlyFFP: 'apdActivityQuarterlyFFP'
       },
       foreignKey: 'activity_id',
       withRelated: [
@@ -89,7 +94,8 @@ module.exports = {
         'schedule',
         'statePersonnel',
         'statePersonnel.years',
-        'costAllocation'
+        'costAllocation',
+        'quarterlyFFP'
       ]
     },
 
@@ -133,7 +139,8 @@ module.exports = {
         },
         costAllocation: this.related('costAllocation'),
         standardsAndConditions: this.get('standards_and_conditions'),
-        fundingSource: this.get('funding_source')
+        fundingSource: this.get('funding_source'),
+        quarterlyFFP: this.related('quarterlyFFP')
       };
     }
   }

--- a/api/db/activity/activity.test.js
+++ b/api/db/activity/activity.test.js
@@ -19,6 +19,7 @@ tap.test('activity data model', async activityModelTests => {
           statePersonnel: Function,
           costAllocation: Function,
           format: Function,
+          quarterlyFFP: Function,
 
           static: {
             updateableFields: [
@@ -36,7 +37,8 @@ tap.test('activity data model', async activityModelTests => {
               expenses: 'apdActivityExpense',
               schedule: 'apdActivitySchedule',
               statePersonnel: 'apdActivityStatePersonnel',
-              costAllocation: 'apdActivityCostAllocation'
+              costAllocation: 'apdActivityCostAllocation',
+              quarterlyFFP: 'apdActivityQuarterlyFFP'
             },
             foreignKey: 'activity_id',
             withRelated: [
@@ -48,7 +50,8 @@ tap.test('activity data model', async activityModelTests => {
               'schedule',
               'statePersonnel',
               'statePersonnel.years',
-              'costAllocation'
+              'costAllocation',
+              'quarterlyFFP'
             ]
           }
         }
@@ -172,6 +175,23 @@ tap.test('activity data model', async activityModelTests => {
         apdTests.ok(
           self.hasMany.calledWith('apdActivityCostAllocation'),
           'sets up the relationship mapping to cost allocation'
+        );
+        apdTests.equal(output, 'can', 'returns the expected value');
+      }
+    );
+
+    relationshipTests.test(
+      'activity model sets up quarterly FFP relationship',
+      async apdTests => {
+        const self = {
+          hasMany: sinon.stub().returns('can')
+        };
+
+        const output = activity.apdActivity.quarterlyFFP.bind(self)();
+
+        apdTests.ok(
+          self.hasMany.calledWith('apdActivityQuarterlyFFP'),
+          'sets up the relationship mapping to quarterly FFP'
         );
         apdTests.equal(output, 'can', 'returns the expected value');
       }

--- a/api/db/activity/index.js
+++ b/api/db/activity/index.js
@@ -7,6 +7,7 @@ const expenseEntry = require('./expenseEntry');
 const goal = require('./goal');
 const schedule = require('./schedule');
 const statePersonnel = require('./statePersonnel');
+const quarterlyFFP = require('./quarterlyFFP');
 
 // Just rolls up activity models into one object
 // so db/index only has to load this one thing
@@ -19,5 +20,6 @@ module.exports = () => ({
   ...expenseEntry,
   ...goal,
   ...schedule,
-  ...statePersonnel
+  ...statePersonnel,
+  ...quarterlyFFP
 });

--- a/api/db/activity/index.test.js
+++ b/api/db/activity/index.test.js
@@ -20,7 +20,8 @@ tap.test('activity model index', async activityIndexTests => {
       'apdActivityGoal',
       'apdActivitySchedule',
       'apdActivityStatePersonnel',
-      'apdActivityStatePersonnelCost'
+      'apdActivityStatePersonnelCost',
+      'apdActivityQuarterlyFFP'
     ],
     'exports the expected models'
   );

--- a/api/db/activity/quarterlyFFP.js
+++ b/api/db/activity/quarterlyFFP.js
@@ -1,0 +1,63 @@
+module.exports = {
+  apdActivityQuarterlyFFP: {
+    tableName: 'activity_quarterly_ffp',
+
+    activity() {
+      return this.belongsTo('apdActivity');
+    },
+
+    format(attributes) {
+      const out = {
+        activity_id: attributes.activity_id,
+        year: attributes.year
+      };
+
+      [1, 2, 3, 4].forEach(q => {
+        const qq = `q${q}`;
+        if (attributes[qq]) {
+          out[`${qq}_combined`] = +attributes[qq].combined;
+          out[`${qq}_contractors`] = +attributes[qq].contractors;
+          out[`${qq}_state`] = +attributes[qq].state;
+        }
+      });
+
+      return out;
+    },
+
+    async validate() {
+      if (!this.attributes.year) {
+        throw new Error('invalid-activity-quarterly-ffp');
+      }
+    },
+
+    toJSON() {
+      return {
+        q1: {
+          combined: +this.get('q1_combined'),
+          contractors: +this.get('q1_contractors'),
+          state: +this.get('q1_state')
+        },
+        q2: {
+          combined: +this.get('q2_combined'),
+          contractors: +this.get('q2_contractors'),
+          state: +this.get('q2_state')
+        },
+        q3: {
+          combined: +this.get('q3_combined'),
+          contractors: +this.get('q3_contractors'),
+          state: +this.get('q3_state')
+        },
+        q4: {
+          combined: +this.get('q4_combined'),
+          contractors: +this.get('q4_contractors'),
+          state: +this.get('q4_state')
+        },
+        year: this.get('year')
+      };
+    },
+
+    static: {
+      updateableFields: ['q1', 'q2', 'q3', 'q4', 'year']
+    }
+  }
+};

--- a/api/db/activity/quarterlyFFP.test.js
+++ b/api/db/activity/quarterlyFFP.test.js
@@ -1,0 +1,162 @@
+const tap = require('tap');
+const sinon = require('sinon');
+
+const quarterlyFFP = require('./quarterlyFFP').apdActivityQuarterlyFFP;
+
+tap.test('activity quarterly FFP data model', async tests => {
+  tests.test('setup', async test => {
+    test.match(
+      quarterlyFFP,
+      {
+        tableName: 'activity_quarterly_ffp',
+        activity: Function,
+        format: Function,
+        validate: Function,
+        toJSON: Function,
+        static: {
+          updateableFields: ['q1', 'q2', 'q3', 'q4', 'year']
+        }
+      },
+      'get the expected model definitions'
+    );
+  });
+
+  tests.test('approach model sets up activity relationship', async test => {
+    const self = {
+      belongsTo: sinon.stub().returns('baz')
+    };
+
+    const output = quarterlyFFP.activity.bind(self)();
+
+    test.ok(
+      self.belongsTo.calledWith('apdActivity'),
+      'sets up the relationship mapping to an activity'
+    );
+    test.equal(output, 'baz', 'returns the expected value');
+  });
+
+  tests.test(
+    'formats attributes for insertion into the database',
+    async test => {
+      test.match(
+        quarterlyFFP.format({
+          activity_id: '0U812',
+          q1: {
+            combined: 0,
+            contractors: 1,
+            state: 2
+          },
+          q2: {
+            combined: 3,
+            contractors: '4',
+            state: '5'
+          },
+          q4: {
+            combined: 6,
+            contractors: 7,
+            state: '8'
+          },
+          year: 1927,
+          someOtherJunk: 'gets thrown out'
+        }),
+        {
+          activity_id: '0U812',
+          q1_combined: 0,
+          q1_contractors: 1,
+          q1_state: 2,
+          q2_combined: 3,
+          q2_contractors: 4,
+          q2_state: 5,
+          q4_combined: 6,
+          q4_contractors: 7,
+          q4_state: 8,
+          year: 1927
+        },
+        'formats data'
+      );
+    }
+  );
+
+  tests.test('has validate method', async validationTests => {
+    validationTests.test('throws if year is empty', async test => {
+      test.rejects(
+        quarterlyFFP.validate.bind({
+          attributes: {
+            year: undefined
+          }
+        }),
+        'fails if year is undefined'
+      );
+
+      test.rejects(
+        quarterlyFFP.validate.bind({
+          attributes: {
+            year: null
+          }
+        }),
+        'fails if value is null'
+      );
+
+      test.rejects(
+        quarterlyFFP.validate.bind({
+          attributes: {
+            year: ''
+          }
+        }),
+        'fails if value is empty string'
+      );
+
+      test.resolves(
+        quarterlyFFP.validate.bind({
+          attributes: {
+            year: 2001
+          }
+        }),
+        'passes if at year is not empty'
+      );
+    });
+  });
+
+  tests.test('overrides toJSON method', async test => {
+    const self = { get: sinon.stub() };
+    self.get.withArgs('q1_combined').returns('100');
+    self.get.withArgs('q1_contractors').returns('200');
+    self.get.withArgs('q1_state').returns(300);
+    self.get.withArgs('q2_combined').returns(400);
+    self.get.withArgs('q2_contractors').returns(500);
+    self.get.withArgs('q2_state').returns(600);
+    self.get.withArgs('q3_combined').returns(700);
+    self.get.withArgs('q3_contractors').returns(800);
+    self.get.withArgs('q3_state').returns(900);
+    self.get.withArgs('q4_combined').returns(150);
+    self.get.withArgs('q4_contractors').returns(250);
+    self.get.withArgs('q4_state').returns(350);
+    self.get.withArgs('year').returns('THE FEDERAL FISCAL YEAR');
+
+    const output = quarterlyFFP.toJSON.bind(self)();
+
+    test.match(output, {
+      q1: {
+        combined: 100,
+        contractors: 200,
+        state: 300
+      },
+      q2: {
+        combined: 400,
+        contractors: 500,
+        state: 600
+      },
+      q3: {
+        combined: 700,
+        contractors: 800,
+        state: 900
+      },
+      q4: {
+        combined: 150,
+        contractors: 250,
+        state: 350
+      },
+      year: 'THE FEDERAL FISCAL YEAR'
+    });
+  });
+});

--- a/api/db/apd.js
+++ b/api/db/apd.js
@@ -147,6 +147,7 @@ module.exports = () => ({
         'activities.schedule',
         'activities.statePersonnel',
         'activities.statePersonnel.years',
+        'activities.quarterlyFFP',
         'incentivePayments',
         'keyPersonnel',
         'keyPersonnel.years',

--- a/api/db/apd.test.js
+++ b/api/db/apd.test.js
@@ -50,6 +50,7 @@ tap.test('apd data model', async apdModelTests => {
               'activities.schedule',
               'activities.statePersonnel',
               'activities.statePersonnel.years',
+              'activities.quarterlyFFP',
               'incentivePayments',
               'keyPersonnel',
               'keyPersonnel.years',

--- a/api/endpoint-tests/activities/put.js
+++ b/api/endpoint-tests/activities/put.js
@@ -144,7 +144,8 @@ tap.test(
               standardsAndConditions: null,
               summary: null,
               fundingSource: null,
-              statePersonnel: []
+              statePersonnel: [],
+              quarterlyFFP: []
             },
             'sends back the updated activity object'
           );

--- a/api/migrations/20180716210930_activity-quarterly-ffp.js
+++ b/api/migrations/20180716210930_activity-quarterly-ffp.js
@@ -1,0 +1,22 @@
+exports.up = async knex =>
+  knex.schema.createTable('activity_quarterly_ffp', table => {
+    table.increments();
+    table.integer('activity_id');
+    table.integer('year');
+    table.decimal('q1_combined', 12, 2);
+    table.decimal('q1_contractors', 12, 2);
+    table.decimal('q1_state', 12, 2);
+    table.decimal('q2_combined', 12, 2);
+    table.decimal('q2_contractors', 12, 2);
+    table.decimal('q2_state', 12, 2);
+    table.decimal('q3_combined', 12, 2);
+    table.decimal('q3_contractors', 12, 2);
+    table.decimal('q3_state', 12, 2);
+    table.decimal('q4_combined', 12, 2);
+    table.decimal('q4_contractors', 12, 2);
+    table.decimal('q4_state', 12, 2);
+
+    table.foreign('activity_id').references('activities.id');
+  });
+
+exports.down = async () => {};

--- a/api/routes/openAPI/index.js
+++ b/api/routes/openAPI/index.js
@@ -66,7 +66,6 @@ module.exports = {
             type: 'string',
             description: 'Alternative considerations for the activity'
           },
-
           contractorResources: arrayOf({
             type: 'object',
             description: 'Activity contractor resource',
@@ -259,6 +258,101 @@ module.exports = {
                   }
                 }
               })
+            }
+          }),
+          quarterlyFFP: arrayOf({
+            type: 'object',
+            description:
+              'Federal share of this activity cost, by expense type, per fiscal quarter',
+            properties: {
+              q1: {
+                type: 'object',
+                description: 'First fiscal quarter FFP',
+                properties: {
+                  combined: {
+                    type: 'number',
+                    description:
+                      'Percent of the federal share of the FFY total to be paid in this quarter'
+                  },
+                  contractors: {
+                    type: 'number',
+                    description:
+                      'Percent of the federal share of the FFY total contractor expense to be paid in this quarter'
+                  },
+                  state: {
+                    type: 'number',
+                    description:
+                      'Percent of the federal share of the FFY total state expense to be paid in this quarter'
+                  }
+                }
+              },
+              q2: {
+                type: 'object',
+                description: 'Second fiscal quarter FFP',
+                properties: {
+                  combined: {
+                    type: 'number',
+                    description:
+                      'Percent of the federal share of the FFY total to be paid in this quarter'
+                  },
+                  contractors: {
+                    type: 'number',
+                    description:
+                      'Percent of the federal share of the FFY total contractor expense to be paid in this quarter'
+                  },
+                  state: {
+                    type: 'number',
+                    description:
+                      'Percent of the federal share of the FFY total state expense to be paid in this quarter'
+                  }
+                }
+              },
+              q3: {
+                type: 'object',
+                description: 'Third fiscal quarter FFP',
+                properties: {
+                  combined: {
+                    type: 'number',
+                    description:
+                      'Percent of the federal share of the FFY total to be paid in this quarter'
+                  },
+                  contractors: {
+                    type: 'number',
+                    description:
+                      'Percent of the federal share of the FFY total contractor expense to be paid in this quarter'
+                  },
+                  state: {
+                    type: 'number',
+                    description:
+                      'Percent of the federal share of the FFY total state expense to be paid in this quarter'
+                  }
+                }
+              },
+              q4: {
+                type: 'object',
+                description: 'Fourth fiscal quarter FFP',
+                properties: {
+                  combined: {
+                    type: 'number',
+                    description:
+                      'Percent of the federal share of the FFY total to be paid in this quarter'
+                  },
+                  contractors: {
+                    type: 'number',
+                    description:
+                      'Percent of the federal share of the FFY total contractor expense to be paid in this quarter'
+                  },
+                  state: {
+                    type: 'number',
+                    description:
+                      'Percent of the federal share of the FFY total state expense to be paid in this quarter'
+                  }
+                }
+              },
+              year: {
+                type: 'number',
+                description: 'Federal fiscal year this quarterly FFP applies to'
+              }
             }
           })
         }

--- a/web/src/actions/apd.js
+++ b/web/src/actions/apd.js
@@ -2,6 +2,7 @@ import { push } from 'react-router-redux';
 
 import { notify } from './notification';
 import axios from '../util/api';
+import { applyToNumbers } from '../util';
 
 export const ADD_APD_KEY_PERSON = 'ADD_APD_KEY_PERSON';
 export const ADD_APD_POC = 'ADD_APD_POC';
@@ -238,7 +239,16 @@ export const saveApd = () => (dispatch, state) => {
         modularity: activity.standardsAndConditions.modularity,
         mita: activity.standardsAndConditions.mita,
         reporting: activity.standardsAndConditions.reporting
-      }
+      },
+      quarterlyFFP: Object.entries(activity.quarterlyFFP).map(
+        ([year, ffp]) => ({
+          q1: applyToNumbers(ffp[1], v => v / 100),
+          q2: applyToNumbers(ffp[2], v => v / 100),
+          q3: applyToNumbers(ffp[3], v => v / 100),
+          q4: applyToNumbers(ffp[4], v => v / 100),
+          year
+        })
+      )
     });
   });
 

--- a/web/src/actions/apd.test.js
+++ b/web/src/actions/apd.test.js
@@ -362,6 +362,52 @@ describe('apd actions', () => {
               modularity: 'modularity',
               mita: 'mita',
               reporting: 'reporting'
+            },
+            quarterlyFFP: {
+              '1993': {
+                '1': {
+                  combined: 20,
+                  contractors: 30,
+                  state: 40
+                },
+                '2': {
+                  combined: 20,
+                  contractors: 30,
+                  state: 40
+                },
+                '3': {
+                  combined: 20,
+                  contractors: 30,
+                  state: 40
+                },
+                '4': {
+                  combined: 20,
+                  contractors: 30,
+                  state: 40
+                }
+              },
+              '1994': {
+                '1': {
+                  combined: 20,
+                  contractors: 30,
+                  state: 40
+                },
+                '2': {
+                  combined: 20,
+                  contractors: 30,
+                  state: 40
+                },
+                '3': {
+                  combined: 20,
+                  contractors: 30,
+                  state: 40
+                },
+                '4': {
+                  combined: 20,
+                  contractors: 30,
+                  state: 40
+                }
+              }
             }
           }
         }
@@ -393,6 +439,8 @@ describe('apd actions', () => {
     it('creates save request and save success actions if the save succeeds', () => {
       const store = mockStore(state);
       fetchMock.onPut('/apds/id-to-update').reply(200, [{ foo: 'bar' }]);
+
+      // TODO: Need to test what's actually sent to the API to make sure transformations are right
 
       const expectedActions = [
         { type: actions.SAVE_APD_REQUEST },

--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -448,10 +448,37 @@ const reducer = (state = initialState, action) => {
             mitigation: a.standardsAndConditions.mitigationStrategy || '',
             reporting: a.standardsAndConditions.reporting || ''
           },
-          quarterlyFFP: {
-            ...arrToObj(action.apd.years, quarterlyFFPEntry())
-          },
-
+          quarterlyFFP:
+            a.quarterlyFFP && a.quarterlyFFP.length
+              ? a.quarterlyFFP.reduce(
+                  (quarterlyAcc, ffy) => ({
+                    ...quarterlyAcc,
+                    [ffy.year]: {
+                      1: {
+                        combined: ffy.q1.combined * 100,
+                        contractors: ffy.q1.contractors * 100,
+                        state: ffy.q1.state * 100
+                      },
+                      2: {
+                        combined: ffy.q2.combined * 100,
+                        contractors: ffy.q2.contractors * 100,
+                        state: ffy.q2.state * 100
+                      },
+                      3: {
+                        combined: ffy.q3.combined * 100,
+                        contractors: ffy.q3.contractors * 100,
+                        state: ffy.q3.state * 100
+                      },
+                      4: {
+                        combined: ffy.q4.combined * 100,
+                        contractors: ffy.q4.contractors * 100,
+                        state: ffy.q4.state * 100
+                      }
+                    }
+                  }),
+                  {}
+                )
+              : { ...arrToObj(action.apd.years, quarterlyFFPEntry()) },
           meta: {
             expanded: false
           }

--- a/web/src/reducers/activities.test.js
+++ b/web/src/reducers/activities.test.js
@@ -717,7 +717,55 @@ describe('activities reducer', () => {
                     mita: 'meeta',
                     mitigationStrategy: 'run away',
                     reporting: 'moop moop'
-                  }
+                  },
+                  quarterlyFFP: [
+                    {
+                      q1: {
+                        combined: 0.2,
+                        contractors: 0.3,
+                        state: 0.4
+                      },
+                      q2: {
+                        combined: 0.4,
+                        contractors: 0.3,
+                        state: 0.2
+                      },
+                      q3: {
+                        combined: 0.3,
+                        contractors: 0.2,
+                        state: 0.4
+                      },
+                      q4: {
+                        combined: 0.3,
+                        contractors: 0.4,
+                        state: 0.2
+                      },
+                      year: 2018
+                    },
+                    {
+                      q1: {
+                        combined: 0.25,
+                        contractors: 0.25,
+                        state: 0.25
+                      },
+                      q2: {
+                        combined: 0.25,
+                        contractors: 0.25,
+                        state: 0.25
+                      },
+                      q3: {
+                        combined: 0.25,
+                        contractors: 0.25,
+                        state: 0.25
+                      },
+                      q4: {
+                        combined: 0.25,
+                        contractors: 0.25,
+                        state: 0.25
+                      },
+                      year: 2019
+                    }
+                  ]
                 }
               ],
               years: ['2018', '2019']
@@ -815,24 +863,24 @@ describe('activities reducer', () => {
             quarterlyFFP: {
               '2018': {
                 '1': {
-                  combined: 25,
-                  contractors: 25,
-                  state: 25
+                  combined: 20,
+                  contractors: 30,
+                  state: 40
                 },
                 '2': {
-                  combined: 25,
-                  contractors: 25,
-                  state: 25
+                  combined: 40,
+                  contractors: 30,
+                  state: 20
                 },
                 '3': {
-                  combined: 25,
-                  contractors: 25,
-                  state: 25
+                  combined: 30,
+                  contractors: 20,
+                  state: 40
                 },
                 '4': {
-                  combined: 25,
-                  contractors: 25,
-                  state: 25
+                  combined: 30,
+                  contractors: 40,
+                  state: 20
                 }
               },
               '2019': {

--- a/web/src/util/index.js
+++ b/web/src/util/index.js
@@ -166,6 +166,15 @@ export const titleCase = str => str.replace(/\b\S/g, t => t.toUpperCase());
 export const isProgamAdmin = activity =>
   activity.name === 'Program Administration' || activity.id === 1;
 
+export const applyToNumbers = (obj, fn) => {
+  const o = { ...obj };
+  Object.keys(o).forEach(k => {
+    if (typeof o[k] === 'number') o[k] = fn(o[k]);
+    else if (typeof o[k] === 'object') o[k] = applyToNumbers(o[k], fn);
+  });
+  return o;
+};
+
 export const replaceNulls = (obj, newValue = '') => {
   const replace = o => {
     Object.keys(o).forEach(k => {

--- a/web/src/util/index.test.js
+++ b/web/src/util/index.test.js
@@ -44,6 +44,7 @@ describe('provides default years based on now', () => {
 describe('utility functions', () => {
   const {
     addObjVals,
+    applyToNumbers,
     arrToObj,
     getParams,
     nextSequence,
@@ -64,6 +65,14 @@ describe('utility functions', () => {
         foo2: 123
       }
     );
+  });
+
+  test('apply a function to numbers in an object, deeply', () => {
+    expect(applyToNumbers({ a: 1, b: 2, c: { d: 7 } }, () => 'boop')).toEqual({
+      a: 'boop',
+      b: 'boop',
+      c: { d: 'boop' }
+    });
   });
 
   test('finds a state by two-letter code', () => {


### PR DESCRIPTION
Adds the backend pieces and tweaks the frontend data state pieces so we can save and retrieve activity quarterly FFP data.

### This pull request changes...
- when you push the "save APD" button, your activity quarterly FFP data gets saved too!
- when you reload the page, your activity quarterly FFP data is restored!

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [x] The change has been documented
  - [x] Associated OpenAPI documentation has been updated