### PR TITLE
Update certify/submit UI

### DIFF
--- a/api/routes/apds/versions/post.js
+++ b/api/routes/apds/versions/post.js
@@ -27,7 +27,7 @@ module.exports = (
         content: { ...tables, ...apd.toJSON() }
       });
 
-      apd.set({ status: 'in review' });
+      apd.set({ status: 'submitted' });
       await apd.save();
 
       await version.save();

--- a/api/routes/apds/versions/post.test.js
+++ b/api/routes/apds/versions/post.test.js
@@ -114,8 +114,8 @@ tap.test('apds version POST endpoint', async tests => {
       'creates a version'
     );
     test.ok(
-      apd.set.calledWith({ status: 'in review' }),
-      'sets APD status to "in review"'
+      apd.set.calledWith({ status: 'submitted' }),
+      'sets APD status to "submitted"'
     );
     test.ok(apd.save.calledAfter(apd.set), 'APD is saved after status is set');
     test.ok(version.save.calledOnce, 'version is saved');

--- a/web/src/components/Icons.js
+++ b/web/src/components/Icons.js
@@ -3,10 +3,13 @@ import Icon from '@fortawesome/react-fontawesome';
 // to optimize bundle, explicitly importing only the icons used
 import faHelp from '@fortawesome/fontawesome-free-regular/faQuestionCircle';
 import faBell from '@fortawesome/fontawesome-free-solid/faBell';
+import faCheckCircle from '@fortawesome/fontawesome-free-solid/faCheckCircle';
 import faChevronDown from '@fortawesome/fontawesome-free-solid/faChevronDown';
 import faChevronUp from '@fortawesome/fontawesome-free-solid/faChevronUp';
+import faClock from '@fortawesome/fontawesome-free-regular/faClock';
 import faCode from '@fortawesome/fontawesome-free-solid/faCode';
 import faCog from '@fortawesome/fontawesome-free-solid/faCog';
+import faExclamationTriangle from '@fortawesome/fontawesome-free-solid/faExclamationTriangle';
 import faSpinner from '@fortawesome/fontawesome-free-solid/faSpinner';
 import faHelpSolid from '@fortawesome/fontawesome-free-solid/faQuestionCircle';
 import faSignOut from '@fortawesome/fontawesome-free-solid/faSignOutAlt';
@@ -15,10 +18,13 @@ export {
   faHelp,
   faHelpSolid,
   faBell,
+  faCheckCircle,
   faChevronDown,
   faChevronUp,
+  faClock,
   faCode,
   faCog,
+  faExclamationTriangle,
   faSignOut,
   faSpinner
 };

--- a/web/src/containers/CertifyAndSubmit.js
+++ b/web/src/containers/CertifyAndSubmit.js
@@ -1,26 +1,127 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { push } from 'react-router-redux';
 
 import { submitAPD as submitAPDAction } from '../actions/apd';
 import Btn from '../components/Btn';
+import Icon, {
+  faCheckCircle,
+  faClock,
+  faExclamationTriangle
+} from '../components/Icons';
+import { Input } from '../components/Inputs';
 import { Section, Subsection } from '../components/Section';
 import { t } from '../i18n';
+import { STATES } from '../util';
 
-const CertifyAndSubmit = ({ submitAPD }) => (
+const AlreadySubmitted = ({ dashboard, state, year }) => (
+  <div className="pl3 relative">
+    <Icon icon={faCheckCircle} color="green" className="absolute left-0" />
+    <p className="bold">
+      {t('certifyAndSubmit.certify.submitted.thanks.header')}
+    </p>
+
+    <p>
+      {t('certifyAndSubmit.certify.submitted.thanks.helpText', {
+        state,
+        year,
+        date: 'ddd',
+        time: 'time'
+      })}
+    </p>
+
+    <Icon icon={faClock} color="blue" className="absolute left-0" />
+    <p className="bold">
+      {t('certifyAndSubmit.certify.submitted.next.header')}
+    </p>
+
+    <p>{t('certifyAndSubmit.certify.submitted.next.helpText')}</p>
+
+    <Btn onClick={() => dashboard()}>
+      {t('certifyAndSubmit.certify.submitted.buttonText')}
+    </Btn>
+  </div>
+);
+AlreadySubmitted.propTypes = {
+  dashboard: PropTypes.func.isRequired,
+  state: PropTypes.string.isRequired,
+  year: PropTypes.string.isRequired
+};
+
+class Submit extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      submitter: ''
+    };
+  }
+
+  render() {
+    const { submitAPD } = this.props;
+    const { submitter } = this.state;
+
+    return (
+      <div className="pl3 relative">
+        <Icon
+          icon={faExclamationTriangle}
+          color="orange"
+          className="absolute left-0"
+        />
+
+        <p className="bold">{t('certifyAndSubmit.certify.draft.header')}</p>
+
+        <p>{t('certifyAndSubmit.certify.draft.helpText')}</p>
+
+        <Input
+          name="submit_submitter_name"
+          label="First and last name"
+          value={submitter}
+          onChange={e => this.setState({ submitter: e.target.value })}
+        />
+
+        <Btn onClick={() => submitAPD()} disabled={submitter.length === 0}>
+          {t('certifyAndSubmit.certify.buttonText')}
+        </Btn>
+      </div>
+    );
+  }
+}
+Submit.propTypes = { submitAPD: PropTypes.func.isRequired };
+
+const CertifyAndSubmit = ({ canSubmit, pushRoute, state, submitAPD, year }) => (
   <Section id="certify-submit" resource="certifyAndSubmit">
     <Subsection id="certify-submit-submit" resource="certifyAndSubmit.certify">
-      <Btn onClick={() => submitAPD()}>
-        {t('certifyAndSubmit.certify.buttonText')}
-      </Btn>
+      <div className="pl3 relative">
+        {canSubmit ? (
+          <Submit submitAPD={submitAPD} />
+        ) : (
+          <AlreadySubmitted
+            dashboard={() => pushRoute('/dash')}
+            state={state}
+            year={year}
+          />
+        )}
+      </div>
     </Subsection>
   </Section>
 );
 
 CertifyAndSubmit.propTypes = {
-  submitAPD: PropTypes.func.isRequired
+  canSubmit: PropTypes.bool.isRequired,
+  pushRoute: PropTypes.func.isRequired,
+  state: PropTypes.string.isRequired,
+  submitAPD: PropTypes.func.isRequired,
+  year: PropTypes.string.isRequired
 };
 
-const mapDispatchToProps = { submitAPD: submitAPDAction };
+const mapStateToProps = ({ apd: { data: { state, status, years } } }) => ({
+  canSubmit: status === 'draft',
+  state: STATES.find(s => s.id === state).name,
+  year: years[0]
+});
 
-export default connect(null, mapDispatchToProps)(CertifyAndSubmit);
+const mapDispatchToProps = { submitAPD: submitAPDAction, pushRoute: push };
+
+export default connect(mapStateToProps, mapDispatchToProps)(CertifyAndSubmit);

--- a/web/src/containers/CertifyAndSubmit.js
+++ b/web/src/containers/CertifyAndSubmit.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
@@ -16,7 +16,7 @@ import { t } from '../i18n';
 import { STATES } from '../util';
 
 const AlreadySubmitted = ({ dashboard, state, year }) => (
-  <div className="pl3 relative">
+  <Fragment>
     <Icon icon={faCheckCircle} color="green" className="absolute left-0" />
     <p className="bold">
       {t('certifyAndSubmit.certify.submitted.thanks.header')}
@@ -41,7 +41,7 @@ const AlreadySubmitted = ({ dashboard, state, year }) => (
     <Btn onClick={() => dashboard()}>
       {t('certifyAndSubmit.certify.submitted.buttonText')}
     </Btn>
-  </div>
+  </Fragment>
 );
 AlreadySubmitted.propTypes = {
   dashboard: PropTypes.func.isRequired,
@@ -63,7 +63,7 @@ class Submit extends Component {
     const { submitter } = this.state;
 
     return (
-      <div className="pl3 relative">
+      <Fragment>
         <Icon
           icon={faExclamationTriangle}
           color="orange"
@@ -84,7 +84,7 @@ class Submit extends Component {
         <Btn onClick={() => submitAPD()} disabled={submitter.length === 0}>
           {t('certifyAndSubmit.certify.buttonText')}
         </Btn>
-      </div>
+      </Fragment>
     );
   }
 }

--- a/web/src/i18n/locales/en.yaml
+++ b/web/src/i18n/locales/en.yaml
@@ -771,8 +771,38 @@
     helpText: Complete your APD submission below.
     certify:
       title: Certification
-      helpText: >-
+      draft:
+        header: >-
+          Before you submit your APD, double-check that you have
+          entered everything correctly because once you submit,
+          your APD document will be locked from further edits
+          until reviewed by a CMS analyst.
+        helpText: >-
+          To submit your APD for reviews, sign your name in the
+          box below then select the Submit APD button
+        buttonText: Submit APD
+      submitted:
+        buttonText: My Dashboard
+        thanks:
+          header: Submitted!
+          helpText: >-
+            Thank you for your {{state}} {{year}} HITECH APD
+            submission.
+        next:
+          header: What to expect next
+          helpText: >-
+            Your CMS analyst has been notified of your submission
+            and will begin the review process.  If they have any
+            questions for you, you will receive a notification
+            through the app with a link to respond.
+
+
+            If you would like to check the status of your request
+            or start a new document, please go to your state's
+            dashboard.
+      helpTextx: >-
         Upon submission, this APD will be locked from further
         edits until reviewed by a CMS analyst. If complete, select the
         button below.
+      
       buttonText: Submit APD

--- a/web/src/reducers/apd.js
+++ b/web/src/reducers/apd.js
@@ -10,6 +10,7 @@ import {
   REMOVE_APD_POC,
   SELECT_APD,
   SET_SELECT_APD_ON_LOAD,
+  SUBMIT_APD_SUCCESS,
   UPDATE_APD
 } from '../actions/apd';
 import { INCENTIVE_ENTRIES, arrToObj, defaultAPDYearOptions } from '../util';
@@ -90,6 +91,8 @@ const reducer = (state = initialState, action) => {
       return { ...state, data: { ...action.apd } };
     case SET_SELECT_APD_ON_LOAD:
       return { ...state, selectAPDOnLoad: true };
+    case SUBMIT_APD_SUCCESS:
+      return u({ data: { status: 'submitted' } }, state);
     case UPDATE_APD: {
       if (!action.updates.years) {
         return u({ data: { ...action.updates } }, state);


### PR DESCRIPTION
Addresses #833

![screen shot 2018-08-29 at 4 37 30 pm](https://user-images.githubusercontent.com/1775733/44817177-382c0880-abaa-11e8-8e5b-04cca0404460.png)

The button is disabled until they've typed something into the box.

![screen shot 2018-08-29 at 4 36 36 pm](https://user-images.githubusercontent.com/1775733/44817187-42e69d80-abaa-11e8-8996-cd58a9ede144.png)

I left the date/time out for now because there's not a mechanism for getting that information from the API.  It shouldn't be a big lift to add it, just need to do it.

### This pull request changes...
- updates the layout of the certify/submit section
- adds a separate certify/submit layout for when the APD has already been submitted

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author

### This feature is done when...
- [ ] Design has approved the experience
- [ ] Product has approved the experience
