### PR TITLE
resizable rich text

### DIFF
--- a/web/src/styles/app/editor.css
+++ b/web/src/styles/app/editor.css
@@ -26,8 +26,9 @@
   overflow: inherit;
 }
 
-.DraftEditor-root {
-  height: 400px;
+.DraftEditor-root,
+.public-DraftEditor-content {
+  min-height: 240px;
 }
 
 .public-DraftEditor-content {


### PR DESCRIPTION
Addresses and closes https://github.com/18F/cms-hitech-apd/issues/850

@NAretakis -- this is maybe the best we can do here... as the user adds more text, the box becomes larger --there's no explicit resize box button, it just happens as the content fills the space -- is that kewl?

preview:
https://cl.ly/tMsw

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author

### This feature is done when...
- [ ] Product has approved the experience
