### PR TITLE
Restores missing helpText to the Standard Activity Overview section

### DIFF
--- a/web/src/i18n/locales/en/activities/overview.yaml
+++ b/web/src/i18n/locales/en/activities/overview.yaml
@@ -12,7 +12,6 @@ summary:
 detail:
   # Standard is for HIT and MMIS
   standard:
-    subheader
     helpText: >-
       Include as much detail necessary to explain the activity.
   hie:

--- a/web/src/i18n/locales/en/activities/overview.yaml
+++ b/web/src/i18n/locales/en/activities/overview.yaml
@@ -12,7 +12,7 @@ summary:
 detail:
   # Standard is for HIT and MMIS
   standard:
-    ? subheader
+    subheader
     helpText: >-
       Include as much detail necessary to explain the activity.
   hie:

--- a/web/src/i18n/locales/en/activities/overview.yaml
+++ b/web/src/i18n/locales/en/activities/overview.yaml
@@ -13,7 +13,7 @@ detail:
   # Standard is for HIT and MMIS
   standard:
     helpText: >-
-      Include as much detail necessary to explain the activity.
+      Include as much detail as is necessary to explain the activity.
   hie:
     ? subheader
     helpText: >-

--- a/web/src/i18n/locales/en/activities/overview.yaml
+++ b/web/src/i18n/locales/en/activities/overview.yaml
@@ -13,7 +13,8 @@ detail:
   # Standard is for HIT and MMIS
   standard:
     ? subheader
-
+    helpText: >-
+      Include as much detail necessary to explain the activity.
   hie:
     ? subheader
     helpText: >-


### PR DESCRIPTION
Digging through an old en.yaml file, this adds back in the text that was missing from the standard helptext activity overview. If this works, this should close #1024.

Note: Also using this as a learning experience to see how to edit the YAML files. 

@jameshupp Feel free to edit the language. I took a look at #1056 and this change does not overlap with your proposed changes.

### This pull request changes...
- Adds text "Include as much detail necessary to explain the activity." to the helpText in the overview section

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated

### This feature is done when...
- [ ] Design has approved the experience
- [ ] Product has approved the experience
