### PR TITLE
add list row entries for expenses

### DIFF
--- a/web/src/containers/activity/Expenses.js
+++ b/web/src/containers/activity/Expenses.js
@@ -14,6 +14,7 @@ import Label from '../../components/Label';
 import { Subsection } from '../../components/Section';
 import Select from '../../components/Select';
 import { t } from '../../i18n';
+import { arrToObj } from '../../util';
 import { formatMoney } from '../../util/formats';
 
 const EXPENSE_CATEGORIES = [
@@ -138,7 +139,10 @@ class Expenses extends Component {
 
     if (lastExpense && !(lastExpense in state.showForm)) {
       return {
-        showForm: { ...state.showForm, [lastExpense]: true }
+        showForm: {
+          ...arrToObj(Object.keys(state.showForm), false),
+          [lastExpense]: true
+        }
       };
     }
 

--- a/web/src/containers/activity/Expenses.js
+++ b/web/src/containers/activity/Expenses.js
@@ -14,7 +14,6 @@ import Label from '../../components/Label';
 import { Subsection } from '../../components/Section';
 import Select from '../../components/Select';
 import { t } from '../../i18n';
-import { arrToObj } from '../../util';
 import { formatMoney } from '../../util/formats';
 
 const EXPENSE_CATEGORIES = [
@@ -74,6 +73,13 @@ const ExpenseForm = ({
   handleDelete
 }) => (
   <div className="mt2 mb3">
+    <Btn
+      kind="outline"
+      extraCss="right px-tiny py0 h5 xs-hide"
+      onClick={handleDelete}
+    >
+      ✗
+    </Btn>
     <div className="mb3 md-flex">
       <Label>Category</Label>
       <Select
@@ -111,11 +117,6 @@ const ExpenseForm = ({
         />
       </div>
     ))}
-    <div>
-      <Btn kind="outline" extraCss="px1 py-tiny h5" onClick={handleDelete}>
-        Remove expense
-      </Btn>
-    </div>
   </div>
 );
 
@@ -149,9 +150,12 @@ class Expenses extends Component {
 
     const expenseKeys = props.expenses.map(e => e.key);
 
-    this.state = {
-      showForm: arrToObj(expenseKeys, false)
-    };
+    const showForm = expenseKeys.reduce(
+      (obj, key, i) => ({ ...obj, [key]: i === 0 }),
+      {}
+    );
+
+    this.state = { showForm };
   }
 
   handleChange = (index, field) => e => {

--- a/web/src/containers/activity/Expenses.js
+++ b/web/src/containers/activity/Expenses.js
@@ -14,6 +14,8 @@ import Label from '../../components/Label';
 import { Subsection } from '../../components/Section';
 import Select from '../../components/Select';
 import { t } from '../../i18n';
+import { arrToObj } from '../../util';
+import { formatMoney } from '../../util/formats';
 
 const EXPENSE_CATEGORIES = [
   'Hardware, software, and licensing',
@@ -24,26 +26,172 @@ const EXPENSE_CATEGORIES = [
   'Miscellaneous expenses for the project'
 ];
 
+const ExpenseEntry = ({ expense, idx, years, handleDelete, toggleForm }) => (
+  <div className="mb1 h5 flex justify-between">
+    <button
+      type="button"
+      onClick={toggleForm}
+      className="btn btn-no-focus p1 col-12 left-align bg-blue-light rounded-left"
+    >
+      <div className="flex items-center justify-between">
+        <div className="col-5 truncate">
+          {idx + 1}. <strong>{expense.category}</strong>
+        </div>
+        {years.map(year => (
+          <div key={year} className="col-2 truncate">
+            {year}:{' '}
+            <span className="bold mono">
+              {formatMoney(expense.years[year])}
+            </span>
+          </div>
+        ))}
+      </div>
+    </button>
+    <button
+      type="button"
+      onClick={handleDelete}
+      className="btn btn-no-focus p1 bg-blue-light rounded-right"
+    >
+      ✗
+    </button>
+  </div>
+);
+
+ExpenseEntry.propTypes = {
+  expense: PropTypes.object.isRequired,
+  idx: PropTypes.number.isRequired,
+  years: PropTypes.array.isRequired,
+  handleDelete: PropTypes.func.isRequired,
+  toggleForm: PropTypes.func.isRequired
+};
+
+const ExpenseForm = ({
+  expense,
+  idx,
+  years,
+  handleChange,
+  handleYearChange,
+  handleDelete
+}) => (
+  <div className="mt2 mb3">
+    <div className="mb3 md-flex">
+      <Label>Category</Label>
+      <Select
+        name={`expense-${expense.key}-category`}
+        options={EXPENSE_CATEGORIES}
+        label="Expense category"
+        hideLabel
+        value={expense.category}
+        onChange={handleChange(idx, 'category')}
+        wrapperClass="md-col-6"
+      />
+    </div>
+    <div className="mb3 md-flex">
+      <Label>Description</Label>
+      <Textarea
+        name={`expense-${expense.key}-desc`}
+        label="Describe the expense"
+        hideLabel
+        rows="3"
+        value={expense.desc}
+        onChange={handleChange(idx, 'desc')}
+        wrapperClass="md-col-6"
+      />
+    </div>
+    {years.map(year => (
+      <div key={year} className="mb3 md-flex">
+        <Label>{year} Cost</Label>
+        <DollarInput
+          name={`expense-${expense.key}-${year}-cost`}
+          label={`Cost for ${year}`}
+          hideLabel
+          value={expense.years[year]}
+          onChange={handleYearChange(idx, year)}
+          wrapperClass="md-col-3"
+        />
+      </div>
+    ))}
+    <div>
+      <Btn kind="outline" extraCss="px1 py-tiny h5" onClick={handleDelete}>
+        Remove expense
+      </Btn>
+    </div>
+  </div>
+);
+
+ExpenseForm.propTypes = {
+  expense: PropTypes.object.isRequired,
+  idx: PropTypes.number.isRequired,
+  years: PropTypes.array.isRequired,
+  handleChange: PropTypes.func.isRequired,
+  handleYearChange: PropTypes.func.isRequired,
+  handleDelete: PropTypes.func.isRequired
+};
+
+const getLastExpense = expenses =>
+  expenses.length ? expenses[expenses.length - 1].key : null;
+
 class Expenses extends Component {
+  static getDerivedStateFromProps(props, state) {
+    const lastExpense = getLastExpense(props.expenses);
+
+    if (lastExpense && !(lastExpense in state.showForm)) {
+      return {
+        showForm: { ...state.showForm, [lastExpense]: true }
+      };
+    }
+
+    return null;
+  }
+
+  constructor(props) {
+    super(props);
+
+    const expenseKeys = props.expenses.map(e => e.key);
+
+    this.state = {
+      showForm: arrToObj(expenseKeys, false)
+    };
+  }
+
   handleChange = (index, field) => e => {
     const { value } = e.target;
-    const { activity, updateActivity } = this.props;
+    const { activityKey, updateActivity } = this.props;
 
     const updates = { expenses: { [index]: { [field]: value } } };
-    updateActivity(activity.key, updates);
+    updateActivity(activityKey, updates);
   };
 
   handleYearChange = (index, year) => e => {
     const { value } = e.target;
-    const { activity, updateActivity } = this.props;
+    const { activityKey, updateActivity } = this.props;
 
     const updates = { expenses: { [index]: { years: { [year]: value } } } };
-    updateActivity(activity.key, updates, true);
+    updateActivity(activityKey, updates, true);
+  };
+
+  handleAdd = () => {
+    const { activityKey, addExpense } = this.props;
+    addExpense(activityKey);
+  };
+
+  handleDelete = expenseKey => () => {
+    const { activityKey, removeExpense } = this.props;
+    removeExpense(activityKey, expenseKey);
+  };
+
+  toggleForm = expenseKey => () => {
+    this.setState(prev => ({
+      showForm: {
+        ...prev.showForm,
+        [expenseKey]: !prev.showForm[expenseKey]
+      }
+    }));
   };
 
   render() {
-    const { activity, years, addExpense, removeExpense } = this.props;
-    const { key: activityKey, expenses } = activity;
+    const { expenses, years } = this.props;
+    const { showForm } = this.state;
 
     return (
       <Subsection resource="activities.expenses" nested>
@@ -52,68 +200,37 @@ class Expenses extends Component {
         ) : (
           <div className="mt3 pt3 border-top border-grey">
             {expenses.map((expense, i) => (
-              <div
-                key={expense.key}
-                className="mb3 pb3 border-bottom border-grey relative"
-              >
-                <div className="mb3 md-flex">
-                  <Label>Category</Label>
-                  <Select
-                    name={`expense-${expense.key}-category`}
-                    options={EXPENSE_CATEGORIES}
-                    label="Expense category"
-                    hideLabel
-                    value={expense.category}
-                    onChange={this.handleChange(i, 'category')}
-                    wrapperClass="md-col-6"
+              <div key={expense.key}>
+                <ExpenseEntry
+                  expense={expense}
+                  idx={i}
+                  years={years}
+                  handleDelete={this.handleDelete(expense.key)}
+                  toggleForm={this.toggleForm(expense.key)}
+                />
+                {showForm[expense.key] && (
+                  <ExpenseForm
+                    expense={expense}
+                    idx={i}
+                    years={years}
+                    handleChange={this.handleChange}
+                    handleYearChange={this.handleYearChange}
+                    handleDelete={this.handleDelete(expense.key)}
                   />
-                </div>
-                <div className="mb3 md-flex">
-                  <Label>Description</Label>
-                  <Textarea
-                    name={`expense-${expense.key}-desc`}
-                    label="Describe the expense"
-                    hideLabel
-                    rows="3"
-                    value={expense.desc}
-                    onChange={this.handleChange(i, 'desc')}
-                    wrapperClass="md-col-6"
-                  />
-                </div>
-                {years.map(year => (
-                  <div key={year} className="mb3 md-flex">
-                    <Label>{year} Cost</Label>
-                    <DollarInput
-                      name={`expense-${expense.key}-${year}-cost`}
-                      label={`Cost for ${year}`}
-                      hideLabel
-                      value={expense.years[year]}
-                      onChange={this.handleYearChange(i, year)}
-                      wrapperClass="md-col-3"
-                    />
-                  </div>
-                ))}
-                <div>
-                  <Btn
-                    kind="outline"
-                    extraCss="px1 py-tiny h5"
-                    onClick={() => removeExpense(activityKey, expense.key)}
-                  >
-                    Remove expense
-                  </Btn>
-                </div>
+                )}
               </div>
             ))}
           </div>
         )}
-        <Btn onClick={() => addExpense(activityKey)}>Add expense</Btn>
+        <Btn onClick={this.handleAdd}>Add expense</Btn>
       </Subsection>
     );
   }
 }
 
 Expenses.propTypes = {
-  activity: PropTypes.object.isRequired,
+  activityKey: PropTypes.string.isRequired,
+  expenses: PropTypes.array.isRequired,
   years: PropTypes.array.isRequired,
   addExpense: PropTypes.func.isRequired,
   removeExpense: PropTypes.func.isRequired,
@@ -121,7 +238,8 @@ Expenses.propTypes = {
 };
 
 const mapStateToProps = ({ activities: { byKey }, apd }, { aKey }) => ({
-  activity: byKey[aKey],
+  activityKey: aKey,
+  expenses: byKey[aKey].expenses,
   years: apd.data.years
 });
 

--- a/web/src/styles/app/misc.css
+++ b/web/src/styles/app/misc.css
@@ -15,6 +15,10 @@
   box-shadow: none;
 }
 
+.btn-no-focus:focus {
+  box-shadow: none;
+}
+
 /*
 * for some reason, the file upload input nested within
 * our custom 'btn-dropzone' div had a large width by default


### PR DESCRIPTION
related to https://github.com/18F/cms-hitech-apd/issues/938, adds clickable list entries for expenses so you can see the relevant info at a glance and/or edit when needed.

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author

### This feature is done when...
- [ ] Design has approved the experience
- [ ] Product has approved the experience
