### PR TITLE
state personnel refine

### DIFF
--- a/api/routes/apds/post.data.js
+++ b/api/routes/apds/post.data.js
@@ -148,7 +148,7 @@ const getNewApd = async (stateID, { StateModel = defaultStateModel } = {}) => {
           mita: '',
           reporting: ''
         },
-        statePersonnel: repeat(3, getStatePersonnel(years)),
+        statePersonnel: repeat(1, getStatePersonnel(years)),
         summary: '',
         quarterlyFFP: yearsToArray(years, { q1: 0, q2: 0, q3: 0, q4: 0 })
       }

--- a/api/routes/apds/post.data.test.js
+++ b/api/routes/apds/post.data.test.js
@@ -129,38 +129,6 @@ tap.test('APD data initializer', async test => {
                 year: '2019'
               }
             ]
-          },
-          {
-            description: '',
-            title: '',
-            years: [
-              {
-                cost: 0,
-                fte: 0,
-                year: '2018'
-              },
-              {
-                cost: 0,
-                fte: 0,
-                year: '2019'
-              }
-            ]
-          },
-          {
-            description: '',
-            title: '',
-            years: [
-              {
-                cost: 0,
-                fte: 0,
-                year: '2018'
-              },
-              {
-                cost: 0,
-                fte: 0,
-                year: '2019'
-              }
-            ]
           }
         ],
         summary: '',

--- a/web/src/components/Label.js
+++ b/web/src/components/Label.js
@@ -1,0 +1,12 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const Label = props => (
+  <h3 className="md-col-3 lg-col-2 my-tiny pr1 h5">{props.children}</h3>
+);
+
+Label.propTypes = {
+  children: PropTypes.node.isRequired
+};
+
+export default Label;

--- a/web/src/containers/activity/ContractorResources.js
+++ b/web/src/containers/activity/ContractorResources.js
@@ -12,18 +12,11 @@ import {
 import Btn from '../../components/Btn';
 import DeleteButton from '../../components/DeleteConfirm';
 import { Input, DollarInput, Textarea } from '../../components/Inputs';
+import Label from '../../components/Label';
 import NoDataMsg from '../../components/NoDataMsg';
 import { Subsection } from '../../components/Section';
 import Select from '../../components/Select';
 import { t } from '../../i18n';
-
-const Label = props => (
-  <h3 className="md-col-2 my-tiny pr1 h5">{props.children}</h3>
-);
-
-Label.propTypes = {
-  children: PropTypes.node.isRequired
-};
 
 const DOC_TYPES = ['Contract', 'Contract Amendment', 'RFP'];
 

--- a/web/src/containers/activity/Expenses.js
+++ b/web/src/containers/activity/Expenses.js
@@ -10,17 +10,10 @@ import {
 import Btn from '../../components/Btn';
 import NoDataMsg from '../../components/NoDataMsg';
 import { DollarInput, Textarea } from '../../components/Inputs';
+import Label from '../../components/Label';
 import { Subsection } from '../../components/Section';
 import Select from '../../components/Select';
 import { t } from '../../i18n';
-
-const Label = props => (
-  <h3 className="md-col-2 my-tiny pr1 h5">{props.children}</h3>
-);
-
-Label.propTypes = {
-  children: PropTypes.node.isRequired
-};
 
 const EXPENSE_CATEGORIES = [
   'Hardware, software, and licensing',

--- a/web/src/containers/activity/StatePersonnel.js
+++ b/web/src/containers/activity/StatePersonnel.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import {
@@ -14,35 +14,32 @@ import {
   PercentInput,
   Textarea
 } from '../../components/Inputs';
+import Label from '../../components/Label';
 import NoDataMsg from '../../components/NoDataMsg';
 import { Subsection } from '../../components/Section';
 import { t } from '../../i18n';
 
-const Label = props => (
-  <h3 className="md-col-2 my-tiny pr1 h5">{props.children}</h3>
-);
-
-Label.propTypes = {
-  children: PropTypes.node.isRequired
-};
-
 class StatePersonnel extends Component {
   handleChange = (index, field, year) => e => {
-    const { checked, type, value } = e.target;
-    const valueNorm = type === 'checkbox' ? checked : value;
-
+    const { value } = e.target;
     const { activity, updateActivity } = this.props;
 
     const toUpdate =
       year !== undefined
-        ? { years: { [year]: { [field]: valueNorm } } }
-        : { [field]: valueNorm };
+        ? { years: { [year]: { [field]: value } } }
+        : { [field]: value };
 
     updateActivity(
       activity.key,
       { statePersonnel: { [index]: toUpdate } },
       field === 'amt' || field === 'perc'
     );
+  };
+
+  handleKeyPersonnel = (index, bool) => () => {
+    const { activity, updateActivity } = this.props;
+    const updates = { statePersonnel: { [index]: { isKeyPersonnel: bool } } };
+    updateActivity(activity.key, updates);
   };
 
   render() {
@@ -54,7 +51,7 @@ class StatePersonnel extends Component {
         {statePersonnel.length === 0 ? (
           <NoDataMsg>{t('activities.statePersonnel.noDataNotice')}</NoDataMsg>
         ) : (
-          <div className="mt3">
+          <div className="mt3 pt3 border-top border-grey">
             {statePersonnel.map((d, i) => (
               <div key={d.key} className="mb3 pb3 border-bottom border-grey">
                 <div className="mb3 md-flex">
@@ -64,21 +61,28 @@ class StatePersonnel extends Component {
                     label={t('activities.statePersonnel.labels.title')}
                     value={d.title}
                     onChange={this.handleChange(i, 'title')}
-                    wrapperClass="md-col-6"
+                    wrapperClass="md-col-7 lg-col-6"
                     hideLabel
                   />
                 </div>
                 <div className="mb3 md-flex">
                   <Label>Key Personnel</Label>
-                  <label className="block">
-                    <input
-                      type="checkbox"
-                      className="mr1"
-                      checked={d.isKeyPersonnel}
-                      onChange={this.handleChange(i, 'isKeyPersonnel')}
-                    />
-                    {t('activities.statePersonnel.labels.keyPersonnel')}
-                  </label>
+                  <div>
+                    <Btn
+                      kind="outline"
+                      extraCss={d.isKeyPersonnel ? 'bg-black white' : ''}
+                      onClick={this.handleKeyPersonnel(i, true)}
+                    >
+                      Yes
+                    </Btn>{' '}
+                    <Btn
+                      kind="outline"
+                      extraCss={d.isKeyPersonnel ? '' : 'bg-black white'}
+                      onClick={this.handleKeyPersonnel(i, false)}
+                    >
+                      No
+                    </Btn>
+                  </div>
                 </div>
                 <div className="mb3 md-flex">
                   <Label>{t('activities.statePersonnel.labels.desc')}</Label>
@@ -88,27 +92,27 @@ class StatePersonnel extends Component {
                     rows="3"
                     value={d.desc}
                     onChange={this.handleChange(i, 'desc')}
-                    wrapperClass="md-col-6"
+                    wrapperClass="md-col-7 lg-col-6"
                     hideLabel
                   />
                 </div>
                 {years.map(year => (
                   <div key={year} className="mb3 md-flex">
                     <Label>{year} Cost</Label>
-                    <div className="md-col-7 lg-col-5 flex">
+                    <div className="md-col-7 lg-col-6 flex justify-between">
                       <DollarInput
                         name={`state-person-${d.key}-${year}-amt`}
                         label={t('activities.statePersonnel.labels.costAmt')}
                         value={d.years[year].amt}
                         onChange={this.handleChange(i, 'amt', year)}
-                        wrapperClass="mr2 flex-auto"
+                        wrapperClass="mr3 flex-auto"
                       />
                       <PercentInput
                         name={`state-person-${d.key}-${year}-perc`}
                         label={t('activities.statePersonnel.labels.costPerc')}
                         value={d.years[year].perc}
                         onChange={this.handleChange(i, 'perc', year)}
-                        wrapperClass="mr2 flex-auto"
+                        wrapperClass="flex-auto"
                       />
                     </div>
                   </div>
@@ -124,136 +128,6 @@ class StatePersonnel extends Component {
                 </div>
               </div>
             ))}
-
-            <table
-              className="mb2 h5 table table-condensed table-fixed"
-              style={{ minWidth: 800 }}
-            >
-              <thead>
-                <tr>
-                  <th className="col-1" id="act_state_person_null1" />
-                  <th className="col-4" id="act_state_person_null2" />
-                  <th className="col-5" id="act_state_person_null3" />
-                  {years.map(year => (
-                    <th
-                      key={year}
-                      className="col-4"
-                      colSpan="2"
-                      id={`act_state_person_${year}`}
-                    >
-                      {t('activities.statePersonnel.labels.yearCost', {
-                        year
-                      })}
-                    </th>
-                  ))}
-                  <th className="col-1" id="act_state_person_null4" />
-                </tr>
-                <tr>
-                  <th className="col-1" id="act_state_person_number">
-                    {t('activities.statePersonnel.labels.entryNum')}
-                  </th>
-                  <th className="col-4" id="act_state_person_title">
-                    {t('activities.statePersonnel.labels.title')}
-                  </th>
-                  <th className="col-5" id="act_state_person_desc">
-                    {t('activities.statePersonnel.labels.desc')}
-                  </th>
-                  {years.map(year => (
-                    <Fragment key={year}>
-                      <th id={`act_state_person_amt_${year}`}>
-                        {t('activities.statePersonnel.labels.costAmt')}
-                      </th>
-                      <th id={`act_state_person_pct_${year}`}>
-                        {t('activities.statePersonnel.labels.costPerc')}
-                      </th>
-                    </Fragment>
-                  ))}
-                  <th className="col-1" id="act_state_person_null5" />
-                </tr>
-              </thead>
-              <tbody>
-                {statePersonnel.map((d, i) => (
-                  <tr key={d.key}>
-                    <td
-                      className="mono"
-                      headers="act_state_person_null1 act_state_person_number"
-                    >
-                      {i + 1}.
-                    </td>
-                    <td headers="act_state_person_null2 act_state_person_title">
-                      <Input
-                        name={`state-person-${d.key}-title`}
-                        label={t('activities.statePersonnel.labels.title')}
-                        hideLabel
-                        value={d.title}
-                        onChange={this.handleChange(i, 'title')}
-                      />
-                      <label className="block bold">
-                        <input
-                          type="checkbox"
-                          className="mr1"
-                          checked={d.isKeyPersonnel}
-                          onChange={this.handleChange(i, 'isKeyPersonnel')}
-                        />
-                        {t('activities.statePersonnel.labels.keyPersonnel')}
-                      </label>
-                    </td>
-                    <td headers="act_state_person_null3 act_state_person_desc">
-                      <Textarea
-                        name={`state-person-${d.key}-desc`}
-                        label={t('activities.statePersonnel.labels.desc')}
-                        hideLabel
-                        rows="3"
-                        value={d.desc}
-                        onChange={this.handleChange(i, 'desc')}
-                      />
-                    </td>
-                    {years.map(year => (
-                      <Fragment key={year}>
-                        <td
-                          headers={`act_state_person_${year} act_state_person_amt_${year}`}
-                        >
-                          <DollarInput
-                            name={`state-person-${d.key}-${year}-amt`}
-                            label={t(
-                              'activities.statePersonnel.labels.costAmt'
-                            )}
-                            hideLabel
-                            value={d.years[year].amt}
-                            onChange={this.handleChange(i, 'amt', year)}
-                          />
-                        </td>
-                        <td
-                          headers={`act_state_person_${year} act_state_person_pct_${year}`}
-                        >
-                          <PercentInput
-                            name={`state-person-${d.key}-${year}-perc`}
-                            label={t(
-                              'activities.statePersonnel.labels.costPerc'
-                            )}
-                            hideLabel
-                            value={d.years[year].perc}
-                            onChange={this.handleChange(i, 'perc', year)}
-                          />
-                        </td>
-                      </Fragment>
-                    ))}
-                    <td
-                      className="center"
-                      headers="act_state_person_null4 act_state_person_null5"
-                    >
-                      <Btn
-                        kind="outline"
-                        extraCss="px1 py-tiny mt-tiny"
-                        onClick={() => removePerson(activityKey, d.key)}
-                      >
-                        ✗
-                      </Btn>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
           </div>
         )}
         <Btn onClick={() => addPerson(activityKey)}>

--- a/web/src/containers/activity/StatePersonnel.js
+++ b/web/src/containers/activity/StatePersonnel.js
@@ -18,6 +18,14 @@ import NoDataMsg from '../../components/NoDataMsg';
 import { Subsection } from '../../components/Section';
 import { t } from '../../i18n';
 
+const Label = props => (
+  <h3 className="md-col-2 my-tiny pr1 h5">{props.children}</h3>
+);
+
+Label.propTypes = {
+  children: PropTypes.node.isRequired
+};
+
 class StatePersonnel extends Component {
   handleChange = (index, field, year) => e => {
     const { checked, type, value } = e.target;
@@ -46,7 +54,77 @@ class StatePersonnel extends Component {
         {statePersonnel.length === 0 ? (
           <NoDataMsg>{t('activities.statePersonnel.noDataNotice')}</NoDataMsg>
         ) : (
-          <div className="overflow-auto">
+          <div className="mt3">
+            {statePersonnel.map((d, i) => (
+              <div key={d.key} className="mb3 pb3 border-bottom border-grey">
+                <div className="mb3 md-flex">
+                  <Label>{t('activities.statePersonnel.labels.title')}</Label>
+                  <Input
+                    name={`state-person-${d.key}-title`}
+                    label={t('activities.statePersonnel.labels.title')}
+                    value={d.title}
+                    onChange={this.handleChange(i, 'title')}
+                    wrapperClass="md-col-6"
+                    hideLabel
+                  />
+                </div>
+                <div className="mb3 md-flex">
+                  <Label>Key Personnel</Label>
+                  <label className="block">
+                    <input
+                      type="checkbox"
+                      className="mr1"
+                      checked={d.isKeyPersonnel}
+                      onChange={this.handleChange(i, 'isKeyPersonnel')}
+                    />
+                    {t('activities.statePersonnel.labels.keyPersonnel')}
+                  </label>
+                </div>
+                <div className="mb3 md-flex">
+                  <Label>{t('activities.statePersonnel.labels.desc')}</Label>
+                  <Textarea
+                    name={`state-person-${d.key}-desc`}
+                    label={t('activities.statePersonnel.labels.desc')}
+                    rows="3"
+                    value={d.desc}
+                    onChange={this.handleChange(i, 'desc')}
+                    wrapperClass="md-col-6"
+                    hideLabel
+                  />
+                </div>
+                {years.map(year => (
+                  <div key={year} className="mb3 md-flex">
+                    <Label>{year} Cost</Label>
+                    <div className="md-col-7 lg-col-5 flex">
+                      <DollarInput
+                        name={`state-person-${d.key}-${year}-amt`}
+                        label={t('activities.statePersonnel.labels.costAmt')}
+                        value={d.years[year].amt}
+                        onChange={this.handleChange(i, 'amt', year)}
+                        wrapperClass="mr2 flex-auto"
+                      />
+                      <PercentInput
+                        name={`state-person-${d.key}-${year}-perc`}
+                        label={t('activities.statePersonnel.labels.costPerc')}
+                        value={d.years[year].perc}
+                        onChange={this.handleChange(i, 'perc', year)}
+                        wrapperClass="mr2 flex-auto"
+                      />
+                    </div>
+                  </div>
+                ))}
+                <div>
+                  <Btn
+                    kind="outline"
+                    extraCss="px1 py-tiny h5"
+                    onClick={() => removePerson(activityKey, d.key)}
+                  >
+                    Remove person
+                  </Btn>
+                </div>
+              </div>
+            ))}
+
             <table
               className="mb2 h5 table table-condensed table-fixed"
               style={{ minWidth: 800 }}

--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -109,11 +109,7 @@ const newActivity = ({
   otherFundingDesc: '',
   goals: [newGoal()],
   milestones: [newMilestone()],
-  statePersonnel: [
-    newStatePerson(years),
-    newStatePerson(years),
-    newStatePerson(years)
-  ],
+  statePersonnel: [newStatePerson(years)],
   contractorResources: [newContractor(years)],
   expenses: [newExpense(years)],
   costAllocation: arrToObj(years, costAllocationEntry()),

--- a/web/src/reducers/activities.test.js
+++ b/web/src/reducers/activities.test.js
@@ -84,7 +84,7 @@ describe('activities reducer', () => {
       modularity: '',
       reporting: ''
     },
-    statePersonnel: [newPerson(keyFn), newPerson(keyFn), newPerson(keyFn)],
+    statePersonnel: [newPerson(keyFn)],
     quarterlyFFP: {
       '2018': {
         '1': {
@@ -435,20 +435,6 @@ describe('activities reducer', () => {
                   ...stateWithOne.byKey['1'].statePersonnel[0].years,
                   '2020': { amt: '', perc: '' }
                 }
-              },
-              {
-                ...stateWithOne.byKey['1'].statePersonnel[1],
-                years: {
-                  ...stateWithOne.byKey['1'].statePersonnel[1].years,
-                  '2020': { amt: '', perc: '' }
-                }
-              },
-              {
-                ...stateWithOne.byKey['1'].statePersonnel[2],
-                years: {
-                  ...stateWithOne.byKey['1'].statePersonnel[2].years,
-                  '2020': { amt: '', perc: '' }
-                }
               }
             ],
             quarterlyFFP: {
@@ -512,18 +498,6 @@ describe('activities reducer', () => {
             statePersonnel: [
               {
                 ...stateWithOne.byKey['1'].statePersonnel[0],
-                years: {
-                  '2018': { amt: '', perc: '' }
-                }
-              },
-              {
-                ...stateWithOne.byKey['1'].statePersonnel[1],
-                years: {
-                  '2018': { amt: '', perc: '' }
-                }
-              },
-              {
-                ...stateWithOne.byKey['1'].statePersonnel[2],
                 years: {
                   '2018': { amt: '', perc: '' }
                 }


### PR DESCRIPTION
brings personnel section in line with the new structure / style of contractor and expense sections.

(now that stuff is not in a table, i don't think we need to prefill 3 blank entries, hence the switch to 1)

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author

### This feature is done when...
- [ ] Product has approved the experience
