### PR TITLE
Save/retrieve contractor hourly data on the backend

### DIFF
--- a/api/db/activity/activity.js
+++ b/api/db/activity/activity.js
@@ -97,6 +97,7 @@ module.exports = {
       withRelated: [
         'contractorResources',
         'contractorResources.files',
+        'contractorResources.hourlyData',
         'contractorResources.years',
         'goals',
         'expenses',

--- a/api/db/activity/activity.test.js
+++ b/api/db/activity/activity.test.js
@@ -45,6 +45,7 @@ tap.test('activity data model', async activityModelTests => {
             withRelated: [
               'contractorResources',
               'contractorResources.files',
+              'contractorResources.hourlyData',
               'contractorResources.years',
               'goals',
               'expenses',

--- a/api/db/activity/contractorResource.js
+++ b/api/db/activity/contractorResource.js
@@ -19,6 +19,13 @@ module.exports = {
       );
     },
 
+    hourlyData() {
+      return this.hasMany(
+        'apdActivityContractorResourceHourly',
+        'contractor_resource_id'
+      );
+    },
+
     years() {
       return this.hasMany(
         'apdActivityContractorResourceCost',
@@ -45,19 +52,24 @@ module.exports = {
 
     toJSON() {
       return {
+        description: this.get('description'),
+        end: getDate(this.get('end')),
+        files: this.related('files'),
+        hourlyData: this.related('hourlyData'),
         id: this.get('id'),
         name: this.get('name'),
-        description: this.get('description'),
-        files: this.related('files'),
         start: getDate(this.get('start')),
-        end: getDate(this.get('end')),
+        useHourly: this.get('useHourly'),
         years: this.related('years')
       };
     },
 
     static: {
-      updateableFields: ['name', 'description', 'start', 'end'],
-      owns: { years: 'apdActivityContractorResourceCost' },
+      updateableFields: ['name', 'description', 'end', 'start', 'useHourly'],
+      owns: {
+        years: 'apdActivityContractorResourceCost',
+        hourlyData: 'apdActivityContractorResourceHourly'
+      },
       foreignKey: 'contractor_resource_id'
     }
   },
@@ -88,6 +100,30 @@ module.exports = {
 
     static: {
       updateableFields: ['year', 'cost']
+    }
+  },
+
+  apdActivityContractorResourceHourly: {
+    tableName: 'activity_contractor_resources_hourly',
+
+    contractorResource() {
+      return this.belongsTo(
+        'apdActivityContractorResource',
+        'contractor_resource_id'
+      );
+    },
+
+    toJSON() {
+      return {
+        id: this.get('id'),
+        year: this.get('year'),
+        hours: +this.get('hours'),
+        rate: +this.get('rate')
+      };
+    },
+
+    static: {
+      updateableFields: ['year', 'hours', 'rate']
     }
   }
 };

--- a/api/db/activity/index.test.js
+++ b/api/db/activity/index.test.js
@@ -13,6 +13,7 @@ tap.test('activity model index', async activityIndexTests => {
       'apdActivity',
       'apdActivityContractorResource',
       'apdActivityContractorResourceCost',
+      'apdActivityContractorResourceHourly',
       'apdActivityCostAllocation',
       'apdActivityExpense',
       'apdActivityExpenseEntry',

--- a/api/db/apd.js
+++ b/api/db/apd.js
@@ -134,6 +134,7 @@ module.exports = () => ({
         { activities: query => query.orderBy('id') },
         'activities.contractorResources',
         'activities.contractorResources.files',
+        'activities.contractorResources.hourlyData',
         'activities.contractorResources.years',
         'activities.costAllocation',
         'activities.goals',

--- a/api/db/apd.test.js
+++ b/api/db/apd.test.js
@@ -41,6 +41,7 @@ tap.test('apd data model', async apdModelTests => {
               { activities: Function },
               'activities.contractorResources',
               'activities.contractorResources.files',
+              'activities.contractorResources.hourlyData',
               'activities.contractorResources.years',
               'activities.costAllocation',
               'activities.goals',

--- a/api/endpoint-tests/activities/put.js
+++ b/api/endpoint-tests/activities/put.js
@@ -129,8 +129,10 @@ tap.test(
                       size: null
                     }
                   ],
+                  hourlyData: [],
                   name: null,
                   start: null,
+                  useHourly: false,
                   years: []
                 }
               ],

--- a/api/migrations/20180801141938_add-contractor-hourly.js
+++ b/api/migrations/20180801141938_add-contractor-hourly.js
@@ -1,0 +1,22 @@
+exports.up = async knex => {
+  await knex.schema.alterTable('activity_contractor_resources', table => {
+    table.boolean('useHourly').defaultTo(false);
+  });
+
+  await knex.schema.createTable(
+    'activity_contractor_resources_hourly',
+    table => {
+      table.increments();
+      table.integer('contractor_resource_id');
+      table.integer('year');
+      table.decimal('hours', 15, 2);
+      table.decimal('rate', 15, 2);
+
+      table
+        .foreign('contractor_resource_id')
+        .references('activity_contractor_resources.id');
+    }
+  );
+};
+
+exports.down = async () => {};

--- a/api/routes/apds/post.data.js
+++ b/api/routes/apds/post.data.js
@@ -15,11 +15,9 @@ const getActivityCostAllocations = years =>
 
 const getContractor = years => ({
   description: '',
+  hourlyData: yearsToArray(years, { hours: 0, rate: 0 }),
   name: '',
-  hourly: {
-    useHourly: false,
-    data: yearsToArray(years, { hours: '', rate: '' })
-  },
+  useHourly: false,
   years: yearsToArray(years, { cost: 0 })
 });
 

--- a/api/routes/apds/post.data.test.js
+++ b/api/routes/apds/post.data.test.js
@@ -36,21 +36,19 @@ tap.test('APD data initializer', async test => {
           {
             description: '',
             name: '',
-            hourly: {
-              useHourly: false,
-              data: [
-                {
-                  hours: '',
-                  rate: '',
-                  year: '2018'
-                },
-                {
-                  hours: '',
-                  rate: '',
-                  year: '2019'
-                }
-              ]
-            },
+            hourlyData: [
+              {
+                hours: '',
+                rate: '',
+                year: '2018'
+              },
+              {
+                hours: '',
+                rate: '',
+                year: '2019'
+              }
+            ],
+            useHourly: false,
             years: [
               {
                 cost: 0,

--- a/api/routes/openAPI/index.js
+++ b/api/routes/openAPI/index.js
@@ -83,6 +83,23 @@ module.exports = {
               files: arrayOf({
                 $ref: '#/components/schemas/file'
               }),
+              hourlyData: arrayOf({
+                type: 'object',
+                properties: {
+                  hours: {
+                    type: 'number',
+                    description: 'Number of hours this contractor works/ed'
+                  },
+                  rates: {
+                    type: 'number',
+                    description: 'Hourly rate for this contractor'
+                  },
+                  year: {
+                    type: 'string',
+                    description: 'Year this hourly rate applies to'
+                  }
+                }
+              }),
               start: {
                 type: 'string',
                 format: 'date-time',
@@ -94,6 +111,10 @@ module.exports = {
                 format: 'date-time',
                 description:
                   'When the contractor resource will end work; date only'
+              },
+              useHourly: {
+                type: 'boolean',
+                description: 'Whether to use hourly rates for this contractor'
               },
               years: arrayOf({
                 type: 'object',

--- a/api/seeds/shared/delete-everything.js
+++ b/api/seeds/shared/delete-everything.js
@@ -6,6 +6,7 @@ exports.seed = async knex =>
     // These tables don't reference any other tables, so
     // they can be cleared out right off the bat.
     knex('activity_contractor_files').del(),
+    knex('activity_contractor_resources_hourly').del(),
     knex('activity_files').del(),
     knex('activity_contractor_resources_yearly').del(),
     knex('activity_cost_allocation').del(),


### PR DESCRIPTION
Just what it says on the tin.

Closes #864

### This pull request changes...
- can save and retrieve contractor hourly data

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated