### PR TITLE
Save activity quarterly FFP when submitting APD

### DIFF
--- a/web/src/actions/apd.js
+++ b/web/src/actions/apd.js
@@ -68,7 +68,7 @@ export const createApd = () => dispatch => {
 };
 
 export const requestSave = () => ({ type: SAVE_APD_REQUEST });
-export const saveSuccess = () => ({ type: SAVE_APD_SUCCESS });
+export const saveSuccess = data => ({ type: SAVE_APD_SUCCESS, data });
 export const saveFailure = () => ({ type: SAVE_APD_FAILURE });
 
 export const fetchApd = () => dispatch => {
@@ -276,9 +276,20 @@ export const submitAPD = (save = saveApd) => (dispatch, getState) =>
     .then(() => {
       dispatch({ type: SUBMIT_APD_REQUEST });
 
-      const { apd: { data: { id: apdID } }, budget } = getState();
+      const {
+        activities: { byKey: activities },
+        apd: { data: { id: apdID } },
+        budget
+      } = getState();
 
       const tables = {
+        activityQuarterlyFederalShare: Object.entries(budget.activities).reduce(
+          (acc, [key, activity]) => ({
+            ...acc,
+            [activities[key].name]: activity.quarterlyFFP
+          }),
+          {}
+        ),
         summaryBudgetTable: {
           hie: budget.hie,
           hit: budget.hit,

--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -17,7 +17,7 @@ import {
   TOGGLE_ACTIVITY_SECTION,
   UPDATE_ACTIVITY
 } from '../actions/activities';
-import { SELECT_APD, UPDATE_APD } from '../actions/apd';
+import { SAVE_APD_SUCCESS, SELECT_APD, UPDATE_APD } from '../actions/apd';
 
 import {
   arrToObj,
@@ -513,6 +513,30 @@ const reducer = (state = initialState, action) => {
         byKey,
         allKeys: Object.keys(byKey)
       };
+    }
+    case SAVE_APD_SUCCESS: {
+      // When an APD is saved, we should grab any local activities that
+      // don't have IDs and pull their new IDs from the API data.
+      const activitiesWithoutIDs = Object.values(state.byKey).filter(
+        a => !a.id
+      );
+      if (activitiesWithoutIDs.length) {
+        const updates = { byKey: {} };
+        activitiesWithoutIDs.forEach(localActivity => {
+          const { id } = [
+            ...action.data.activities.filter(
+              apdActivity => apdActivity.name === localActivity.name
+            ),
+            {}
+          ][0];
+          if (id) {
+            updates.byKey[localActivity.key] = { id };
+          }
+        });
+
+        return u(updates, state);
+      }
+      return state;
     }
     default:
       return state;

--- a/web/src/reducers/activities.test.js
+++ b/web/src/reducers/activities.test.js
@@ -930,6 +930,54 @@ describe('activities reducer', () => {
     });
   });
 
+  describe('assigns IDs to new activities after an APD save', () => {
+    it('skips updates if all local activities have IDs', () => {
+      const state = {
+        byKey: {
+          activityKey1: { id: 1, key: 'activityKey1', name: 'one' },
+          activityKey2: { id: 2, key: 'activityKey2', name: 'two' }
+        }
+      };
+
+      expect(activities(state, { type: 'SAVE_APD_SUCCESS', data: {} })).toEqual(
+        state
+      );
+    });
+
+    it('only updates local activities without IDs', () => {
+      expect(
+        activities(
+          {
+            byKey: {
+              activityKey1: { id: 1, key: 'activityKey1', name: 'one' },
+              activityKey2: { key: 'activityKey2', name: 'two' }
+            }
+          },
+          {
+            type: 'SAVE_APD_SUCCESS',
+            data: {
+              activities: [
+                {
+                  id: 1,
+                  name: 'one'
+                },
+                {
+                  id: 2,
+                  name: 'two'
+                }
+              ]
+            }
+          }
+        )
+      ).toMatchObject({
+        byKey: {
+          activityKey1: { id: 1, key: 'activityKey1', name: 'one' },
+          activityKey2: { id: 2, key: 'activityKey2', name: 'two' }
+        }
+      });
+    });
+  });
+
   it('aggregates data by year', () => {
     expect(
       aggregateByYear(


### PR DESCRIPTION
Closes #804.

### This pull request changes...
- When submitting an APD, the activity quarterly FFP tables are also saved

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author