### PR TITLE
Reload previous APD where the makes sense

### DIFF
--- a/web/src/components/Icons.js
+++ b/web/src/components/Icons.js
@@ -7,6 +7,7 @@ import faChevronDown from '@fortawesome/fontawesome-free-solid/faChevronDown';
 import faChevronUp from '@fortawesome/fontawesome-free-solid/faChevronUp';
 import faCode from '@fortawesome/fontawesome-free-solid/faCode';
 import faCog from '@fortawesome/fontawesome-free-solid/faCog';
+import faSpinner from '@fortawesome/fontawesome-free-solid/faSpinner';
 import faHelpSolid from '@fortawesome/fontawesome-free-solid/faQuestionCircle';
 import faSignOut from '@fortawesome/fontawesome-free-solid/faSignOutAlt';
 
@@ -18,7 +19,8 @@ export {
   faChevronUp,
   faCode,
   faCog,
-  faSignOut
+  faSignOut,
+  faSpinner
 };
 
 export default Icon;

--- a/web/src/containers/ApdApplication.js
+++ b/web/src/containers/ApdApplication.js
@@ -12,11 +12,17 @@ import PreviousActivities from './PreviousActivities';
 import ScheduleSummary from './ScheduleSummary';
 import Sidebar from './Sidebar';
 import TopBtns from './TopBtns';
+import { selectApdOnLoad } from '../actions/apd';
 import StateProfile from '../components/ApdStateProfile';
 import ProposedBudget from '../components/ProposedBudget';
 
-const ApdApplication = ({ apdSelected, place }) => {
+const ApdApplication = ({
+  apdSelected,
+  place,
+  selectApdOnLoad: dispatchSelectApdOnLoad
+}) => {
   if (!apdSelected) {
+    dispatchSelectApdOnLoad('/apd');
     return <Redirect to="/" />;
   }
 
@@ -41,7 +47,8 @@ const ApdApplication = ({ apdSelected, place }) => {
 
 ApdApplication.propTypes = {
   apdSelected: PropTypes.bool.isRequired,
-  place: PropTypes.object.isRequired
+  place: PropTypes.object.isRequired,
+  selectApdOnLoad: PropTypes.func.isRequired
 };
 
 const mapStateToProps = ({ apd: { data }, user: { data: { state } } }) => ({
@@ -49,4 +56,6 @@ const mapStateToProps = ({ apd: { data }, user: { data: { state } } }) => ({
   place: state
 });
 
-export default connect(mapStateToProps)(ApdApplication);
+const mapDispatchToProps = { selectApdOnLoad };
+
+export default connect(mapStateToProps, mapDispatchToProps)(ApdApplication);

--- a/web/src/containers/Landing.js
+++ b/web/src/containers/Landing.js
@@ -1,10 +1,11 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 
 import { createApd, selectApd } from '../actions/apd';
 import Btn from '../components/Btn';
 import Container from '../components/Container';
+import Icon, { faSpinner } from '../components/Icons';
 
 class Landing extends Component {
   createApd = () => {
@@ -16,36 +17,50 @@ class Landing extends Component {
   };
 
   render() {
-    const { apds } = this.props;
+    const { apds, fetching } = this.props;
+
+    let content = (
+      <Fragment>
+        {apds.length > 0 && (
+          <div>
+            <h3>Manage an existing APD:</h3>
+            {apds.map(({ status, years, id }) => (
+              <Btn
+                key={id}
+                extraCss="mb1 h5 block pill"
+                onClick={this.pickApd(id)}
+              >
+                {status} APD{years
+                  ? ` for ${years.join(', ')}`
+                  : ' (years not defined yet)'}
+              </Btn>
+            ))}
+          </div>
+        )}
+        <hr />
+        <Btn
+          kind="outline"
+          extraCss="bg-white blue pill"
+          onClick={this.createApd}
+        >
+          Create new APD
+        </Btn>
+      </Fragment>
+    );
+
+    if (fetching) {
+      content = (
+        <Fragment>
+          <Icon icon={faSpinner} spin size="sm" /> Loading APDs
+        </Fragment>
+      );
+    }
 
     return (
       <Container>
         <div className="md-col-6 mx-auto">
           <h1>Welcome!</h1>
-          {apds.length > 0 && (
-            <div>
-              <h3>Manage an existing APD:</h3>
-              {apds.map(({ status, years, id }) => (
-                <Btn
-                  key={id}
-                  extraCss="mb1 h5 block pill"
-                  onClick={this.pickApd(id)}
-                >
-                  {status} APD{years
-                    ? ` for ${years.join(', ')}`
-                    : ' (years not defined yet)'}
-                </Btn>
-              ))}
-            </div>
-          )}
-          <hr />
-          <Btn
-            kind="outline"
-            extraCss="bg-white blue pill"
-            onClick={this.createApd}
-          >
-            Create new APD
-          </Btn>
+          {content}
         </div>
       </Container>
     );
@@ -55,10 +70,15 @@ class Landing extends Component {
 Landing.propTypes = {
   apds: PropTypes.array.isRequired,
   createApd: PropTypes.func.isRequired,
+  fetching: PropTypes.bool.isRequired,
+
   selectApd: PropTypes.func.isRequired
 };
 
-const mapStateToProps = ({ apd }) => ({ apds: Object.values(apd.byId) });
+const mapStateToProps = ({ apd }) => ({
+  apds: Object.values(apd.byId),
+  fetching: apd.fetching
+});
 
 const mapDispatchToProps = { createApd, selectApd };
 

--- a/web/src/reducers/apd.js
+++ b/web/src/reducers/apd.js
@@ -8,6 +8,7 @@ import {
   GET_APD_FAILURE,
   REMOVE_APD_POC,
   SELECT_APD,
+  SET_SELECT_APD_ON_LOAD,
   UPDATE_APD
 } from '../actions/apd';
 import { INCENTIVE_ENTRIES, arrToObj, defaultAPDYearOptions } from '../util';
@@ -26,7 +27,8 @@ const initialState = {
   byId: {},
   fetching: false,
   loaded: false,
-  error: ''
+  error: '',
+  selectAPDOnLoad: false
 };
 
 const reducer = (state = initialState, action) => {
@@ -85,6 +87,8 @@ const reducer = (state = initialState, action) => {
       );
     case SELECT_APD:
       return { ...state, data: { ...action.apd } };
+    case SET_SELECT_APD_ON_LOAD:
+      return { ...state, selectAPDOnLoad: true };
     case UPDATE_APD:
       return u({ data: { ...action.updates } }, state);
     default:

--- a/web/src/reducers/apd.test.js
+++ b/web/src/reducers/apd.test.js
@@ -6,7 +6,8 @@ describe('APD reducer', () => {
     data: {},
     fetching: false,
     loaded: false,
-    error: ''
+    error: '',
+    selectAPDOnLoad: false
   };
 
   it('should handle initial state', () => {
@@ -27,7 +28,8 @@ describe('APD reducer', () => {
       data: { ...initialState.data },
       fetching: true,
       loaded: false,
-      error: ''
+      error: '',
+      selectAPDOnLoad: false
     });
   });
 
@@ -96,6 +98,7 @@ describe('APD reducer', () => {
           }
         ],
         stateProfile: 'this is the state profile as a string',
+        status: 'draft',
         years: [2013, 2014]
       };
 
@@ -156,13 +159,15 @@ describe('APD reducer', () => {
               2012: { hie: '2012 hie', hit: '2012 hit', mmis: '2012 mmis' },
               2011: { hie: '2011 hie', hit: '2011 hit', mmis: '2011 mmis' }
             },
-            stateProfile: 'this is the state profile as a string'
+            stateProfile: 'this is the state profile as a string',
+            status: 'draft'
           }
         },
         data: {},
         fetching: false,
         loaded: true,
-        error: ''
+        error: '',
+        selectAPDOnLoad: false
       };
     });
 
@@ -184,7 +189,8 @@ describe('APD reducer', () => {
       data: { ...initialState.data },
       fetching: false,
       loaded: false,
-      error: 'some error'
+      error: 'some error',
+      selectAPDOnLoad: false
     });
   });
 
@@ -197,6 +203,13 @@ describe('APD reducer', () => {
     ).toEqual({
       ...initialState,
       data: { value: `hurr hurr i'm a burr` }
+    });
+  });
+
+  it('should handle enabling auto-load for an APD', () => {
+    expect(apd(initialState, { type: 'SET_SELECT_APD_ON_LOAD' })).toEqual({
+      ...initialState,
+      selectAPDOnLoad: true
     });
   });
 

--- a/web/src/reducers/apd.test.js
+++ b/web/src/reducers/apd.test.js
@@ -160,7 +160,8 @@ describe('APD reducer', () => {
               2011: { hie: '2011 hie', hit: '2011 hit', mmis: '2011 mmis' }
             },
             programOverview: 'moop moop',
-            stateProfile: 'this is the state profile as a string'
+            stateProfile: 'this is the state profile as a string',
+            status: 'draft'
           }
         },
         data: {},


### PR DESCRIPTION
Reloading previous APD:
- if you browse to the `/apd` page AND
- your browser supports local storage AND
- your local storage contains the ID of the last APD you looked at THEN
- select your previous APD once APDs are loaded from the API

Storing previous APD
- if you're on the `/` page AND
- you select an APD from the list AND
- your browser supports local storage THEN
- the APD ID is written to local storage so we can reload it next time

Closes #802 

### This pull request changes...
- if you're looking at an APD and you reload the page, you'll end up right back at that APD
- the `/` page gets a "loading" spinner so you know it's fetching your APDs

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author

### This feature is done when...
- [ ] Product has approved the experience
