### PR TITLE
Fix for scrolly tables in IE

### DIFF
--- a/web/src/styles/app/table.css
+++ b/web/src/styles/app/table.css
@@ -115,6 +115,7 @@
 .table-frozen-left-pane .table-frozen-spacer-cell {
   visibility: hidden;
   width: 0;
+  border-right: 0px; /* ie fix */
 }
 
 .table-frozen-data tr > th:first-child,


### PR DESCRIPTION
For some reason, IE doesn't hide the borders on the spacer cells. Ugh.
<img width="227" alt="screen shot 2018-11-14 at 4 37 59 pm" src="https://user-images.githubusercontent.com/509309/48519877-c28c1c00-e82b-11e8-88c2-51c6cddc622a.png">

### This pull request changes...
- hide right border

### This pull request is ready to merge when...
- [ ] This code has been reviewed by someone other than the original author