### PR TITLE
Fix the federal fiscal years on newly-created APDs

### DIFF
--- a/api/routes/apds/post.data.js
+++ b/api/routes/apds/post.data.js
@@ -101,9 +101,19 @@ const getStateProfile = () => ({
 const repeat = (number, obj) => [...Array(number)].map(() => obj);
 
 const getNewApd = async (stateID, { StateModel = defaultStateModel } = {}) => {
-  // TODO: Fix these years.  Maybe copy over from how we
-  // compute them on the frontend. 🤷‍♂️
-  const yearOptions = ['2018', '2019', '2020'];
+  const thisFFY = (() => {
+    const year = new Date().getFullYear();
+
+    // Federal fiscal year starts October 1,
+    // but Javascript months start with 0 for
+    // some reason, so October is month 9.
+    if (new Date().getMonth() > 8) {
+      return year + 1;
+    }
+    return year;
+  })();
+
+  const yearOptions = [thisFFY, thisFFY + 1, thisFFY + 2].map(y => `${y}`);
   const years = yearOptions.slice(0, 2);
 
   const stateProfile = getStateProfile();

--- a/api/routes/apds/post.data.test.js
+++ b/api/routes/apds/post.data.test.js
@@ -1,5 +1,6 @@
 const tap = require('tap');
 const sinon = require('sinon');
+const diff = require('deep-object-diff').updatedDiff;
 
 const getNewApd = require('./post.data');
 
@@ -40,23 +41,23 @@ tap.test('APD data initializer', async test => {
               {
                 hours: '',
                 rate: '',
-                year: '2018'
+                year: '2019'
               },
               {
                 hours: '',
                 rate: '',
-                year: '2019'
+                year: '2020'
               }
             ],
             useHourly: false,
             years: [
               {
                 cost: 0,
-                year: '2018'
+                year: '2019'
               },
               {
                 cost: 0,
-                year: '2019'
+                year: '2020'
               }
             ]
           }
@@ -66,13 +67,13 @@ tap.test('APD data initializer', async test => {
             federalPercent: 0.9,
             statePercent: 0.1,
             otherAmount: 0,
-            year: '2018'
+            year: '2019'
           },
           {
             federalPercent: 0.9,
             statePercent: 0.1,
             otherAmount: 0,
-            year: '2019'
+            year: '2020'
           }
         ],
         costAllocationNarrative: {
@@ -87,11 +88,11 @@ tap.test('APD data initializer', async test => {
             entries: [
               {
                 amount: 0,
-                year: '2018'
+                year: '2019'
               },
               {
                 amount: 0,
-                year: '2019'
+                year: '2020'
               }
             ]
           }
@@ -121,20 +122,20 @@ tap.test('APD data initializer', async test => {
               {
                 cost: 0,
                 fte: 0,
-                year: '2018'
+                year: '2019'
               },
               {
                 cost: 0,
                 fte: 0,
-                year: '2019'
+                year: '2020'
               }
             ]
           }
         ],
         summary: '',
         quarterlyFFP: [
-          { q1: 0, q2: 0, q3: 0, q4: 0, year: '2018' },
-          { q1: 0, q2: 0, q3: 0, q4: 0, year: '2019' }
+          { q1: 0, q2: 0, q3: 0, q4: 0, year: '2019' },
+          { q1: 0, q2: 0, q3: 0, q4: 0, year: '2020' }
         ]
       }
     ],
@@ -144,14 +145,14 @@ tap.test('APD data initializer', async test => {
         q2: { ehPayment: 0, epPayment: 0 },
         q3: { ehPayment: 0, epPayment: 0 },
         q4: { ehPayment: 0, epPayment: 0 },
-        year: '2018'
+        year: '2019'
       },
       {
         q1: { ehPayment: 0, epPayment: 0 },
         q2: { ehPayment: 0, epPayment: 0 },
         q3: { ehPayment: 0, epPayment: 0 },
         q4: { ehPayment: 0, epPayment: 0 },
-        year: '2019'
+        year: '2020'
       }
     ],
     narrativeHIE: '',
@@ -159,6 +160,35 @@ tap.test('APD data initializer', async test => {
     narrativeMMIS: '',
     pointsOfContact: ['State Person 1', 'State Person 2'],
     previousActivityExpenses: [
+      {
+        hie: {
+          federalActual: 0,
+          federalApproved: 0,
+          stateActual: 0,
+          stateApproved: 0
+        },
+        hit: {
+          federalActual: 0,
+          federalApproved: 0,
+          stateActual: 0,
+          stateApproved: 0
+        },
+        mmis: {
+          federal90Actual: 0,
+          federal90Approved: 0,
+          federal75Actual: 0,
+          federal75Approved: 0,
+          federal50Actual: 0,
+          federal50Approved: 0,
+          state10Actual: 0,
+          state10Approved: 0,
+          state25Actual: 0,
+          state25Approved: 0,
+          state50Actual: 0,
+          state50Approved: 0
+        },
+        year: '2019'
+      },
       {
         hie: {
           federalActual: 0,
@@ -216,35 +246,6 @@ tap.test('APD data initializer', async test => {
           state50Approved: 0
         },
         year: '2017'
-      },
-      {
-        hie: {
-          federalActual: 0,
-          federalApproved: 0,
-          stateActual: 0,
-          stateApproved: 0
-        },
-        hit: {
-          federalActual: 0,
-          federalApproved: 0,
-          stateActual: 0,
-          stateApproved: 0
-        },
-        mmis: {
-          federal90Actual: 0,
-          federal90Approved: 0,
-          federal75Actual: 0,
-          federal75Approved: 0,
-          federal50Actual: 0,
-          federal50Approved: 0,
-          state10Actual: 0,
-          state10Approved: 0,
-          state25Actual: 0,
-          state25Approved: 0,
-          state50Actual: 0,
-          state50Approved: 0
-        },
-        year: '2016'
       }
     ],
     previousActivitySummary: '',
@@ -253,6 +254,6 @@ tap.test('APD data initializer', async test => {
       medicaidDirector: 'Director of Medicaid Operations',
       medicaidOffice: 'Office Where the Director Sites'
     },
-    years: ['2018', '2019']
+    years: ['2019', '2020']
   });
 });

--- a/api/routes/apds/post.data.test.js
+++ b/api/routes/apds/post.data.test.js
@@ -1,9 +1,21 @@
 const tap = require('tap');
 const sinon = require('sinon');
 
+// The Mars Pathfinder mission landed on Mars on July 4, 1997.  The Sojourner
+// rover wandered around the surface for 83 solar days before communications
+// failed.  It was designed for a 7-day mission.  Our Martian robots have a
+// really good track record of exceeding their design lifes.  FFY 1997.  Set
+// this clock before we import anything, so that the stuff we import will use
+// our faked-out clock.
+const mockClock = sinon.useFakeTimers(new Date(1997, 6, 4).getTime());
+
 const getNewApd = require('./post.data');
 
 tap.test('APD data initializer', async test => {
+  tap.tearDown(() => {
+    mockClock.restore();
+  });
+
   const state = {
     get: sinon.stub()
   };
@@ -40,23 +52,23 @@ tap.test('APD data initializer', async test => {
               {
                 hours: '',
                 rate: '',
-                year: '2019'
+                year: '1997'
               },
               {
                 hours: '',
                 rate: '',
-                year: '2020'
+                year: '1998'
               }
             ],
             useHourly: false,
             years: [
               {
                 cost: 0,
-                year: '2019'
+                year: '1997'
               },
               {
                 cost: 0,
-                year: '2020'
+                year: '1998'
               }
             ]
           }
@@ -66,13 +78,13 @@ tap.test('APD data initializer', async test => {
             federalPercent: 0.9,
             statePercent: 0.1,
             otherAmount: 0,
-            year: '2019'
+            year: '1997'
           },
           {
             federalPercent: 0.9,
             statePercent: 0.1,
             otherAmount: 0,
-            year: '2020'
+            year: '1998'
           }
         ],
         costAllocationNarrative: {
@@ -87,11 +99,11 @@ tap.test('APD data initializer', async test => {
             entries: [
               {
                 amount: 0,
-                year: '2019'
+                year: '1997'
               },
               {
                 amount: 0,
-                year: '2020'
+                year: '1998'
               }
             ]
           }
@@ -121,20 +133,20 @@ tap.test('APD data initializer', async test => {
               {
                 cost: 0,
                 fte: 0,
-                year: '2019'
+                year: '1997'
               },
               {
                 cost: 0,
                 fte: 0,
-                year: '2020'
+                year: '1998'
               }
             ]
           }
         ],
         summary: '',
         quarterlyFFP: [
-          { q1: 0, q2: 0, q3: 0, q4: 0, year: '2019' },
-          { q1: 0, q2: 0, q3: 0, q4: 0, year: '2020' }
+          { q1: 0, q2: 0, q3: 0, q4: 0, year: '1997' },
+          { q1: 0, q2: 0, q3: 0, q4: 0, year: '1998' }
         ]
       }
     ],
@@ -144,14 +156,14 @@ tap.test('APD data initializer', async test => {
         q2: { ehPayment: 0, epPayment: 0 },
         q3: { ehPayment: 0, epPayment: 0 },
         q4: { ehPayment: 0, epPayment: 0 },
-        year: '2019'
+        year: '1997'
       },
       {
         q1: { ehPayment: 0, epPayment: 0 },
         q2: { ehPayment: 0, epPayment: 0 },
         q3: { ehPayment: 0, epPayment: 0 },
         q4: { ehPayment: 0, epPayment: 0 },
-        year: '2020'
+        year: '1998'
       }
     ],
     narrativeHIE: '',
@@ -186,7 +198,7 @@ tap.test('APD data initializer', async test => {
           state50Actual: 0,
           state50Approved: 0
         },
-        year: '2019'
+        year: '1997'
       },
       {
         hie: {
@@ -215,7 +227,7 @@ tap.test('APD data initializer', async test => {
           state50Actual: 0,
           state50Approved: 0
         },
-        year: '2018'
+        year: '1996'
       },
       {
         hie: {
@@ -244,7 +256,7 @@ tap.test('APD data initializer', async test => {
           state50Actual: 0,
           state50Approved: 0
         },
-        year: '2017'
+        year: '1995'
       }
     ],
     previousActivitySummary: '',
@@ -253,6 +265,6 @@ tap.test('APD data initializer', async test => {
       medicaidDirector: 'Director of Medicaid Operations',
       medicaidOffice: 'Office Where the Director Sites'
     },
-    years: ['2019', '2020']
+    years: ['1997', '1998']
   });
 });

--- a/api/routes/apds/post.data.test.js
+++ b/api/routes/apds/post.data.test.js
@@ -1,6 +1,5 @@
 const tap = require('tap');
 const sinon = require('sinon');
-const diff = require('deep-object-diff').updatedDiff;
 
 const getNewApd = require('./post.data');
 


### PR DESCRIPTION
The API had 2018, 2019, and 2020 hard-coded into newly-created APDs.  This PR updates the API so that it calculates the current FFY and uses that as the basis for everything date-related in the new APD.

Closes #1048 

### This pull request changes...
- when you create an APD, its first FFY should be the current FFY, not 2018, unless you have a time machine

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author