### PR TITLE
Add endpoint for CMS analysts to set APD status

### DIFF
--- a/api/routes/apds/index.js
+++ b/api/routes/apds/index.js
@@ -3,6 +3,7 @@ const get = require('./get');
 const post = require('./post');
 const put = require('./put');
 const activities = require('./activities');
+const status = require('./status/put.js');
 const versions = require('./versions');
 
 module.exports = (
@@ -11,6 +12,7 @@ module.exports = (
   postEndpoint = post,
   putEndpoint = put,
   activitiesEndpoints = activities,
+  statusEndpoints = status,
   versionsEndpoints = versions
 ) => {
   logger.silly('setting up GET endpoint');
@@ -22,6 +24,9 @@ module.exports = (
 
   logger.silly('setting up APD activities endpoints');
   activitiesEndpoints(app);
+
+  logger.silly('setting up APD status endpoints');
+  statusEndpoints(app);
 
   logger.silly('setting up APD versions endpoints');
   versionsEndpoints(app);

--- a/api/routes/apds/index.test.js
+++ b/api/routes/apds/index.test.js
@@ -9,6 +9,7 @@ tap.test('apds endpoint setup', async endpointTest => {
   const postEndpoint = sinon.spy();
   const putEndpoint = sinon.spy();
   const activitiesEndpoint = sinon.spy();
+  const statusEndpoint = sinon.spy();
   const versionsEndpoint = sinon.spy();
 
   apdsIndex(
@@ -17,6 +18,7 @@ tap.test('apds endpoint setup', async endpointTest => {
     postEndpoint,
     putEndpoint,
     activitiesEndpoint,
+    statusEndpoint,
     versionsEndpoint
   );
 
@@ -36,6 +38,11 @@ tap.test('apds endpoint setup', async endpointTest => {
   endpointTest.ok(
     activitiesEndpoint.calledWith(app),
     'apds activities endpoints are setup with the app'
+  );
+
+  endpointTest.ok(
+    statusEndpoint.calledWith(app),
+    'apds status endpoints are setup with the app'
   );
 
   endpointTest.ok(

--- a/api/routes/apds/openAPI.js
+++ b/api/routes/apds/openAPI.js
@@ -64,6 +64,51 @@ const openAPI = {
     }
   },
 
+  '/apds/{id}/status': {
+    put: {
+      tags: ['APD'],
+      summary: 'Set an APD status',
+      description:
+        'An endpoint for CMS analysts to change an APD status after it has been submitted.  The APD cannot currently be in draft status, or else this method will fail with an HTTP 400 error.',
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          description: 'The ID of the APD to update',
+          required: true,
+          schema: { type: 'number' }
+        }
+      ],
+      requestBody: {
+        description: 'The status value to set',
+        required: true,
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                status: {
+                  type: 'string',
+                  description: 'New status to set'
+                }
+              }
+            }
+          }
+        }
+      },
+      responses: {
+        204: {
+          description: 'The APD status was successfully set'
+        },
+        400: {
+          description:
+            'The APD is currently in draft, or the selected status is invalid',
+          content: errorToken
+        }
+      }
+    }
+  },
+
   '/apds/{id}/versions': {
     delete: {
       tags: ['APDs'],

--- a/api/routes/apds/status/put.js
+++ b/api/routes/apds/status/put.js
@@ -1,0 +1,41 @@
+const logger = require('../../../logger')('apd status route put');
+const { can, loadApd } = require('../../../middleware');
+
+module.exports = app => {
+  logger.silly('setting up PUT /apds/:id/status route');
+  app.put(
+    '/apds/:id/status',
+    can('submit-federal-response'),
+    loadApd(),
+    async (req, res) => {
+      const apd = req.meta.apd;
+
+      if (apd.get('status') === 'draft') {
+        return res
+          .status(400)
+          .send({
+            error: 'apd-in-draft'
+          })
+          .end();
+      }
+
+      const acceptableStatuses = [
+        'in review',
+        'state response',
+        'in clearance',
+        'approved',
+        'denied'
+      ];
+
+      if (!acceptableStatuses.includes(req.body.status)) {
+        return res
+          .status(400)
+          .send({ error: 'apd-invalid-status' })
+          .end();
+      }
+
+      await req.meta.apd.set({ status: req.body.status }).save();
+      return res.status(204).end();
+    }
+  );
+};

--- a/api/routes/apds/status/put.test.js
+++ b/api/routes/apds/status/put.test.js
@@ -1,0 +1,98 @@
+const tap = require('tap');
+const sinon = require('sinon');
+
+const { can, loadApd } = require('../../../middleware');
+const endpoint = require('./put');
+
+tap.test('apds status PUT endpoint', async tests => {
+  const sandbox = sinon.createSandbox();
+
+  const req = {
+    body: {},
+    meta: {
+      apd: {
+        get: sandbox.stub(),
+        set: sandbox.stub(),
+        save: sandbox.stub()
+      }
+    }
+  };
+
+  const res = {
+    end: sandbox.stub(),
+    send: sandbox.stub(),
+    status: sandbox.stub()
+  };
+
+  const app = {
+    put: sandbox.stub()
+  };
+
+  tests.beforeEach(async () => {
+    sandbox.resetBehavior();
+    sandbox.resetHistory();
+
+    req.body = {};
+    req.meta.apd.set.returns(req.meta.apd);
+
+    res.send.returns(res);
+    res.status.returns(res);
+  });
+
+  const handler = () => {
+    endpoint(app);
+    return app.put.args[0][app.put.args[0].length - 1];
+  };
+
+  tests.test('setup', async test => {
+    endpoint(app);
+
+    test.ok(
+      app.put.calledWith(
+        '/apds/:id/status',
+        can('submit-federal-response'),
+        loadApd(),
+        sinon.match.func
+      ),
+      'apd-specific status setting PUT endpoint is registered'
+    );
+  });
+
+  tests.test('rejects if the current status is draft', async test => {
+    req.meta.apd.get.withArgs('status').returns('draft');
+
+    await handler()(req, res);
+
+    test.ok(res.status.calledWith(400), 'sets HTTP status 400');
+    test.ok(
+      res.send.calledWith({ error: 'apd-in-draft' }),
+      'sends an error message'
+    );
+    test.ok(res.end.calledOnce, 'response is closed');
+  });
+
+  tests.test('rejects if target status is invalid', async test => {
+    req.meta.apd.get.withArgs('status').returns('not draft');
+    req.body = { status: 'something or other' };
+
+    await handler()(req, res);
+
+    test.ok(res.status.calledWith(400), 'sets HTTP status 400');
+    test.ok(
+      res.send.calledWith({ error: 'apd-invalid-status' }),
+      'sends an error message'
+    );
+    test.ok(res.end.calledOnce, 'response is closed');
+  });
+
+  tests.test('updates status if everything is good', async test => {
+    req.meta.apd.get.withArgs('status').returns('not draft');
+    req.body = { status: 'in clearance' };
+
+    await handler()(req, res);
+
+    test.ok(res.status.calledWith(204), 'sets HTTP status 400');
+    test.ok(res.send.notCalled, 'does not send a body');
+    test.ok(res.end.calledOnce, 'response is closed');
+  });
+});


### PR DESCRIPTION
Just what it says on the tin.  A couple of notes:

- the endpoint returns an error if an analyst tries to set an APD's status and the APD is currently in draft (i.e., CMS analysts are not allowed to change an APD's status until a state has submitted it)
- the endpoint returns an error if an analyst tries to set an invalid status; valid statuses are (currently):
  - `in review`
  - `state response`
  - `in clearance`
  - `approved`
  - `denied`
  (this list is pending the discussion in #1029)

### This pull request changes...
- no visual changes

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [x] The change has been documented
  - [x] Associated OpenAPI documentation has been updated