### PR TITLE
new help text stylez

### DIFF
--- a/web/src/components/HelpText.js
+++ b/web/src/components/HelpText.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import Md from './Md';
 import { t } from '../i18n';
 
 const HelpText = ({ text: textResource, reminder: reminderResource }) => {
@@ -12,7 +13,11 @@ const HelpText = ({ text: textResource, reminder: reminderResource }) => {
       <div className="mb2">
         {text && <div>{text}</div>}
         {reminder && (
-          <div className="my1 p1 h6 alert alert-info">{reminder}</div>
+          <Md
+            content={reminder}
+            wrapper="div"
+            className="my1 p1 h6 alert alert-help"
+          />
         )}
       </div>
     )

--- a/web/src/components/HelpText.js
+++ b/web/src/components/HelpText.js
@@ -16,7 +16,7 @@ const HelpText = ({ text: textResource, reminder: reminderResource }) => {
           <Md
             content={reminder}
             wrapper="div"
-            className="my1 p1 h6 alert alert-help"
+            className="my1 p1 alert alert-help"
           />
         )}
       </div>

--- a/web/src/components/__snapshots__/HelpText.test.js.snap
+++ b/web/src/components/__snapshots__/HelpText.test.js.snap
@@ -22,11 +22,11 @@ ShallowWrapper {
     "props": Object {
       "children": Array [
         false,
-        <div
-          className="my1 p1 h6 alert alert-info"
-        >
-          [missing {{year}} value] HITECH APD
-        </div>,
+        <Md
+          className="my1 p1 h6 alert alert-help"
+          content="[missing {{year}} value] HITECH APD"
+          wrapper="div"
+        />,
       ],
       "className": "mb2",
     },
@@ -36,14 +36,15 @@ ShallowWrapper {
       Object {
         "instance": null,
         "key": undefined,
-        "nodeType": "host",
+        "nodeType": "function",
         "props": Object {
-          "children": "[missing {{year}} value] HITECH APD",
-          "className": "my1 p1 h6 alert alert-info",
+          "className": "my1 p1 h6 alert alert-help",
+          "content": "[missing {{year}} value] HITECH APD",
+          "wrapper": "div",
         },
         "ref": null,
-        "rendered": "[missing {{year}} value] HITECH APD",
-        "type": "div",
+        "rendered": null,
+        "type": [Function],
       },
     ],
     "type": "div",
@@ -56,11 +57,11 @@ ShallowWrapper {
       "props": Object {
         "children": Array [
           false,
-          <div
-            className="my1 p1 h6 alert alert-info"
-          >
-            [missing {{year}} value] HITECH APD
-          </div>,
+          <Md
+            className="my1 p1 h6 alert alert-help"
+            content="[missing {{year}} value] HITECH APD"
+            wrapper="div"
+          />,
         ],
         "className": "mb2",
       },
@@ -70,14 +71,15 @@ ShallowWrapper {
         Object {
           "instance": null,
           "key": undefined,
-          "nodeType": "host",
+          "nodeType": "function",
           "props": Object {
-            "children": "[missing {{year}} value] HITECH APD",
-            "className": "my1 p1 h6 alert alert-info",
+            "className": "my1 p1 h6 alert alert-help",
+            "content": "[missing {{year}} value] HITECH APD",
+            "wrapper": "div",
           },
           "ref": null,
-          "rendered": "[missing {{year}} value] HITECH APD",
-          "type": "div",
+          "rendered": null,
+          "type": [Function],
         },
       ],
       "type": "div",
@@ -146,11 +148,11 @@ ShallowWrapper {
         <div>
           [missing {{year}} value] HITECH APD
         </div>,
-        <div
-          className="my1 p1 h6 alert alert-info"
-        >
-          [missing {{year}} value] HITECH APD
-        </div>,
+        <Md
+          className="my1 p1 h6 alert alert-help"
+          content="[missing {{year}} value] HITECH APD"
+          wrapper="div"
+        />,
       ],
       "className": "mb2",
     },
@@ -170,14 +172,15 @@ ShallowWrapper {
       Object {
         "instance": null,
         "key": undefined,
-        "nodeType": "host",
+        "nodeType": "function",
         "props": Object {
-          "children": "[missing {{year}} value] HITECH APD",
-          "className": "my1 p1 h6 alert alert-info",
+          "className": "my1 p1 h6 alert alert-help",
+          "content": "[missing {{year}} value] HITECH APD",
+          "wrapper": "div",
         },
         "ref": null,
-        "rendered": "[missing {{year}} value] HITECH APD",
-        "type": "div",
+        "rendered": null,
+        "type": [Function],
       },
     ],
     "type": "div",
@@ -192,11 +195,11 @@ ShallowWrapper {
           <div>
             [missing {{year}} value] HITECH APD
           </div>,
-          <div
-            className="my1 p1 h6 alert alert-info"
-          >
-            [missing {{year}} value] HITECH APD
-          </div>,
+          <Md
+            className="my1 p1 h6 alert alert-help"
+            content="[missing {{year}} value] HITECH APD"
+            wrapper="div"
+          />,
         ],
         "className": "mb2",
       },
@@ -216,14 +219,15 @@ ShallowWrapper {
         Object {
           "instance": null,
           "key": undefined,
-          "nodeType": "host",
+          "nodeType": "function",
           "props": Object {
-            "children": "[missing {{year}} value] HITECH APD",
-            "className": "my1 p1 h6 alert alert-info",
+            "className": "my1 p1 h6 alert alert-help",
+            "content": "[missing {{year}} value] HITECH APD",
+            "wrapper": "div",
           },
           "ref": null,
-          "rendered": "[missing {{year}} value] HITECH APD",
-          "type": "div",
+          "rendered": null,
+          "type": [Function],
         },
       ],
       "type": "div",

--- a/web/src/components/__snapshots__/HelpText.test.js.snap
+++ b/web/src/components/__snapshots__/HelpText.test.js.snap
@@ -23,7 +23,7 @@ ShallowWrapper {
       "children": Array [
         false,
         <Md
-          className="my1 p1 h6 alert alert-help"
+          className="my1 p1 alert alert-help"
           content="[missing {{year}} value] HITECH APD"
           wrapper="div"
         />,
@@ -38,7 +38,7 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "function",
         "props": Object {
-          "className": "my1 p1 h6 alert alert-help",
+          "className": "my1 p1 alert alert-help",
           "content": "[missing {{year}} value] HITECH APD",
           "wrapper": "div",
         },
@@ -58,7 +58,7 @@ ShallowWrapper {
         "children": Array [
           false,
           <Md
-            className="my1 p1 h6 alert alert-help"
+            className="my1 p1 alert alert-help"
             content="[missing {{year}} value] HITECH APD"
             wrapper="div"
           />,
@@ -73,7 +73,7 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "function",
           "props": Object {
-            "className": "my1 p1 h6 alert alert-help",
+            "className": "my1 p1 alert alert-help",
             "content": "[missing {{year}} value] HITECH APD",
             "wrapper": "div",
           },
@@ -149,7 +149,7 @@ ShallowWrapper {
           [missing {{year}} value] HITECH APD
         </div>,
         <Md
-          className="my1 p1 h6 alert alert-help"
+          className="my1 p1 alert alert-help"
           content="[missing {{year}} value] HITECH APD"
           wrapper="div"
         />,
@@ -174,7 +174,7 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "function",
         "props": Object {
-          "className": "my1 p1 h6 alert alert-help",
+          "className": "my1 p1 alert alert-help",
           "content": "[missing {{year}} value] HITECH APD",
           "wrapper": "div",
         },
@@ -196,7 +196,7 @@ ShallowWrapper {
             [missing {{year}} value] HITECH APD
           </div>,
           <Md
-            className="my1 p1 h6 alert alert-help"
+            className="my1 p1 alert alert-help"
             content="[missing {{year}} value] HITECH APD"
             wrapper="div"
           />,
@@ -221,7 +221,7 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "function",
           "props": Object {
-            "className": "my1 p1 h6 alert alert-help",
+            "className": "my1 p1 alert alert-help",
             "content": "[missing {{year}} value] HITECH APD",
             "wrapper": "div",
           },

--- a/web/src/i18n/locales/en.yaml
+++ b/web/src/i18n/locales/en.yaml
@@ -1,11 +1,11 @@
 ---
   title: "{{year}} HITECH APD"
-  titleBasic: "CMS HITECH APD"
-  login: "Log in"
-  logout: "Log out"
-  notifications: "Notifications"
+  titleBasic: CMS HITECH APD
+  login: Log in
+  logout: Log out
+  notifications: Notifications
   dashboard: State dashboard
-  help: "Help"
+  help: Help
   wip: "**Stay tuned!** This section is a work in progress."
   ffy: FFY {{year}}
   table:
@@ -15,15 +15,23 @@
   sidebar: 
     titles:
       activity-set: "Activity {{number}}: {{name}}"
-      activity-unset: "Activity {{number}}"
-    savePdfButtonText: "Save as PDF"
+      activity-unset: Activity {{number}}
+    savePdfButtonText: Save as PDF
     saveApdButtonText: Save APD
   apd: 
-    title: "Program Summary"
-    helpText: "Provide an introduction for the state program. Include context for this funding request by providing information such as current size of program, future vision, and how the program is positioned within the state. This information is similar to the content from the IAPD executive summary template section."
+    title: Program Summary
+    helpText: >-
+      Provide an introduction for the state program. Include context for this
+      funding request by providing information such as current size of program,
+      future vision, and how the program is positioned within the state. This
+      information is similar to the content from the IAPD executive summary
+      template section.
     stateProfile:
       title: State Profile Contact Information
-      helpText: In this section, list relevant state contacts. If the information is on record, it will be listed below. Ensure the director(s) name and office address are listed correctly.
+      helpText: >-
+        In this section, list relevant state contacts. If the information is
+        on record, it will be listed below. Ensure the director(s) name and
+        office address are listed correctly.
       directorAndAddress:
         title: State Medicaid Director & Medicaid Office Address
         director:
@@ -60,7 +68,9 @@
     overview: 
       title: "Program Overview"
       helpText: "Provide a high level summary of the state program including history, and future vision. This initial overview is intended to be brief, there will be opportunities to explain in more detail in the activity details section."
-      reminder: "Indicate the federal fiscal years for which this APD is requesting funding."
+      reminder: >-
+        Indicate the federal fiscal years for which this APD is requesting
+        funding.
       yearsCovered: "What federal fiscal year(s) does this APD cover?"
       labels: 
         desc: "Program Introduction"

--- a/web/src/styles/app/alert.css
+++ b/web/src/styles/app/alert.css
@@ -14,6 +14,11 @@
   border-color: #02bfe7;
 }
 
+.alert-help {
+  background-color: #fff1d2;
+  border-color: #fdb81e;
+}
+
 .alert-success {
   background-color: #e7f4e4;
   border-color: #2e8540;

--- a/web/src/util/md.js
+++ b/web/src/util/md.js
@@ -1,5 +1,5 @@
 import MarkdownIt from 'markdown-it';
 
-const md = new MarkdownIt({ xhtmlOut: true, breaks: true });
+const md = new MarkdownIt({ html: true, xhtmlOut: true, breaks: true });
 
 export default md;


### PR DESCRIPTION
Addresses and closes https://github.com/18F/cms-hitech-apd/issues/830

The reminder field now also supports using markdown or html in our big yaml file. for example:

`foo: This has something **bolded**.`

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author

### This feature is done when...
- [ ] Design has approved the experience
- [ ] Product has approved the experience
