### PR TITLE
Automatically open new APDs + some frontend cleanup

### DIFF
--- a/web/src/actions/apd.js
+++ b/web/src/actions/apd.js
@@ -51,16 +51,22 @@ export const updateApd = updates => dispatch => {
   }
 };
 
+export const selectApd = (id, pushRoute = push) => (dispatch, getState) => {
+  dispatch({ type: SELECT_APD, apd: getState().apd.byId[id] });
+  dispatch(updateBudget());
+  dispatch(pushRoute('/apd'));
+};
+
 export const createRequest = () => ({ type: CREATE_APD_REQUEST });
 export const createSuccess = data => ({ type: CREATE_APD_SUCCESS, data });
 export const createFailure = () => ({ type: CREATE_APD_FAILURE });
-export const createApd = () => dispatch => {
+export const createApd = ({ pushRoute = push } = {}) => dispatch => {
   dispatch(createRequest());
   return axios
     .post('/apds')
     .then(req => {
       dispatch(createSuccess(req.data));
-      dispatch(selectApd(req.data.id));
+      dispatch(selectApd(req.data.id, pushRoute));
     })
     .catch(error => {
       const reason = error.response ? error.response.data : 'N/A';
@@ -97,12 +103,6 @@ export const fetchApdDataIfNeeded = () => (dispatch, getState) => {
   }
 
   return null;
-};
-
-export const selectApd = (id, pushRoute = push) => (dispatch, getState) => {
-  dispatch({ type: SELECT_APD, apd: getState().apd.byId[id] });
-  dispatch(updateBudget());
-  dispatch(pushRoute('/apd'));
 };
 
 export const notifyNetError = (action, error) => {

--- a/web/src/actions/apd.js
+++ b/web/src/actions/apd.js
@@ -52,14 +52,20 @@ export const updateApd = updates => dispatch => {
 };
 
 export const createRequest = () => ({ type: CREATE_APD_REQUEST });
-export const createSuccess = () => ({ type: CREATE_APD_SUCCESS });
+export const createSuccess = data => ({ type: CREATE_APD_SUCCESS, data });
 export const createFailure = () => ({ type: CREATE_APD_FAILURE });
 export const createApd = () => dispatch => {
   dispatch(createRequest());
-  return axios.post('/apds').catch(error => {
-    const reason = error.response ? error.response.data : 'N/A';
-    dispatch(createFailure(reason));
-  });
+  return axios
+    .post('/apds')
+    .then(req => {
+      dispatch(createSuccess(req.data));
+      dispatch(selectApd(req.data.id));
+    })
+    .catch(error => {
+      const reason = error.response ? error.response.data : 'N/A';
+      dispatch(createFailure(reason));
+    });
 };
 
 export const requestSave = () => ({ type: SAVE_APD_REQUEST });

--- a/web/src/actions/apd.test.js
+++ b/web/src/actions/apd.test.js
@@ -90,13 +90,29 @@ describe('apd actions', () => {
 
   describe('create APD', () => {
     // TODO: But for real.
-    it('uh...  does not do anything on success... we should change this', () => {
-      fetchMock.onPost('/apds').reply(200);
-      const store = mockStore();
+    it('adds the new APD to the store and switches to it on success', () => {
+      const newapd = { id: 'bloop' };
+      fetchMock.onPost('/apds').reply(200, newapd);
 
-      const expectedActions = [{ type: actions.CREATE_APD_REQUEST }];
+      const push = route => ({ type: 'FAKE_PUSH', pushRoute: route });
+      const state = {
+        apd: {
+          byId: {
+            bloop: { hello: 'world' }
+          }
+        }
+      };
+      const store = mockStore(state);
 
-      store.dispatch(actions.createApd()).then(() => {
+      const expectedActions = [
+        { type: actions.CREATE_APD_REQUEST },
+        { type: actions.CREATE_APD_SUCCESS, data: newapd },
+        { type: actions.SELECT_APD, apd: { hello: 'world' } },
+        { type: actions.UPDATE_BUDGET, state },
+        { type: 'FAKE_PUSH', pushRoute: '/apd' }
+      ];
+
+      return store.dispatch(actions.createApd({ pushRoute: push })).then(() => {
         expect(store.getActions()).toEqual(expectedActions);
       });
     });

--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -399,8 +399,10 @@ const reducer = (state = initialState, action) => {
     case SELECT_APD: {
       const byKey = {};
       ((action.apd || {}).activities || []).forEach(a => {
-        byKey[a.key] = a;
-        byKey[a.key].meta = { expanded: a.name === 'Program Administration' };
+        byKey[a.key] = {
+          ...a,
+          meta: { expanded: a.name === 'Program Administration' }
+        };
       });
 
       if (Object.keys(byKey).length === 0) {

--- a/web/src/reducers/apd.js
+++ b/web/src/reducers/apd.js
@@ -2,6 +2,7 @@ import u from 'updeep';
 
 import {
   ADD_APD_POC,
+  CREATE_APD_SUCCESS,
   GET_APD_REQUEST,
   GET_APD_SUCCESS,
   GET_APD_FAILURE,
@@ -9,15 +10,8 @@ import {
   SELECT_APD,
   UPDATE_APD
 } from '../actions/apd';
-import {
-  INCENTIVE_ENTRIES,
-  arrToObj,
-  defaultAPDYearOptions,
-  defaultAPDYears
-} from '../util';
+import { INCENTIVE_ENTRIES, arrToObj, defaultAPDYearOptions } from '../util';
 import { fromAPI } from '../util/serialization/apd';
-
-import assurancesList from '../data/assurancesAndCompliance.yaml';
 
 export const initIncentiveData = () =>
   arrToObj(
@@ -25,103 +19,15 @@ export const initIncentiveData = () =>
     arrToObj(defaultAPDYearOptions, { 1: 0, 2: 0, 3: 0, 4: 0 })
   );
 
-export const initialAssurances = Object.entries(assurancesList).reduce(
-  (acc, [name, regulations]) => ({
-    ...acc,
-    [name]: Object.keys(regulations).map(reg => ({
-      title: reg,
-      checked: false,
-      explanation: ''
-    }))
-  }),
-  {}
-);
-
-export const getPreviousActivityExpense = () => ({
-  hie: {
-    federalActual: 0,
-    federalApproved: 0,
-    stateActual: 0,
-    stateApproved: 0
-  },
-  hit: {
-    federalActual: 0,
-    federalApproved: 0,
-    stateActual: 0,
-    stateApproved: 0
-  },
-  mmis: {
-    federal90Actual: 0,
-    federal90Approved: 0,
-    federal75Actual: 0,
-    federal75Approved: 0,
-    federal50Actual: 0,
-    federal50Approved: 0,
-    state10Actual: 0,
-    state10Approved: 0,
-    state25Actual: 0,
-    state25Approved: 0,
-    state50Actual: 0,
-    state50Approved: 0
-  }
-});
-
 export const getPointOfContact = () => ({ name: '', position: '', email: '' });
 
 const initialState = {
-  data: {
-    id: '',
-    years: defaultAPDYears,
-    yearOptions: defaultAPDYearOptions,
-    overview: '',
-    hitNarrative: '',
-    hieNarrative: '',
-    mmisNarrative: '',
-    pointsOfContact: [getPointOfContact()],
-    previousActivitySummary: '',
-    previousActivityExpenses: defaultAPDYearOptions.reduce(
-      (acc, year) => ({
-        ...acc,
-        [year - 2]: getPreviousActivityExpense()
-      }),
-      {}
-    ),
-    incentivePayments: initIncentiveData(),
-    stateProfile: {
-      medicaidDirector: {
-        name: '',
-        email: '',
-        phone: ''
-      },
-      medicaidOffice: {
-        address1: '',
-        address2: '',
-        city: '',
-        state: '',
-        zip: ''
-      }
-    },
-    assurancesAndCompliance: { ...initialAssurances }
-  },
+  data: {},
   byId: {},
   fetching: false,
   loaded: false,
   error: ''
 };
-
-const defaults = () => ({
-  assurancesAndCompliance: initialAssurances,
-  incentivePayments: initIncentiveData(),
-  previousActivityExpenses: defaultAPDYearOptions.reduce(
-    (previous, year) => ({
-      ...previous,
-      [year - 2]: getPreviousActivityExpense()
-    }),
-    {}
-  ),
-  previousActivitySummary: '',
-  years: defaultAPDYears
-});
 
 const reducer = (state = initialState, action) => {
   switch (action.type) {
@@ -130,6 +36,18 @@ const reducer = (state = initialState, action) => {
         {
           data: {
             pointsOfContact: pocs => [...pocs, getPointOfContact()]
+          }
+        },
+        state
+      );
+    case CREATE_APD_SUCCESS:
+      return u(
+        {
+          byId: {
+            [action.data.id]: {
+              ...fromAPI(action.data),
+              yearOptions: defaultAPDYearOptions
+            }
           }
         },
         state
@@ -145,7 +63,7 @@ const reducer = (state = initialState, action) => {
           (acc, apd) => ({
             ...acc,
             [apd.id]: {
-              ...fromAPI(apd, defaults()),
+              ...fromAPI(apd),
               yearOptions: defaultAPDYearOptions
             }
           }),

--- a/web/src/reducers/apd.test.js
+++ b/web/src/reducers/apd.test.js
@@ -1,45 +1,9 @@
-import apd, {
-  initIncentiveData,
-  initialAssurances,
-  getPreviousActivityExpense
-} from './apd';
+import apd from './apd';
 
 describe('APD reducer', () => {
-  const incentivePayments = initIncentiveData();
   const initialState = {
     byId: {},
-    data: {
-      id: '',
-      years: ['2018', '2019'],
-      yearOptions: ['2018', '2019', '2020'],
-      overview: '',
-      hitNarrative: '',
-      hieNarrative: '',
-      mmisNarrative: '',
-      assurancesAndCompliance: initialAssurances,
-      pointsOfContact: [{ email: '', name: '', position: '' }],
-      previousActivitySummary: '',
-      previousActivityExpenses: {
-        2016: getPreviousActivityExpense(),
-        2017: getPreviousActivityExpense(),
-        2018: getPreviousActivityExpense()
-      },
-      incentivePayments,
-      stateProfile: {
-        medicaidDirector: {
-          name: '',
-          email: '',
-          phone: ''
-        },
-        medicaidOffice: {
-          address1: '',
-          address2: '',
-          city: '',
-          state: '',
-          zip: ''
-        }
-      }
-    },
+    data: {},
     fetching: false,
     loaded: false,
     error: ''
@@ -47,37 +11,6 @@ describe('APD reducer', () => {
 
   it('should handle initial state', () => {
     expect(apd(undefined, {})).toEqual(initialState);
-  });
-
-  it('has helper to build previous activities expenses', () => {
-    expect(getPreviousActivityExpense()).toEqual({
-      hie: {
-        federalActual: 0,
-        federalApproved: 0,
-        stateActual: 0,
-        stateApproved: 0
-      },
-      hit: {
-        federalActual: 0,
-        federalApproved: 0,
-        stateActual: 0,
-        stateApproved: 0
-      },
-      mmis: {
-        federal90Actual: 0,
-        federal90Approved: 0,
-        state10Actual: 0,
-        state10Approved: 0,
-        federal75Actual: 0,
-        federal75Approved: 0,
-        state25Actual: 0,
-        state25Approved: 0,
-        federal50Actual: 0,
-        federal50Approved: 0,
-        state50Actual: 0,
-        state50Approved: 0
-      }
-    });
   });
 
   it('should handle adding a POC', () => {
@@ -105,6 +38,7 @@ describe('APD reducer', () => {
     beforeEach(() => {
       data = {
         id: 'apd-id',
+        activities: [],
         federalCitations:
           'The Third Sentence of the Ninth Paragraph of the Three Hundred and Twenty-First Section of the Ninety-Fifth Part of the Forty-Fifth Title of the Federal Code of Regulations',
         programOverview: 'moop moop',
@@ -141,6 +75,26 @@ describe('APD reducer', () => {
             }
           }
         ],
+        previousActivityExpenses: [
+          {
+            hie: '2013 hie',
+            hit: '2013 hit',
+            mmis: '2013 mmis',
+            year: '2013'
+          },
+          {
+            hie: '2012 hie',
+            hit: '2012 hit',
+            mmis: '2012 mmis',
+            year: '2012'
+          },
+          {
+            hie: '2011 hie',
+            hit: '2011 hit',
+            mmis: '2011 mmis',
+            year: '2011'
+          }
+        ],
         stateProfile: 'this is the state profile as a string',
         years: [2013, 2014]
       };
@@ -148,7 +102,7 @@ describe('APD reducer', () => {
       expected = {
         byId: {
           'apd-id': {
-            activities: undefined,
+            activities: [],
             id: 'apd-id',
             assurancesAndCompliance:
               'The Third Sentence of the Ninth Paragraph of the Three Hundred and Twenty-First Section of the Ninety-Fifth Part of the Forty-Fifth Title of the Federal Code of Regulations',
@@ -198,106 +152,18 @@ describe('APD reducer', () => {
             pointsOfContact: 'here be points of contact',
             previousActivitySummary: '',
             previousActivityExpenses: {
-              2016: getPreviousActivityExpense(),
-              2017: getPreviousActivityExpense(),
-              2018: getPreviousActivityExpense()
+              2013: { hie: '2013 hie', hit: '2013 hit', mmis: '2013 mmis' },
+              2012: { hie: '2012 hie', hit: '2012 hit', mmis: '2012 mmis' },
+              2011: { hie: '2011 hie', hit: '2011 hit', mmis: '2011 mmis' }
             },
             stateProfile: 'this is the state profile as a string'
           }
         },
-        data: {
-          id: '',
-          overview: '',
-          hitNarrative: '',
-          hieNarrative: '',
-          mmisNarrative: '',
-          assurancesAndCompliance: initialAssurances,
-          pointsOfContact: [{ email: '', name: '', position: '' }],
-          previousActivitySummary: '',
-          previousActivityExpenses: {
-            2016: getPreviousActivityExpense(),
-            2017: getPreviousActivityExpense(),
-            2018: getPreviousActivityExpense()
-          },
-          incentivePayments,
-          stateProfile: {
-            medicaidDirector: {
-              name: '',
-              email: '',
-              phone: ''
-            },
-            medicaidOffice: {
-              address1: '',
-              address2: '',
-              city: '',
-              state: '',
-              zip: ''
-            }
-          },
-          // TODO: This value is computed based on the current datetime.
-          // Probably ought to mock the time (sinon can do this) so
-          // the test is deterministic.
-          years: ['2018', '2019'],
-          yearOptions: ['2018', '2019', '2020']
-        },
+        data: {},
         fetching: false,
         loaded: true,
         error: ''
       };
-    });
-
-    it('handles the previous activity expenses being an empty array', () => {
-      data.previousActivityExpenses = [];
-      expect(
-        apd(initialState, {
-          type: 'GET_APD_SUCCESS',
-          data: [data]
-        })
-      ).toEqual(expected);
-    });
-
-    it('handles the previous activity expenses being set', () => {
-      data.previousActivityExpenses = [
-        {
-          hie: {
-            federalActual: 10,
-            federalApproved: 20,
-            stateActual: 30,
-            stateApproved: 40
-          },
-          hit: {
-            federalActual: 100,
-            federalApproved: 200,
-            stateActual: 300,
-            stateApproved: 400
-          },
-          year: 1776
-        }
-      ];
-
-      expected.byId['apd-id'].previousActivityExpenses = {
-        1776: {
-          hie: {
-            federalActual: 10,
-            federalApproved: 20,
-            stateActual: 30,
-            stateApproved: 40
-          },
-          hit: {
-            federalActual: 100,
-            federalApproved: 200,
-            stateActual: 300,
-            stateApproved: 400
-          }
-        }
-      };
-
-      expect(
-        apd(initialState, {
-          type: 'GET_APD_SUCCESS',
-          data: [data]
-        })
-      ).toEqual(expected);
     });
 
     it('sets values from the API, and defaults otherwise', () => {

--- a/web/src/util/serialization/activities.js
+++ b/web/src/util/serialization/activities.js
@@ -105,10 +105,8 @@ export const toAPI = activityState => {
  * object matching redux state shape.
  * @param {Object} activityAPI - The activity object from the API
  * @param {Array.<string>} years - the years for the associated APD
- * @param {Object} defaults - default values for missing properties
- * @param {Object} defaults.quarterlyFFP - default quarterly FFP for this activity
  */
-export const fromAPI = (activityAPI, years, { quarterlyFFP } = {}) => ({
+export const fromAPI = (activityAPI, years) => ({
   // These properties are just copied over, maybe renamed,
   // but no data massaging necessary
   altApproach: activityAPI.alternatives || '',
@@ -223,35 +221,32 @@ export const fromAPI = (activityAPI, years, { quarterlyFFP } = {}) => ({
     )
   })),
 
-  quarterlyFFP:
-    activityAPI.quarterlyFFP && activityAPI.quarterlyFFP.length
-      ? activityAPI.quarterlyFFP.reduce(
-          (acc, ffy) => ({
-            ...acc,
-            [ffy.year]: {
-              1: {
-                combined: ffy.q1.combined * 100,
-                contractors: ffy.q1.contractors * 100,
-                state: ffy.q1.state * 100
-              },
-              2: {
-                combined: ffy.q2.combined * 100,
-                contractors: ffy.q2.contractors * 100,
-                state: ffy.q2.state * 100
-              },
-              3: {
-                combined: ffy.q3.combined * 100,
-                contractors: ffy.q3.contractors * 100,
-                state: ffy.q3.state * 100
-              },
-              4: {
-                combined: ffy.q4.combined * 100,
-                contractors: ffy.q4.contractors * 100,
-                state: ffy.q4.state * 100
-              }
-            }
-          }),
-          {}
-        )
-      : quarterlyFFP
+  quarterlyFFP: activityAPI.quarterlyFFP.reduce(
+    (acc, ffy) => ({
+      ...acc,
+      [ffy.year]: {
+        1: {
+          combined: ffy.q1.combined * 100,
+          contractors: ffy.q1.contractors * 100,
+          state: ffy.q1.state * 100
+        },
+        2: {
+          combined: ffy.q2.combined * 100,
+          contractors: ffy.q2.contractors * 100,
+          state: ffy.q2.state * 100
+        },
+        3: {
+          combined: ffy.q3.combined * 100,
+          contractors: ffy.q3.contractors * 100,
+          state: ffy.q3.state * 100
+        },
+        4: {
+          combined: ffy.q4.combined * 100,
+          contractors: ffy.q4.contractors * 100,
+          state: ffy.q4.state * 100
+        }
+      }
+    }),
+    {}
+  )
 });

--- a/web/src/util/serialization/activities.test.js
+++ b/web/src/util/serialization/activities.test.js
@@ -362,62 +362,6 @@ describe('APD activity serializer', () => {
         })
       );
     });
-
-    it('uses defaults for missing properties', () => {
-      const defaults = {
-        quarterlyFFP: 'bloop'
-      };
-
-      expect(
-        fromAPI(
-          {
-            contractorResources: [],
-            costAllocation: [],
-            costAllocationNarrative: {},
-            expenses: [],
-            goals: [],
-            schedule: [],
-            statePersonnel: [],
-            standardsAndConditions: {}
-          },
-          ['1000'],
-          defaults
-        )
-      ).toMatchObject(
-        expect.objectContaining({
-          altApproach: '',
-          contractorResources: [],
-          costAllocation: {},
-          costAllocationDesc: '',
-          descLong: '',
-          descShort: '',
-          expenses: [],
-          fundingSource: undefined,
-          goals: [],
-          id: undefined,
-          key: expect.stringMatching(/[a-f0-9]{8}/),
-          milestones: [],
-          name: undefined,
-          otherFundingDesc: '',
-          statePersonnel: [],
-          standardsAndConditions: {
-            bizResults: '',
-            documentation: '',
-            industry: '',
-            interoperability: '',
-            keyPersonnel: '',
-            leverage: '',
-            minimizeCost: '',
-            mita: '',
-            mitigation: '',
-            modularity: '',
-            reporting: ''
-          },
-          quarterlyFFP: 'bloop',
-          years: ['1000']
-        })
-      );
-    });
   });
 
   describe('serializes redux state shape into API format', () => {

--- a/web/src/util/serialization/apd.test.js
+++ b/web/src/util/serialization/apd.test.js
@@ -57,7 +57,7 @@ describe('APD serializer', () => {
         years: ['1431']
       };
 
-      expect(fromAPI(apdAPI, undefined, a => a)).toEqual({
+      expect(fromAPI(apdAPI, a => a)).toEqual({
         id: 'apd id',
         activities: ['an activity'],
         assurancesAndCompliance:
@@ -86,39 +86,6 @@ describe('APD serializer', () => {
           other: 'text'
         },
         years: ['1431']
-      });
-    });
-
-    it('uses defaults for missing properties', () => {
-      const defaults = {
-        activities: 'a a a',
-        assurancesAndCompliance: 'b b b',
-        hieNarrative: 'c c c',
-        hitNarrative: 'd d d',
-        incentivePayments: 'e e e',
-        mmisNarrative: 'f f f',
-        overview: 'g g g',
-        pointsOfContact: 'h h h',
-        previousActivityExpenses: 'i i i',
-        previousActivitySummary: 'j j j',
-        stateProfile: 'l l l',
-        years: [987654321]
-      };
-
-      expect(fromAPI({}, defaults, a => a)).toEqual({
-        id: undefined,
-        activities: 'a a a',
-        assurancesAndCompliance: 'b b b',
-        hieNarrative: 'c c c',
-        hitNarrative: 'd d d',
-        incentivePayments: 'e e e',
-        mmisNarrative: 'f f f',
-        overview: 'g g g',
-        pointsOfContact: 'h h h',
-        previousActivityExpenses: 'i i i',
-        previousActivitySummary: 'j j j',
-        stateProfile: 'l l l',
-        years: ['987654321']
       });
     });
   });


### PR DESCRIPTION
When you click the "create an APD" button, it is created and then opened.  Just one click!

Also removes a lot of APD initialization and defaulting code since the API generates a valid APD now.  There's no need for the frontend code to do it.

Closes #876 

### This pull request changes...
- click the "create an APD" button, get taken to your fancy-pants 👖 new APD

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author

### This feature is done when...
- [ ] Product has approved the experience
