### PR TITLE
add entries atop contractor section

### DIFF
--- a/web/src/containers/activity/ContractorResources.js
+++ b/web/src/containers/activity/ContractorResources.js
@@ -21,6 +21,201 @@ import { t } from '../../i18n';
 
 const DOC_TYPES = ['Contract', 'Contract Amendment', 'RFP'];
 
+const ContractorForm = ({
+  idx,
+  contractor,
+  docType,
+  years,
+  handleChange,
+  handleDelete,
+  handleDocChange,
+  handleFileDelete,
+  handleFileUpload,
+  handleHourlyChange,
+  handleTermChange,
+  handleUseHourly,
+  handleYearChange
+}) => (
+  <div className="mt2 mb3">
+    <Btn
+      kind="outline"
+      extraCss="right px-tiny py0 h5 xs-hide"
+      onClick={handleDelete}
+    >
+      ✗
+    </Btn>
+    <div className="mb3 md-flex">
+      <Label>{t('activities.contractorResources.labels.contractorName')}</Label>
+      <Input
+        name={`contractor-${contractor.key}-name`}
+        label={t('activities.contractorResources.srLabels.name')}
+        type="text"
+        value={contractor.name}
+        onChange={handleChange(idx, 'name')}
+        wrapperClass="md-col-5"
+        hideLabel
+      />
+    </div>
+    <div className="mb3 md-flex">
+      <Label>{t('activities.contractorResources.labels.description')}</Label>
+      <Textarea
+        id={`contractor-${contractor.key}-desc`}
+        name={`contractor-${contractor.key}-desc`}
+        label={t('activities.contractorResources.srLabels.description')}
+        value={contractor.desc}
+        onChange={handleChange(idx, 'desc')}
+        wrapperClass="md-col-8"
+        hideLabel
+      />
+    </div>
+    <div className="mb3 md-flex">
+      <Label>{t('activities.contractorResources.labels.term')}</Label>
+      <DatePickerWrapper
+        startDateId={`contractor-${contractor.key}-start`}
+        endDateId={`contractor-${contractor.key}-end`}
+        initialStartDate={contractor.start}
+        initialEndDate={contractor.end}
+        onChange={handleTermChange(idx)}
+        numberOfMonths={2}
+        daySize={32}
+      />
+    </div>
+    <div className="mb3 md-flex">
+      <Label>{t('activities.contractorResources.labels.attachments')}</Label>
+      <div className="md-col-9 md-flex items-start">
+        <div className="md-col-6 flex items-end mr2">
+          <Select
+            name={`${contractor.key}-attachment-type`}
+            options={DOC_TYPES}
+            label="Document Type"
+            wrapperClass="col-6 mr2"
+            value={docType}
+            onChange={handleDocChange}
+          />
+          <Dropzone
+            className="btn btn-primary btn-dropzone"
+            onDrop={handleFileUpload(idx)}
+            multiple={false}
+            inputProps={{
+              title: 'select a file to attach for this contractor'
+            }}
+          >
+            Select file
+          </Dropzone>
+        </div>
+        {(contractor.files || []).length > 0 && (
+          <div className="md-col-4">
+            <h5 className="md-mt0 mb-tiny">Attached files</h5>
+            {contractor.files.map((file, fileIdx) => (
+              <div key={`${file.name}-${fileIdx}`} className="mb1">
+                <div>
+                  <DeleteButton
+                    kind="outline"
+                    extraCss="px-tiny py0 right"
+                    remove={handleFileDelete(idx, fileIdx)}
+                    resource="activities.contractorResources.delete"
+                  />
+                  <a
+                    className="block bold truncate"
+                    href={file.preview}
+                    target="_blank"
+                  >
+                    {file.name}
+                  </a>
+                </div>
+                <div className="h6">({file.category})</div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+    <div className="mb3 md-flex">
+      <Label>{t('activities.contractorResources.labels.cost')}</Label>
+      <div className="md-col-6 flex">
+        {years.map(year => (
+          <DollarInput
+            key={year}
+            name={`contractor-${contractor.key}-cost-${year}`}
+            label={year}
+            value={contractor.years[year]}
+            onChange={handleYearChange(idx, year)}
+            disabled={contractor.hourly.useHourly}
+            wrapperClass="mr2 flex-auto"
+          />
+        ))}
+      </div>
+    </div>
+    <div className="mb3 md-flex">
+      <Label>{t('activities.contractorResources.labels.hourly')}</Label>
+      <div className="md-col-6">
+        <div className="flex items-center">
+          <div className="mr2">This is an hourly resource</div>
+          <div>
+            <Btn
+              kind="outline"
+              extraCss={contractor.hourly.useHourly ? 'bg-black white' : ''}
+              onClick={handleUseHourly(contractor, true)}
+              disabled={contractor.hourly.useHourly}
+            >
+              Yes
+            </Btn>{' '}
+            <Btn
+              kind="outline"
+              extraCss={contractor.hourly.useHourly ? '' : 'bg-black white'}
+              onClick={handleUseHourly(contractor, false)}
+              disabled={!contractor.hourly.useHourly}
+            >
+              No
+            </Btn>
+          </div>
+        </div>
+        {contractor.hourly.useHourly && (
+          <div className="mt3">
+            {years.map(year => (
+              <div key={year} className="mb2 flex items-center justify-between">
+                <div className="col-3 bold">FFY {year}</div>
+                <Input
+                  name={`c-${contractor.key}-${year}-hrs`}
+                  label="Number of hours"
+                  wrapperClass="col-4"
+                  className="m0 input mono"
+                  type="number"
+                  value={contractor.hourly.data[year].hours}
+                  onChange={handleHourlyChange(idx, year, 'hours')}
+                />
+                <DollarInput
+                  name={`c-${contractor.key}-${year}-rate`}
+                  label="Hourly rate"
+                  wrapperClass="col-4"
+                  value={contractor.hourly.data[year].rate}
+                  onChange={handleHourlyChange(idx, year, 'rate')}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  </div>
+);
+
+ContractorForm.propTypes = {
+  idx: PropTypes.number.isRequired,
+  contractor: PropTypes.object.isRequired,
+  docType: PropTypes.string.isRequired,
+  years: PropTypes.array.isRequired,
+  handleChange: PropTypes.func.isRequired,
+  handleDelete: PropTypes.func.isRequired,
+  handleDocChange: PropTypes.func.isRequired,
+  handleFileDelete: PropTypes.func.isRequired,
+  handleFileUpload: PropTypes.func.isRequired,
+  handleHourlyChange: PropTypes.func.isRequired,
+  handleTermChange: PropTypes.func.isRequired,
+  handleUseHourly: PropTypes.func.isRequired,
+  handleYearChange: PropTypes.func.isRequired
+};
+
 class ContractorResources extends Component {
   state = { docType: DOC_TYPES[0] };
 
@@ -105,8 +300,13 @@ class ContractorResources extends Component {
     updateActivity(activity.key, { contractorResources: updates });
   };
 
+  handleDelete = entryKey => () => {
+    const { activity, removeContractor } = this.props;
+    removeContractor(activity.key, entryKey);
+  };
+
   render() {
-    const { activity, years, addContractor, removeContractor } = this.props;
+    const { activity, years, addContractor } = this.props;
     const { docType } = this.state;
 
     if (!activity) return null;
@@ -122,204 +322,22 @@ class ContractorResources extends Component {
         ) : (
           <div className="mt3 pt3 border-top border-grey">
             {contractorResources.map((contractor, i) => (
-              <div
+              <ContractorForm
                 key={contractor.key}
-                className="mb3 pb3 border-bottom border-grey"
-              >
-                <div className="mb3 md-flex">
-                  <Label>
-                    {t('activities.contractorResources.labels.contractorName')}
-                  </Label>
-                  <Input
-                    name={`contractor-${contractor.key}-name`}
-                    label={t('activities.contractorResources.srLabels.name')}
-                    type="text"
-                    value={contractor.name}
-                    onChange={this.handleChange(i, 'name')}
-                    wrapperClass="md-col-5"
-                    hideLabel
-                  />
-                </div>
-                <div className="mb3 md-flex">
-                  <Label>
-                    {t('activities.contractorResources.labels.description')}
-                  </Label>
-                  <Textarea
-                    id={`contractor-${contractor.key}-desc`}
-                    name={`contractor-${contractor.key}-desc`}
-                    label={t(
-                      'activities.contractorResources.srLabels.description'
-                    )}
-                    value={contractor.desc}
-                    onChange={this.handleChange(i, 'desc')}
-                    wrapperClass="md-col-8"
-                    hideLabel
-                  />
-                </div>
-                <div className="mb3 md-flex">
-                  <Label>
-                    {t('activities.contractorResources.labels.term')}
-                  </Label>
-                  <DatePickerWrapper
-                    startDateId={`contractor-${contractor.key}-start`}
-                    endDateId={`contractor-${contractor.key}-end`}
-                    initialStartDate={contractor.start}
-                    initialEndDate={contractor.end}
-                    onChange={this.handleTermChange(i)}
-                    numberOfMonths={2}
-                    daySize={32}
-                  />
-                </div>
-                <div className="mb3 md-flex">
-                  <Label>
-                    {t('activities.contractorResources.labels.attachments')}
-                  </Label>
-                  <div className="md-col-9 md-flex items-start">
-                    <div className="md-col-6 flex items-end mr2">
-                      <Select
-                        name={`${contractor.key}-attachment-type`}
-                        options={DOC_TYPES}
-                        label="Document Type"
-                        wrapperClass="col-6 mr2"
-                        value={docType}
-                        onChange={this.updateDocType}
-                      />
-                      <Dropzone
-                        className="btn btn-primary btn-dropzone"
-                        onDrop={this.handleFileUpload(i)}
-                        multiple={false}
-                        inputProps={{
-                          title: 'select a file to attach for this contractor'
-                        }}
-                      >
-                        Select file
-                      </Dropzone>
-                    </div>
-                    {(contractor.files || []).length > 0 && (
-                      <div className="md-col-4">
-                        <h5 className="md-mt0 mb-tiny">Attached files</h5>
-                        {contractor.files.map((f, j) => (
-                          <div key={`${f.name}-${j}`} className="mb1">
-                            <div>
-                              <DeleteButton
-                                kind="outline"
-                                extraCss="px-tiny py0 right"
-                                remove={this.handleFileDelete(i, j)}
-                                resource="activities.contractorResources.delete"
-                              />
-                              <a
-                                className="block bold truncate"
-                                href={f.preview}
-                                target="_blank"
-                              >
-                                {f.name}
-                              </a>
-                            </div>
-                            <div className="h6">({f.category})</div>
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                </div>
-                <div className="mb3 md-flex">
-                  <Label>
-                    {t('activities.contractorResources.labels.cost')}
-                  </Label>
-                  <div className="md-col-6 flex">
-                    {years.map(year => (
-                      <DollarInput
-                        key={year}
-                        name={`contractor-${contractor.key}-cost-${year}`}
-                        label={year}
-                        value={contractor.years[year]}
-                        onChange={this.handleYearChange(i, year)}
-                        disabled={contractor.hourly.useHourly}
-                        wrapperClass="mr2 flex-auto"
-                      />
-                    ))}
-                  </div>
-                </div>
-                <div className="mb3 md-flex">
-                  <Label>
-                    {t('activities.contractorResources.labels.hourly')}
-                  </Label>
-                  <div className="md-col-6">
-                    <div className="flex items-center">
-                      <div className="mr2">This is an hourly resource</div>
-                      <div>
-                        <Btn
-                          kind="outline"
-                          extraCss={
-                            contractor.hourly.useHourly ? 'bg-black white' : ''
-                          }
-                          onClick={this.handleUseHourly(contractor, true)}
-                          disabled={contractor.hourly.useHourly}
-                        >
-                          Yes
-                        </Btn>{' '}
-                        <Btn
-                          kind="outline"
-                          extraCss={
-                            contractor.hourly.useHourly ? '' : 'bg-black white'
-                          }
-                          onClick={this.handleUseHourly(contractor, false)}
-                          disabled={!contractor.hourly.useHourly}
-                        >
-                          No
-                        </Btn>
-                      </div>
-                    </div>
-                    {contractor.hourly.useHourly && (
-                      <div className="mt3">
-                        {years.map(year => (
-                          <div
-                            key={year}
-                            className="mb2 flex items-center justify-between"
-                          >
-                            <div className="col-3 bold">FFY {year}</div>
-                            <Input
-                              name={`c-${contractor.key}-${year}-hrs`}
-                              label="Number of hours"
-                              wrapperClass="col-4"
-                              className="m0 input mono"
-                              type="number"
-                              value={contractor.hourly.data[year].hours}
-                              onChange={this.handleHourlyChange(
-                                i,
-                                year,
-                                'hours'
-                              )}
-                            />
-                            <DollarInput
-                              name={`c-${contractor.key}-${year}-rate`}
-                              label="Hourly rate"
-                              wrapperClass="col-4"
-                              value={contractor.hourly.data[year].rate}
-                              onChange={this.handleHourlyChange(
-                                i,
-                                year,
-                                'rate'
-                              )}
-                            />
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                </div>
-                <div>
-                  <Btn
-                    kind="outline"
-                    extraCss="px1 py-tiny h5"
-                    onClick={() =>
-                      removeContractor(activityKey, contractor.key)
-                    }
-                  >
-                    {t('activities.contractorResources.removeLabel')}
-                  </Btn>
-                </div>
-              </div>
+                idx={i}
+                contractor={contractor}
+                docType={docType}
+                years={years}
+                handleChange={this.handleChange}
+                handleDelete={this.handleDelete}
+                handleDocChange={this.updateDocType}
+                handleFileUpload={this.handleFileUpload}
+                handleFileDelete={this.handleFileDelete}
+                handleHourlyChange={this.handleHourlyChange}
+                handleTermChange={this.handleTermChange}
+                handleUseHourly={this.handleUseHourly}
+                handleYearChange={this.handleYearChange}
+              />
             ))}
           </div>
         )}

--- a/web/src/containers/activity/ContractorResources.test.js
+++ b/web/src/containers/activity/ContractorResources.test.js
@@ -17,30 +17,28 @@ import {
 describe('the ContractorResources component', () => {
   const sandbox = sinon.createSandbox();
   const props = {
-    activity: {
-      key: 'activity key',
-      contractorResources: [
-        {
-          id: 'contractor id',
-          key: 'contractor key',
-          name: 'contractor name',
-          desc: 'contractor description',
-          start: 'start date',
-          end: 'end date',
-          years: {
-            '1066': 100,
-            '1067': 200
-          },
-          hourly: {
-            useHourly: false,
-            data: {
-              '1066': { hours: '', rate: '' },
-              '1067': { hours: '', rate: '' }
-            }
+    activityKey: 'activity key',
+    contractors: [
+      {
+        id: 'contractor id',
+        key: 'contractor key',
+        name: 'contractor name',
+        desc: 'contractor description',
+        start: 'start date',
+        end: 'end date',
+        years: {
+          '1066': 100,
+          '1067': 200
+        },
+        hourly: {
+          useHourly: false,
+          data: {
+            '1066': { hours: '', rate: '' },
+            '1067': { hours: '', rate: '' }
           }
         }
-      ]
-    },
+      }
+    ],
     years: ['1066', '1067'],
     addContractor: sinon.stub(),
     removeContractor: sinon.stub(),
@@ -66,14 +64,22 @@ describe('the ContractorResources component', () => {
 
   test('removes a contractor', () => {
     const component = shallow(<ContractorResources {...props} />);
-    component.find('Btn[children="Remove resource"]').simulate('click');
+
+    component
+      .find('ContractorForm')
+      .dive()
+      .find('Btn[children="✗"]')
+      .simulate('click');
+
     expect(
       props.removeContractor.calledWith('activity key', 'contractor key')
     ).toBeTruthy();
   });
 
   test('handles changing contractor info', () => {
-    const component = shallow(<ContractorResources {...props} />);
+    const component = shallow(<ContractorResources {...props} />)
+      .find('ContractorForm')
+      .dive();
 
     const nameInput = component
       .find('InputHolder')
@@ -97,7 +103,9 @@ describe('the ContractorResources component', () => {
   });
 
   test('handles changing contractor expense info', () => {
-    const component = shallow(<ContractorResources {...props} />);
+    const component = shallow(<ContractorResources {...props} />)
+      .find('ContractorForm')
+      .dive();
     const yearInput = component
       .find('InputHolder')
       .filterWhere(n => n.props().value === 100);
@@ -118,7 +126,7 @@ describe('the ContractorResources component', () => {
         {
           activities: {
             byKey: {
-              key: 'this is the activity'
+              key: { contractorResources: 'contractorz' }
             }
           },
           apd: {
@@ -130,7 +138,8 @@ describe('the ContractorResources component', () => {
         { aKey: 'key' }
       )
     ).toEqual({
-      activity: 'this is the activity',
+      activityKey: 'key',
+      contractors: 'contractorz',
       years: 'seven'
     });
   });

--- a/web/src/containers/activity/Expenses.js
+++ b/web/src/containers/activity/Expenses.js
@@ -130,18 +130,16 @@ ExpenseForm.propTypes = {
   handleDelete: PropTypes.func.isRequired
 };
 
-const getLastExpense = expenses =>
-  expenses.length ? expenses[expenses.length - 1].key : null;
-
 class Expenses extends Component {
   static getDerivedStateFromProps(props, state) {
-    const lastExpense = getLastExpense(props.expenses);
+    const { expenses: data } = props;
+    const lastKey = data.length ? data[data.length - 1].key : null;
 
-    if (lastExpense && !(lastExpense in state.showForm)) {
+    if (lastKey && !(lastKey in state.showForm)) {
       return {
         showForm: {
           ...arrToObj(Object.keys(state.showForm), false),
-          [lastExpense]: true
+          [lastKey]: true
         }
       };
     }

--- a/web/src/containers/activity/StatePersonnel.js
+++ b/web/src/containers/activity/StatePersonnel.js
@@ -157,14 +157,14 @@ PersonnelForm.propTypes = {
 
 class StatePersonnel extends Component {
   static getDerivedStateFromProps(props, state) {
-    const { personnel: p } = props;
-    const lastPerson = p.length ? p[p.length - 1].key : null;
+    const { personnel: data } = props;
+    const lastKey = data.length ? data[data.length - 1].key : null;
 
-    if (lastPerson && !(lastPerson in state.showForm)) {
+    if (lastKey && !(lastKey in state.showForm)) {
       return {
         showForm: {
           ...arrToObj(Object.keys(state.showForm), false),
-          [lastPerson]: true
+          [lastKey]: true
         }
       };
     }

--- a/web/src/containers/activity/__snapshots__/ContractorResources.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/ContractorResources.test.js.snap
@@ -5,39 +5,37 @@ ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <ContractorResources
-    activity={
-      Object {
-        "contractorResources": Array [
-          Object {
-            "desc": "contractor description",
-            "end": "end date",
-            "hourly": Object {
-              "data": Object {
-                "1066": Object {
-                  "hours": "",
-                  "rate": "",
-                },
-                "1067": Object {
-                  "hours": "",
-                  "rate": "",
-                },
-              },
-              "useHourly": false,
-            },
-            "id": "contractor id",
-            "key": "contractor key",
-            "name": "contractor name",
-            "start": "start date",
-            "years": Object {
-              "1066": 100,
-              "1067": 200,
-            },
-          },
-        ],
-        "key": "activity key",
-      }
-    }
+    activityKey="activity key"
     addContractor={[Function]}
+    contractors={
+      Array [
+        Object {
+          "desc": "contractor description",
+          "end": "end date",
+          "hourly": Object {
+            "data": Object {
+              "1066": Object {
+                "hours": "",
+                "rate": "",
+              },
+              "1067": Object {
+                "hours": "",
+                "rate": "",
+              },
+            },
+            "useHourly": false,
+          },
+          "id": "contractor id",
+          "key": "contractor key",
+          "name": "contractor name",
+          "start": "start date",
+          "years": Object {
+            "1066": 100,
+            "1067": 200,
+          },
+        },
+      ]
+    }
     removeContractor={[Function]}
     toggleContractorHourly={[Function]}
     updateActivity={[Function]}
@@ -64,188 +62,91 @@ ShallowWrapper {
         <div
           className="mt3 pt3 border-top border-grey"
         >
-          <div
-            className="mb3 pb3 border-bottom border-grey"
-          >
-            <div
-              className="mb3 md-flex"
-            >
-              <Label>
-                Contractor Name
-              </Label>
-              <InputHolder
-                hideLabel={true}
-                label="Contractor name"
-                name="contractor-contractor key-name"
-                onChange={[Function]}
-                type="text"
-                value="contractor name"
-                wrapperClass="md-col-5"
-              />
-            </div>
-            <div
-              className="mb3 md-flex"
-            >
-              <Label>
-                Description of Services
-              </Label>
-              <InputHolder
-                hideLabel={true}
-                id="contractor-contractor key-desc"
-                label="Describe the services each contractor will provide."
-                name="contractor-contractor key-desc"
-                onChange={[Function]}
-                type="text"
-                value="contractor description"
-                wrapperClass="md-col-8"
-              />
-            </div>
-            <div
-              className="mb3 md-flex"
-            >
-              <Label>
-                Term Period
-              </Label>
-              <DatePickerWrapper
-                daySize={32}
-                endDateId="contractor-contractor key-end"
-                initialEndDate="end date"
-                initialStartDate="start date"
-                numberOfMonths={2}
-                onChange={[Function]}
-                startDateId="contractor-contractor key-start"
-              />
-            </div>
-            <div
-              className="mb3 md-flex"
-            >
-              <Label>
-                Attachments
-              </Label>
-              <div
-                className="md-col-9 md-flex items-start"
-              >
-                <div
-                  className="md-col-6 flex items-end mr2"
-                >
-                  <Select
-                    hideLabel={false}
-                    label="Document Type"
-                    name="contractor key-attachment-type"
-                    onChange={[Function]}
-                    options={
-                      Array [
-                        "Contract",
-                        "Contract Amendment",
-                        "RFP",
-                      ]
-                    }
-                    value="Contract"
-                    wrapperClass="col-6 mr2"
-                  />
-                  <t
-                    className="btn btn-primary btn-dropzone"
-                    disableClick={false}
-                    disablePreview={false}
-                    disabled={false}
-                    inputProps={
-                      Object {
-                        "title": "select a file to attach for this contractor",
-                      }
-                    }
-                    maxSize={Infinity}
-                    minSize={0}
-                    multiple={false}
-                    onDrop={[Function]}
-                    preventDropOnDocument={true}
-                  >
-                    Select file
-                  </t>
-                </div>
-              </div>
-            </div>
-            <div
-              className="mb3 md-flex"
-            >
-              <Label>
-                Cost
-              </Label>
-              <div
-                className="md-col-6 flex"
-              >
-                <InputHolder
-                  disabled={false}
-                  hideLabel={false}
-                  label="1066"
-                  name="contractor-contractor key-cost-1066"
-                  onChange={[Function]}
-                  type="text"
-                  value={100}
-                  wrapperClass="mr2 flex-auto"
-                />
-                <InputHolder
-                  disabled={false}
-                  hideLabel={false}
-                  label="1067"
-                  name="contractor-contractor key-cost-1067"
-                  onChange={[Function]}
-                  type="text"
-                  value={200}
-                  wrapperClass="mr2 flex-auto"
-                />
-              </div>
-            </div>
-            <div
-              className="mb3 md-flex"
-            >
-              <Label>
-                Hourly Resource
-              </Label>
-              <div
-                className="md-col-6"
-              >
-                <div
-                  className="flex items-center"
-                >
-                  <div
-                    className="mr2"
-                  >
-                    This is an hourly resource
-                  </div>
-                  <div>
-                    <Btn
-                      disabled={false}
-                      extraCss=""
-                      kind="outline"
-                      onClick={[Function]}
-                      size={null}
-                    >
-                      Yes
-                    </Btn>
-                     
-                    <Btn
-                      disabled={true}
-                      extraCss="bg-black white"
-                      kind="outline"
-                      onClick={[Function]}
-                      size={null}
-                    >
-                      No
-                    </Btn>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div>
-              <Btn
-                extraCss="px1 py-tiny h5"
-                kind="outline"
-                onClick={[Function]}
-                size={null}
-              >
-                Remove resource
-              </Btn>
-            </div>
+          <div>
+            <ContractorEntry
+              contractor={
+                Object {
+                  "desc": "contractor description",
+                  "end": "end date",
+                  "hourly": Object {
+                    "data": Object {
+                      "1066": Object {
+                        "hours": "",
+                        "rate": "",
+                      },
+                      "1067": Object {
+                        "hours": "",
+                        "rate": "",
+                      },
+                    },
+                    "useHourly": false,
+                  },
+                  "id": "contractor id",
+                  "key": "contractor key",
+                  "name": "contractor name",
+                  "start": "start date",
+                  "years": Object {
+                    "1066": 100,
+                    "1067": 200,
+                  },
+                }
+              }
+              handleDelete={[Function]}
+              idx={0}
+              toggleForm={[Function]}
+              years={
+                Array [
+                  "1066",
+                  "1067",
+                ]
+              }
+            />
+            <ContractorForm
+              contractor={
+                Object {
+                  "desc": "contractor description",
+                  "end": "end date",
+                  "hourly": Object {
+                    "data": Object {
+                      "1066": Object {
+                        "hours": "",
+                        "rate": "",
+                      },
+                      "1067": Object {
+                        "hours": "",
+                        "rate": "",
+                      },
+                    },
+                    "useHourly": false,
+                  },
+                  "id": "contractor id",
+                  "key": "contractor key",
+                  "name": "contractor name",
+                  "start": "start date",
+                  "years": Object {
+                    "1066": 100,
+                    "1067": 200,
+                  },
+                }
+              }
+              docType="Contract"
+              handleChange={[Function]}
+              handleDelete={[Function]}
+              handleDocChange={[Function]}
+              handleFileDelete={[Function]}
+              handleFileUpload={[Function]}
+              handleHourlyChange={[Function]}
+              handleTermChange={[Function]}
+              handleUseHourly={[Function]}
+              handleYearChange={[Function]}
+              idx={0}
+              years={
+                Array [
+                  "1066",
+                  "1067",
+                ]
+              }
+            />
           </div>
         </div>,
         <Btn
@@ -270,188 +171,91 @@ ShallowWrapper {
         "nodeType": "host",
         "props": Object {
           "children": Array [
-            <div
-              className="mb3 pb3 border-bottom border-grey"
-            >
-              <div
-                className="mb3 md-flex"
-              >
-                <Label>
-                  Contractor Name
-                </Label>
-                <InputHolder
-                  hideLabel={true}
-                  label="Contractor name"
-                  name="contractor-contractor key-name"
-                  onChange={[Function]}
-                  type="text"
-                  value="contractor name"
-                  wrapperClass="md-col-5"
-                />
-              </div>
-              <div
-                className="mb3 md-flex"
-              >
-                <Label>
-                  Description of Services
-                </Label>
-                <InputHolder
-                  hideLabel={true}
-                  id="contractor-contractor key-desc"
-                  label="Describe the services each contractor will provide."
-                  name="contractor-contractor key-desc"
-                  onChange={[Function]}
-                  type="text"
-                  value="contractor description"
-                  wrapperClass="md-col-8"
-                />
-              </div>
-              <div
-                className="mb3 md-flex"
-              >
-                <Label>
-                  Term Period
-                </Label>
-                <DatePickerWrapper
-                  daySize={32}
-                  endDateId="contractor-contractor key-end"
-                  initialEndDate="end date"
-                  initialStartDate="start date"
-                  numberOfMonths={2}
-                  onChange={[Function]}
-                  startDateId="contractor-contractor key-start"
-                />
-              </div>
-              <div
-                className="mb3 md-flex"
-              >
-                <Label>
-                  Attachments
-                </Label>
-                <div
-                  className="md-col-9 md-flex items-start"
-                >
-                  <div
-                    className="md-col-6 flex items-end mr2"
-                  >
-                    <Select
-                      hideLabel={false}
-                      label="Document Type"
-                      name="contractor key-attachment-type"
-                      onChange={[Function]}
-                      options={
-                        Array [
-                          "Contract",
-                          "Contract Amendment",
-                          "RFP",
-                        ]
-                      }
-                      value="Contract"
-                      wrapperClass="col-6 mr2"
-                    />
-                    <t
-                      className="btn btn-primary btn-dropzone"
-                      disableClick={false}
-                      disablePreview={false}
-                      disabled={false}
-                      inputProps={
-                        Object {
-                          "title": "select a file to attach for this contractor",
-                        }
-                      }
-                      maxSize={Infinity}
-                      minSize={0}
-                      multiple={false}
-                      onDrop={[Function]}
-                      preventDropOnDocument={true}
-                    >
-                      Select file
-                    </t>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="mb3 md-flex"
-              >
-                <Label>
-                  Cost
-                </Label>
-                <div
-                  className="md-col-6 flex"
-                >
-                  <InputHolder
-                    disabled={false}
-                    hideLabel={false}
-                    label="1066"
-                    name="contractor-contractor key-cost-1066"
-                    onChange={[Function]}
-                    type="text"
-                    value={100}
-                    wrapperClass="mr2 flex-auto"
-                  />
-                  <InputHolder
-                    disabled={false}
-                    hideLabel={false}
-                    label="1067"
-                    name="contractor-contractor key-cost-1067"
-                    onChange={[Function]}
-                    type="text"
-                    value={200}
-                    wrapperClass="mr2 flex-auto"
-                  />
-                </div>
-              </div>
-              <div
-                className="mb3 md-flex"
-              >
-                <Label>
-                  Hourly Resource
-                </Label>
-                <div
-                  className="md-col-6"
-                >
-                  <div
-                    className="flex items-center"
-                  >
-                    <div
-                      className="mr2"
-                    >
-                      This is an hourly resource
-                    </div>
-                    <div>
-                      <Btn
-                        disabled={false}
-                        extraCss=""
-                        kind="outline"
-                        onClick={[Function]}
-                        size={null}
-                      >
-                        Yes
-                      </Btn>
-                       
-                      <Btn
-                        disabled={true}
-                        extraCss="bg-black white"
-                        kind="outline"
-                        onClick={[Function]}
-                        size={null}
-                      >
-                        No
-                      </Btn>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div>
-                <Btn
-                  extraCss="px1 py-tiny h5"
-                  kind="outline"
-                  onClick={[Function]}
-                  size={null}
-                >
-                  Remove resource
-                </Btn>
-              </div>
+            <div>
+              <ContractorEntry
+                contractor={
+                  Object {
+                    "desc": "contractor description",
+                    "end": "end date",
+                    "hourly": Object {
+                      "data": Object {
+                        "1066": Object {
+                          "hours": "",
+                          "rate": "",
+                        },
+                        "1067": Object {
+                          "hours": "",
+                          "rate": "",
+                        },
+                      },
+                      "useHourly": false,
+                    },
+                    "id": "contractor id",
+                    "key": "contractor key",
+                    "name": "contractor name",
+                    "start": "start date",
+                    "years": Object {
+                      "1066": 100,
+                      "1067": 200,
+                    },
+                  }
+                }
+                handleDelete={[Function]}
+                idx={0}
+                toggleForm={[Function]}
+                years={
+                  Array [
+                    "1066",
+                    "1067",
+                  ]
+                }
+              />
+              <ContractorForm
+                contractor={
+                  Object {
+                    "desc": "contractor description",
+                    "end": "end date",
+                    "hourly": Object {
+                      "data": Object {
+                        "1066": Object {
+                          "hours": "",
+                          "rate": "",
+                        },
+                        "1067": Object {
+                          "hours": "",
+                          "rate": "",
+                        },
+                      },
+                      "useHourly": false,
+                    },
+                    "id": "contractor id",
+                    "key": "contractor key",
+                    "name": "contractor name",
+                    "start": "start date",
+                    "years": Object {
+                      "1066": 100,
+                      "1067": 200,
+                    },
+                  }
+                }
+                docType="Contract"
+                handleChange={[Function]}
+                handleDelete={[Function]}
+                handleDocChange={[Function]}
+                handleFileDelete={[Function]}
+                handleFileUpload={[Function]}
+                handleHourlyChange={[Function]}
+                handleTermChange={[Function]}
+                handleUseHourly={[Function]}
+                handleYearChange={[Function]}
+                idx={0}
+                years={
+                  Array [
+                    "1066",
+                    "1067",
+                  ]
+                }
+              />
             </div>,
           ],
           "className": "mt3 pt3 border-top border-grey",
@@ -464,945 +268,185 @@ ShallowWrapper {
             "nodeType": "host",
             "props": Object {
               "children": Array [
-                <div
-                  className="mb3 md-flex"
-                >
-                  <Label>
-                    Contractor Name
-                  </Label>
-                  <InputHolder
-                    hideLabel={true}
-                    label="Contractor name"
-                    name="contractor-contractor key-name"
-                    onChange={[Function]}
-                    type="text"
-                    value="contractor name"
-                    wrapperClass="md-col-5"
-                  />
-                </div>,
-                <div
-                  className="mb3 md-flex"
-                >
-                  <Label>
-                    Description of Services
-                  </Label>
-                  <InputHolder
-                    hideLabel={true}
-                    id="contractor-contractor key-desc"
-                    label="Describe the services each contractor will provide."
-                    name="contractor-contractor key-desc"
-                    onChange={[Function]}
-                    type="text"
-                    value="contractor description"
-                    wrapperClass="md-col-8"
-                  />
-                </div>,
-                <div
-                  className="mb3 md-flex"
-                >
-                  <Label>
-                    Term Period
-                  </Label>
-                  <DatePickerWrapper
-                    daySize={32}
-                    endDateId="contractor-contractor key-end"
-                    initialEndDate="end date"
-                    initialStartDate="start date"
-                    numberOfMonths={2}
-                    onChange={[Function]}
-                    startDateId="contractor-contractor key-start"
-                  />
-                </div>,
-                <div
-                  className="mb3 md-flex"
-                >
-                  <Label>
-                    Attachments
-                  </Label>
-                  <div
-                    className="md-col-9 md-flex items-start"
-                  >
-                    <div
-                      className="md-col-6 flex items-end mr2"
-                    >
-                      <Select
-                        hideLabel={false}
-                        label="Document Type"
-                        name="contractor key-attachment-type"
-                        onChange={[Function]}
-                        options={
-                          Array [
-                            "Contract",
-                            "Contract Amendment",
-                            "RFP",
-                          ]
-                        }
-                        value="Contract"
-                        wrapperClass="col-6 mr2"
-                      />
-                      <t
-                        className="btn btn-primary btn-dropzone"
-                        disableClick={false}
-                        disablePreview={false}
-                        disabled={false}
-                        inputProps={
-                          Object {
-                            "title": "select a file to attach for this contractor",
-                          }
-                        }
-                        maxSize={Infinity}
-                        minSize={0}
-                        multiple={false}
-                        onDrop={[Function]}
-                        preventDropOnDocument={true}
-                      >
-                        Select file
-                      </t>
-                    </div>
-                  </div>
-                </div>,
-                <div
-                  className="mb3 md-flex"
-                >
-                  <Label>
-                    Cost
-                  </Label>
-                  <div
-                    className="md-col-6 flex"
-                  >
-                    <InputHolder
-                      disabled={false}
-                      hideLabel={false}
-                      label="1066"
-                      name="contractor-contractor key-cost-1066"
-                      onChange={[Function]}
-                      type="text"
-                      value={100}
-                      wrapperClass="mr2 flex-auto"
-                    />
-                    <InputHolder
-                      disabled={false}
-                      hideLabel={false}
-                      label="1067"
-                      name="contractor-contractor key-cost-1067"
-                      onChange={[Function]}
-                      type="text"
-                      value={200}
-                      wrapperClass="mr2 flex-auto"
-                    />
-                  </div>
-                </div>,
-                <div
-                  className="mb3 md-flex"
-                >
-                  <Label>
-                    Hourly Resource
-                  </Label>
-                  <div
-                    className="md-col-6"
-                  >
-                    <div
-                      className="flex items-center"
-                    >
-                      <div
-                        className="mr2"
-                      >
-                        This is an hourly resource
-                      </div>
-                      <div>
-                        <Btn
-                          disabled={false}
-                          extraCss=""
-                          kind="outline"
-                          onClick={[Function]}
-                          size={null}
-                        >
-                          Yes
-                        </Btn>
-                         
-                        <Btn
-                          disabled={true}
-                          extraCss="bg-black white"
-                          kind="outline"
-                          onClick={[Function]}
-                          size={null}
-                        >
-                          No
-                        </Btn>
-                      </div>
-                    </div>
-                  </div>
-                </div>,
-                <div>
-                  <Btn
-                    extraCss="px1 py-tiny h5"
-                    kind="outline"
-                    onClick={[Function]}
-                    size={null}
-                  >
-                    Remove resource
-                  </Btn>
-                </div>,
+                <ContractorEntry
+                  contractor={
+                    Object {
+                      "desc": "contractor description",
+                      "end": "end date",
+                      "hourly": Object {
+                        "data": Object {
+                          "1066": Object {
+                            "hours": "",
+                            "rate": "",
+                          },
+                          "1067": Object {
+                            "hours": "",
+                            "rate": "",
+                          },
+                        },
+                        "useHourly": false,
+                      },
+                      "id": "contractor id",
+                      "key": "contractor key",
+                      "name": "contractor name",
+                      "start": "start date",
+                      "years": Object {
+                        "1066": 100,
+                        "1067": 200,
+                      },
+                    }
+                  }
+                  handleDelete={[Function]}
+                  idx={0}
+                  toggleForm={[Function]}
+                  years={
+                    Array [
+                      "1066",
+                      "1067",
+                    ]
+                  }
+                />,
+                <ContractorForm
+                  contractor={
+                    Object {
+                      "desc": "contractor description",
+                      "end": "end date",
+                      "hourly": Object {
+                        "data": Object {
+                          "1066": Object {
+                            "hours": "",
+                            "rate": "",
+                          },
+                          "1067": Object {
+                            "hours": "",
+                            "rate": "",
+                          },
+                        },
+                        "useHourly": false,
+                      },
+                      "id": "contractor id",
+                      "key": "contractor key",
+                      "name": "contractor name",
+                      "start": "start date",
+                      "years": Object {
+                        "1066": 100,
+                        "1067": 200,
+                      },
+                    }
+                  }
+                  docType="Contract"
+                  handleChange={[Function]}
+                  handleDelete={[Function]}
+                  handleDocChange={[Function]}
+                  handleFileDelete={[Function]}
+                  handleFileUpload={[Function]}
+                  handleHourlyChange={[Function]}
+                  handleTermChange={[Function]}
+                  handleUseHourly={[Function]}
+                  handleYearChange={[Function]}
+                  idx={0}
+                  years={
+                    Array [
+                      "1066",
+                      "1067",
+                    ]
+                  }
+                />,
               ],
-              "className": "mb3 pb3 border-bottom border-grey",
             },
             "ref": null,
             "rendered": Array [
               Object {
                 "instance": null,
                 "key": undefined,
-                "nodeType": "host",
+                "nodeType": "function",
                 "props": Object {
-                  "children": Array [
-                    <Label>
-                      Contractor Name
-                    </Label>,
-                    <InputHolder
-                      hideLabel={true}
-                      label="Contractor name"
-                      name="contractor-contractor key-name"
-                      onChange={[Function]}
-                      type="text"
-                      value="contractor name"
-                      wrapperClass="md-col-5"
-                    />,
-                  ],
-                  "className": "mb3 md-flex",
-                },
-                "ref": null,
-                "rendered": Array [
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "function",
-                    "props": Object {
-                      "children": "Contractor Name",
-                    },
-                    "ref": null,
-                    "rendered": "Contractor Name",
-                    "type": [Function],
-                  },
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "function",
-                    "props": Object {
-                      "hideLabel": true,
-                      "label": "Contractor name",
-                      "name": "contractor-contractor key-name",
-                      "onChange": [Function],
-                      "type": "text",
-                      "value": "contractor name",
-                      "wrapperClass": "md-col-5",
-                    },
-                    "ref": null,
-                    "rendered": null,
-                    "type": [Function],
-                  },
-                ],
-                "type": "div",
-              },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": Array [
-                    <Label>
-                      Description of Services
-                    </Label>,
-                    <InputHolder
-                      hideLabel={true}
-                      id="contractor-contractor key-desc"
-                      label="Describe the services each contractor will provide."
-                      name="contractor-contractor key-desc"
-                      onChange={[Function]}
-                      type="text"
-                      value="contractor description"
-                      wrapperClass="md-col-8"
-                    />,
-                  ],
-                  "className": "mb3 md-flex",
-                },
-                "ref": null,
-                "rendered": Array [
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "function",
-                    "props": Object {
-                      "children": "Description of Services",
-                    },
-                    "ref": null,
-                    "rendered": "Description of Services",
-                    "type": [Function],
-                  },
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "function",
-                    "props": Object {
-                      "hideLabel": true,
-                      "id": "contractor-contractor key-desc",
-                      "label": "Describe the services each contractor will provide.",
-                      "name": "contractor-contractor key-desc",
-                      "onChange": [Function],
-                      "type": "text",
-                      "value": "contractor description",
-                      "wrapperClass": "md-col-8",
-                    },
-                    "ref": null,
-                    "rendered": null,
-                    "type": [Function],
-                  },
-                ],
-                "type": "div",
-              },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": Array [
-                    <Label>
-                      Term Period
-                    </Label>,
-                    <DatePickerWrapper
-                      daySize={32}
-                      endDateId="contractor-contractor key-end"
-                      initialEndDate="end date"
-                      initialStartDate="start date"
-                      numberOfMonths={2}
-                      onChange={[Function]}
-                      startDateId="contractor-contractor key-start"
-                    />,
-                  ],
-                  "className": "mb3 md-flex",
-                },
-                "ref": null,
-                "rendered": Array [
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "function",
-                    "props": Object {
-                      "children": "Term Period",
-                    },
-                    "ref": null,
-                    "rendered": "Term Period",
-                    "type": [Function],
-                  },
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "class",
-                    "props": Object {
-                      "daySize": 32,
-                      "endDateId": "contractor-contractor key-end",
-                      "initialEndDate": "end date",
-                      "initialStartDate": "start date",
-                      "numberOfMonths": 2,
-                      "onChange": [Function],
-                      "startDateId": "contractor-contractor key-start",
-                    },
-                    "ref": null,
-                    "rendered": null,
-                    "type": [Function],
-                  },
-                ],
-                "type": "div",
-              },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": Array [
-                    <Label>
-                      Attachments
-                    </Label>,
-                    <div
-                      className="md-col-9 md-flex items-start"
-                    >
-                      <div
-                        className="md-col-6 flex items-end mr2"
-                      >
-                        <Select
-                          hideLabel={false}
-                          label="Document Type"
-                          name="contractor key-attachment-type"
-                          onChange={[Function]}
-                          options={
-                            Array [
-                              "Contract",
-                              "Contract Amendment",
-                              "RFP",
-                            ]
-                          }
-                          value="Contract"
-                          wrapperClass="col-6 mr2"
-                        />
-                        <t
-                          className="btn btn-primary btn-dropzone"
-                          disableClick={false}
-                          disablePreview={false}
-                          disabled={false}
-                          inputProps={
-                            Object {
-                              "title": "select a file to attach for this contractor",
-                            }
-                          }
-                          maxSize={Infinity}
-                          minSize={0}
-                          multiple={false}
-                          onDrop={[Function]}
-                          preventDropOnDocument={true}
-                        >
-                          Select file
-                        </t>
-                      </div>
-                    </div>,
-                  ],
-                  "className": "mb3 md-flex",
-                },
-                "ref": null,
-                "rendered": Array [
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "function",
-                    "props": Object {
-                      "children": "Attachments",
-                    },
-                    "ref": null,
-                    "rendered": "Attachments",
-                    "type": [Function],
-                  },
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "host",
-                    "props": Object {
-                      "children": Array [
-                        <div
-                          className="md-col-6 flex items-end mr2"
-                        >
-                          <Select
-                            hideLabel={false}
-                            label="Document Type"
-                            name="contractor key-attachment-type"
-                            onChange={[Function]}
-                            options={
-                              Array [
-                                "Contract",
-                                "Contract Amendment",
-                                "RFP",
-                              ]
-                            }
-                            value="Contract"
-                            wrapperClass="col-6 mr2"
-                          />
-                          <t
-                            className="btn btn-primary btn-dropzone"
-                            disableClick={false}
-                            disablePreview={false}
-                            disabled={false}
-                            inputProps={
-                              Object {
-                                "title": "select a file to attach for this contractor",
-                              }
-                            }
-                            maxSize={Infinity}
-                            minSize={0}
-                            multiple={false}
-                            onDrop={[Function]}
-                            preventDropOnDocument={true}
-                          >
-                            Select file
-                          </t>
-                        </div>,
-                        false,
-                      ],
-                      "className": "md-col-9 md-flex items-start",
-                    },
-                    "ref": null,
-                    "rendered": Array [
-                      Object {
-                        "instance": null,
-                        "key": undefined,
-                        "nodeType": "host",
-                        "props": Object {
-                          "children": Array [
-                            <Select
-                              hideLabel={false}
-                              label="Document Type"
-                              name="contractor key-attachment-type"
-                              onChange={[Function]}
-                              options={
-                                Array [
-                                  "Contract",
-                                  "Contract Amendment",
-                                  "RFP",
-                                ]
-                              }
-                              value="Contract"
-                              wrapperClass="col-6 mr2"
-                            />,
-                            <t
-                              className="btn btn-primary btn-dropzone"
-                              disableClick={false}
-                              disablePreview={false}
-                              disabled={false}
-                              inputProps={
-                                Object {
-                                  "title": "select a file to attach for this contractor",
-                                }
-                              }
-                              maxSize={Infinity}
-                              minSize={0}
-                              multiple={false}
-                              onDrop={[Function]}
-                              preventDropOnDocument={true}
-                            >
-                              Select file
-                            </t>,
-                          ],
-                          "className": "md-col-6 flex items-end mr2",
+                  "contractor": Object {
+                    "desc": "contractor description",
+                    "end": "end date",
+                    "hourly": Object {
+                      "data": Object {
+                        "1066": Object {
+                          "hours": "",
+                          "rate": "",
                         },
-                        "ref": null,
-                        "rendered": Array [
-                          Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "function",
-                            "props": Object {
-                              "hideLabel": false,
-                              "label": "Document Type",
-                              "name": "contractor key-attachment-type",
-                              "onChange": [Function],
-                              "options": Array [
-                                "Contract",
-                                "Contract Amendment",
-                                "RFP",
-                              ],
-                              "value": "Contract",
-                              "wrapperClass": "col-6 mr2",
-                            },
-                            "ref": null,
-                            "rendered": null,
-                            "type": [Function],
-                          },
-                          Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "class",
-                            "props": Object {
-                              "children": "Select file",
-                              "className": "btn btn-primary btn-dropzone",
-                              "disableClick": false,
-                              "disablePreview": false,
-                              "disabled": false,
-                              "inputProps": Object {
-                                "title": "select a file to attach for this contractor",
-                              },
-                              "maxSize": Infinity,
-                              "minSize": 0,
-                              "multiple": false,
-                              "onDrop": [Function],
-                              "preventDropOnDocument": true,
-                            },
-                            "ref": null,
-                            "rendered": "Select file",
-                            "type": [Function],
-                          },
-                        ],
-                        "type": "div",
+                        "1067": Object {
+                          "hours": "",
+                          "rate": "",
+                        },
                       },
-                      false,
-                    ],
-                    "type": "div",
+                      "useHourly": false,
+                    },
+                    "id": "contractor id",
+                    "key": "contractor key",
+                    "name": "contractor name",
+                    "start": "start date",
+                    "years": Object {
+                      "1066": 100,
+                      "1067": 200,
+                    },
                   },
-                ],
-                "type": "div",
-              },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": Array [
-                    <Label>
-                      Cost
-                    </Label>,
-                    <div
-                      className="md-col-6 flex"
-                    >
-                      <InputHolder
-                        disabled={false}
-                        hideLabel={false}
-                        label="1066"
-                        name="contractor-contractor key-cost-1066"
-                        onChange={[Function]}
-                        type="text"
-                        value={100}
-                        wrapperClass="mr2 flex-auto"
-                      />
-                      <InputHolder
-                        disabled={false}
-                        hideLabel={false}
-                        label="1067"
-                        name="contractor-contractor key-cost-1067"
-                        onChange={[Function]}
-                        type="text"
-                        value={200}
-                        wrapperClass="mr2 flex-auto"
-                      />
-                    </div>,
+                  "handleDelete": [Function],
+                  "idx": 0,
+                  "toggleForm": [Function],
+                  "years": Array [
+                    "1066",
+                    "1067",
                   ],
-                  "className": "mb3 md-flex",
                 },
                 "ref": null,
-                "rendered": Array [
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "function",
-                    "props": Object {
-                      "children": "Cost",
-                    },
-                    "ref": null,
-                    "rendered": "Cost",
-                    "type": [Function],
-                  },
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "host",
-                    "props": Object {
-                      "children": Array [
-                        <InputHolder
-                          disabled={false}
-                          hideLabel={false}
-                          label="1066"
-                          name="contractor-contractor key-cost-1066"
-                          onChange={[Function]}
-                          type="text"
-                          value={100}
-                          wrapperClass="mr2 flex-auto"
-                        />,
-                        <InputHolder
-                          disabled={false}
-                          hideLabel={false}
-                          label="1067"
-                          name="contractor-contractor key-cost-1067"
-                          onChange={[Function]}
-                          type="text"
-                          value={200}
-                          wrapperClass="mr2 flex-auto"
-                        />,
-                      ],
-                      "className": "md-col-6 flex",
-                    },
-                    "ref": null,
-                    "rendered": Array [
-                      Object {
-                        "instance": null,
-                        "key": "1066",
-                        "nodeType": "function",
-                        "props": Object {
-                          "disabled": false,
-                          "hideLabel": false,
-                          "label": "1066",
-                          "name": "contractor-contractor key-cost-1066",
-                          "onChange": [Function],
-                          "type": "text",
-                          "value": 100,
-                          "wrapperClass": "mr2 flex-auto",
-                        },
-                        "ref": null,
-                        "rendered": null,
-                        "type": [Function],
-                      },
-                      Object {
-                        "instance": null,
-                        "key": "1067",
-                        "nodeType": "function",
-                        "props": Object {
-                          "disabled": false,
-                          "hideLabel": false,
-                          "label": "1067",
-                          "name": "contractor-contractor key-cost-1067",
-                          "onChange": [Function],
-                          "type": "text",
-                          "value": 200,
-                          "wrapperClass": "mr2 flex-auto",
-                        },
-                        "ref": null,
-                        "rendered": null,
-                        "type": [Function],
-                      },
-                    ],
-                    "type": "div",
-                  },
-                ],
-                "type": "div",
+                "rendered": null,
+                "type": [Function],
               },
               Object {
                 "instance": null,
-                "key": undefined,
-                "nodeType": "host",
+                "key": "contractor key",
+                "nodeType": "function",
                 "props": Object {
-                  "children": Array [
-                    <Label>
-                      Hourly Resource
-                    </Label>,
-                    <div
-                      className="md-col-6"
-                    >
-                      <div
-                        className="flex items-center"
-                      >
-                        <div
-                          className="mr2"
-                        >
-                          This is an hourly resource
-                        </div>
-                        <div>
-                          <Btn
-                            disabled={false}
-                            extraCss=""
-                            kind="outline"
-                            onClick={[Function]}
-                            size={null}
-                          >
-                            Yes
-                          </Btn>
-                           
-                          <Btn
-                            disabled={true}
-                            extraCss="bg-black white"
-                            kind="outline"
-                            onClick={[Function]}
-                            size={null}
-                          >
-                            No
-                          </Btn>
-                        </div>
-                      </div>
-                    </div>,
+                  "contractor": Object {
+                    "desc": "contractor description",
+                    "end": "end date",
+                    "hourly": Object {
+                      "data": Object {
+                        "1066": Object {
+                          "hours": "",
+                          "rate": "",
+                        },
+                        "1067": Object {
+                          "hours": "",
+                          "rate": "",
+                        },
+                      },
+                      "useHourly": false,
+                    },
+                    "id": "contractor id",
+                    "key": "contractor key",
+                    "name": "contractor name",
+                    "start": "start date",
+                    "years": Object {
+                      "1066": 100,
+                      "1067": 200,
+                    },
+                  },
+                  "docType": "Contract",
+                  "handleChange": [Function],
+                  "handleDelete": [Function],
+                  "handleDocChange": [Function],
+                  "handleFileDelete": [Function],
+                  "handleFileUpload": [Function],
+                  "handleHourlyChange": [Function],
+                  "handleTermChange": [Function],
+                  "handleUseHourly": [Function],
+                  "handleYearChange": [Function],
+                  "idx": 0,
+                  "years": Array [
+                    "1066",
+                    "1067",
                   ],
-                  "className": "mb3 md-flex",
                 },
                 "ref": null,
-                "rendered": Array [
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "function",
-                    "props": Object {
-                      "children": "Hourly Resource",
-                    },
-                    "ref": null,
-                    "rendered": "Hourly Resource",
-                    "type": [Function],
-                  },
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "host",
-                    "props": Object {
-                      "children": Array [
-                        <div
-                          className="flex items-center"
-                        >
-                          <div
-                            className="mr2"
-                          >
-                            This is an hourly resource
-                          </div>
-                          <div>
-                            <Btn
-                              disabled={false}
-                              extraCss=""
-                              kind="outline"
-                              onClick={[Function]}
-                              size={null}
-                            >
-                              Yes
-                            </Btn>
-                             
-                            <Btn
-                              disabled={true}
-                              extraCss="bg-black white"
-                              kind="outline"
-                              onClick={[Function]}
-                              size={null}
-                            >
-                              No
-                            </Btn>
-                          </div>
-                        </div>,
-                        false,
-                      ],
-                      "className": "md-col-6",
-                    },
-                    "ref": null,
-                    "rendered": Array [
-                      Object {
-                        "instance": null,
-                        "key": undefined,
-                        "nodeType": "host",
-                        "props": Object {
-                          "children": Array [
-                            <div
-                              className="mr2"
-                            >
-                              This is an hourly resource
-                            </div>,
-                            <div>
-                              <Btn
-                                disabled={false}
-                                extraCss=""
-                                kind="outline"
-                                onClick={[Function]}
-                                size={null}
-                              >
-                                Yes
-                              </Btn>
-                               
-                              <Btn
-                                disabled={true}
-                                extraCss="bg-black white"
-                                kind="outline"
-                                onClick={[Function]}
-                                size={null}
-                              >
-                                No
-                              </Btn>
-                            </div>,
-                          ],
-                          "className": "flex items-center",
-                        },
-                        "ref": null,
-                        "rendered": Array [
-                          Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "host",
-                            "props": Object {
-                              "children": "This is an hourly resource",
-                              "className": "mr2",
-                            },
-                            "ref": null,
-                            "rendered": "This is an hourly resource",
-                            "type": "div",
-                          },
-                          Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "host",
-                            "props": Object {
-                              "children": Array [
-                                <Btn
-                                  disabled={false}
-                                  extraCss=""
-                                  kind="outline"
-                                  onClick={[Function]}
-                                  size={null}
-                                >
-                                  Yes
-                                </Btn>,
-                                " ",
-                                <Btn
-                                  disabled={true}
-                                  extraCss="bg-black white"
-                                  kind="outline"
-                                  onClick={[Function]}
-                                  size={null}
-                                >
-                                  No
-                                </Btn>,
-                              ],
-                            },
-                            "ref": null,
-                            "rendered": Array [
-                              Object {
-                                "instance": null,
-                                "key": undefined,
-                                "nodeType": "function",
-                                "props": Object {
-                                  "children": "Yes",
-                                  "disabled": false,
-                                  "extraCss": "",
-                                  "kind": "outline",
-                                  "onClick": [Function],
-                                  "size": null,
-                                },
-                                "ref": null,
-                                "rendered": "Yes",
-                                "type": [Function],
-                              },
-                              " ",
-                              Object {
-                                "instance": null,
-                                "key": undefined,
-                                "nodeType": "function",
-                                "props": Object {
-                                  "children": "No",
-                                  "disabled": true,
-                                  "extraCss": "bg-black white",
-                                  "kind": "outline",
-                                  "onClick": [Function],
-                                  "size": null,
-                                },
-                                "ref": null,
-                                "rendered": "No",
-                                "type": [Function],
-                              },
-                            ],
-                            "type": "div",
-                          },
-                        ],
-                        "type": "div",
-                      },
-                      false,
-                    ],
-                    "type": "div",
-                  },
-                ],
-                "type": "div",
-              },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": <Btn
-                    extraCss="px1 py-tiny h5"
-                    kind="outline"
-                    onClick={[Function]}
-                    size={null}
-                  >
-                    Remove resource
-                  </Btn>,
-                },
-                "ref": null,
-                "rendered": Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "function",
-                  "props": Object {
-                    "children": "Remove resource",
-                    "extraCss": "px1 py-tiny h5",
-                    "kind": "outline",
-                    "onClick": [Function],
-                    "size": null,
-                  },
-                  "ref": null,
-                  "rendered": "Remove resource",
-                  "type": [Function],
-                },
-                "type": "div",
+                "rendered": null,
+                "type": [Function],
               },
             ],
             "type": "div",
@@ -1438,188 +482,91 @@ ShallowWrapper {
           <div
             className="mt3 pt3 border-top border-grey"
           >
-            <div
-              className="mb3 pb3 border-bottom border-grey"
-            >
-              <div
-                className="mb3 md-flex"
-              >
-                <Label>
-                  Contractor Name
-                </Label>
-                <InputHolder
-                  hideLabel={true}
-                  label="Contractor name"
-                  name="contractor-contractor key-name"
-                  onChange={[Function]}
-                  type="text"
-                  value="contractor name"
-                  wrapperClass="md-col-5"
-                />
-              </div>
-              <div
-                className="mb3 md-flex"
-              >
-                <Label>
-                  Description of Services
-                </Label>
-                <InputHolder
-                  hideLabel={true}
-                  id="contractor-contractor key-desc"
-                  label="Describe the services each contractor will provide."
-                  name="contractor-contractor key-desc"
-                  onChange={[Function]}
-                  type="text"
-                  value="contractor description"
-                  wrapperClass="md-col-8"
-                />
-              </div>
-              <div
-                className="mb3 md-flex"
-              >
-                <Label>
-                  Term Period
-                </Label>
-                <DatePickerWrapper
-                  daySize={32}
-                  endDateId="contractor-contractor key-end"
-                  initialEndDate="end date"
-                  initialStartDate="start date"
-                  numberOfMonths={2}
-                  onChange={[Function]}
-                  startDateId="contractor-contractor key-start"
-                />
-              </div>
-              <div
-                className="mb3 md-flex"
-              >
-                <Label>
-                  Attachments
-                </Label>
-                <div
-                  className="md-col-9 md-flex items-start"
-                >
-                  <div
-                    className="md-col-6 flex items-end mr2"
-                  >
-                    <Select
-                      hideLabel={false}
-                      label="Document Type"
-                      name="contractor key-attachment-type"
-                      onChange={[Function]}
-                      options={
-                        Array [
-                          "Contract",
-                          "Contract Amendment",
-                          "RFP",
-                        ]
-                      }
-                      value="Contract"
-                      wrapperClass="col-6 mr2"
-                    />
-                    <t
-                      className="btn btn-primary btn-dropzone"
-                      disableClick={false}
-                      disablePreview={false}
-                      disabled={false}
-                      inputProps={
-                        Object {
-                          "title": "select a file to attach for this contractor",
-                        }
-                      }
-                      maxSize={Infinity}
-                      minSize={0}
-                      multiple={false}
-                      onDrop={[Function]}
-                      preventDropOnDocument={true}
-                    >
-                      Select file
-                    </t>
-                  </div>
-                </div>
-              </div>
-              <div
-                className="mb3 md-flex"
-              >
-                <Label>
-                  Cost
-                </Label>
-                <div
-                  className="md-col-6 flex"
-                >
-                  <InputHolder
-                    disabled={false}
-                    hideLabel={false}
-                    label="1066"
-                    name="contractor-contractor key-cost-1066"
-                    onChange={[Function]}
-                    type="text"
-                    value={100}
-                    wrapperClass="mr2 flex-auto"
-                  />
-                  <InputHolder
-                    disabled={false}
-                    hideLabel={false}
-                    label="1067"
-                    name="contractor-contractor key-cost-1067"
-                    onChange={[Function]}
-                    type="text"
-                    value={200}
-                    wrapperClass="mr2 flex-auto"
-                  />
-                </div>
-              </div>
-              <div
-                className="mb3 md-flex"
-              >
-                <Label>
-                  Hourly Resource
-                </Label>
-                <div
-                  className="md-col-6"
-                >
-                  <div
-                    className="flex items-center"
-                  >
-                    <div
-                      className="mr2"
-                    >
-                      This is an hourly resource
-                    </div>
-                    <div>
-                      <Btn
-                        disabled={false}
-                        extraCss=""
-                        kind="outline"
-                        onClick={[Function]}
-                        size={null}
-                      >
-                        Yes
-                      </Btn>
-                       
-                      <Btn
-                        disabled={true}
-                        extraCss="bg-black white"
-                        kind="outline"
-                        onClick={[Function]}
-                        size={null}
-                      >
-                        No
-                      </Btn>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div>
-                <Btn
-                  extraCss="px1 py-tiny h5"
-                  kind="outline"
-                  onClick={[Function]}
-                  size={null}
-                >
-                  Remove resource
-                </Btn>
-              </div>
+            <div>
+              <ContractorEntry
+                contractor={
+                  Object {
+                    "desc": "contractor description",
+                    "end": "end date",
+                    "hourly": Object {
+                      "data": Object {
+                        "1066": Object {
+                          "hours": "",
+                          "rate": "",
+                        },
+                        "1067": Object {
+                          "hours": "",
+                          "rate": "",
+                        },
+                      },
+                      "useHourly": false,
+                    },
+                    "id": "contractor id",
+                    "key": "contractor key",
+                    "name": "contractor name",
+                    "start": "start date",
+                    "years": Object {
+                      "1066": 100,
+                      "1067": 200,
+                    },
+                  }
+                }
+                handleDelete={[Function]}
+                idx={0}
+                toggleForm={[Function]}
+                years={
+                  Array [
+                    "1066",
+                    "1067",
+                  ]
+                }
+              />
+              <ContractorForm
+                contractor={
+                  Object {
+                    "desc": "contractor description",
+                    "end": "end date",
+                    "hourly": Object {
+                      "data": Object {
+                        "1066": Object {
+                          "hours": "",
+                          "rate": "",
+                        },
+                        "1067": Object {
+                          "hours": "",
+                          "rate": "",
+                        },
+                      },
+                      "useHourly": false,
+                    },
+                    "id": "contractor id",
+                    "key": "contractor key",
+                    "name": "contractor name",
+                    "start": "start date",
+                    "years": Object {
+                      "1066": 100,
+                      "1067": 200,
+                    },
+                  }
+                }
+                docType="Contract"
+                handleChange={[Function]}
+                handleDelete={[Function]}
+                handleDocChange={[Function]}
+                handleFileDelete={[Function]}
+                handleFileUpload={[Function]}
+                handleHourlyChange={[Function]}
+                handleTermChange={[Function]}
+                handleUseHourly={[Function]}
+                handleYearChange={[Function]}
+                idx={0}
+                years={
+                  Array [
+                    "1066",
+                    "1067",
+                  ]
+                }
+              />
             </div>
           </div>,
           <Btn
@@ -1644,188 +591,91 @@ ShallowWrapper {
           "nodeType": "host",
           "props": Object {
             "children": Array [
-              <div
-                className="mb3 pb3 border-bottom border-grey"
-              >
-                <div
-                  className="mb3 md-flex"
-                >
-                  <Label>
-                    Contractor Name
-                  </Label>
-                  <InputHolder
-                    hideLabel={true}
-                    label="Contractor name"
-                    name="contractor-contractor key-name"
-                    onChange={[Function]}
-                    type="text"
-                    value="contractor name"
-                    wrapperClass="md-col-5"
-                  />
-                </div>
-                <div
-                  className="mb3 md-flex"
-                >
-                  <Label>
-                    Description of Services
-                  </Label>
-                  <InputHolder
-                    hideLabel={true}
-                    id="contractor-contractor key-desc"
-                    label="Describe the services each contractor will provide."
-                    name="contractor-contractor key-desc"
-                    onChange={[Function]}
-                    type="text"
-                    value="contractor description"
-                    wrapperClass="md-col-8"
-                  />
-                </div>
-                <div
-                  className="mb3 md-flex"
-                >
-                  <Label>
-                    Term Period
-                  </Label>
-                  <DatePickerWrapper
-                    daySize={32}
-                    endDateId="contractor-contractor key-end"
-                    initialEndDate="end date"
-                    initialStartDate="start date"
-                    numberOfMonths={2}
-                    onChange={[Function]}
-                    startDateId="contractor-contractor key-start"
-                  />
-                </div>
-                <div
-                  className="mb3 md-flex"
-                >
-                  <Label>
-                    Attachments
-                  </Label>
-                  <div
-                    className="md-col-9 md-flex items-start"
-                  >
-                    <div
-                      className="md-col-6 flex items-end mr2"
-                    >
-                      <Select
-                        hideLabel={false}
-                        label="Document Type"
-                        name="contractor key-attachment-type"
-                        onChange={[Function]}
-                        options={
-                          Array [
-                            "Contract",
-                            "Contract Amendment",
-                            "RFP",
-                          ]
-                        }
-                        value="Contract"
-                        wrapperClass="col-6 mr2"
-                      />
-                      <t
-                        className="btn btn-primary btn-dropzone"
-                        disableClick={false}
-                        disablePreview={false}
-                        disabled={false}
-                        inputProps={
-                          Object {
-                            "title": "select a file to attach for this contractor",
-                          }
-                        }
-                        maxSize={Infinity}
-                        minSize={0}
-                        multiple={false}
-                        onDrop={[Function]}
-                        preventDropOnDocument={true}
-                      >
-                        Select file
-                      </t>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  className="mb3 md-flex"
-                >
-                  <Label>
-                    Cost
-                  </Label>
-                  <div
-                    className="md-col-6 flex"
-                  >
-                    <InputHolder
-                      disabled={false}
-                      hideLabel={false}
-                      label="1066"
-                      name="contractor-contractor key-cost-1066"
-                      onChange={[Function]}
-                      type="text"
-                      value={100}
-                      wrapperClass="mr2 flex-auto"
-                    />
-                    <InputHolder
-                      disabled={false}
-                      hideLabel={false}
-                      label="1067"
-                      name="contractor-contractor key-cost-1067"
-                      onChange={[Function]}
-                      type="text"
-                      value={200}
-                      wrapperClass="mr2 flex-auto"
-                    />
-                  </div>
-                </div>
-                <div
-                  className="mb3 md-flex"
-                >
-                  <Label>
-                    Hourly Resource
-                  </Label>
-                  <div
-                    className="md-col-6"
-                  >
-                    <div
-                      className="flex items-center"
-                    >
-                      <div
-                        className="mr2"
-                      >
-                        This is an hourly resource
-                      </div>
-                      <div>
-                        <Btn
-                          disabled={false}
-                          extraCss=""
-                          kind="outline"
-                          onClick={[Function]}
-                          size={null}
-                        >
-                          Yes
-                        </Btn>
-                         
-                        <Btn
-                          disabled={true}
-                          extraCss="bg-black white"
-                          kind="outline"
-                          onClick={[Function]}
-                          size={null}
-                        >
-                          No
-                        </Btn>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div>
-                  <Btn
-                    extraCss="px1 py-tiny h5"
-                    kind="outline"
-                    onClick={[Function]}
-                    size={null}
-                  >
-                    Remove resource
-                  </Btn>
-                </div>
+              <div>
+                <ContractorEntry
+                  contractor={
+                    Object {
+                      "desc": "contractor description",
+                      "end": "end date",
+                      "hourly": Object {
+                        "data": Object {
+                          "1066": Object {
+                            "hours": "",
+                            "rate": "",
+                          },
+                          "1067": Object {
+                            "hours": "",
+                            "rate": "",
+                          },
+                        },
+                        "useHourly": false,
+                      },
+                      "id": "contractor id",
+                      "key": "contractor key",
+                      "name": "contractor name",
+                      "start": "start date",
+                      "years": Object {
+                        "1066": 100,
+                        "1067": 200,
+                      },
+                    }
+                  }
+                  handleDelete={[Function]}
+                  idx={0}
+                  toggleForm={[Function]}
+                  years={
+                    Array [
+                      "1066",
+                      "1067",
+                    ]
+                  }
+                />
+                <ContractorForm
+                  contractor={
+                    Object {
+                      "desc": "contractor description",
+                      "end": "end date",
+                      "hourly": Object {
+                        "data": Object {
+                          "1066": Object {
+                            "hours": "",
+                            "rate": "",
+                          },
+                          "1067": Object {
+                            "hours": "",
+                            "rate": "",
+                          },
+                        },
+                        "useHourly": false,
+                      },
+                      "id": "contractor id",
+                      "key": "contractor key",
+                      "name": "contractor name",
+                      "start": "start date",
+                      "years": Object {
+                        "1066": 100,
+                        "1067": 200,
+                      },
+                    }
+                  }
+                  docType="Contract"
+                  handleChange={[Function]}
+                  handleDelete={[Function]}
+                  handleDocChange={[Function]}
+                  handleFileDelete={[Function]}
+                  handleFileUpload={[Function]}
+                  handleHourlyChange={[Function]}
+                  handleTermChange={[Function]}
+                  handleUseHourly={[Function]}
+                  handleYearChange={[Function]}
+                  idx={0}
+                  years={
+                    Array [
+                      "1066",
+                      "1067",
+                    ]
+                  }
+                />
               </div>,
             ],
             "className": "mt3 pt3 border-top border-grey",
@@ -1838,945 +688,185 @@ ShallowWrapper {
               "nodeType": "host",
               "props": Object {
                 "children": Array [
-                  <div
-                    className="mb3 md-flex"
-                  >
-                    <Label>
-                      Contractor Name
-                    </Label>
-                    <InputHolder
-                      hideLabel={true}
-                      label="Contractor name"
-                      name="contractor-contractor key-name"
-                      onChange={[Function]}
-                      type="text"
-                      value="contractor name"
-                      wrapperClass="md-col-5"
-                    />
-                  </div>,
-                  <div
-                    className="mb3 md-flex"
-                  >
-                    <Label>
-                      Description of Services
-                    </Label>
-                    <InputHolder
-                      hideLabel={true}
-                      id="contractor-contractor key-desc"
-                      label="Describe the services each contractor will provide."
-                      name="contractor-contractor key-desc"
-                      onChange={[Function]}
-                      type="text"
-                      value="contractor description"
-                      wrapperClass="md-col-8"
-                    />
-                  </div>,
-                  <div
-                    className="mb3 md-flex"
-                  >
-                    <Label>
-                      Term Period
-                    </Label>
-                    <DatePickerWrapper
-                      daySize={32}
-                      endDateId="contractor-contractor key-end"
-                      initialEndDate="end date"
-                      initialStartDate="start date"
-                      numberOfMonths={2}
-                      onChange={[Function]}
-                      startDateId="contractor-contractor key-start"
-                    />
-                  </div>,
-                  <div
-                    className="mb3 md-flex"
-                  >
-                    <Label>
-                      Attachments
-                    </Label>
-                    <div
-                      className="md-col-9 md-flex items-start"
-                    >
-                      <div
-                        className="md-col-6 flex items-end mr2"
-                      >
-                        <Select
-                          hideLabel={false}
-                          label="Document Type"
-                          name="contractor key-attachment-type"
-                          onChange={[Function]}
-                          options={
-                            Array [
-                              "Contract",
-                              "Contract Amendment",
-                              "RFP",
-                            ]
-                          }
-                          value="Contract"
-                          wrapperClass="col-6 mr2"
-                        />
-                        <t
-                          className="btn btn-primary btn-dropzone"
-                          disableClick={false}
-                          disablePreview={false}
-                          disabled={false}
-                          inputProps={
-                            Object {
-                              "title": "select a file to attach for this contractor",
-                            }
-                          }
-                          maxSize={Infinity}
-                          minSize={0}
-                          multiple={false}
-                          onDrop={[Function]}
-                          preventDropOnDocument={true}
-                        >
-                          Select file
-                        </t>
-                      </div>
-                    </div>
-                  </div>,
-                  <div
-                    className="mb3 md-flex"
-                  >
-                    <Label>
-                      Cost
-                    </Label>
-                    <div
-                      className="md-col-6 flex"
-                    >
-                      <InputHolder
-                        disabled={false}
-                        hideLabel={false}
-                        label="1066"
-                        name="contractor-contractor key-cost-1066"
-                        onChange={[Function]}
-                        type="text"
-                        value={100}
-                        wrapperClass="mr2 flex-auto"
-                      />
-                      <InputHolder
-                        disabled={false}
-                        hideLabel={false}
-                        label="1067"
-                        name="contractor-contractor key-cost-1067"
-                        onChange={[Function]}
-                        type="text"
-                        value={200}
-                        wrapperClass="mr2 flex-auto"
-                      />
-                    </div>
-                  </div>,
-                  <div
-                    className="mb3 md-flex"
-                  >
-                    <Label>
-                      Hourly Resource
-                    </Label>
-                    <div
-                      className="md-col-6"
-                    >
-                      <div
-                        className="flex items-center"
-                      >
-                        <div
-                          className="mr2"
-                        >
-                          This is an hourly resource
-                        </div>
-                        <div>
-                          <Btn
-                            disabled={false}
-                            extraCss=""
-                            kind="outline"
-                            onClick={[Function]}
-                            size={null}
-                          >
-                            Yes
-                          </Btn>
-                           
-                          <Btn
-                            disabled={true}
-                            extraCss="bg-black white"
-                            kind="outline"
-                            onClick={[Function]}
-                            size={null}
-                          >
-                            No
-                          </Btn>
-                        </div>
-                      </div>
-                    </div>
-                  </div>,
-                  <div>
-                    <Btn
-                      extraCss="px1 py-tiny h5"
-                      kind="outline"
-                      onClick={[Function]}
-                      size={null}
-                    >
-                      Remove resource
-                    </Btn>
-                  </div>,
+                  <ContractorEntry
+                    contractor={
+                      Object {
+                        "desc": "contractor description",
+                        "end": "end date",
+                        "hourly": Object {
+                          "data": Object {
+                            "1066": Object {
+                              "hours": "",
+                              "rate": "",
+                            },
+                            "1067": Object {
+                              "hours": "",
+                              "rate": "",
+                            },
+                          },
+                          "useHourly": false,
+                        },
+                        "id": "contractor id",
+                        "key": "contractor key",
+                        "name": "contractor name",
+                        "start": "start date",
+                        "years": Object {
+                          "1066": 100,
+                          "1067": 200,
+                        },
+                      }
+                    }
+                    handleDelete={[Function]}
+                    idx={0}
+                    toggleForm={[Function]}
+                    years={
+                      Array [
+                        "1066",
+                        "1067",
+                      ]
+                    }
+                  />,
+                  <ContractorForm
+                    contractor={
+                      Object {
+                        "desc": "contractor description",
+                        "end": "end date",
+                        "hourly": Object {
+                          "data": Object {
+                            "1066": Object {
+                              "hours": "",
+                              "rate": "",
+                            },
+                            "1067": Object {
+                              "hours": "",
+                              "rate": "",
+                            },
+                          },
+                          "useHourly": false,
+                        },
+                        "id": "contractor id",
+                        "key": "contractor key",
+                        "name": "contractor name",
+                        "start": "start date",
+                        "years": Object {
+                          "1066": 100,
+                          "1067": 200,
+                        },
+                      }
+                    }
+                    docType="Contract"
+                    handleChange={[Function]}
+                    handleDelete={[Function]}
+                    handleDocChange={[Function]}
+                    handleFileDelete={[Function]}
+                    handleFileUpload={[Function]}
+                    handleHourlyChange={[Function]}
+                    handleTermChange={[Function]}
+                    handleUseHourly={[Function]}
+                    handleYearChange={[Function]}
+                    idx={0}
+                    years={
+                      Array [
+                        "1066",
+                        "1067",
+                      ]
+                    }
+                  />,
                 ],
-                "className": "mb3 pb3 border-bottom border-grey",
               },
               "ref": null,
               "rendered": Array [
                 Object {
                   "instance": null,
                   "key": undefined,
-                  "nodeType": "host",
+                  "nodeType": "function",
                   "props": Object {
-                    "children": Array [
-                      <Label>
-                        Contractor Name
-                      </Label>,
-                      <InputHolder
-                        hideLabel={true}
-                        label="Contractor name"
-                        name="contractor-contractor key-name"
-                        onChange={[Function]}
-                        type="text"
-                        value="contractor name"
-                        wrapperClass="md-col-5"
-                      />,
-                    ],
-                    "className": "mb3 md-flex",
-                  },
-                  "ref": null,
-                  "rendered": Array [
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "function",
-                      "props": Object {
-                        "children": "Contractor Name",
-                      },
-                      "ref": null,
-                      "rendered": "Contractor Name",
-                      "type": [Function],
-                    },
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "function",
-                      "props": Object {
-                        "hideLabel": true,
-                        "label": "Contractor name",
-                        "name": "contractor-contractor key-name",
-                        "onChange": [Function],
-                        "type": "text",
-                        "value": "contractor name",
-                        "wrapperClass": "md-col-5",
-                      },
-                      "ref": null,
-                      "rendered": null,
-                      "type": [Function],
-                    },
-                  ],
-                  "type": "div",
-                },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": Array [
-                      <Label>
-                        Description of Services
-                      </Label>,
-                      <InputHolder
-                        hideLabel={true}
-                        id="contractor-contractor key-desc"
-                        label="Describe the services each contractor will provide."
-                        name="contractor-contractor key-desc"
-                        onChange={[Function]}
-                        type="text"
-                        value="contractor description"
-                        wrapperClass="md-col-8"
-                      />,
-                    ],
-                    "className": "mb3 md-flex",
-                  },
-                  "ref": null,
-                  "rendered": Array [
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "function",
-                      "props": Object {
-                        "children": "Description of Services",
-                      },
-                      "ref": null,
-                      "rendered": "Description of Services",
-                      "type": [Function],
-                    },
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "function",
-                      "props": Object {
-                        "hideLabel": true,
-                        "id": "contractor-contractor key-desc",
-                        "label": "Describe the services each contractor will provide.",
-                        "name": "contractor-contractor key-desc",
-                        "onChange": [Function],
-                        "type": "text",
-                        "value": "contractor description",
-                        "wrapperClass": "md-col-8",
-                      },
-                      "ref": null,
-                      "rendered": null,
-                      "type": [Function],
-                    },
-                  ],
-                  "type": "div",
-                },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": Array [
-                      <Label>
-                        Term Period
-                      </Label>,
-                      <DatePickerWrapper
-                        daySize={32}
-                        endDateId="contractor-contractor key-end"
-                        initialEndDate="end date"
-                        initialStartDate="start date"
-                        numberOfMonths={2}
-                        onChange={[Function]}
-                        startDateId="contractor-contractor key-start"
-                      />,
-                    ],
-                    "className": "mb3 md-flex",
-                  },
-                  "ref": null,
-                  "rendered": Array [
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "function",
-                      "props": Object {
-                        "children": "Term Period",
-                      },
-                      "ref": null,
-                      "rendered": "Term Period",
-                      "type": [Function],
-                    },
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "class",
-                      "props": Object {
-                        "daySize": 32,
-                        "endDateId": "contractor-contractor key-end",
-                        "initialEndDate": "end date",
-                        "initialStartDate": "start date",
-                        "numberOfMonths": 2,
-                        "onChange": [Function],
-                        "startDateId": "contractor-contractor key-start",
-                      },
-                      "ref": null,
-                      "rendered": null,
-                      "type": [Function],
-                    },
-                  ],
-                  "type": "div",
-                },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": Array [
-                      <Label>
-                        Attachments
-                      </Label>,
-                      <div
-                        className="md-col-9 md-flex items-start"
-                      >
-                        <div
-                          className="md-col-6 flex items-end mr2"
-                        >
-                          <Select
-                            hideLabel={false}
-                            label="Document Type"
-                            name="contractor key-attachment-type"
-                            onChange={[Function]}
-                            options={
-                              Array [
-                                "Contract",
-                                "Contract Amendment",
-                                "RFP",
-                              ]
-                            }
-                            value="Contract"
-                            wrapperClass="col-6 mr2"
-                          />
-                          <t
-                            className="btn btn-primary btn-dropzone"
-                            disableClick={false}
-                            disablePreview={false}
-                            disabled={false}
-                            inputProps={
-                              Object {
-                                "title": "select a file to attach for this contractor",
-                              }
-                            }
-                            maxSize={Infinity}
-                            minSize={0}
-                            multiple={false}
-                            onDrop={[Function]}
-                            preventDropOnDocument={true}
-                          >
-                            Select file
-                          </t>
-                        </div>
-                      </div>,
-                    ],
-                    "className": "mb3 md-flex",
-                  },
-                  "ref": null,
-                  "rendered": Array [
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "function",
-                      "props": Object {
-                        "children": "Attachments",
-                      },
-                      "ref": null,
-                      "rendered": "Attachments",
-                      "type": [Function],
-                    },
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "host",
-                      "props": Object {
-                        "children": Array [
-                          <div
-                            className="md-col-6 flex items-end mr2"
-                          >
-                            <Select
-                              hideLabel={false}
-                              label="Document Type"
-                              name="contractor key-attachment-type"
-                              onChange={[Function]}
-                              options={
-                                Array [
-                                  "Contract",
-                                  "Contract Amendment",
-                                  "RFP",
-                                ]
-                              }
-                              value="Contract"
-                              wrapperClass="col-6 mr2"
-                            />
-                            <t
-                              className="btn btn-primary btn-dropzone"
-                              disableClick={false}
-                              disablePreview={false}
-                              disabled={false}
-                              inputProps={
-                                Object {
-                                  "title": "select a file to attach for this contractor",
-                                }
-                              }
-                              maxSize={Infinity}
-                              minSize={0}
-                              multiple={false}
-                              onDrop={[Function]}
-                              preventDropOnDocument={true}
-                            >
-                              Select file
-                            </t>
-                          </div>,
-                          false,
-                        ],
-                        "className": "md-col-9 md-flex items-start",
-                      },
-                      "ref": null,
-                      "rendered": Array [
-                        Object {
-                          "instance": null,
-                          "key": undefined,
-                          "nodeType": "host",
-                          "props": Object {
-                            "children": Array [
-                              <Select
-                                hideLabel={false}
-                                label="Document Type"
-                                name="contractor key-attachment-type"
-                                onChange={[Function]}
-                                options={
-                                  Array [
-                                    "Contract",
-                                    "Contract Amendment",
-                                    "RFP",
-                                  ]
-                                }
-                                value="Contract"
-                                wrapperClass="col-6 mr2"
-                              />,
-                              <t
-                                className="btn btn-primary btn-dropzone"
-                                disableClick={false}
-                                disablePreview={false}
-                                disabled={false}
-                                inputProps={
-                                  Object {
-                                    "title": "select a file to attach for this contractor",
-                                  }
-                                }
-                                maxSize={Infinity}
-                                minSize={0}
-                                multiple={false}
-                                onDrop={[Function]}
-                                preventDropOnDocument={true}
-                              >
-                                Select file
-                              </t>,
-                            ],
-                            "className": "md-col-6 flex items-end mr2",
+                    "contractor": Object {
+                      "desc": "contractor description",
+                      "end": "end date",
+                      "hourly": Object {
+                        "data": Object {
+                          "1066": Object {
+                            "hours": "",
+                            "rate": "",
                           },
-                          "ref": null,
-                          "rendered": Array [
-                            Object {
-                              "instance": null,
-                              "key": undefined,
-                              "nodeType": "function",
-                              "props": Object {
-                                "hideLabel": false,
-                                "label": "Document Type",
-                                "name": "contractor key-attachment-type",
-                                "onChange": [Function],
-                                "options": Array [
-                                  "Contract",
-                                  "Contract Amendment",
-                                  "RFP",
-                                ],
-                                "value": "Contract",
-                                "wrapperClass": "col-6 mr2",
-                              },
-                              "ref": null,
-                              "rendered": null,
-                              "type": [Function],
-                            },
-                            Object {
-                              "instance": null,
-                              "key": undefined,
-                              "nodeType": "class",
-                              "props": Object {
-                                "children": "Select file",
-                                "className": "btn btn-primary btn-dropzone",
-                                "disableClick": false,
-                                "disablePreview": false,
-                                "disabled": false,
-                                "inputProps": Object {
-                                  "title": "select a file to attach for this contractor",
-                                },
-                                "maxSize": Infinity,
-                                "minSize": 0,
-                                "multiple": false,
-                                "onDrop": [Function],
-                                "preventDropOnDocument": true,
-                              },
-                              "ref": null,
-                              "rendered": "Select file",
-                              "type": [Function],
-                            },
-                          ],
-                          "type": "div",
+                          "1067": Object {
+                            "hours": "",
+                            "rate": "",
+                          },
                         },
-                        false,
-                      ],
-                      "type": "div",
+                        "useHourly": false,
+                      },
+                      "id": "contractor id",
+                      "key": "contractor key",
+                      "name": "contractor name",
+                      "start": "start date",
+                      "years": Object {
+                        "1066": 100,
+                        "1067": 200,
+                      },
                     },
-                  ],
-                  "type": "div",
-                },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": Array [
-                      <Label>
-                        Cost
-                      </Label>,
-                      <div
-                        className="md-col-6 flex"
-                      >
-                        <InputHolder
-                          disabled={false}
-                          hideLabel={false}
-                          label="1066"
-                          name="contractor-contractor key-cost-1066"
-                          onChange={[Function]}
-                          type="text"
-                          value={100}
-                          wrapperClass="mr2 flex-auto"
-                        />
-                        <InputHolder
-                          disabled={false}
-                          hideLabel={false}
-                          label="1067"
-                          name="contractor-contractor key-cost-1067"
-                          onChange={[Function]}
-                          type="text"
-                          value={200}
-                          wrapperClass="mr2 flex-auto"
-                        />
-                      </div>,
+                    "handleDelete": [Function],
+                    "idx": 0,
+                    "toggleForm": [Function],
+                    "years": Array [
+                      "1066",
+                      "1067",
                     ],
-                    "className": "mb3 md-flex",
                   },
                   "ref": null,
-                  "rendered": Array [
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "function",
-                      "props": Object {
-                        "children": "Cost",
-                      },
-                      "ref": null,
-                      "rendered": "Cost",
-                      "type": [Function],
-                    },
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "host",
-                      "props": Object {
-                        "children": Array [
-                          <InputHolder
-                            disabled={false}
-                            hideLabel={false}
-                            label="1066"
-                            name="contractor-contractor key-cost-1066"
-                            onChange={[Function]}
-                            type="text"
-                            value={100}
-                            wrapperClass="mr2 flex-auto"
-                          />,
-                          <InputHolder
-                            disabled={false}
-                            hideLabel={false}
-                            label="1067"
-                            name="contractor-contractor key-cost-1067"
-                            onChange={[Function]}
-                            type="text"
-                            value={200}
-                            wrapperClass="mr2 flex-auto"
-                          />,
-                        ],
-                        "className": "md-col-6 flex",
-                      },
-                      "ref": null,
-                      "rendered": Array [
-                        Object {
-                          "instance": null,
-                          "key": "1066",
-                          "nodeType": "function",
-                          "props": Object {
-                            "disabled": false,
-                            "hideLabel": false,
-                            "label": "1066",
-                            "name": "contractor-contractor key-cost-1066",
-                            "onChange": [Function],
-                            "type": "text",
-                            "value": 100,
-                            "wrapperClass": "mr2 flex-auto",
-                          },
-                          "ref": null,
-                          "rendered": null,
-                          "type": [Function],
-                        },
-                        Object {
-                          "instance": null,
-                          "key": "1067",
-                          "nodeType": "function",
-                          "props": Object {
-                            "disabled": false,
-                            "hideLabel": false,
-                            "label": "1067",
-                            "name": "contractor-contractor key-cost-1067",
-                            "onChange": [Function],
-                            "type": "text",
-                            "value": 200,
-                            "wrapperClass": "mr2 flex-auto",
-                          },
-                          "ref": null,
-                          "rendered": null,
-                          "type": [Function],
-                        },
-                      ],
-                      "type": "div",
-                    },
-                  ],
-                  "type": "div",
+                  "rendered": null,
+                  "type": [Function],
                 },
                 Object {
                   "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
+                  "key": "contractor key",
+                  "nodeType": "function",
                   "props": Object {
-                    "children": Array [
-                      <Label>
-                        Hourly Resource
-                      </Label>,
-                      <div
-                        className="md-col-6"
-                      >
-                        <div
-                          className="flex items-center"
-                        >
-                          <div
-                            className="mr2"
-                          >
-                            This is an hourly resource
-                          </div>
-                          <div>
-                            <Btn
-                              disabled={false}
-                              extraCss=""
-                              kind="outline"
-                              onClick={[Function]}
-                              size={null}
-                            >
-                              Yes
-                            </Btn>
-                             
-                            <Btn
-                              disabled={true}
-                              extraCss="bg-black white"
-                              kind="outline"
-                              onClick={[Function]}
-                              size={null}
-                            >
-                              No
-                            </Btn>
-                          </div>
-                        </div>
-                      </div>,
+                    "contractor": Object {
+                      "desc": "contractor description",
+                      "end": "end date",
+                      "hourly": Object {
+                        "data": Object {
+                          "1066": Object {
+                            "hours": "",
+                            "rate": "",
+                          },
+                          "1067": Object {
+                            "hours": "",
+                            "rate": "",
+                          },
+                        },
+                        "useHourly": false,
+                      },
+                      "id": "contractor id",
+                      "key": "contractor key",
+                      "name": "contractor name",
+                      "start": "start date",
+                      "years": Object {
+                        "1066": 100,
+                        "1067": 200,
+                      },
+                    },
+                    "docType": "Contract",
+                    "handleChange": [Function],
+                    "handleDelete": [Function],
+                    "handleDocChange": [Function],
+                    "handleFileDelete": [Function],
+                    "handleFileUpload": [Function],
+                    "handleHourlyChange": [Function],
+                    "handleTermChange": [Function],
+                    "handleUseHourly": [Function],
+                    "handleYearChange": [Function],
+                    "idx": 0,
+                    "years": Array [
+                      "1066",
+                      "1067",
                     ],
-                    "className": "mb3 md-flex",
                   },
                   "ref": null,
-                  "rendered": Array [
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "function",
-                      "props": Object {
-                        "children": "Hourly Resource",
-                      },
-                      "ref": null,
-                      "rendered": "Hourly Resource",
-                      "type": [Function],
-                    },
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "host",
-                      "props": Object {
-                        "children": Array [
-                          <div
-                            className="flex items-center"
-                          >
-                            <div
-                              className="mr2"
-                            >
-                              This is an hourly resource
-                            </div>
-                            <div>
-                              <Btn
-                                disabled={false}
-                                extraCss=""
-                                kind="outline"
-                                onClick={[Function]}
-                                size={null}
-                              >
-                                Yes
-                              </Btn>
-                               
-                              <Btn
-                                disabled={true}
-                                extraCss="bg-black white"
-                                kind="outline"
-                                onClick={[Function]}
-                                size={null}
-                              >
-                                No
-                              </Btn>
-                            </div>
-                          </div>,
-                          false,
-                        ],
-                        "className": "md-col-6",
-                      },
-                      "ref": null,
-                      "rendered": Array [
-                        Object {
-                          "instance": null,
-                          "key": undefined,
-                          "nodeType": "host",
-                          "props": Object {
-                            "children": Array [
-                              <div
-                                className="mr2"
-                              >
-                                This is an hourly resource
-                              </div>,
-                              <div>
-                                <Btn
-                                  disabled={false}
-                                  extraCss=""
-                                  kind="outline"
-                                  onClick={[Function]}
-                                  size={null}
-                                >
-                                  Yes
-                                </Btn>
-                                 
-                                <Btn
-                                  disabled={true}
-                                  extraCss="bg-black white"
-                                  kind="outline"
-                                  onClick={[Function]}
-                                  size={null}
-                                >
-                                  No
-                                </Btn>
-                              </div>,
-                            ],
-                            "className": "flex items-center",
-                          },
-                          "ref": null,
-                          "rendered": Array [
-                            Object {
-                              "instance": null,
-                              "key": undefined,
-                              "nodeType": "host",
-                              "props": Object {
-                                "children": "This is an hourly resource",
-                                "className": "mr2",
-                              },
-                              "ref": null,
-                              "rendered": "This is an hourly resource",
-                              "type": "div",
-                            },
-                            Object {
-                              "instance": null,
-                              "key": undefined,
-                              "nodeType": "host",
-                              "props": Object {
-                                "children": Array [
-                                  <Btn
-                                    disabled={false}
-                                    extraCss=""
-                                    kind="outline"
-                                    onClick={[Function]}
-                                    size={null}
-                                  >
-                                    Yes
-                                  </Btn>,
-                                  " ",
-                                  <Btn
-                                    disabled={true}
-                                    extraCss="bg-black white"
-                                    kind="outline"
-                                    onClick={[Function]}
-                                    size={null}
-                                  >
-                                    No
-                                  </Btn>,
-                                ],
-                              },
-                              "ref": null,
-                              "rendered": Array [
-                                Object {
-                                  "instance": null,
-                                  "key": undefined,
-                                  "nodeType": "function",
-                                  "props": Object {
-                                    "children": "Yes",
-                                    "disabled": false,
-                                    "extraCss": "",
-                                    "kind": "outline",
-                                    "onClick": [Function],
-                                    "size": null,
-                                  },
-                                  "ref": null,
-                                  "rendered": "Yes",
-                                  "type": [Function],
-                                },
-                                " ",
-                                Object {
-                                  "instance": null,
-                                  "key": undefined,
-                                  "nodeType": "function",
-                                  "props": Object {
-                                    "children": "No",
-                                    "disabled": true,
-                                    "extraCss": "bg-black white",
-                                    "kind": "outline",
-                                    "onClick": [Function],
-                                    "size": null,
-                                  },
-                                  "ref": null,
-                                  "rendered": "No",
-                                  "type": [Function],
-                                },
-                              ],
-                              "type": "div",
-                            },
-                          ],
-                          "type": "div",
-                        },
-                        false,
-                      ],
-                      "type": "div",
-                    },
-                  ],
-                  "type": "div",
-                },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": <Btn
-                      extraCss="px1 py-tiny h5"
-                      kind="outline"
-                      onClick={[Function]}
-                      size={null}
-                    >
-                      Remove resource
-                    </Btn>,
-                  },
-                  "ref": null,
-                  "rendered": Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "function",
-                    "props": Object {
-                      "children": "Remove resource",
-                      "extraCss": "px1 py-tiny h5",
-                      "kind": "outline",
-                      "onClick": [Function],
-                      "size": null,
-                    },
-                    "ref": null,
-                    "rendered": "Remove resource",
-                    "type": [Function],
-                  },
-                  "type": "div",
+                  "rendered": null,
+                  "type": [Function],
                 },
               ],
               "type": "div",


### PR DESCRIPTION
Completes and closes: https://github.com/18F/cms-hitech-apd/issues/938

This adds entries for contractor section. There is now a bit of duplicate code around toggling and editing these entries across these three sections (contractors, personnel, expenses), but that's probably fine for now and refactoring to a higher level component might make it too confusing...

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author

### This feature is done when...
- [ ] Design has approved the experience
