### PR TITLE
Fix place display [skip deploy]

### DIFF
--- a/api/auth/authenticate.js
+++ b/api/auth/authenticate.js
@@ -11,13 +11,17 @@ module.exports = (
 
     const user = await userModel
       .query('whereRaw', 'LOWER(email) = ?', [username.toLowerCase()])
-      .fetch();
+      .fetch({ withRelated: ['state'] });
 
     if (user && (await bcrypt.compare(password, user.get('password')))) {
       logger.verbose(`authenticated user [${username}]`);
       done(null, {
         username: user.get('email'),
-        id: user.get('id')
+        id: user.get('id'),
+        role: user.get('auth_role'),
+        state: user.get('state_id'),
+        activities: await user.activities(),
+        model: user
       });
     } else {
       logger.verbose(`no user found or password mismatch for [${username}]`);
@@ -25,7 +29,6 @@ module.exports = (
     }
   } catch (e) {
     logger.error(e);
-    console.log(e);
     done('Database error');
   }
 };

--- a/api/auth/authenticate.test.js
+++ b/api/auth/authenticate.test.js
@@ -105,7 +105,14 @@ tap.test('local authentication', async authTest => {
     get.withArgs('email').returns('hello@world');
     get.withArgs('password').returns('test-password');
     get.withArgs('id').returns(57);
-    userModel.fetch.resolves({ get });
+    get.withArgs('auth_role').returns('do a barrel role');
+    get.withArgs('state_id').returns('liquid');
+
+    const model = {
+      activities: sinon.stub().resolves('play fetch'),
+      get
+    };
+    userModel.fetch.resolves(model);
     bcrypt.compare.resolves(true);
 
     await auth('user', 'password', doneCallback);
@@ -128,7 +135,14 @@ tap.test('local authentication', async authTest => {
 
     validTest.equal(doneCallback.callCount, 1, 'called done callback once');
     validTest.ok(
-      doneCallback.calledWith(null, { username: 'hello@world', id: 57 }),
+      doneCallback.calledWith(null, {
+        username: 'hello@world',
+        id: 57,
+        role: 'do a barrel role',
+        state: 'liquid',
+        activities: 'play fetch',
+        model
+      }),
       'did not get an error message, did get a user object'
     );
   });

--- a/api/auth/index.js
+++ b/api/auth/index.js
@@ -51,7 +51,14 @@ module.exports.setup = function setup(
   app.post('/auth/login', passport.authenticate('local'), (req, res) => {
     res
       .status(200)
-      .send({ id: req.user.id })
+      .send({
+        ...req.user,
+        state: {
+          id: req.user.model.related('state').get('id'),
+          name: req.user.model.related('state').get('name')
+        },
+        model: undefined
+      })
       .end();
   });
 };

--- a/api/auth/index.test.js
+++ b/api/auth/index.test.js
@@ -181,12 +181,34 @@ tap.test('authentication setup', async authTest => {
     res.send.returns(res);
     res.status.returns(res);
 
-    post({ user: { id: 'test-user-id' } }, res);
+    const state = sinon.stub();
+    state.withArgs('id').returns('state id');
+    state.withArgs('name').returns('state name');
+
+    const req = {
+      user: {
+        im: 'weasel',
+        ir: 'baboon',
+        model: {
+          related: sinon
+            .stub()
+            .withArgs('state')
+            .returns({ get: state })
+        }
+      }
+    };
+
+    post(req, res);
 
     postTest.ok(res.status.calledOnce, 'an HTTP status is set once');
     postTest.ok(res.status.calledWith(200), 'sets a 200 HTTP status');
     postTest.ok(
-      res.send.calledWith({ id: 'test-user-id' }),
+      res.send.calledWith({
+        im: 'weasel',
+        ir: 'baboon',
+        model: undefined,
+        state: { id: 'state id', name: 'state name' }
+      }),
       'HTTP body is set to the user ID'
     );
     postTest.ok(res.end.calledOnce, 'response is ended one time');

--- a/api/auth/serialization.js
+++ b/api/auth/serialization.js
@@ -17,7 +17,9 @@ module.exports.deserializeUser = async (
 ) => {
   try {
     logger.silly(`attempting to deserialize a user`, userID);
-    const user = await userModel.where({ id: userID }).fetch();
+    const user = await userModel
+      .where({ id: userID })
+      .fetch({ withRelated: ['state'] });
     if (user) {
       logger.silly(`successfully deserialized the user`);
       done(null, {

--- a/api/db/user.js
+++ b/api/db/user.js
@@ -28,7 +28,7 @@ module.exports = (zxcvbn = defaultZxcvbn, bcrypt = defaultBcrypt) => ({
 
     async apds() {
       logger.silly('getting user apds');
-      if (!this.relations.state || !this.relations.state.apds) {
+      if (!this.relations.state || !this.relations.state.relations.apds) {
         logger.silly('user apds are not loaded yet... loading them');
         await this.load('state.apds');
       }

--- a/api/db/user.test.js
+++ b/api/db/user.test.js
@@ -283,8 +283,7 @@ tap.test('user data model', async userModelTests => {
     apdsTests.test(
       'resolves a list of apds when the state relationship is already loaded',
       async alreadyLoadedTests => {
-        self.relations.state = {};
-        self.relations.state.apds = true;
+        self.relations.state = { relations: { apds: true } };
         const list = await apds();
 
         alreadyLoadedTests.ok(
@@ -292,6 +291,17 @@ tap.test('user data model', async userModelTests => {
           'the model load method is not called'
         );
         alreadyLoadedTests.same(list, [1, 2, 3], 'returns the list of apds');
+      }
+    );
+
+    apdsTests.test(
+      'resolves a list of apds when the state relationship is loaded but its APDs are not',
+      async test => {
+        self.relations.state = { relations: {} };
+        const list = await apds();
+
+        test.ok(self.load.calledOnce, 'the model load method is called');
+        test.same(list, [1, 2, 3], 'returns the list of apds');
       }
     );
 

--- a/api/endpoint-tests/auth/login.js
+++ b/api/endpoint-tests/auth/login.js
@@ -113,7 +113,17 @@ tap.test('login endpoint | /auth/login', async loginTest => {
         ),
         'sends an http-only session cookie'
       );
-      validTest.same(body, { id: 2000 }, 'sends back the user ID');
+      validTest.match(
+        body,
+        {
+          activities: Array,
+          id: 2000,
+          role: 'admin',
+          state: { id: 'mn', name: 'Minnesota' },
+          username: 'all-permissions-and-state'
+        },
+        'sends back the user'
+      );
     }
   );
 
@@ -135,7 +145,17 @@ tap.test('login endpoint | /auth/login', async loginTest => {
         ),
         'sends an http-only session cookie'
       );
-      validTest.same(body, { id: 2000 }, 'sends back the user ID');
+      validTest.match(
+        body,
+        {
+          activities: Array,
+          id: 2000,
+          role: 'admin',
+          state: { id: 'mn', name: 'Minnesota' },
+          username: 'all-permissions-and-state'
+        },
+        'sends back the user'
+      );
     }
   );
 
@@ -157,7 +177,17 @@ tap.test('login endpoint | /auth/login', async loginTest => {
         ),
         'sends an http-only session cookie'
       );
-      validTest.same(body, { id: 2000 }, 'sends back the user ID');
+      validTest.match(
+        body,
+        {
+          activities: Array,
+          id: 2000,
+          role: 'admin',
+          state: { id: 'mn', name: 'Minnesota' },
+          username: 'all-permissions-and-state'
+        },
+        'sends back the user'
+      );
     }
   );
 });

--- a/api/endpoint-tests/me/get.js
+++ b/api/endpoint-tests/me/get.js
@@ -30,7 +30,7 @@ tap.test('own-info endpoint | GET /me', async meTests => {
         id: 2000,
         username: 'all-permissions-and-state',
         role: 'admin',
-        state: 'mn',
+        state: { id: 'mn', name: 'Minnesota' },
         activities: [
           'add-users',
           'create-draft',

--- a/api/routes/me/get.js
+++ b/api/routes/me/get.js
@@ -4,8 +4,15 @@ const loggedIn = require('../../middleware').loggedIn;
 module.exports = app => {
   logger.silly('setting up GET endpoint');
   app.get('/me', loggedIn, (req, res) => {
-    // Get rid of the model object before sending
-    // it back to the client.
-    res.send({ ...req.user, model: undefined });
+    // Send back state info and get rid of the model object
+    // before sending it back to the client.
+    res.send({
+      ...req.user,
+      state: {
+        id: req.user.model.related('state').get('id'),
+        name: req.user.model.related('state').get('name')
+      },
+      model: undefined
+    });
   });
 };

--- a/api/routes/me/get.js
+++ b/api/routes/me/get.js
@@ -3,7 +3,7 @@ const loggedIn = require('../../middleware').loggedIn;
 
 module.exports = app => {
   logger.silly('setting up GET endpoint');
-  app.get('/me', loggedIn, (req, res) => {
+  app.get('/me', loggedIn, async (req, res) => {
     // Send back state info and get rid of the model object
     // before sending it back to the client.
     res.send({

--- a/api/routes/me/get.test.js
+++ b/api/routes/me/get.test.js
@@ -37,10 +37,31 @@ tap.test('me GET endpoint', async endpointTest => {
     getEndpoint(app);
     const meHandler = app.get.args.filter(arg => arg[0] === '/me')[0][2];
 
-    meHandler({ user: { id: 'user-id' } }, res);
+    const get = sinon.stub();
+    get.withArgs('id').returns('state id');
+    get.withArgs('name').returns('state name');
+
+    const userModel = {
+      related: sinon
+        .stub()
+        .withArgs('state')
+        .returns({ get })
+    };
+
+    const user = {
+      id: 'user-id',
+      model: userModel
+    };
+
+    meHandler({ user }, res);
 
     handlerTest.ok(
-      res.send.calledWith(sinon.match({ id: 'user-id' })),
+      res.send.calledWith(
+        sinon.match({
+          id: 'user-id',
+          state: { id: 'state id', name: 'state name' }
+        })
+      ),
       'sends back the user object'
     );
   });

--- a/api/routes/me/openAPI.js
+++ b/api/routes/me/openAPI.js
@@ -24,7 +24,21 @@ const openAPI = {
                 description: `User's unique ID, used internally and for identifying the user when interacting with the API`
               },
               role: {},
-              state: {},
+              state: {
+                type: 'object',
+                description:
+                  'The state/territory/district that this user is assigned to',
+                properties: {
+                  id: {
+                    type: 'string',
+                    description: 'Lowercase 2-letter code'
+                  },
+                  name: {
+                    type: 'string',
+                    description: 'State/territory/district full name'
+                  }
+                }
+              },
               username: {
                 type: 'string',
                 description: `User's unique username (email address)`

--- a/web/src/actions/auth.js
+++ b/web/src/actions/auth.js
@@ -22,7 +22,7 @@ export const completeAuthCheck = user => ({
 export const failAuthCheck = () => ({ type: AUTH_CHECK_FAILURE });
 
 export const requestLogin = () => ({ type: LOGIN_REQUEST });
-export const completeLogin = () => ({ type: LOGIN_SUCCESS });
+export const completeLogin = user => ({ type: LOGIN_SUCCESS, data: user });
 export const failLogin = error => ({ type: LOGIN_FAILURE, error });
 
 export const completeLogout = () => ({ type: LOGOUT_SUCCESS });
@@ -32,8 +32,8 @@ export const login = (username, password) => dispatch => {
 
   return axios
     .post(`${API_URL}/auth/login`, { username, password })
-    .then(() => {
-      dispatch(completeLogin());
+    .then(req => {
+      dispatch(completeLogin(req.data));
       dispatch(fetchApd());
     })
     .catch(error => {

--- a/web/src/actions/auth.js
+++ b/web/src/actions/auth.js
@@ -15,7 +15,10 @@ export const LOGIN_FAILURE = 'LOGIN_FAILURE';
 export const LOGOUT_SUCCESS = 'LOGOUT_SUCCESS';
 
 export const requestAuthCheck = () => ({ type: AUTH_CHECK_REQUEST });
-export const completeAuthCheck = () => ({ type: AUTH_CHECK_SUCCESS });
+export const completeAuthCheck = user => ({
+  type: AUTH_CHECK_SUCCESS,
+  data: user
+});
 export const failAuthCheck = () => ({ type: AUTH_CHECK_FAILURE });
 
 export const requestLogin = () => ({ type: LOGIN_REQUEST });
@@ -47,8 +50,8 @@ export const checkAuth = () => dispatch => {
 
   return axios
     .get(`${API_URL}/me`)
-    .then(() => {
-      dispatch(completeAuthCheck());
+    .then(req => {
+      dispatch(completeAuthCheck(req.data));
       dispatch(fetchApd());
     })
     .catch(() => dispatch(failAuthCheck()));

--- a/web/src/actions/auth.test.js
+++ b/web/src/actions/auth.test.js
@@ -36,11 +36,11 @@ describe('auth actions', () => {
 
     it('creates LOGIN_SUCCESS after successful auth', () => {
       const store = mockStore({});
-      fetchMock.onPost().reply(200);
+      fetchMock.onPost().reply(200, { moop: 'moop' });
 
       const expectedActions = [
         { type: actions.LOGIN_REQUEST },
-        { type: actions.LOGIN_SUCCESS },
+        { type: actions.LOGIN_SUCCESS, data: { moop: 'moop' } },
         { type: apdActions.GET_APD_REQUEST }
       ];
 

--- a/web/src/actions/auth.test.js
+++ b/web/src/actions/auth.test.js
@@ -86,13 +86,13 @@ describe('auth actions', () => {
       fetchMock.reset();
     });
 
-    it('creates LOGIN_SUCCESS after successful auth', () => {
+    it('creates AUTH_CHEK_SUCCESS after successful auth and loads APDs', () => {
       const store = mockStore({});
-      fetchMock.onGet().reply(200);
+      fetchMock.onGet().reply(200, { name: 'bloop' });
 
       const expectedActions = [
         { type: actions.AUTH_CHECK_REQUEST },
-        { type: actions.AUTH_CHECK_SUCCESS },
+        { type: actions.AUTH_CHECK_SUCCESS, data: { name: 'bloop' } },
         { type: apdActions.GET_APD_REQUEST }
       ];
 
@@ -101,7 +101,7 @@ describe('auth actions', () => {
       });
     });
 
-    it('creates LOGIN_FAILURE after unsuccessful auth', () => {
+    it('creates AUTH_CHECK_FAILURE after unsuccessful auth and does not load APDs', () => {
       const store = mockStore({});
       fetchMock.onGet().reply(403);
 

--- a/web/src/containers/ApdApplication.js
+++ b/web/src/containers/ApdApplication.js
@@ -15,16 +15,14 @@ import TopBtns from './TopBtns';
 import StateProfile from '../components/ApdStateProfile';
 import ProposedBudget from '../components/ProposedBudget';
 
-const PLACE = { id: 'tx', name: 'Texas' };
-
-const ApdApplication = ({ apdSelected }) => {
+const ApdApplication = ({ apdSelected, place }) => {
   if (!apdSelected) {
     return <Redirect to="/" />;
   }
 
   return (
     <div className="site-body">
-      <Sidebar place={PLACE} />
+      <Sidebar place={place} />
       <div className="site-main p2 sm-p4 md-px0">
         <TopBtns />
         <StateProfile />
@@ -42,9 +40,13 @@ const ApdApplication = ({ apdSelected }) => {
 };
 
 ApdApplication.propTypes = {
-  apdSelected: PropTypes.bool.isRequired
+  apdSelected: PropTypes.bool.isRequired,
+  place: PropTypes.object.isRequired
 };
 
-const mapStateToProps = ({ apd: { data } }) => ({ apdSelected: !!data.id });
+const mapStateToProps = ({ apd: { data }, user: { data: { state } } }) => ({
+  apdSelected: !!data.id,
+  place: state
+});
 
 export default connect(mapStateToProps)(ApdApplication);

--- a/web/src/reducers/user.js
+++ b/web/src/reducers/user.js
@@ -1,3 +1,4 @@
+import { AUTH_CHECK_SUCCESS } from '../actions/auth';
 import {
   GET_USER_REQUEST,
   GET_USER_SUCCESS,
@@ -22,6 +23,7 @@ const user = (state = initialState, action) => {
     case GET_USER_REQUEST:
       return { ...state, fetching: true, error: '' };
     case GET_USER_SUCCESS:
+    case AUTH_CHECK_SUCCESS:
       return {
         ...state,
         fetching: false,

--- a/web/src/reducers/user.js
+++ b/web/src/reducers/user.js
@@ -1,4 +1,8 @@
-import { AUTH_CHECK_SUCCESS } from '../actions/auth';
+import {
+  AUTH_CHECK_SUCCESS,
+  LOGIN_SUCCESS,
+  LOGOUT_SUCCESS
+} from '../actions/auth';
 import {
   GET_USER_REQUEST,
   GET_USER_SUCCESS,
@@ -22,8 +26,9 @@ const user = (state = initialState, action) => {
   switch (action.type) {
     case GET_USER_REQUEST:
       return { ...state, fetching: true, error: '' };
-    case GET_USER_SUCCESS:
     case AUTH_CHECK_SUCCESS:
+    case GET_USER_SUCCESS:
+    case LOGIN_SUCCESS:
       return {
         ...state,
         fetching: false,
@@ -32,6 +37,8 @@ const user = (state = initialState, action) => {
       };
     case GET_USER_FAILURE:
       return { ...state, fetching: false, error: action.error };
+    case LOGOUT_SUCCESS:
+      return initialState;
     case UPDATE_USER_REQUEST:
       return { ...state, fetching: true, error: '' };
     case UPDATE_USER_SUCCESS:

--- a/web/src/reducers/user.test.js
+++ b/web/src/reducers/user.test.js
@@ -20,19 +20,23 @@ describe('user reducer', () => {
     });
   });
 
-  it('should handle a successful user fetch', () => {
-    expect(
-      user(initialState, {
-        type: 'GET_USER_SUCCESS',
-        data: { this: 'is', my: 'user' }
-      })
-    ).toEqual({
-      ...initialState,
-      fetching: false,
-      error: '',
-      loaded: true,
-      data: { this: 'is', my: 'user' }
-    });
+  it('should handle a successful user fetch, user check, or login', () => {
+    ['AUTH_CHECK_SUCCESS', 'GET_USER_SUCCESS', 'LOGIN_SUCCESS'].forEach(
+      action => {
+        expect(
+          user(initialState, {
+            type: action,
+            data: { this: 'is', my: 'user' }
+          })
+        ).toEqual({
+          ...initialState,
+          fetching: false,
+          error: '',
+          loaded: true,
+          data: { this: 'is', my: 'user' }
+        });
+      }
+    );
   });
 
   it('should handle an unsuccessful user fetch', () => {
@@ -76,5 +80,11 @@ describe('user reducer', () => {
       loaded: false,
       error: 'booped'
     });
+  });
+
+  it('should handle a logout', () => {
+    expect(user({ not: 'initial state' }, { type: 'LOGOUT_SUCCESS' })).toEqual(
+      initialState
+    );
   });
 });


### PR DESCRIPTION
Sends back useful user information from the API when logging in or checking your current authentication status.  Captures that user information in the app and stores it in the user application state.  Then we can do cool stuff with it.

### This pull request changes...
- the state name and graphic displayed in the sidebar will match the state associated with your user account

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [x] The change has been documented
  - [x] Associated OpenAPI documentation has been updated