### PR TITLE
Add file download endpoint to the API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,14 +138,14 @@ jobs:
       - image: node:8
         environment:
           - NODE_ENV=test
+          - STORE_TYPE=fs
+          - STORE_PATH=endpoint-tests/files
       - image: postgres:latest
         name: db
         environment:
           - POSTGRES_USER=postgres
           - POSTGRES_PASSWORD=cms
           - POSTGRES_DB=hitech_apd_test
-          - STORE_TYPE=fs
-          - STORE_PATH=endpoint-tests/files
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,9 @@ jobs:
           - POSTGRES_USER=postgres
           - POSTGRES_PASSWORD=cms
           - POSTGRES_DB=hitech_apd_test
+          - STORE_TYPE=fs
+          - STORE_PATH=endpoint-tests/files
+
     steps:
       - checkout
       - restore_cache:

--- a/api/docker-compose.endpoint-tests.yml
+++ b/api/docker-compose.endpoint-tests.yml
@@ -18,6 +18,8 @@ services:
       - API_PORT=8000
       - API_HOST=api-for-testing
       - ENDPOINT_COVERAGE_CAPTURE=yes
+      - STORE_TYPE=fs
+      - STORE_PATH=endpoint-tests/files
     command: npm start
     expose:
       - 8000

--- a/api/endpoint-tests/activities/put.js
+++ b/api/endpoint-tests/activities/put.js
@@ -116,14 +116,44 @@ tap.test(
               name: 'updated name',
               description: 'updated description',
               alternatives: null,
-              contractorResources: [],
+              contractorResources: [
+                {
+                  id: 4300,
+                  description: null,
+                  end: null,
+                  files: [
+                    {
+                      id: 5002,
+                      key: 'download.txt',
+                      metadata: null,
+                      size: null
+                    }
+                  ],
+                  name: null,
+                  start: null,
+                  years: []
+                }
+              ],
               costAllocationNarrative: {
                 methodology: null,
                 otherSources: null
               },
               costAllocation: [],
               expenses: [],
-              files: [],
+              files: [
+                {
+                  id: 5000,
+                  key: 'download.txt',
+                  metadata: null,
+                  size: null
+                },
+                {
+                  id: 5004,
+                  key: 'not real',
+                  metadata: null,
+                  size: null
+                }
+              ],
               goals: [
                 {
                   id: 4200,

--- a/api/endpoint-tests/files/download.txt
+++ b/api/endpoint-tests/files/download.txt
@@ -1,0 +1,1 @@
+hello, this is downloaded

--- a/api/endpoint-tests/files/get.js
+++ b/api/endpoint-tests/files/get.js
@@ -1,0 +1,104 @@
+const tap = require('tap'); // eslint-disable-line import/no-extraneous-dependencies
+const {
+  db,
+  getFullPath,
+  login,
+  request,
+  unauthenticatedTest
+} = require('../utils');
+
+const url = id => getFullPath(`/files/${id}`);
+
+const get = async id => {
+  const jar = await login();
+  return request.get(url(id), { jar });
+};
+
+tap.test('files endpoint | GET /files/:fileID', async endpointTests => {
+  await db().seed.run();
+
+  unauthenticatedTest('get', url(3), endpointTests);
+
+  endpointTests.test('when authenticated', async tests => {
+    tests.test('with an invalid ID', async test => {
+      const { response, body } = await get('hello');
+
+      test.equal(response.statusCode, 400, 'gives a 400 status code');
+      test.notOk(body, 'does not send a body');
+    });
+
+    tests.test('with a non-existant file ID', async test => {
+      const { response, body } = await get(3);
+
+      test.equal(response.statusCode, 404, 'gives a 404 status code');
+      test.notOk(body, 'does not send a body');
+    });
+
+    tests.test(
+      'with an existant file ID, but file does not exist in the store',
+      async test => {
+        const { response, body } = await get(5004);
+        test.equal(response.statusCode, 404, 'gives a 404 status code');
+        test.notOk(body, 'does not send a body');
+      }
+    );
+
+    tests.test(
+      'with an existant file ID, but without access',
+      async accessTests => {
+        accessTests.test(
+          'file is attached to inaccessible activity',
+          async test => {
+            const { response, body } = await get(5001);
+
+            test.equal(response.statusCode, 404, 'gives a 404 status code');
+            test.notOk(body, 'does not send a body');
+          }
+        );
+
+        accessTests.test(
+          'file is attached to inaccessible contractor',
+          async test => {
+            const { response, body } = await get(5003);
+
+            test.equal(response.statusCode, 404, 'gives a 404 status code');
+            test.notOk(body, 'does not send a body');
+          }
+        );
+      }
+    );
+
+    tests.test(
+      'with an existant file ID, and with access',
+      async accessTests => {
+        accessTests.test(
+          'file is attached to accessible activity',
+          async test => {
+            const { response, body } = await get(5000);
+
+            test.equal(response.statusCode, 200, 'gives a 200 status code');
+            test.equal(
+              body,
+              'hello, this is downloaded',
+              'downloads the expected file'
+            );
+          }
+        );
+
+        accessTests.test(
+          'file is attached to accessible contractor',
+          async test => {
+            const { response, body } = await get(5002);
+
+            test.equal(response.statusCode, 200, 'gives a 200 status code');
+            test.equal(
+              body,
+              'hello, this is downloaded',
+              'downloads the expected file'
+            );
+          }
+        );
+      }
+    );
+  });
+});

--- a/api/routes/files/get.js
+++ b/api/routes/files/get.js
@@ -14,7 +14,12 @@ module.exports = (
       const { id } = req.params;
       logger.silly(req, `asked for file with id ${id}`);
 
-      const file = await FileModel.where({ id }).fetch({
+      if (Number.isNaN(+id)) {
+        logger.verbose('invalid id');
+        return res.status(400).end();
+      }
+
+      const file = await FileModel.where({ id: +id }).fetch({
         withRelated: ['activities.apd', 'contractors.activity.apd']
       });
 

--- a/api/routes/files/get.js
+++ b/api/routes/files/get.js
@@ -1,0 +1,54 @@
+const logger = require('../../logger')('files route get');
+const loggedIn = require('../../middleware').loggedIn;
+
+const { file: defaultFileModel } = require('../../db').models;
+const defaultStore = require('../../store');
+
+module.exports = (
+  app,
+  { FileModel = defaultFileModel, store = defaultStore } = {}
+) => {
+  logger.silly('setting up GET endpoint');
+  app.get('/files/:key', loggedIn, async (req, res) => {
+    try {
+      const { key } = req.params;
+      logger.silly(req, `asked for file with key ${key}`);
+
+      const file = await FileModel.where({ key }).fetch({
+        withRelated: ['activities.apd', 'contractors.activity.apd']
+      });
+
+      if (file && (await store.exists(key))) {
+        const userApds = await req.user.model.apds();
+        logger.silly(req, `user has access to apds: [${userApds}]`);
+
+        const fileApds = [
+          ...file.related('activities').map(a => a.related('apd').get('id')),
+          ...file.related('contractors').map(c =>
+            c
+              .related('activity')
+              .related('apd')
+              .get('id')
+          )
+        ];
+        logger.silly(req, `file is mapped to apds: [${fileApds}]`);
+
+        if (fileApds.some(a => userApds.includes(a))) {
+          logger.silly(req, `user has access!`);
+          return store.getReadStream(key).pipe(res);
+        }
+        logger.info(
+          req,
+          `User does not have permission to file with key ${key}`
+        );
+      } else {
+        logger.info(req, `No such file with key ${key}`);
+      }
+
+      return res.status(404).end();
+    } catch (e) {
+      logger.error(req, e);
+      return res.status(500).end();
+    }
+  });
+};

--- a/api/routes/files/get.test.js
+++ b/api/routes/files/get.test.js
@@ -12,7 +12,7 @@ tap.test('files GET endpoint', async endpointTest => {
 
   const req = {
     params: {
-      id: 'file id'
+      id: 3
     },
     user: {
       model: {
@@ -61,6 +61,13 @@ tap.test('files GET endpoint', async endpointTest => {
   endpointTest.test('get files handler', async handlerTest => {
     getEndpoint(app, { FileModel, store });
     const handler = app.get.args.filter(arg => arg[0] === '/files/:id')[0][2];
+
+    handlerTest.test('handles an invalid file id', async test => {
+      await handler({ params: { id: 'bob' } }, res);
+
+      test.ok(res.status.calledWith(400), 'sends an HTTP 400');
+      test.ok(res.end.calledOnce, 'response is terminated');
+    });
 
     handlerTest.test('handles a database error', async test => {
       FileModel.fetch.rejects();

--- a/api/routes/files/get.test.js
+++ b/api/routes/files/get.test.js
@@ -1,0 +1,205 @@
+const tap = require('tap');
+const sinon = require('sinon');
+
+const loggedIn = require('../..//middleware').loggedIn;
+const getEndpoint = require('./get');
+
+tap.test('files GET endpoint', async endpointTest => {
+  const sandbox = sinon.createSandbox();
+  const app = {
+    get: sandbox.stub()
+  };
+
+  const req = {
+    params: {
+      key: 'file key'
+    },
+    user: {
+      model: {
+        apds: sandbox.stub()
+      }
+    }
+  };
+
+  const res = {
+    status: sandbox.stub(),
+    send: sandbox.stub(),
+    end: sandbox.stub()
+  };
+
+  const FileModel = {
+    fetch: sandbox.stub(),
+    where: sandbox.stub()
+  };
+
+  const store = {
+    exists: sandbox.stub(),
+    getReadStream: sandbox.stub()
+  };
+
+  endpointTest.beforeEach(async () => {
+    sandbox.resetBehavior();
+    sandbox.resetHistory();
+
+    res.status.returns(res);
+    res.send.returns(res);
+    res.end.returns(res);
+
+    FileModel.where.returns(FileModel);
+  });
+
+  endpointTest.test('setup', async setupTest => {
+    getEndpoint(app);
+
+    setupTest.ok(
+      app.get.calledWith('/files/:key', loggedIn, sinon.match.func),
+      'me GET endpoint is registered'
+    );
+  });
+
+  endpointTest.test('get files handler', async handlerTest => {
+    getEndpoint(app, { FileModel, store });
+    const handler = app.get.args.filter(arg => arg[0] === '/files/:key')[0][2];
+
+    handlerTest.test('handles a database error', async test => {
+      FileModel.fetch.rejects();
+      await handler(req, res);
+
+      test.ok(res.status.calledWith(500), 'sends an HTTP 500');
+      test.ok(res.end.calledOnce, 'response is terminated');
+    });
+
+    handlerTest.test(
+      'handles when the file is not in the database',
+      async test => {
+        FileModel.fetch.resolves(false);
+
+        await handler(req, res);
+
+        test.ok(res.status.calledWith(404), 'sends an HTTP 404');
+        test.ok(res.end.calledOnce, 'response is terminated');
+      }
+    );
+
+    handlerTest.test(
+      'handles when the file is not in the store',
+      async test => {
+        FileModel.fetch.resolves({});
+        store.exists.resolves(false);
+
+        await handler(req, res);
+
+        test.ok(res.status.calledWith(404), 'sends an HTTP 404');
+        test.ok(res.end.calledOnce, 'response is terminated');
+      }
+    );
+
+    handlerTest.test(
+      'when the file exists in the database and the store',
+      async existTests => {
+        const file = {
+          related: sandbox.stub()
+        };
+        const pipe = sandbox.spy();
+
+        existTests.beforeEach(async () => {
+          FileModel.fetch.resolves(file);
+          store.exists.resolves(true);
+
+          store.getReadStream.returns({ pipe });
+
+          // File is associated with APD id 1 via activities
+          file.related.withArgs('activities').returns([
+            {
+              related: sandbox
+                .stub()
+                .withArgs('apd')
+                .returns({
+                  get: sandbox
+                    .stub()
+                    .withArgs('id')
+                    .returns(1)
+                })
+            }
+          ]);
+
+          // File is associated with APD id 2 via contractors
+          file.related.withArgs('contractors').returns([
+            {
+              related: sandbox
+                .stub()
+                .withArgs('activity')
+                .returns({
+                  related: sandbox
+                    .stub()
+                    .withArgs('apd')
+                    .returns({
+                      get: sandbox
+                        .stub()
+                        .withArgs('id')
+                        .returns(2)
+                    })
+                })
+            }
+          ]);
+        });
+
+        existTests.test(
+          'user does not have access to any APD this file is associated with',
+          async test => {
+            req.user.model.apds.returns([3]);
+
+            await handler(req, res);
+
+            test.ok(res.status.calledWith(404), 'sends an HTTP 404');
+            test.ok(res.end.calledOnce, 'response is terminated');
+          }
+        );
+
+        existTests.test(
+          'user has access to an APD via activities',
+          async test => {
+            req.user.model.apds.returns([1]);
+
+            await handler(req, res);
+
+            test.ok(
+              store.getReadStream.calledOnce,
+              'only one read stream is fetched'
+            );
+            test.ok(
+              store.getReadStream.calledWith('file key'),
+              'read stream is fetched with correct key'
+            );
+            test.ok(
+              pipe.calledWith(res),
+              'the file is piped into the response'
+            );
+          }
+        );
+
+        existTests.test(
+          'user has access to an APD via contractors',
+          async test => {
+            req.user.model.apds.returns([2]);
+
+            await handler(req, res);
+
+            test.ok(
+              store.getReadStream.calledOnce,
+              'only one read stream is fetched'
+            );
+            test.ok(
+              store.getReadStream.calledWith('file key'),
+              'read stream is fetched with correct key'
+            );
+            test.ok(
+              pipe.calledWith(res),
+              'the file is piped into the response'
+            );
+          }
+        );
+      }
+    );
+  });
+});

--- a/api/routes/files/openAPI.js
+++ b/api/routes/files/openAPI.js
@@ -1,0 +1,44 @@
+const { requiresAuth } = require('../openAPI/helpers');
+
+const openAPI = {
+  '/files/{id}': {
+    get: {
+      tags: ['Files'],
+      summary: `Downloads a file`,
+      description: `Downloads the specified file if it exists and the user has permission`,
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          description: 'The ID of the file to download',
+          required: true,
+          schema: {
+            type: 'integer'
+          }
+        }
+      ],
+      responses: {
+        200: {
+          description: 'The file',
+          content: {
+            '*/*': {
+              schema: {
+                type: 'string',
+                format: 'binary'
+              }
+            }
+          }
+        },
+        400: {
+          description: 'The provided file ID was invalid'
+        },
+        404: {
+          description:
+            'The file ID does not match any known files, or the file does not exist in storage'
+        }
+      }
+    }
+  }
+};
+
+module.exports = requiresAuth(openAPI, { has401: false });

--- a/api/routes/index.js
+++ b/api/routes/index.js
@@ -1,6 +1,7 @@
 const logger = require('../logger')('routes index');
 const auth = require('./auth');
 const apds = require('./apds');
+const files = require('./files/get');
 const me = require('./me/get');
 const states = require('./states');
 const users = require('./users');
@@ -10,6 +11,7 @@ module.exports = (
   app,
   apdsEndpoint = apds,
   authEndpoint = auth,
+  filesEndpoint = files,
   meEndpoint = me,
   statesEndpoint = states,
   usersEndpoint = users,
@@ -19,6 +21,8 @@ module.exports = (
   apdsEndpoint(app);
   logger.silly('setting up routes for auth');
   authEndpoint(app);
+  logger.silly('settup up routes for files');
+  filesEndpoint(app);
   logger.silly('setting up routes for me');
   meEndpoint(app);
   logger.silly('setting up routes for states');

--- a/api/routes/index.test.js
+++ b/api/routes/index.test.js
@@ -12,6 +12,7 @@ tap.test('endpoint setup', async endpointTest => {
 
   const apdsEndpoint = sinon.spy();
   const authEndpoint = sinon.spy();
+  const filesEndpoint = sinon.spy();
   const meEndpoint = sinon.spy();
   const statesEndpoint = sinon.spy();
   const usersEndpoint = sinon.spy();
@@ -21,6 +22,7 @@ tap.test('endpoint setup', async endpointTest => {
     app,
     apdsEndpoint,
     authEndpoint,
+    filesEndpoint,
     meEndpoint,
     statesEndpoint,
     usersEndpoint,
@@ -34,6 +36,10 @@ tap.test('endpoint setup', async endpointTest => {
   endpointTest.ok(
     authEndpoint.calledWith(app),
     'auth endpoint is setup with the app'
+  );
+  endpointTest.ok(
+    filesEndpoint.calledWith(app),
+    'files endpoint is setup with the app'
   );
   endpointTest.ok(
     meEndpoint.calledWith(app),

--- a/api/routes/openAPI/index.js
+++ b/api/routes/openAPI/index.js
@@ -4,6 +4,7 @@ const auth = require('./auth');
 const apds = require('../apds/openAPI');
 const authActivities = require('../auth/activities/openAPI');
 const authRoles = require('../auth/roles/openAPI');
+const files = require('../files/openAPI');
 const me = require('../me/openAPI');
 const users = require('../users/openAPI');
 const states = require('../states/openAPI');
@@ -21,6 +22,7 @@ module.exports = {
     ...auth,
     ...authActivities,
     ...authRoles,
+    ...files,
     ...me,
     ...users,
     ...states,

--- a/api/seeds/shared/delete-everything.js
+++ b/api/seeds/shared/delete-everything.js
@@ -2,6 +2,10 @@ exports.seed = async knex => {
   // These need to be deleted in a particular order to handle
   // relationships between them, otherwise we get a key
   // constraint violation.
+  await knex('activity_contractor_files').del();
+  await knex('activity_files').del();
+  await knex('files').del();
+
   await knex('activity_contractor_resources_yearly').del();
   await knex('activity_contractor_resources').del();
 

--- a/api/seeds/test.js
+++ b/api/seeds/test.js
@@ -1,6 +1,8 @@
-const apds = require('./test/apds');
 const truncate = require('./shared/delete-everything');
 const states = require('./shared/states');
+
+const apds = require('./test/apds');
+const files = require('./test/files');
 const roles = require('./test/roles');
 const testStates = require('./test/states');
 const users = require('./test/users');
@@ -16,6 +18,7 @@ exports.seed = async knex => {
   await roles.seed(knex);
   await states.seed(knex);
   await apds.seed(knex);
+  await files.seed(knex);
   await testStates.seed(knex);
   await users.seed(knex);
 };

--- a/api/seeds/test/apds.js
+++ b/api/seeds/test/apds.js
@@ -2,7 +2,7 @@ exports.seed = async knex => {
   // 40xx IDs refer to apds
   // 41xx IDs refer to activities
   // 42xx IDs refer to goals
-  // 43xx IDs refer to objectives
+  // 43xx IDs refer to contractors
 
   await knex('apds').insert([
     {
@@ -60,6 +60,17 @@ exports.seed = async knex => {
       description: 'Go on Ellen',
       objective: 'Learn to dance',
       activity_id: 4100
+    }
+  ]);
+
+  await knex('activity_contractor_resources').insert([
+    {
+      id: 4300,
+      activity_id: 4100
+    },
+    {
+      id: 4301,
+      activity_id: 4110
     }
   ]);
 };

--- a/api/seeds/test/files.js
+++ b/api/seeds/test/files.js
@@ -1,0 +1,40 @@
+exports.seed = async knex => {
+  // 40xx IDs refer to apds
+  // 41xx IDs refer to activities
+  // 42xx IDs refer to goals
+  // 43xx IDs refer to objectives
+
+  await knex('files').insert([
+    { id: 5000, key: 'download.txt' },
+    { id: 5001, key: 'download.txt' },
+    { id: 5002, key: 'download.txt' },
+    { id: 5003, key: 'download.txt' },
+    { id: 5004, key: 'not real' }
+  ]);
+
+  await knex('activity_files').insert([
+    {
+      file_id: 5000,
+      activity_id: 4100
+    },
+    {
+      file_id: 5004,
+      activity_id: 4100
+    },
+    {
+      file_id: 5001,
+      activity_id: 4110
+    }
+  ]);
+
+  await knex('activity_contractor_files').insert([
+    {
+      file_id: 5002,
+      activity_contractor_resource_id: 4300
+    },
+    {
+      file_id: 5003,
+      activity_contractor_resource_id: 4301
+    }
+  ]);
+};


### PR DESCRIPTION
Adds an API endpoint at `GET /files/:key` for downloading files.  The authorization logic goes like this:

1. does the file exist in the database?
2. does the file exist in the file store?
3. does the file belong to an APD that the user has access to?
  - a file belongs to an APD if the file is associated with an activity in the APD, OR if the file is associated with a contractor that is associated with an activity in the APD

Also associated with #735

### Still needs...
Endpoint tests and OpenAPI documentation

### This pull request changes...
- no visible changes

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated