### PR TITLE
Bugfix - quarterly table row naming match

### DIFF
--- a/web/src/i18n/locales/en.yaml
+++ b/web/src/i18n/locales/en.yaml
@@ -381,9 +381,9 @@
           resources in current FFY by quarter.
         reminder:
         expenseNames:
-          state: State personnel + non-personnel expenses
-          contractor: Contractor resources
-          combined: Total enhanced FFP
+          state: In-House Costs
+          contractor: Private Contractor Costs
+          combined: Total Enhanced FFP
       otherFunding: 
         title: Other funding description
         helpText:
@@ -707,9 +707,9 @@
       title: Federal share by FFY Quarter
       helpText: 
       expenseNames:
-        state: State personnel + non-personnel expenses
-        contractor: Contractor resources
-        combined: Total enhanced FFP
+        state: In-House Costs
+        contractor: Private Contractor Costs
+        combined: Total Enhanced FFP
     paymentsByFFYQuarter: 
       title: Incentive Payments by FFY Quarter
   assurancesAndCompliance: 


### PR DESCRIPTION
Adjusts the quarterly tables within activities and summary to reflect In-House and Private Contractor naming. Closes #783 

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author