### PR TITLE
Remove "example" document items from the state dashboard

### DIFF
--- a/web/src/containers/StateDashboardCurrentDocuments.js
+++ b/web/src/containers/StateDashboardCurrentDocuments.js
@@ -187,19 +187,6 @@ class CurrentDocuments extends Component {
             buttonClick={this.open(apd.id)}
           />
         ))}
-        <DocumentItem name="Ex: APD in draft" status={APD_STATUS.DRAFT} />
-        <DocumentItem name="Ex: APD in review" status={APD_STATUS.IN_REVIEW} />
-        <DocumentItem
-          name="Ex: Reviewed, with comments"
-          status={APD_STATUS.STATE_RESPONSE}
-        />
-        <DocumentItem
-          name="Ex: In clearance"
-          status={APD_STATUS.IN_CLEARANCE}
-        />
-        <DocumentItem name="Ex: Approved" status={APD_STATUS.APPROVED} />
-        <DocumentItem name="Ex: Disapproved" status={APD_STATUS.DISAPPROVED} />
-        <DocumentItem name="Ex: Withdrawn" status={APD_STATUS.WITHDRAWN} />
       </div>
     );
   }
@@ -217,7 +204,10 @@ const mapStateToProps = ({ apd: { byId, fetching } }) => ({
 });
 const mapDispatchToProps = { selectApd };
 
-export default connect(mapStateToProps, mapDispatchToProps)(CurrentDocuments);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(CurrentDocuments);
 
 export {
   CurrentDocuments as plain,

--- a/web/src/containers/__snapshots__/StateDashboardCurrentDocuments.test.js.snap
+++ b/web/src/containers/__snapshots__/StateDashboardCurrentDocuments.test.js.snap
@@ -14375,47 +14375,10 @@ ShallowWrapper {
     "nodeType": "host",
     "props": Object {
       "children": Array [
-        Array [
-          <DocumentItem
-            buttonClick={[Function]}
-            name="APD for 1, 2, 3"
-            status={Symbol(draft)}
-          />,
-        ],
         <DocumentItem
           buttonClick={[Function]}
-          name="Ex: APD in draft"
+          name="APD for 1, 2, 3"
           status={Symbol(draft)}
-        />,
-        <DocumentItem
-          buttonClick={[Function]}
-          name="Ex: APD in review"
-          status={Symbol(in review)}
-        />,
-        <DocumentItem
-          buttonClick={[Function]}
-          name="Ex: Reviewed, with comments"
-          status={Symbol(awaiting state response)}
-        />,
-        <DocumentItem
-          buttonClick={[Function]}
-          name="Ex: In clearance"
-          status={Symbol(in clearance)}
-        />,
-        <DocumentItem
-          buttonClick={[Function]}
-          name="Ex: Approved"
-          status={Symbol(approved)}
-        />,
-        <DocumentItem
-          buttonClick={[Function]}
-          name="Ex: Disapproved"
-          status={Symbol(disapproved)}
-        />,
-        <DocumentItem
-          buttonClick={[Function]}
-          name="Ex: Withdrawn"
-          status={Symbol(withdrawn)}
         />,
       ],
     },
@@ -14434,97 +14397,6 @@ ShallowWrapper {
         "rendered": null,
         "type": [Function],
       },
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "function",
-        "props": Object {
-          "buttonClick": [Function],
-          "name": "Ex: APD in draft",
-          "status": Symbol(draft),
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "function",
-        "props": Object {
-          "buttonClick": [Function],
-          "name": "Ex: APD in review",
-          "status": Symbol(in review),
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "function",
-        "props": Object {
-          "buttonClick": [Function],
-          "name": "Ex: Reviewed, with comments",
-          "status": Symbol(awaiting state response),
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "function",
-        "props": Object {
-          "buttonClick": [Function],
-          "name": "Ex: In clearance",
-          "status": Symbol(in clearance),
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "function",
-        "props": Object {
-          "buttonClick": [Function],
-          "name": "Ex: Approved",
-          "status": Symbol(approved),
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "function",
-        "props": Object {
-          "buttonClick": [Function],
-          "name": "Ex: Disapproved",
-          "status": Symbol(disapproved),
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "function",
-        "props": Object {
-          "buttonClick": [Function],
-          "name": "Ex: Withdrawn",
-          "status": Symbol(withdrawn),
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
     ],
     "type": "div",
   },
@@ -14535,47 +14407,10 @@ ShallowWrapper {
       "nodeType": "host",
       "props": Object {
         "children": Array [
-          Array [
-            <DocumentItem
-              buttonClick={[Function]}
-              name="APD for 1, 2, 3"
-              status={Symbol(draft)}
-            />,
-          ],
           <DocumentItem
             buttonClick={[Function]}
-            name="Ex: APD in draft"
+            name="APD for 1, 2, 3"
             status={Symbol(draft)}
-          />,
-          <DocumentItem
-            buttonClick={[Function]}
-            name="Ex: APD in review"
-            status={Symbol(in review)}
-          />,
-          <DocumentItem
-            buttonClick={[Function]}
-            name="Ex: Reviewed, with comments"
-            status={Symbol(awaiting state response)}
-          />,
-          <DocumentItem
-            buttonClick={[Function]}
-            name="Ex: In clearance"
-            status={Symbol(in clearance)}
-          />,
-          <DocumentItem
-            buttonClick={[Function]}
-            name="Ex: Approved"
-            status={Symbol(approved)}
-          />,
-          <DocumentItem
-            buttonClick={[Function]}
-            name="Ex: Disapproved"
-            status={Symbol(disapproved)}
-          />,
-          <DocumentItem
-            buttonClick={[Function]}
-            name="Ex: Withdrawn"
-            status={Symbol(withdrawn)}
           />,
         ],
       },
@@ -14589,97 +14424,6 @@ ShallowWrapper {
             "buttonClick": [Function],
             "name": "APD for 1, 2, 3",
             "status": Symbol(draft),
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "buttonClick": [Function],
-            "name": "Ex: APD in draft",
-            "status": Symbol(draft),
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "buttonClick": [Function],
-            "name": "Ex: APD in review",
-            "status": Symbol(in review),
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "buttonClick": [Function],
-            "name": "Ex: Reviewed, with comments",
-            "status": Symbol(awaiting state response),
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "buttonClick": [Function],
-            "name": "Ex: In clearance",
-            "status": Symbol(in clearance),
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "buttonClick": [Function],
-            "name": "Ex: Approved",
-            "status": Symbol(approved),
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "buttonClick": [Function],
-            "name": "Ex: Disapproved",
-            "status": Symbol(disapproved),
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "buttonClick": [Function],
-            "name": "Ex: Withdrawn",
-            "status": Symbol(withdrawn),
           },
           "ref": null,
           "rendered": null,


### PR DESCRIPTION
Just what it says on the tin.  Those things are confusing and shouldn't be there - they were only ever meant to demo what the various status/progress things might look like.  Now that we've moved on from that, they're just noise!

### This pull request changes...
- state dashboard should only show active APDs in the "Current Statuses" section

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author

### This feature is done when...
- [ ] Design has approved the experience
- [ ] Product has approved the experience
