### PR TITLE
fix apd year change bug

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8945,6 +8945,11 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
+    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -63,6 +63,7 @@
     "html-to-draftjs": "1.4.0",
     "i18n-js": "^3.0.3",
     "is_js": "^0.9.0",
+    "lodash.difference": "^4.5.0",
     "lodash.kebabcase": "^4.1.1",
     "lodash.omit": "^4.5.0",
     "markdown-it": "^8.4.1",

--- a/web/src/reducers/apd.js
+++ b/web/src/reducers/apd.js
@@ -115,7 +115,17 @@ const reducer = (state = initialState, action) => {
         else incentivePayments[key][yearDelta] = { 1: 0, 2: 0, 3: 0, 4: 0 };
       });
 
-      return u({ data: { years, incentivePayments } }, state);
+      // using updeep was not deleting year objects (even
+      // though `incentivePayments` was changed), hence using
+      // the traditional way to update state here
+      return {
+        ...state,
+        data: {
+          ...state.data,
+          years,
+          incentivePayments
+        }
+      };
     }
     default:
       return state;

--- a/web/src/reducers/apd.test.js
+++ b/web/src/reducers/apd.test.js
@@ -226,7 +226,7 @@ describe('APD reducer', () => {
     });
   });
 
-  it('should handle an APD year update (which impacts incentive payments)', () => {
+  it('should handle an APD year add update (which impacts incentive payments)', () => {
     const state = {
       ...initialState,
       data: {
@@ -266,6 +266,53 @@ describe('APD reducer', () => {
               2: 0,
               3: 0,
               4: 0
+            }
+          }
+        }
+      }
+    });
+  });
+
+  it('should handle an APD year removal update', () => {
+    const state = {
+      ...initialState,
+      data: {
+        years: [1, 2],
+        incentivePayments: {
+          ehAmt: {
+            1: {
+              1: 1,
+              2: 10,
+              3: 100,
+              4: 1000
+            },
+            2: {
+              1: 1,
+              2: 10,
+              3: 100,
+              4: 1000
+            }
+          }
+        }
+      }
+    };
+
+    expect(
+      apd(state, {
+        type: 'UPDATE_APD',
+        updates: { years: [1] }
+      })
+    ).toEqual({
+      ...state,
+      data: {
+        years: [1],
+        incentivePayments: {
+          ehAmt: {
+            1: {
+              1: 1,
+              2: 10,
+              3: 100,
+              4: 1000
             }
           }
         }

--- a/web/src/reducers/apd.test.js
+++ b/web/src/reducers/apd.test.js
@@ -225,4 +225,51 @@ describe('APD reducer', () => {
       }
     });
   });
+
+  it('should handle an APD year update (which impacts incentive payments)', () => {
+    const state = {
+      ...initialState,
+      data: {
+        years: [1],
+        incentivePayments: {
+          ehAmt: {
+            1: {
+              1: 1,
+              2: 10,
+              3: 100,
+              4: 1000
+            }
+          }
+        }
+      }
+    };
+
+    expect(
+      apd(state, {
+        type: 'UPDATE_APD',
+        updates: { years: [1, 2] }
+      })
+    ).toEqual({
+      ...state,
+      data: {
+        years: [1, 2],
+        incentivePayments: {
+          ehAmt: {
+            1: {
+              1: 1,
+              2: 10,
+              3: 100,
+              4: 1000
+            },
+            2: {
+              1: 0,
+              2: 0,
+              3: 0,
+              4: 0
+            }
+          }
+        }
+      }
+    });
+  });
 });


### PR DESCRIPTION
there was a bug where if you added a year to your APD, the app blew up (because we weren't initializing incentive payment data for this new year). This PR resolves that.

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
