### PR TITLE
hotfix: fix app crashing when date becomes null

### DIFF
--- a/web/src/components/DatePickerWrapper.js
+++ b/web/src/components/DatePickerWrapper.js
@@ -21,8 +21,8 @@ class DatePickerWrapper extends Component {
   onDatesChange = ({ startDate, endDate }) => {
     if (this.props.onChange) {
       this.props.onChange({
-        start: startDate && dateToStr(startDate),
-        end: endDate && dateToStr(endDate)
+        start: startDate ? dateToStr(startDate) : '',
+        end: endDate ? dateToStr(endDate) : ''
       });
     }
 


### PR DESCRIPTION
as @jeromeleecms discovered, the app was crashing if a date was edited via the keyboard - the reason for this: while a date is being edited and before it's a valid date, it's actually stored as null in our redux store, which our reducer didn't like; making this an empty string instead fixes this (and is equivalent to what the date field is on initiation anyway)  

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
