### PR TITLE
Refactor budget reducer [skip deploy]

### DIFF
--- a/web/.eslintrc.json
+++ b/web/.eslintrc.json
@@ -17,6 +17,7 @@
         }
       }
     ],
+    "no-param-reassign": [2, { "props": false }],
 
     "react/forbid-prop-types": ["error", { "forbid": ["any"] }],
     "react/jsx-filename-extension": 0,

--- a/web/src/reducers/budget.js
+++ b/web/src/reducers/budget.js
@@ -300,14 +300,14 @@ const buildBudget = bigState => {
          * source for the current property and fiscal year.
          * @param {String} fs Funding source to apply this to.
          */
-        const addShares = fs => {
+        const addShares = (fs, p = prop) => {
           // Add total federal share, and federal share for the year
-          newState[fs][prop][year].federal += cost.fedShare;
-          newState[fs][prop].total.federal += cost.fedShare;
+          newState[fs][p][year].federal += cost.fedShare;
+          newState[fs][p].total.federal += cost.fedShare;
 
           // ...then state share for the same.
-          newState[fs][prop][year].state += cost.stateShare;
-          newState[fs][prop].total.state += cost.stateShare;
+          newState[fs][p][year].state += cost.stateShare;
+          newState[fs][p].total.state += cost.stateShare;
 
           // Then add those to combined costs, also as total and yearly.
           newState[fs].combined[year].federal += cost.fedShare;
@@ -329,25 +329,12 @@ const buildBudget = bigState => {
             allocation[year].ffp.state
           }`;
 
-          // Add state, federal, and total cost for this FFP level
-          // for the current FFY
-          newState.mmisByFFP[ffpLevel][year].federal += cost.fedShare;
-          newState.mmisByFFP[ffpLevel][year].state += cost.stateShare;
+          addShares('mmisByFFP', ffpLevel);
+
+          // MMIS-by-FFP has additional totals that the others don't have
           newState.mmisByFFP[ffpLevel][year].total += totalCost;
-
-          // Then add them to the subtotals for the FFP level
-          newState.mmisByFFP[ffpLevel].total.federal += cost.fedShare;
-          newState.mmisByFFP[ffpLevel].total.state += cost.stateShare;
           newState.mmisByFFP[ffpLevel].total.total += totalCost;
-
-          // And the subtotals for the FFY
-          newState.mmisByFFP.combined[year].federal += cost.fedShare;
-          newState.mmisByFFP.combined[year].state += cost.stateShare;
           newState.mmisByFFP.combined[year].total += totalCost;
-
-          // And finally the grand totals
-          newState.mmisByFFP.combined.total.federal += cost.fedShare;
-          newState.mmisByFFP.combined.total.state += cost.stateShare;
           newState.mmisByFFP.combined.total.total += totalCost;
         }
 

--- a/web/src/reducers/budget.js
+++ b/web/src/reducers/budget.js
@@ -85,29 +85,6 @@ const initialState = years => ({
   years
 });
 
-// const spread = (number, acrossPercents) => {
-//   const out = [];
-//   let remainder = 0;
-
-//   acrossPercents.forEach(percent => {
-//     const value = number * percent + remainder;
-//     remainder = value - Math.floor(value);
-
-//     if (remainder > 0.5) {
-//       // if the cumulative remainder to this point is over half, round up
-//       out.push(Math.ceil(value));
-//       // don't throwaway leftover remainders, or we might accidentally
-//       // roll up a few extra times
-//       remainder -= 1;
-//     } else {
-//       // otherwise round down
-//       out.push(Math.floor(value));
-//     }
-//   });
-
-//   return out;
-// };
-
 // Convert things to numbers, or default to zero.
 const n = x => +x || 0;
 
@@ -169,6 +146,19 @@ const newBuildBudget = bigState => {
       }
     };
 
+    const activityTotals = {
+      fundingSource: activity.fundingSource,
+      id: activity.id,
+      name: activity.name,
+      data: {
+        combined: { ...arrToObj(years, 0), total: 0 },
+        contractors: { ...arrToObj(years, 0), total: 0 },
+        expenses: { ...arrToObj(years, 0), total: 0 },
+        statePersonnel: { ...arrToObj(years, 0), total: 0 }
+      }
+    };
+    newState.activityTotals.push(activityTotals);
+
     /**
      * Get the state and federal share of costs for an amount for
      * a given year of the current activity.
@@ -199,6 +189,10 @@ const newBuildBudget = bigState => {
       Object.entries(contractor.years).forEach(([year, cost]) => {
         addCostToTotals(fundingSource, year, 'contractors', cost);
         activityTotalByCategory[year].contractors += cost;
+        activityTotals.data.contractors[year] += cost;
+        activityTotals.data.contractors.total += cost;
+        activityTotals.data.combined[year] += cost;
+        activityTotals.data.combined.total += cost;
       });
     });
 
@@ -206,6 +200,10 @@ const newBuildBudget = bigState => {
       Object.entries(expense.years).forEach(([year, cost]) => {
         addCostToTotals(fundingSource, year, 'expenses', cost);
         activityTotalByCategory[year].expenses += cost;
+        activityTotals.data.expenses[year] += cost;
+        activityTotals.data.expenses.total += cost;
+        activityTotals.data.combined[year] += cost;
+        activityTotals.data.combined.total += cost;
       });
     });
 
@@ -214,6 +212,10 @@ const newBuildBudget = bigState => {
         const cost = amt * perc / 100;
         addCostToTotals(fundingSource, year, 'statePersonnel', cost);
         activityTotalByCategory[year].statePersonnel += cost;
+        activityTotals.data.statePersonnel[year] += cost;
+        activityTotals.data.statePersonnel.total += cost;
+        activityTotals.data.combined[year] += cost;
+        activityTotals.data.combined.total += cost;
       });
     });
 

--- a/web/src/reducers/budget.js
+++ b/web/src/reducers/budget.js
@@ -93,7 +93,7 @@ const initialState = years => ({
 // Convert things to numbers, or default to zero.
 const n = x => +x || 0;
 
-const newBuildBudget = bigState => {
+const buildBudget = bigState => {
   // Get a shell of our new state object.  This essentially guarantees
   // that all of the properties and stuff will exist, so we don't have
   // to have a bunch of code checking for it.
@@ -403,7 +403,7 @@ const newBuildBudget = bigState => {
 const reducer = (state = initialState([]), action) => {
   switch (action.type) {
     case UPDATE_BUDGET:
-      return newBuildBudget(action.state);
+      return buildBudget(action.state);
     default:
       return state;
   }

--- a/web/src/reducers/budget.js
+++ b/web/src/reducers/budget.js
@@ -1,6 +1,11 @@
 import { UPDATE_BUDGET } from '../actions/apd';
 import { arrToObj } from '../util';
 
+const fixNum = (value, digits = 2) => {
+  const mult = 10 ** digits;
+  return Math.round(value * mult) / mult;
+};
+
 const getFundingSourcesByYear = years => ({
   ...years.reduce(
     (o, year) => ({
@@ -380,6 +385,17 @@ const newBuildBudget = bigState => {
       });
     });
   });
+
+  const roundProps = o => {
+    Object.entries(o).forEach(([key, value]) => {
+      if (typeof value === 'number') {
+        o[key] = fixNum(value);
+      } else if (typeof value === 'object') {
+        roundProps(value);
+      }
+    });
+  };
+  roundProps(newState);
 
   return newState;
 };

--- a/web/src/reducers/budget.js
+++ b/web/src/reducers/budget.js
@@ -162,9 +162,9 @@ const newBuildBudget = bigState => {
           }
         })),
         total: {
-          combined: { dollars: 0, percent: 0 },
-          contractors: { dollars: 0, percent: 0 },
-          state: { dollars: 0, percent: 0 }
+          combined: 0,
+          contractors: 0,
+          state: 0
         }
       }
     };
@@ -335,10 +335,14 @@ const newBuildBudget = bigState => {
 
           activityFFP[year][q + 1][propCostType].dollars += qFFP;
           activityFFP[year][q + 1][propCostType].percent = federalPct;
+          activityFFP[year][q + 1].combined.dollars += qFFP;
           activityFFP[year].subtotal[propCostType].dollars += qFFP;
-          activityFFP[year].subtotal[propCostType].percent += federalPct;
-          activityFFP.total[propCostType].dollars += qFFP;
-          activityFFP.total[propCostType].percent += federalPct;
+          if (prop !== 'expenses') {
+            activityFFP[year].subtotal[propCostType].percent += federalPct;
+          }
+          activityFFP[year].subtotal.combined.dollars += qFFP;
+          activityFFP.total[propCostType] += qFFP;
+          activityFFP.total.combined += qFFP;
 
           // For the expense type, add the federal share for the
           // quarter and the fiscal year subtotal.

--- a/web/src/reducers/budget.js
+++ b/web/src/reducers/budget.js
@@ -239,7 +239,7 @@ const buildBudget = bigState => {
 
     activity.statePersonnel.forEach(person => {
       Object.entries(person.years).forEach(([year, { amt, perc }]) => {
-        const cost = amt * perc / 100;
+        const cost = n(amt) * n(perc) / 100;
         addCostToTotals(fundingSource, year, 'statePersonnel', cost);
         activityTotalByCategory[year].statePersonnel += cost;
 

--- a/web/src/reducers/budget.js
+++ b/web/src/reducers/budget.js
@@ -333,13 +333,29 @@ const newBuildBudget = bigState => {
           const federalPct = ffp[q + 1][propCostType] / 100;
           const qFFP = cost.fedShare * ffp[q + 1][propCostType] / 100;
 
+          // Total cost and percent for this type.  Note that we don't
+          // sum the percent here because there are two categories being
+          // merged into one - if we summed, the "state" percents would
+          // all be doubled.
           activityFFP[year][q + 1][propCostType].dollars += qFFP;
           activityFFP[year][q + 1][propCostType].percent = federalPct;
+
+          // Then the quarterly combined dollars.  We don't bother
+          // with percent for combined because it doesn't make sense.
           activityFFP[year][q + 1].combined.dollars += qFFP;
+
+          // Fiscal year subtotal.  Because "expense" and "statePersonnel"
+          // are combined into the "state" property, we need to be careful
+          // about not adding the percent multiple times.  So, only
+          // add the percent if this is an "expense" type.
           activityFFP[year].subtotal[propCostType].dollars += qFFP;
           if (prop !== 'expenses') {
             activityFFP[year].subtotal[propCostType].percent += federalPct;
           }
+
+          // And finally, fiscal year combined subtotal and activity
+          // grand total.  Note that the grand total props are just
+          // numbers, not objects - we drop the percentage altogether.
           activityFFP[year].subtotal.combined.dollars += qFFP;
           activityFFP.total[propCostType] += qFFP;
           activityFFP.total.combined += qFFP;

--- a/web/src/reducers/budget.test.js
+++ b/web/src/reducers/budget.test.js
@@ -287,7 +287,7 @@ describe('budget reducer', () => {
               },
               subtotal: {
                 state: { dollars: 3060, percent: 1 },
-                contractors: { dollars: 1800, percent: 1.0000000000000002 },
+                contractors: { dollars: 1800, percent: 1 },
                 combined: { dollars: 4860, percent: 0 }
               }
             },
@@ -314,7 +314,7 @@ describe('budget reducer', () => {
               },
               subtotal: {
                 state: { dollars: 2880, percent: 1 },
-                contractors: { dollars: 1800, percent: 0.9999999999999999 },
+                contractors: { dollars: 1800, percent: 1 },
                 combined: { dollars: 4680, percent: 0 }
               }
             },
@@ -341,7 +341,7 @@ describe('budget reducer', () => {
               },
               subtotal: {
                 state: { dollars: 2430, percent: 1 },
-                contractors: { dollars: 1800, percent: 0.9999999999999999 },
+                contractors: { dollars: 1800, percent: 1 },
                 combined: { dollars: 4230, percent: 0 }
               }
             },
@@ -373,7 +373,7 @@ describe('budget reducer', () => {
               },
               subtotal: {
                 state: { dollars: 1800, percent: 1 },
-                contractors: { dollars: 900, percent: 0.9999999999999999 },
+                contractors: { dollars: 900, percent: 1 },
                 combined: { dollars: 2700, percent: 0 }
               }
             },
@@ -400,7 +400,7 @@ describe('budget reducer', () => {
               },
               subtotal: {
                 state: { dollars: 1800, percent: 1 },
-                contractors: { dollars: 900, percent: 1.0000000000000002 },
+                contractors: { dollars: 900, percent: 1 },
                 combined: { dollars: 2700, percent: 0 }
               }
             },
@@ -427,7 +427,7 @@ describe('budget reducer', () => {
               },
               subtotal: {
                 state: { dollars: 1800, percent: 1 },
-                contractors: { dollars: 900, percent: 0.9999999999999999 },
+                contractors: { dollars: 900, percent: 1 },
                 combined: { dollars: 2700, percent: 0 }
               }
             },
@@ -459,7 +459,7 @@ describe('budget reducer', () => {
               },
               subtotal: {
                 state: { dollars: 1800, percent: 1 },
-                contractors: { dollars: 900, percent: 0.9999999999999999 },
+                contractors: { dollars: 900, percent: 1 },
                 combined: { dollars: 2700, percent: 0 }
               }
             },
@@ -486,7 +486,7 @@ describe('budget reducer', () => {
               },
               subtotal: {
                 state: { dollars: 1800, percent: 1 },
-                contractors: { dollars: 900, percent: 0.9999999999999999 },
+                contractors: { dollars: 900, percent: 1 },
                 combined: { dollars: 2700, percent: 0 }
               }
             },
@@ -513,7 +513,7 @@ describe('budget reducer', () => {
               },
               subtotal: {
                 state: { dollars: 1200, percent: 1 },
-                contractors: { dollars: 720, percent: 1.2000000000000002 },
+                contractors: { dollars: 720, percent: 1.2 },
                 combined: { dollars: 1920, percent: 0 }
               }
             },
@@ -545,7 +545,7 @@ describe('budget reducer', () => {
               },
               subtotal: {
                 state: { dollars: 450, percent: 1 },
-                contractors: { dollars: 300, percent: 0.9999999999999999 },
+                contractors: { dollars: 300, percent: 1 },
                 combined: { dollars: 750, percent: 0 }
               }
             },
@@ -572,7 +572,7 @@ describe('budget reducer', () => {
               },
               subtotal: {
                 state: { dollars: 1000, percent: 1 },
-                contractors: { dollars: 600, percent: 1.2000000000000002 },
+                contractors: { dollars: 600, percent: 1.2 },
                 combined: { dollars: 1600, percent: 0 }
               }
             },
@@ -599,7 +599,7 @@ describe('budget reducer', () => {
               },
               subtotal: {
                 state: { dollars: 990, percent: 1 },
-                contractors: { dollars: 900, percent: 0.9999999999999999 },
+                contractors: { dollars: 900, percent: 1 },
                 combined: { dollars: 1890, percent: 0 }
               }
             },
@@ -609,9 +609,9 @@ describe('budget reducer', () => {
       },
       combined: {
         '1931': { federal: 11010, state: 1890, total: 13900 },
-        '1932': { federal: 11580, state: 1620.0100000000002, total: 14200 },
-        '1933': { federal: 10620, state: 1180.0099999999998, total: 12800 },
-        total: { federal: 33210, state: 4690.02, total: 40900 }
+        '1932': { federal: 11580, state: 1620, total: 14200 },
+        '1933': { federal: 10620, state: 1180, total: 12800 },
+        total: { federal: 33210, state: 4690, total: 40900 }
       },
       federalShareByFFYQuarter: {
         hitAndHie: {
@@ -693,8 +693,8 @@ describe('budget reducer', () => {
         combined: {
           '1931': { federal: 2700, state: 300, total: 3000 },
           '1932': { federal: 2700, state: 300, total: 3000 },
-          '1933': { federal: 1800, state: 200.01, total: 3000 },
-          total: { federal: 7200, state: 800.01, total: 9000 }
+          '1933': { federal: 1800, state: 200, total: 3000 },
+          total: { federal: 7200, state: 800, total: 9000 }
         },
         contractors: {
           '1931': { federal: 900, state: 100, total: 1000 },
@@ -719,8 +719,8 @@ describe('budget reducer', () => {
         combined: {
           '1931': { federal: 10260, state: 1140, total: 11400 },
           '1932': { federal: 10080, state: 1120, total: 11200 },
-          '1933': { federal: 8730, state: 970.01, total: 10700 },
-          total: { federal: 29070, state: 3230.01, total: 33300 }
+          '1933': { federal: 8730, state: 970, total: 10700 },
+          total: { federal: 29070, state: 3230, total: 33300 }
         },
         contractors: {
           '1931': { federal: 3600, state: 400, total: 4000 },
@@ -737,16 +737,16 @@ describe('budget reducer', () => {
         statePersonnel: {
           '1931': { federal: 3060, state: 340, total: 3400 },
           '1932': { federal: 2880, state: 320, total: 3200 },
-          '1933': { federal: 2130, state: 236.67000000000002, total: 2700 },
-          total: { federal: 8070, state: 896.6700000000001, total: 9300 }
+          '1933': { federal: 2130, state: 236.67, total: 2700 },
+          total: { federal: 8070, state: 896.67, total: 9300 }
         }
       },
       mmis: {
         combined: {
           '1931': { federal: 750, state: 750, total: 2500 },
-          '1932': { federal: 1500, state: 500.01, total: 3000 },
+          '1932': { federal: 1500, state: 500, total: 3000 },
           '1933': { federal: 1890, state: 210, total: 2100 },
-          total: { federal: 4140, state: 1460.0099999999998, total: 7600 }
+          total: { federal: 4140, state: 1460, total: 7600 }
         },
         contractors: {
           '1931': { federal: 300, state: 300, total: 1000 },
@@ -764,7 +764,7 @@ describe('budget reducer', () => {
           '1931': { federal: 150, state: 150, total: 500 },
           '1932': { federal: 500, state: 166.67, total: 1000 },
           '1933': { federal: 90, state: 10, total: 100 },
-          total: { federal: 740, state: 326.66999999999996, total: 1600 }
+          total: { federal: 740, state: 326.67, total: 1600 }
         }
       },
       mmisByFFP: {

--- a/web/src/util/index.js
+++ b/web/src/util/index.js
@@ -161,8 +161,11 @@ export const generateKey = () =>
 
 export const nextSequence = arrOfNums => Math.max(...arrOfNums, 0) + 1;
 
-export const arrToObj = (array = [], initialValue = 0) =>
-  Object.assign({}, ...array.map(a => ({ [a]: initialValue })));
+export const arrToObj = (array = [], initialValue = 0) => {
+  const init =
+    typeof initialValue === 'function' ? initialValue : () => initialValue;
+  return Object.assign({}, ...array.map(a => ({ [a]: init() })));
+};
 
 export const addObjVals = (obj, getVal = a => a) =>
   Object.values(obj).reduce((a, b) => a + getVal(b), 0);


### PR DESCRIPTION
Refactors the budget reducer to be more straightforward (🤞).  The sequence of computing all the budget data is now almost linear, making it hopefully easier to track where things happen.  Also, lots of comments to explain what's going on.

Closes #883 

### This pull request changes...
- no visible changes

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author