### PR TITLE
Remove an unused budget prop [skip deploy]

### DIFF
--- a/web/src/actions/apd.js
+++ b/web/src/actions/apd.js
@@ -26,7 +26,6 @@ export const SUBMIT_APD_SUCCESS = 'SUBMIT_APD_SUCCESS';
 export const SUBMIT_APD_FAILURE = 'SUBMIT_APD_FAILURE';
 export const UPDATE_APD = 'UPDATE_APD';
 export const UPDATE_BUDGET = 'UPDATE_BUDGET';
-export const UPDATE_BUDGET_QUARTERLY_SHARE = 'UPDATE_BUDGET_QUARTERLY_SHARE';
 
 export const SET_SELECT_APD_ON_LOAD = 'SET_SELECT_APD_ON_LOAD';
 export const selectApdOnLoad = () => ({ type: SET_SELECT_APD_ON_LOAD });
@@ -36,11 +35,6 @@ export const removePointOfContact = index => ({ type: REMOVE_APD_POC, index });
 
 export const updateBudget = () => (dispatch, getState) =>
   dispatch({ type: UPDATE_BUDGET, state: getState() });
-
-export const updateBudgetQuarterlyShare = updates => ({
-  type: UPDATE_BUDGET_QUARTERLY_SHARE,
-  updates
-});
 
 export const requestApd = () => ({ type: GET_APD_REQUEST });
 export const receiveApd = data => ({ type: GET_APD_SUCCESS, data });

--- a/web/src/actions/apd.test.js
+++ b/web/src/actions/apd.test.js
@@ -154,13 +154,6 @@ describe('apd actions', () => {
     expect(store.getActions()).toEqual(expectedActions);
   });
 
-  it('updateBudgetQuarterlyShare should create UPDATE_BUDGET_QUARTERLY_SHARE action', () => {
-    expect(actions.updateBudgetQuarterlyShare('updates')).toEqual({
-      type: actions.UPDATE_BUDGET_QUARTERLY_SHARE,
-      updates: 'updates'
-    });
-  });
-
   describe('update APD', () => {
     it('creates UPDATE_APD action and does not update the budget if the APD years did not change', () => {
       const store = mockStore({});

--- a/web/src/reducers/budget.js
+++ b/web/src/reducers/budget.js
@@ -1,5 +1,3 @@
-import u from 'updeep';
-
 import { UPDATE_BUDGET } from '../actions/apd';
 import { arrToObj } from '../util';
 

--- a/web/src/reducers/budget.js
+++ b/web/src/reducers/budget.js
@@ -1,6 +1,6 @@
 import u from 'updeep';
 
-import { UPDATE_BUDGET, UPDATE_BUDGET_QUARTERLY_SHARE } from '../actions/apd';
+import { UPDATE_BUDGET } from '../actions/apd';
 import { arrToObj } from '../util';
 
 const getFundingSourcesByYear = years => ({
@@ -77,21 +77,6 @@ const defaultFederalShare = years =>
     }
   );
 
-const defaultQuarterlyShares = years => ({
-  ...years.reduce(
-    (o, year) => ({
-      ...o,
-      [year]: { 1: 25, 2: 25, 3: 25, 4: 25 }
-    }),
-    {}
-  )
-});
-
-const initQuarterly = years => ({
-  hitAndHie: defaultQuarterlyShares(years),
-  mmis: defaultQuarterlyShares(years)
-});
-
 const initialState = years => ({
   activities: {},
   combined: getFundingSourcesByYear(years),
@@ -104,7 +89,6 @@ const initialState = years => ({
   mmis: expenseTypes(years),
   hitAndHie: expenseTypes(years),
   mmisByFFP: expenseTypes(years, [...FFPOptions, 'combined']),
-  quarterly: initQuarterly(years),
   activityTotals: [],
   years
 });
@@ -428,8 +412,6 @@ const reducer = (state = initialState([]), action) => {
   switch (action.type) {
     case UPDATE_BUDGET:
       return buildBudget(action.state);
-    case UPDATE_BUDGET_QUARTERLY_SHARE:
-      return u({ quarterly: { ...action.updates } }, state);
     default:
       return state;
   }

--- a/web/src/reducers/budget.test.js
+++ b/web/src/reducers/budget.test.js
@@ -1,4 +1,4 @@
-import budget, { initialState as initialStateFn } from './budget';
+import budget from './budget';
 import { UPDATE_BUDGET } from '../actions/apd';
 
 describe('budget reducer', () => {

--- a/web/src/reducers/budget.test.js
+++ b/web/src/reducers/budget.test.js
@@ -43,25 +43,12 @@ describe('budget reducer', () => {
       '90-10': { total: { federal: 0, state: 0, total: 0 } },
       combined: { total: { federal: 0, state: 0, total: 0 } }
     },
-    quarterly: { hitAndHie: {}, mmis: {} },
     activityTotals: [],
     years: []
   };
 
   it('should handle initial state', () => {
     expect(budget(undefined, {})).toEqual(initialState);
-  });
-
-  it('handles quarterly share updates', () => {
-    const state = initialStateFn(['2018']);
-    const newState = budget(state, {
-      type: 'UPDATE_BUDGET_QUARTERLY_SHARE',
-      updates: { hitAndHie: { '2018': { 1: 10 } } }
-    });
-
-    expect(newState.quarterly.hitAndHie).toEqual({
-      '2018': { 1: 10, 2: 25, 3: 25, 4: 25 }
-    });
   });
 
   it('computes new budget data from state', () => {
@@ -804,18 +791,6 @@ describe('budget reducer', () => {
           '1932': { federal: 1500, state: 500, total: 3000 },
           '1933': { federal: 1890, state: 210, total: 2100 },
           total: { federal: 4140, state: 1460, total: 7600 }
-        }
-      },
-      quarterly: {
-        hitAndHie: {
-          '1931': { '1': 25, '2': 25, '3': 25, '4': 25 },
-          '1932': { '1': 25, '2': 25, '3': 25, '4': 25 },
-          '1933': { '1': 25, '2': 25, '3': 25, '4': 25 }
-        },
-        mmis: {
-          '1931': { '1': 25, '2': 25, '3': 25, '4': 25 },
-          '1932': { '1': 25, '2': 25, '3': 25, '4': 25 },
-          '1933': { '1': 25, '2': 25, '3': 25, '4': 25 }
         }
       },
       activityTotals: [


### PR DESCRIPTION
The budget state has a prop called `quarterly` that's leftover from an earlier version of computing quarterly budget - it's now activity based instead, but this tidbit was never cleaned up.  This PR yanks it out.

This is a piece of #883

### This pull request changes...
- no visible changes

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author