### PR TITLE
Upload file contracts [skip deploy]

### DIFF
--- a/api/db/file.js
+++ b/api/db/file.js
@@ -1,3 +1,5 @@
+const o = v => (typeof v === 'object' ? v : JSON.parse(v));
+
 module.exports = () => ({
   file: {
     tableName: 'files',
@@ -22,10 +24,9 @@ module.exports = () => ({
 
     toJSON() {
       return {
+        ...o(this.get('metadata')),
         id: this.get('id'),
-        key: this.get('key'),
-        size: this.get('size'),
-        metadata: this.get('metadata')
+        size: this.get('size')
       };
     }
   }

--- a/api/db/file.test.js
+++ b/api/db/file.test.js
@@ -60,15 +60,15 @@ tap.test('file data model', async tests => {
     self.get.withArgs('id').returns('Big Ol File');
     self.get.withArgs('key').returns('opens locks');
     self.get.withArgs('size').returns('big ol');
-    self.get.withArgs('metadata').returns('data about the data');
+    self.get.withArgs('metadata').returns('{"a":"json","string":"here"}');
 
     const output = file.toJSON.bind(self)();
 
     test.match(output, {
       id: 'Big Ol File',
-      key: 'opens locks',
       size: 'big ol',
-      metadata: 'data about the data'
+      a: 'json',
+      string: 'here'
     });
   });
 });

--- a/api/db/index.js
+++ b/api/db/index.js
@@ -17,6 +17,8 @@ const file = require('./file');
 
 const exportedModels = {};
 
+let knexObject;
+
 const setup = (
   knex = defaultKnex,
   bookshelf = defaultBookshelf,
@@ -38,13 +40,13 @@ const setup = (
   logger.silly(
     `setting up models using [${process.env.NODE_ENV}] configuration`
   );
-  const db = knex(config[process.env.NODE_ENV]);
+  knexObject = knex(config[process.env.NODE_ENV]);
 
   // Get bookshelf instance with our knex config, then
   // load the "registry" plugin - lets us map model
   // names to actual models to get rid of ciruclar
   // dependency graphs
-  const orm = bookshelf(db);
+  const orm = bookshelf(knexObject);
   orm.plugin('registry');
 
   const BaseModel = baseModel(orm, exportedModels);
@@ -75,6 +77,7 @@ const setup = (
 };
 
 module.exports = {
-  setup,
-  models: exportedModels
+  models: exportedModels,
+  raw: (...args) => (knexObject ? knexObject(...args) : null),
+  setup
 };

--- a/api/endpoint-tests/activities/put.js
+++ b/api/endpoint-tests/activities/put.js
@@ -124,8 +124,6 @@ tap.test(
                   files: [
                     {
                       id: 5002,
-                      key: 'download.txt',
-                      metadata: null,
                       size: null
                     }
                   ],
@@ -145,14 +143,12 @@ tap.test(
               files: [
                 {
                   id: 5000,
-                  key: 'download.txt',
-                  metadata: null,
-                  size: null
+                  size: null,
+                  some: 'metadata',
+                  in: 'here'
                 },
                 {
                   id: 5004,
-                  key: 'not real',
-                  metadata: null,
                   size: null
                 }
               ],

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -106,6 +106,11 @@
         "normalize-path": "^2.1.1"
       }
     },
+    "append-field": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-0.1.0.tgz",
+      "integrity": "sha1-bdxY+gg8e8VF08WZWygwzCNm1Eo="
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -441,6 +446,38 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
+    "busboy": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
+      "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
+      "requires": {
+        "dicer": "0.2.5",
+        "readable-stream": "1.1.x"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -748,7 +785,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
@@ -974,6 +1010,38 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
+    },
+    "dicer": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
+      "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
+      "requires": {
+        "readable-stream": "1.1.x",
+        "streamsearch": "0.1.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
     },
     "diff": {
       "version": "3.4.0",
@@ -3357,6 +3425,28 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "multer": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.3.1.tgz",
+      "integrity": "sha512-JHdEoxkA/5NgZRo91RNn4UT+HdcJV9XUo01DTkKC7vo1erNIngtuaw9Y0WI8RdTlyi+wMIbunflhghzVLuGJyw==",
+      "requires": {
+        "append-field": "^0.1.0",
+        "busboy": "^0.2.11",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.1",
+        "object-assign": "^3.0.0",
+        "on-finished": "^2.3.0",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+        }
+      }
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -7483,6 +7573,11 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
     },
+    "streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -7851,8 +7946,7 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "unc-path-regex": {
       "version": "0.1.2",

--- a/api/package.json
+++ b/api/package.json
@@ -52,6 +52,7 @@
     "lodash.isequal": "^4.5.0",
     "lodash.pick": "^4.4.0",
     "moment": "^2.22.1",
+    "multer": "^1.3.1",
     "passport": "^0.4.0",
     "passport-local": "^1.0.0",
     "pg": "^7.4.1",

--- a/api/routes/files/delete.js
+++ b/api/routes/files/delete.js
@@ -63,7 +63,6 @@ module.exports = (
             const activityLinks = (await rawDB('activity_files')
               .where(where)
               .count('file_id'))[0].count;
-
             logger.silly(
               `${contractorLinks} remaining file/activity links for file ${
                 req.params.fileID

--- a/api/routes/files/delete.js
+++ b/api/routes/files/delete.js
@@ -1,0 +1,108 @@
+const logger = require('../../logger')('files route delete');
+const { can } = require('../../middleware');
+
+const { raw: defaultRawDB } = require('../../db');
+const {
+  apdActivityContractorResource: defaultContractorResourceModel,
+  file: defaultFileModel
+} = require('../../db').models;
+const defaultStore = require('../../store');
+
+module.exports = (
+  app,
+  {
+    ContractorModel = defaultContractorResourceModel,
+    FileModel = defaultFileModel,
+    rawDB = defaultRawDB,
+    store = defaultStore
+  } = {}
+) => {
+  logger.silly('setting up DELETE endpoint');
+
+  app.delete(
+    '/files/contractor/:id/:fileID',
+    can('create-draft'),
+
+    async (req, res) => {
+      try {
+        const userApds = await req.user.model.apds();
+        logger.silly(req, `user has access to apds: [${userApds}]`);
+
+        const contractor = await ContractorModel.where({
+          id: req.params.id
+        }).fetch({ withRelated: ['activity.apd'] });
+
+        if (contractor) {
+          const contractorApd = contractor
+            .related('activity')
+            .related('apd')
+            .get('id');
+          logger.silly(req, `contractor belongs to apd ${contractorApd}`);
+
+          if (userApds.includes(contractorApd)) {
+            logger.silly(req, 'user has access!');
+
+            const where = { file_id: req.params.fileID };
+            await rawDB('activity_contractor_files')
+              .where({
+                activity_contractor_resource_id: req.params.id,
+                ...where
+              })
+              .del();
+            logger.silly('deleted the file/contractor relationship');
+
+            const contractorLinks = (await rawDB('activity_contractor_files')
+              .where(where)
+              .count('file_id'))[0].count;
+            logger.silly(
+              `${contractorLinks} remaining file/contractor links for file ${
+                req.params.fileID
+              }`
+            );
+
+            const activityLinks = (await rawDB('activity_files')
+              .where(where)
+              .count('file_id'))[0].count;
+
+            logger.silly(
+              `${contractorLinks} remaining file/activity links for file ${
+                req.params.fileID
+              }`
+            );
+
+            // If the file isn't linked to anything anymore, we can toss it out.
+            if (+contractorLinks === 0 && +activityLinks === 0) {
+              logger.info('file is no longer linked; deleting');
+
+              const file = await FileModel.where({
+                id: req.params.fileID
+              }).fetch();
+
+              if (file) {
+                await store.remove(file.get('key'));
+
+                await file.destroy();
+              }
+            }
+
+            return res.status(204).end();
+          }
+
+          logger.info(
+            req,
+            `User does not have permission to modify contractor ${
+              req.params.id
+            } (belongs to activity ${
+              contractor.related('activity').id
+            }, apd ${contractorApd}`
+          );
+          return res.status(404).end();
+        }
+        return res.status(404).end();
+      } catch (e) {
+        logger.error(req, e);
+        return res.status(500).end();
+      }
+    }
+  );
+};

--- a/api/routes/files/delete.test.js
+++ b/api/routes/files/delete.test.js
@@ -1,0 +1,215 @@
+const tap = require('tap');
+const sinon = require('sinon');
+const { can } = require('../../middleware/auth');
+
+const del = require('./delete');
+
+tap.test('files delete endpoint', async tests => {
+  const sandbox = sinon.createSandbox();
+
+  const app = { delete: sandbox.stub() };
+
+  tests.beforeEach(async () => {
+    sandbox.resetBehavior();
+    sandbox.resetHistory();
+  });
+
+  tests.test('setup', async test => {
+    del(app);
+
+    test.ok(
+      app.delete.calledWith(
+        '/files/contractor/:id/:fileID',
+        can('create-draft'),
+        sinon.match.func
+      ),
+      'files DELETE endpoint is registered'
+    );
+  });
+
+  tests.test('endpoint handler tests', async epTests => {
+    let handler;
+
+    const ContractorModel = { where: sandbox.stub(), fetch: sandbox.stub() };
+
+    const contractorDB = {
+      get: sandbox.stub(),
+      related: sandbox.stub()
+    };
+
+    const activityDB = {
+      related: sandbox.stub()
+    };
+
+    const apdDB = {
+      get: sandbox.stub()
+    };
+
+    const FileModel = { fetch: sandbox.stub(), where: sandbox.stub() };
+
+    const fileDB = {
+      get: sandbox.stub(),
+      destroy: sandbox.stub()
+    };
+
+    const rawDB = sandbox.stub();
+    const rawWhere = sandbox.stub();
+    const rawCount = sandbox.stub();
+    const rawDel = sandbox.stub();
+
+    const store = {
+      remove: sandbox.stub()
+    };
+
+    const req = {
+      params: { fileID: 'requested file id', id: 'requested contractor id' },
+      user: {
+        model: {
+          apds: sandbox.stub()
+        }
+      }
+    };
+
+    const res = {
+      end: sandbox.stub(),
+      send: sandbox.stub(),
+      status: sandbox.stub()
+    };
+
+    epTests.beforeEach(async () => {
+      del(app, { ContractorModel, FileModel, rawDB, store });
+      handler = app.delete.args[0][app.delete.args[0].length - 1];
+
+      ContractorModel.where.returns(ContractorModel);
+
+      contractorDB.get.withArgs('id').returns('contractor id');
+      contractorDB.related.withArgs('activity').returns(activityDB);
+      activityDB.related.withArgs('apd').returns(apdDB);
+
+      FileModel.where.returns(FileModel);
+      FileModel.fetch.resolves(fileDB);
+      fileDB.get.withArgs('key').returns('file key');
+
+      rawDB.returns({ where: rawWhere });
+      rawWhere.returns({ count: rawCount, del: rawDel });
+      rawCount.resolves([{ count: 0 }]);
+
+      req.user.model.apds.resolves([1, 2, 3]);
+
+      res.send.returns(res);
+      res.status.returns(res);
+    });
+
+    epTests.test('handles a database error', async test => {
+      ContractorModel.fetch.throws(new Error('boop'));
+      await handler(req, res);
+
+      test.ok(res.status.calledWith(500), 'sends status 500');
+      test.ok(res.end.calledOnce, 'response is terminated');
+    });
+
+    epTests.test(
+      'handles where the contractor ID does not exist',
+      async test => {
+        ContractorModel.fetch.resolves(null);
+        await handler(req, res);
+
+        test.ok(
+          ContractorModel.where.calledWith({ id: 'requested contractor id' }),
+          'restricts query to requested ID'
+        );
+        test.ok(res.status.calledWith(404), 'sends status 404');
+        test.ok(res.end.calledOnce, 'response is terminated');
+      }
+    );
+
+    epTests.test(
+      'handles where the requestor does not have access to the APD containing the contractor',
+      async test => {
+        ContractorModel.fetch.resolves(contractorDB);
+        // The APD IDs the user has access to are represented by
+        // req.user.model.apds, mocked in the epTests beforeEach.
+        // If this value is not in that list, we should get the 404.
+        apdDB.get.returns(5);
+        await handler(req, res);
+
+        test.ok(
+          ContractorModel.where.calledWith({ id: 'requested contractor id' }),
+          'restricts query to requested ID'
+        );
+        test.ok(res.status.calledWith(404), 'sends status 404');
+        test.ok(res.end.calledOnce, 'response is terminated');
+      }
+    );
+
+    epTests.test(
+      'updates the database accordingly, but leaves the file if it is still linked to other things',
+      async test => {
+        ContractorModel.fetch.resolves(contractorDB);
+        apdDB.get.returns(1);
+        rawCount.resolves([{ count: 1 }]);
+
+        await handler(req, res);
+
+        test.ok(
+          ContractorModel.where.calledWith({ id: 'requested contractor id' }),
+          'restricts query to requested ID'
+        );
+        test.ok(
+          rawDB.calledWith('activity_contractor_files'),
+          'updates contractor/file link'
+        );
+        test.ok(
+          rawWhere.calledWith({
+            activity_contractor_resource_id: 'requested contractor id',
+            file_id: 'requested file id'
+          }),
+          'specifically the requested contractor and file'
+        );
+        test.ok(rawDel.calledOnce, 'contractor/file link is deleted');
+        test.ok(store.remove.notCalled, 'file is not removed from the store');
+        test.ok(fileDB.destroy.notCalled, 'file is not removed from database');
+        test.ok(res.status.calledWith(204), 'sends status 204');
+        test.ok(res.end.calledOnce, 'response is terminated');
+      }
+    );
+
+    epTests.test(
+      'deletes the file and updates the database accordingly',
+      async test => {
+        ContractorModel.fetch.resolves(contractorDB);
+        apdDB.get.returns(1);
+
+        await handler(req, res);
+
+        test.ok(
+          ContractorModel.where.calledWith({ id: 'requested contractor id' }),
+          'restricts query to requested ID'
+        );
+        test.ok(
+          rawDB.calledWith('activity_contractor_files'),
+          'updates contractor/file link'
+        );
+        test.ok(
+          rawWhere.calledWith({
+            activity_contractor_resource_id: 'requested contractor id',
+            file_id: 'requested file id'
+          }),
+          'specifically the requested contractor and file'
+        );
+        test.ok(rawDel.calledOnce, 'link is deleted');
+        test.ok(
+          FileModel.where.calledWith({ id: 'requested file id' }),
+          'requested file is loaded for deletion'
+        );
+        test.ok(
+          store.remove.calledWith('file key'),
+          'file is removed from the store'
+        );
+        test.ok(fileDB.destroy.calledOnce, 'file is removed from database');
+        test.ok(res.status.calledWith(204), 'sends status 204');
+        test.ok(res.end.calledOnce, 'response is terminated');
+      }
+    );
+  });
+});

--- a/api/routes/files/get.test.js
+++ b/api/routes/files/get.test.js
@@ -54,7 +54,7 @@ tap.test('files GET endpoint', async endpointTest => {
 
     setupTest.ok(
       app.get.calledWith('/files/:id', loggedIn, sinon.match.func),
-      'me GET endpoint is registered'
+      'files GET endpoint is registered'
     );
   });
 

--- a/api/routes/files/index.js
+++ b/api/routes/files/index.js
@@ -1,0 +1,18 @@
+const logger = require('../../logger')('files route index');
+const del = require('./delete');
+const get = require('./get');
+const post = require('./post');
+
+module.exports = (
+  app,
+  delEndpoint = del,
+  getEndpoint = get,
+  postEndpoint = post
+) => {
+  logger.silly('setting up DELETE endpoint');
+  delEndpoint(app);
+  logger.silly('setting up GET endpoint');
+  getEndpoint(app);
+  logger.silly('setting up POST endpoint');
+  postEndpoint(app);
+};

--- a/api/routes/files/index.test.js
+++ b/api/routes/files/index.test.js
@@ -1,0 +1,17 @@
+const tap = require('tap');
+const sinon = require('sinon');
+
+const index = require('./index');
+
+tap.test('files endpoint index', async test => {
+  const app = {};
+  const del = sinon.stub();
+  const post = sinon.stub();
+  const put = sinon.stub();
+
+  index(app, del, post, put);
+
+  test.ok(del.calledWith(app), 'delete endpoint is setup');
+  test.ok(post.calledWith(app), 'post endpoint is setup');
+  test.ok(put.calledWith(app), 'put endpoint is setup');
+});

--- a/api/routes/files/openAPI.js
+++ b/api/routes/files/openAPI.js
@@ -1,4 +1,5 @@
 const { requiresAuth } = require('../openAPI/helpers');
+const { jsonResponse } = require('../openAPI/helpers').schema;
 
 const openAPI = {
   '/files/{id}': {
@@ -35,6 +36,86 @@ const openAPI = {
         404: {
           description:
             'The file ID does not match any known files, or the file does not exist in storage'
+        }
+      }
+    }
+  },
+  '/files/contractor/{id}': {
+    post: {
+      tags: ['Files'],
+      summary: 'Upload a file',
+      description:
+        'Uploads a file and attaches it to a contractor resource, if the user has permission to modify the APD the contractor is attached to',
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          description:
+            'The ID of the contractor resource to attach this file to',
+          required: true,
+          schema: {
+            type: 'integer'
+          }
+        }
+      ],
+      requestBody: {
+        content: {
+          'multipart/form-data': {
+            schema: {
+              properties: {
+                file: {
+                  type: 'string',
+                  format: 'binary',
+                  description: 'The file being uploaded'
+                },
+                metadata: {
+                  type: 'string',
+                  description:
+                    'The metadata to attach to this file. Must be stringified-JSON.'
+                }
+              }
+            }
+          }
+        }
+      },
+      responses: {
+        200: {
+          description: 'The file metadata stored in the database',
+          content: jsonResponse({ $ref: '#/components/schemas/file' })
+        }
+      }
+    }
+  },
+  '/files/contractor/{id}/{fileID}': {
+    delete: {
+      tags: ['Files'],
+      summary: 'Delete a file',
+      description:
+        'Deletes a file associated with a contractor resource, if the user has permission to modify the APD the contractor is attached to',
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          description:
+            'The ID of the contractor resource to delete this file from',
+          required: true,
+          schema: {
+            type: 'integer'
+          }
+        },
+        {
+          name: 'fileID',
+          in: 'path',
+          description: 'The ID of the file to delete',
+          required: true,
+          schema: {
+            type: 'integer'
+          }
+        }
+      ],
+      responses: {
+        204: {
+          description: 'The file is deleted successfully'
         }
       }
     }

--- a/api/routes/files/post.js
+++ b/api/routes/files/post.js
@@ -9,23 +9,24 @@ const {
 } = require('../../db').models;
 const defaultStore = require('../../store');
 
+const upload = multer({ limits: { fileSize: 10 * 2 ** 20 } });
+
 module.exports = (
   app,
   {
     ContractorModel = defaultContractorResourceModel,
     FileModel = defaultFileModel,
     rawDB = defaultRawDB,
-    store = defaultStore
+    store = defaultStore,
+    uploadMiddleware = upload
   } = {}
 ) => {
   logger.silly('setting up POST endpoint');
 
-  const upload = multer({ limits: { fileSize: 10 * 2 ** 20 } });
-
   app.post(
     '/files/contractor/:id',
     can('create-draft'),
-    upload.single('file'),
+    uploadMiddleware.single('file'),
     async (req, res) => {
       try {
         const userApds = await req.user.model.apds();

--- a/api/routes/files/post.js
+++ b/api/routes/files/post.js
@@ -1,0 +1,93 @@
+const multer = require('multer');
+const logger = require('../../logger')('files route post');
+const { can } = require('../../middleware');
+
+const { raw: defaultRawDB } = require('../../db');
+const {
+  apdActivityContractorResource: defaultContractorResourceModel,
+  file: defaultFileModel
+} = require('../../db').models;
+const defaultStore = require('../../store');
+
+module.exports = (
+  app,
+  {
+    ContractorModel = defaultContractorResourceModel,
+    FileModel = defaultFileModel,
+    rawDB = defaultRawDB,
+    store = defaultStore
+  } = {}
+) => {
+  logger.silly('setting up POST endpoint');
+
+  const upload = multer({ limits: { fileSize: 10 * 2 ** 20 } });
+
+  app.post(
+    '/files/contractor/:id',
+    can('create-draft'),
+    upload.single('file'),
+    async (req, res) => {
+      try {
+        const userApds = await req.user.model.apds();
+        logger.silly(req, `user has access to apds: [${userApds}]`);
+
+        const contractor = await ContractorModel.where({
+          id: req.params.id
+        }).fetch({ withRelated: ['activity.apd'] });
+
+        if (contractor) {
+          const contractorApd = contractor
+            .related('activity')
+            .related('apd')
+            .get('id');
+          logger.silly(req, `contractor belongs to apd ${contractorApd}`);
+
+          if (userApds.includes(contractorApd)) {
+            logger.silly(req, 'user has access!');
+
+            const fileKey = [...Array(12)]
+              .map(() => Math.floor(Math.random() * 16).toString(16))
+              .join('');
+
+            await store.write(fileKey, req.file.buffer);
+
+            const file = FileModel.forge({
+              key: fileKey,
+              metadata: req.body.metadata,
+              size: req.file.size
+            });
+            await file.save();
+            logger.silly('file was saved');
+
+            // Inserting a many-to-many link in bookshelf is...  I mean,
+            // the documentation is not clear on how it's supposed to
+            // work, and everything I tried just exploded.  So, drop to
+            // knex and do it manually.  (E.g., the "attach" method is
+            // the intended way, but that removes existing relations,
+            // which is definitely not what we want.)
+            await rawDB('activity_contractor_files').insert({
+              activity_contractor_resource_id: contractor.get('id'),
+              file_id: file.get('id')
+            });
+
+            return res.send(file.toJSON());
+          }
+
+          logger.info(
+            req,
+            `User does not have permission to modify contractor ${
+              req.params.id
+            } (belongs to activity ${
+              contractor.related('activity').id
+            }, apd ${contractorApd}`
+          );
+          return res.status(404).end();
+        }
+        return res.status(404).end();
+      } catch (e) {
+        logger.error(req, e);
+        return res.status(500).end();
+      }
+    }
+  );
+};

--- a/api/routes/files/post.test.js
+++ b/api/routes/files/post.test.js
@@ -1,0 +1,196 @@
+const tap = require('tap');
+const sinon = require('sinon');
+const { can } = require('../../middleware/auth');
+
+const post = require('./post');
+
+tap.test('files post endpoint', async tests => {
+  const sandbox = sinon.createSandbox();
+
+  const app = { post: sandbox.stub() };
+
+  tests.beforeEach(async () => {
+    sandbox.resetBehavior();
+    sandbox.resetHistory();
+  });
+
+  tests.test('setup', async test => {
+    const upload = {};
+    const uploadCreator = { single: sinon.stub().returns(upload) };
+    post(app, { uploadMiddleware: uploadCreator });
+
+    test.ok(
+      app.post.calledWith(
+        '/files/contractor/:id',
+        can('create-draft'),
+        upload,
+        sinon.match.func
+      ),
+      'files POST endpoint is registered'
+    );
+  });
+
+  tests.test('endpoint handler tests', async epTests => {
+    let handler;
+
+    const ContractorModel = { where: sandbox.stub(), fetch: sandbox.stub() };
+
+    const contractorDB = {
+      get: sandbox.stub(),
+      related: sandbox.stub()
+    };
+
+    const activityDB = {
+      related: sandbox.stub()
+    };
+
+    const apdDB = {
+      get: sandbox.stub()
+    };
+
+    const FileModel = {
+      forge: sandbox.stub()
+    };
+
+    const fileDB = {
+      get: sandbox.stub(),
+      save: sandbox.stub(),
+      toJSON: sandbox.stub()
+    };
+
+    const rawDB = sandbox.stub();
+    const rawInsert = sandbox.stub();
+
+    const store = {
+      write: sandbox.stub()
+    };
+
+    const req = {
+      params: { id: 'requested contractor id' },
+      user: {
+        model: {
+          apds: sandbox.stub()
+        }
+      }
+    };
+
+    const res = {
+      end: sandbox.stub(),
+      send: sandbox.stub(),
+      status: sandbox.stub()
+    };
+
+    epTests.beforeEach(async () => {
+      post(app, { ContractorModel, FileModel, rawDB, store });
+      handler = app.post.args[0][app.post.args[0].length - 1];
+
+      ContractorModel.where.returns(ContractorModel);
+
+      contractorDB.get.withArgs('id').returns('contractor id');
+      contractorDB.related.withArgs('activity').returns(activityDB);
+      activityDB.related.withArgs('apd').returns(apdDB);
+
+      FileModel.forge.returns(fileDB);
+      fileDB.get.withArgs('id').returns('file id');
+      fileDB.toJSON.returns('file json');
+
+      rawDB.returns({ insert: rawInsert });
+
+      req.user.model.apds.resolves([1, 2, 3]);
+
+      res.send.returns(res);
+      res.status.returns(res);
+    });
+
+    epTests.test('handles a database error', async test => {
+      ContractorModel.fetch.throws(new Error('boop'));
+      await handler(req, res);
+
+      test.ok(res.status.calledWith(500), 'sends status 500');
+      test.ok(res.end.calledOnce, 'response is terminated');
+    });
+
+    epTests.test(
+      'handles where the contractor ID does not exist',
+      async test => {
+        ContractorModel.fetch.resolves(null);
+        await handler(req, res);
+
+        test.ok(
+          ContractorModel.where.calledWith({ id: 'requested contractor id' }),
+          'restricts query to requested ID'
+        );
+        test.ok(res.status.calledWith(404), 'sends status 404');
+        test.ok(res.end.calledOnce, 'response is terminated');
+      }
+    );
+
+    epTests.test(
+      'handles where the requestor does not have access to the APD containing the contractor',
+      async test => {
+        ContractorModel.fetch.resolves(contractorDB);
+        // The APD IDs the user has access to are represented by
+        // req.user.model.apds, mocked in the epTests beforeEach.
+        // If this value is not in that list, we should get the 404.
+        apdDB.get.returns(5);
+        await handler(req, res);
+
+        test.ok(
+          ContractorModel.where.calledWith({ id: 'requested contractor id' }),
+          'restricts query to requested ID'
+        );
+        test.ok(res.status.calledWith(404), 'sends status 404');
+        test.ok(res.end.calledOnce, 'response is terminated');
+      }
+    );
+
+    epTests.test(
+      'saves the file and updates the database accordingly',
+      async test => {
+        ContractorModel.fetch.resolves(contractorDB);
+        apdDB.get.returns(1);
+
+        store.write.resolves();
+        fileDB.save.resolves();
+
+        req.body = { metadata: 'this is metadata' };
+        req.file = {
+          buffer: {},
+          size: 99
+        };
+
+        await handler(req, res);
+
+        test.ok(
+          ContractorModel.where.calledWith({ id: 'requested contractor id' }),
+          'restricts query to requested ID'
+        );
+        test.ok(res.send.calledWith('file json'), 'sends the file JSON');
+        test.ok(
+          store.write.calledWith(sinon.match(/[0-9a-f]{12}/), req.file.buffer),
+          'writes to store with key and file buffer'
+        );
+        const storedKey = store.write.args[0][0];
+        test.ok(
+          FileModel.forge.calledWith({
+            key: storedKey,
+            metadata: 'this is metadata',
+            size: 99
+          }),
+          'new file model is created with the write information'
+        );
+        test.ok(
+          rawDB.calledWith('activity_contractor_files'),
+          'contractor file link updated'
+        );
+        test.ok(
+          rawInsert.calledWith({
+            activity_contractor_resource_id: 'contractor id',
+            file_id: 'file id'
+          }),
+          'correct link is inserted'
+        );
+      }
+    );
+  });
+});

--- a/api/routes/index.js
+++ b/api/routes/index.js
@@ -1,7 +1,7 @@
 const logger = require('../logger')('routes index');
 const auth = require('./auth');
 const apds = require('./apds');
-const files = require('./files/get');
+const files = require('./files');
 const me = require('./me/get');
 const states = require('./states');
 const users = require('./users');

--- a/api/routes/openAPI/index.js
+++ b/api/routes/openAPI/index.js
@@ -628,18 +628,14 @@ module.exports = {
           id: {
             type: 'number'
           },
-          key: {
-            type: 'string',
-            description:
-              'File store identifier, used to retrieve the actual file'
-          },
           size: {
             type: 'number',
             description: 'Size of the file, in bytes'
           },
           metadata: {
             type: 'object',
-            description: 'Free-form object containing file metadata'
+            description:
+              'The properties from any metadata supplied when the file was uploaded will be added to the file object'
           }
         }
       },

--- a/api/seeds/test/files.js
+++ b/api/seeds/test/files.js
@@ -5,7 +5,11 @@ exports.seed = async knex => {
   // 43xx IDs refer to objectives
 
   await knex('files').insert([
-    { id: 5000, key: 'download.txt' },
+    {
+      id: 5000,
+      key: 'download.txt',
+      metadata: '{"some":"metadata","in":"here"}'
+    },
     { id: 5001, key: 'download.txt' },
     { id: 5002, key: 'download.txt' },
     { id: 5003, key: 'download.txt' },

--- a/api/store.js
+++ b/api/store.js
@@ -117,7 +117,7 @@ class Store {
    * Write data into a blob with a specified key.  The blob
    * will be created if it does not already exist.
    * @param {String} key - Blob identifier
-   * @param {(ReadableStream|*)} - The data to write.  If a ReadableStream is
+   * @param {(ReadableStream|*)} data - The data to write.  If a ReadableStream is
    *    provided, its contents will be piped into the blob.  For everything
    *    else, it will be written directly to the blob.
    * @param {*} opts - Returned value when the write is finished.
@@ -146,6 +146,11 @@ class Store {
         data.pipe(writeStream);
 
         data.on('close', () => {
+          writeStream.end();
+          done();
+        });
+
+        data.on('end', () => {
           writeStream.end();
           done();
         });

--- a/web/src/actions/activities.js
+++ b/web/src/actions/activities.js
@@ -1,4 +1,6 @@
 import { saveApd, updateBudget } from './apd';
+import { notify } from './notification';
+import axios from '../util/api';
 
 export const ADD_ACTIVITY = 'ADD_ACTIVITY';
 export const ADD_ACTIVITY_CONTRACTOR = 'ADD_ACTIVITY_CONTRACTOR';
@@ -18,6 +20,8 @@ export const TOGGLE_ACTIVITY_CONTRACTOR_HOURLY =
   'TOGGLE_ACTIVITY_CONTRACTOR_HOURLY';
 export const TOGGLE_ACTIVITY_SECTION = 'TOGGLE_ACTIVITY_SECTION';
 export const UPDATE_ACTIVITY = 'UPDATE_ACTIVITY';
+
+const getFileURL = id => `${process.env.API_URL}/files/${id}`;
 
 const actionWithYears = (type, other) => (dispatch, getState) =>
   dispatch({ type, ...other, years: getState().apd.data.years });
@@ -65,6 +69,77 @@ export const addActivityContractor = key => async (dispatch, getState) => {
   };
 
   dispatch(updateActivity(key, updates));
+};
+
+export const uploadActivityContractorFile = (
+  activityKey,
+  contractorIdx,
+  docType,
+  file
+) => async (dispatch, getState) => {
+  const { name, size, type } = file;
+  const newFile = {
+    name,
+    size,
+    type,
+    category: docType
+  };
+
+  try {
+    const contractor = getState().activities.byKey[activityKey]
+      .contractorResources[contractorIdx];
+
+    const form = new FormData();
+    form.append('file', file);
+    form.append('metadata', JSON.stringify(newFile));
+    const { data } = await axios.post(
+      `/files/contractor/${contractor.id}`,
+      form
+    );
+
+    const existingFiles = contractor.files || [];
+
+    const updates = {
+      [contractorIdx]: {
+        files: [...existingFiles, { ...data, url: getFileURL(data.id) }]
+      }
+    };
+
+    dispatch(updateActivity(activityKey, { contractorResources: updates }));
+    dispatch(notify('Upload successful!'));
+  } catch (e) {
+    const { response: res } = e;
+    const reason = (res && (res.data || {}).error) || 'not-sure-why';
+
+    dispatch(notify(`Upload failed (${reason})`));
+  }
+};
+
+export const deleteActivityContractorFile = (
+  activityKey,
+  contractorIdx,
+  fileIdx
+) => async (dispatch, getState) => {
+  try {
+    const contractor = getState().activities.byKey[activityKey]
+      .contractorResources[contractorIdx];
+    const file = contractor.files[fileIdx];
+
+    await axios.delete(`/files/contractor/${contractor.id}/${file.id}`);
+
+    const { files } = contractor;
+    const updatedFiles = files.filter((_, i) => i !== fileIdx);
+
+    const updates = { [contractorIdx]: { files: updatedFiles } };
+
+    dispatch(updateActivity(activityKey, { contractorResources: updates }));
+    dispatch(notify('File deleted successfully!'));
+  } catch (e) {
+    const { response: res } = e;
+    const reason = (res && (res.data || {}).error) || 'not-sure-why';
+
+    dispatch(notify(`Deleting file failed (${reason})`));
+  }
 };
 
 export const addActivityGoal = key => ({ type: ADD_ACTIVITY_GOAL, key });

--- a/web/src/actions/apd.js
+++ b/web/src/actions/apd.js
@@ -201,6 +201,7 @@ export const saveApd = ({ serialize = toAPI } = {}) => (dispatch, state) => {
     .then(res => {
       dispatch(notify('Save successful!'));
       dispatch(saveSuccess(res.data));
+      return res.data;
     })
     .catch(error => {
       dispatch(notifyNetError('Save', error));

--- a/web/src/containers/activity/ContractorResources.js
+++ b/web/src/containers/activity/ContractorResources.js
@@ -86,7 +86,14 @@ class ContractorResources extends Component {
 
     // only do one file at a time
     const { name, preview, size, type } = files[0];
-    const newFile = { name, preview, size, type, category: docType };
+    const newFile = {
+      name,
+      preview,
+      size,
+      type,
+      category: docType,
+      file: files[0]
+    };
     const existingFiles = activity.contractorResources[index].files || [];
 
     const updates = { [index]: { files: [...existingFiles, newFile] } };

--- a/web/src/containers/activity/ContractorResources.js
+++ b/web/src/containers/activity/ContractorResources.js
@@ -5,9 +5,11 @@ import { connect } from 'react-redux';
 
 import {
   addActivityContractor,
+  deleteActivityContractorFile,
   removeActivityContractor,
   toggleActivityContractorHourly,
-  updateActivity as updateActivityAction
+  updateActivity as updateActivityAction,
+  uploadActivityContractorFile
 } from '../../actions/activities';
 import Btn from '../../components/Btn';
 import DatePickerWrapper from '../../components/DatePickerWrapper';
@@ -81,35 +83,18 @@ class ContractorResources extends Component {
   handleFileUpload = index => files => {
     if (!files.length) return;
 
-    const { activity, updateActivity } = this.props;
+    const { activity, uploadFile } = this.props;
     const { docType } = this.state;
-
-    // only do one file at a time
-    const { name, preview, size, type } = files[0];
-    const newFile = {
-      name,
-      preview,
-      size,
-      type,
-      category: docType,
-      file: files[0]
-    };
-    const existingFiles = activity.contractorResources[index].files || [];
-
-    const updates = { [index]: { files: [...existingFiles, newFile] } };
-    updateActivity(activity.key, { contractorResources: updates });
+    uploadFile(activity.key, index, docType, files[0]);
 
     // reset document category if necessary
     if (docType !== DOC_TYPES[0]) this.setState({ docType: DOC_TYPES[0] });
   };
 
   handleFileDelete = (cIdx, fIdx) => () => {
-    const { activity, updateActivity } = this.props;
-    const { files } = activity.contractorResources[cIdx];
-    const updatedFiles = files.filter((_, i) => i !== fIdx);
+    const {activity,deleteFile} = this.props;
 
-    const updates = { [cIdx]: { files: updatedFiles } };
-    updateActivity(activity.key, { contractorResources: updates });
+    deleteFile(activity.key, cIdx, fIdx);
   };
 
   render() {
@@ -216,7 +201,7 @@ class ContractorResources extends Component {
                               />
                               <a
                                 className="block bold truncate"
-                                href={f.preview}
+                                href={f.url}
                                 target="_blank"
                               >
                                 {f.name}
@@ -342,9 +327,11 @@ ContractorResources.propTypes = {
   activity: PropTypes.object.isRequired,
   years: PropTypes.array.isRequired,
   addContractor: PropTypes.func.isRequired,
+  deleteFile: PropTypes.func.isRequired,
   removeContractor: PropTypes.func.isRequired,
   toggleContractorHourly: PropTypes.func.isRequired,
-  updateActivity: PropTypes.func.isRequired
+  updateActivity: PropTypes.func.isRequired,
+  uploadFile: PropTypes.func.isRequired
 };
 
 export const mapStateToProps = ({ activities: { byKey }, apd }, { aKey }) => ({
@@ -354,9 +341,11 @@ export const mapStateToProps = ({ activities: { byKey }, apd }, { aKey }) => ({
 
 export const mapDispatchToProps = {
   addContractor: addActivityContractor,
+  deleteFile: deleteActivityContractorFile,
   removeContractor: removeActivityContractor,
   toggleContractorHourly: toggleActivityContractorHourly,
-  updateActivity: updateActivityAction
+  updateActivity: updateActivityAction,
+  uploadFile: uploadActivityContractorFile
 };
 
 export { ContractorResources as ContractorResourcesRaw };

--- a/web/src/containers/activity/ContractorResources.js
+++ b/web/src/containers/activity/ContractorResources.js
@@ -321,13 +321,6 @@ class ContractorResources extends Component {
     const { activityKey, deleteFile } = this.props;
 
     deleteFile(activityKey, cIdx, fIdx);
-
-    // const { activityKey, contractors, updateActivity } = this.props;
-    // const { files } = contractors[cIdx];
-    // const updatedFiles = files.filter((_, i) => i !== fIdx);
-
-    // const updates = { [cIdx]: { files: updatedFiles } };
-    // updateActivity(activityKey, { contractorResources: updates });
   };
 
   handleFileUpload = index => files => {
@@ -336,20 +329,6 @@ class ContractorResources extends Component {
     const { activityKey, uploadFile } = this.props;
     const { docType } = this.state;
     uploadFile(activityKey, index, docType, files[0]);
-
-    // const { activityKey, contractors, updateActivity } = this.props;
-    // const { docType } = this.state;
-
-    // // only do one file at a time
-    // const { name, preview, size, type } = files[0];
-    // const newFile = { name, preview, size, type, category: docType };
-    // const existingFiles = contractors[index].files || [];
-
-    // const updates = { [index]: { files: [...existingFiles, newFile] } };
-    // updateActivity(activityKey, { contractorResources: updates });
-
-    // // reset document category if necessary
-    // if (docType !== DOC_TYPES[0]) this.setState({ docType: DOC_TYPES[0] });
   };
 
   handleHourlyChange = (index, year, field) => e => {

--- a/web/src/containers/activity/ContractorResources.test.js
+++ b/web/src/containers/activity/ContractorResources.test.js
@@ -9,9 +9,11 @@ import {
 } from './ContractorResources';
 import {
   addActivityContractor,
+  deleteActivityContractorFile,
   removeActivityContractor,
   toggleActivityContractorHourly,
-  updateActivity
+  updateActivity,
+  uploadActivityContractorFile
 } from '../../actions/activities';
 
 describe('the ContractorResources component', () => {
@@ -43,9 +45,11 @@ describe('the ContractorResources component', () => {
     },
     years: ['1066', '1067'],
     addContractor: sinon.stub(),
+    deleteFile: sinon.stub(),
     removeContractor: sinon.stub(),
     toggleContractorHourly: sinon.stub(),
-    updateActivity: sinon.stub()
+    updateActivity: sinon.stub(),
+    uploadFile: sinon.stub()
   };
 
   beforeEach(() => {
@@ -138,9 +142,11 @@ describe('the ContractorResources component', () => {
   test('maps dispatch actions to props', () => {
     expect(mapDispatchToProps).toEqual({
       addContractor: addActivityContractor,
+      deleteFile: deleteActivityContractorFile,
       removeContractor: removeActivityContractor,
       toggleContractorHourly: toggleActivityContractorHourly,
-      updateActivity
+      updateActivity,
+      uploadFile: uploadActivityContractorFile
     });
   });
 });

--- a/web/src/containers/activity/__snapshots__/ContractorResources.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/ContractorResources.test.js.snap
@@ -38,9 +38,11 @@ ShallowWrapper {
       }
     }
     addContractor={[Function]}
+    deleteFile={[Function]}
     removeContractor={[Function]}
     toggleContractorHourly={[Function]}
     updateActivity={[Function]}
+    uploadFile={[Function]}
     years={
       Array [
         "1066",

--- a/web/src/util/serialization/activities.js
+++ b/web/src/util/serialization/activities.js
@@ -1,5 +1,7 @@
 import { applyToNumbers, generateKey, replaceNulls } from '../index';
 
+const getFileURL = id => `${process.env.API_URL}/files/${id}`;
+
 /**
  * Serializes an APD object from redux state shape into
  * API format
@@ -119,6 +121,10 @@ export const fromAPI = (activityAPI, years) => {
       desc: c.description,
       start: c.start,
       end: c.end,
+      files: c.files.map(f => ({
+        ...f,
+        url: getFileURL(f.id)
+      })),
       years: c.years.reduce(
         (acc, y) => ({
           ...acc,

--- a/web/src/util/serialization/activities.test.js
+++ b/web/src/util/serialization/activities.test.js
@@ -77,6 +77,7 @@ describe('APD activity serializer', () => {
             description: 'desc 1',
             start: 'start 1',
             end: 'end 1',
+            files: [{ id: 'contractor 1 file' }],
             years: [
               { year: '2018', cost: '1000' },
               { year: '2019', cost: '2000' }
@@ -93,6 +94,7 @@ describe('APD activity serializer', () => {
             description: 'desc 2',
             start: 'start 2',
             end: 'end 2',
+            files: [{ id: 'contractor 2 file' }],
             years: [
               { year: '2018', cost: '3000' },
               { year: '2019', cost: '4000' }
@@ -258,6 +260,12 @@ describe('APD activity serializer', () => {
               desc: 'desc 1',
               start: 'start 1',
               end: 'end 1',
+              files: [
+                {
+                  id: 'contractor 1 file',
+                  url: expect.stringMatching(/.*\/files\/contractor 1 file$/)
+                }
+              ],
               years: { 2018: 1000, 2019: 2000 },
               hourly: {
                 useHourly: false,
@@ -274,6 +282,13 @@ describe('APD activity serializer', () => {
               desc: 'desc 2',
               start: 'start 2',
               end: 'end 2',
+              files: [
+                {
+                  id: 'contractor 2 file',
+                  url: expect.stringMatching(/.*\/files\/contractor 2 file$/)
+                }
+              ],
+
               years: { 2018: 3000, 2019: 4000 },
               hourly: {
                 useHourly: true,


### PR DESCRIPTION
Skipping deploy because it won't work until the API is also deployed, and the PR-based deploys only do the frontend, not the backend.

Closes #839

### This pull request changes...
- when you create a new contractor, the APD is saved - that way the contractor exists in the database, so we can attach files to it later
- when you select a file to add to a contractor, the file is uploaded immediately and then attached to the contractor

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated

### This feature is done when...
- [ ] Product has approved the experience
