### PR TITLE
Add an API endpoint to allow CMS analysts to fetch all submitted APDs

### DIFF
--- a/api/routes/apds/index.js
+++ b/api/routes/apds/index.js
@@ -3,6 +3,7 @@ const get = require('./get');
 const post = require('./post');
 const put = require('./put');
 const activities = require('./activities');
+const submitted = require('./submitted/get');
 const versions = require('./versions');
 
 module.exports = (
@@ -11,6 +12,7 @@ module.exports = (
   postEndpoint = post,
   putEndpoint = put,
   activitiesEndpoints = activities,
+  submittedEndpoints = submitted,
   versionsEndpoints = versions
 ) => {
   logger.silly('setting up GET endpoint');
@@ -22,6 +24,9 @@ module.exports = (
 
   logger.silly('setting up APD activities endpoints');
   activitiesEndpoints(app);
+
+  logger.silly('setting up submitted APD endpoints');
+  submittedEndpoints(app);
 
   logger.silly('setting up APD versions endpoints');
   versionsEndpoints(app);

--- a/api/routes/apds/index.test.js
+++ b/api/routes/apds/index.test.js
@@ -9,6 +9,7 @@ tap.test('apds endpoint setup', async endpointTest => {
   const postEndpoint = sinon.spy();
   const putEndpoint = sinon.spy();
   const activitiesEndpoint = sinon.spy();
+  const submittedEndpoint = sinon.spy();
   const versionsEndpoint = sinon.spy();
 
   apdsIndex(
@@ -17,6 +18,7 @@ tap.test('apds endpoint setup', async endpointTest => {
     postEndpoint,
     putEndpoint,
     activitiesEndpoint,
+    submittedEndpoint,
     versionsEndpoint
   );
 
@@ -36,6 +38,11 @@ tap.test('apds endpoint setup', async endpointTest => {
   endpointTest.ok(
     activitiesEndpoint.calledWith(app),
     'apds activities endpoints are setup with the app'
+  );
+
+  endpointTest.ok(
+    submittedEndpoint.calledWith(app),
+    'submitted apds endpoints are setup with the app'
   );
 
   endpointTest.ok(

--- a/api/routes/apds/openAPI.js
+++ b/api/routes/apds/openAPI.js
@@ -64,6 +64,20 @@ const openAPI = {
     }
   },
 
+  '/apds/submitted': {
+    get: {
+      tags: ['APDs'],
+      summary: 'Get all of the submitted APDs (i.e., not draft)',
+      description: 'Get a list of all submitted APDs known to the system',
+      responses: {
+        200: {
+          description: 'The list of submitted APDs',
+          content: jsonResponse(arrayOf({ $ref: '#/components/schemas/apd' }))
+        }
+      }
+    }
+  },
+
   '/apds/{id}/versions': {
     delete: {
       tags: ['APDs'],

--- a/api/routes/apds/submitted/get.js
+++ b/api/routes/apds/submitted/get.js
@@ -1,0 +1,32 @@
+const logger = require('../../../logger')('submitted apds route get');
+const defaultApdModel = require('../../../db').models.apd;
+const { can } = require('../../../middleware');
+
+module.exports = (app, ApdModel = defaultApdModel) => {
+  logger.silly('setting up GET /apds/submitted route');
+
+  app.get(
+    '/apds/submitted',
+    can('submit-federal-response'),
+    async (req, res) => {
+      logger.silly(req, 'handling GET /apds/submitted');
+
+      try {
+        const apds = (await ApdModel.query(
+          'whereNot',
+          'status',
+          'draft'
+        ).fetchAll({
+          withRelated: ApdModel.withRelated
+        })).toJSON();
+
+        logger.silly(req, `got apds:`);
+        logger.silly(req, apds);
+        return res.send(apds);
+      } catch (e) {
+        logger.error(req, e);
+        return res.status(500).end();
+      }
+    }
+  );
+};


### PR DESCRIPTION
The endpoint requires the `submit-federal-response` activity permission and returns all APDs whose status is not `draft`.

### This pull request changes...
- no visible changes

Closes #1092

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated