### PR TITLE
[WIP] Instruction text prototype demo

### DIFF
--- a/web/src/components/Instruction.js
+++ b/web/src/components/Instruction.js
@@ -4,12 +4,7 @@ import React from 'react';
 import Md from '../components/Md';
 import { t } from '../i18n';
 
-const HelpText = ({ children }) => (
-  <Md content={children} wrapper="p" className="mb2 text-s alert alert-info" />
-);
-HelpText.propTypes = {
-  children: PropTypes.node.isRequired
-};
+const md = (content, props) => <Md content={content} wrapper="p" {...props} />;
 
 const Instruction = ({ reverse, source }) => {
   const heading = t([source, 'heading'], { defaultValue: false });
@@ -20,10 +15,10 @@ const Instruction = ({ reverse, source }) => {
   return (
     <div>
       {heading && <h3>{heading}</h3>}
-      {reverse && detail && <p>{detail}</p>}
+      {reverse && detail && md(detail)}
       {short && <p className="strong">{short}</p>}
-      {!reverse && detail && <p>{detail}</p>}
-      {helpText && <HelpText>{helpText}</HelpText>}
+      {!reverse && detail && md(detail)}
+      {helpText && md(helpText, { className: 'mb2 text-s alert alert-info' })}
     </div>
   );
 };

--- a/web/src/components/Section.js
+++ b/web/src/components/Section.js
@@ -3,6 +3,7 @@ import React, { Fragment } from 'react';
 
 import Collapsible from './Collapsible';
 import HelpText from './HelpText';
+import Instruction from './Instruction';
 import { t } from '../i18n';
 
 const SectionTitle = ({ children }) => (
@@ -47,6 +48,17 @@ Section.defaultProps = {
 
 const SubsectionChunk = ({ children, resource }) => {
   const subheader = t([resource, 'subheader'], { defaultValue: false });
+
+  if (t([resource, 'instruction'], { defaultValue: false })) {
+    // If this subsection has been converted to use instructions, return that.
+
+    return (
+      <Fragment>
+        <Instruction source={`${resource}.instruction`} />
+        {children}
+      </Fragment>
+    );
+  }
 
   return (
     <Fragment>

--- a/web/src/containers/ApdSummary.js
+++ b/web/src/containers/ApdSummary.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 
 import { updateApd as updateApdAction } from '../actions/apd';
 import { RichText } from '../components/Inputs';
+import Instruction from '../components/Instruction';
 import { Section, Subsection } from '../components/Section';
 import HelpText from '../components/HelpText';
 import { t } from '../i18n';
@@ -53,35 +54,28 @@ class ApdSummary extends Component {
             ))}
           </div>
           <div className="mb3">
-            <div className="bold">{t('apd.introduction.title')}</div>
-            <HelpText
-              text="apd.introduction.helpText"
-              reminder="apd.introduction.reminder"
-            />
+            <Instruction source="apd.introduction.instruction" />
             <RichText
               content={programOverview}
               onSync={this.syncRichText('programOverview')}
             />
           </div>
           <div className="mb3">
-            <div className="bold">{t('apd.hit.title')}</div>
-            <HelpText text="apd.hit.helpText" reminder="apd.hit.reminder" />
+            <Instruction source="apd.hit.instruction" />
             <RichText
               content={narrativeHIT}
               onSync={this.syncRichText('narrativeHIT')}
             />
           </div>
           <div className="mb3">
-            <div className="bold">{t('apd.hie.title')}</div>
-            <HelpText text="apd.hie.helpText" reminder="apd.hie.reminder" />
+            <Instruction source="apd.hie.instruction" />
             <RichText
               content={narrativeHIE}
               onSync={this.syncRichText('narrativeHIE')}
             />
           </div>
           <div>
-            <div className="bold">{t('apd.mmis.title')}</div>
-            <HelpText text="apd.mmis.helpText" reminder="apd.mmis.reminder" />
+            <Instruction source="apd.mmis.instruction" />
             <RichText
               content={narrativeMMIS}
               onSync={this.syncRichText('narrativeMMIS')}
@@ -101,6 +95,9 @@ ApdSummary.propTypes = {
 const mapStateToProps = ({ apd: { data } }) => ({ apd: data });
 const mapDispatchToProps = { updateApd: updateApdAction };
 
-export default connect(mapStateToProps, mapDispatchToProps)(ApdSummary);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ApdSummary);
 
 export { ApdSummary as plain, mapStateToProps, mapDispatchToProps };

--- a/web/src/i18n/locales/en/apd/apd.yaml
+++ b/web/src/i18n/locales/en/apd/apd.yaml
@@ -5,49 +5,54 @@ helpText: >-
   future vision, and how the program is positioned within the state. This
   information is similar to the content from the IAPD executive summary
   template section.
+
 overview:
   title: Program Overview
-  helpText: >-
-    Provide a high level summary of the state program including history,
-    and future vision. Include history and summary of future vision of the
-    state program.
-  reminder: >-
-
+  instruction:
+    detail: >-
+      Provide a high level summary of the state program including history,
+      and future vision. Include history and summary of future vision of the
+      state program.
   yearsCovered: Choose the federal fiscal year(s) this APD covers.
 
 introduction:
-  title: Program Introduction
-  helpText: >-
-    Provide an introduction for the program including context, history, and the state's future vision.
+  instruction:
+    heading: Program Introduction
+    detail: >-
+      Provide an introduction for the program including context, history, and
+      the state's future vision.
 
 hit:
-  title: HIT Overview
-  helpText: >-
-    Briefly summarize planned HIT funded activities contained within this APD.
-  reminder: >-
+  instruction:
+    heading: HIT Overview
+    detail: >-
+      Briefly summarize planned HIT funded activities contained within this
+      APD.
 
 hie:
-  title: HIE Overview
-  helpText: >-
-    Summarize planned HIE funded activities within this APD.
+  instruction:
+    heading: HIE Overview
+    detail: >-
+      Summarize planned HIE funded activities within this APD.
 
-    (1) Description of the state's HIE approach (statewide, sub-state
-    health information office (HIOs), etc.);
+      (1) Description of the state's HIE approach (statewide, sub-state
+      health information office (HIOs), etc.);
 
-    (2) Anticipated risks and mitigation strategies;
+      (2) Anticipated risks and mitigation strategies;
 
-    (3) The short and long term value proposition to providers;
+      (3) The short and long term value proposition to providers;
 
-    (4) The role of state government in governance and policy-setting.
-  reminder: >-
-    CMS recommends states connect to regional CMS HITECH contacts prior to
-    developing HIE funding request. HIE funding requests are complex. Early
-    consultation with CMS facilitates a more efficient approval process. (If
-    there are no HIE activities, skip this section.)
+      (4) The role of state government in governance and policy-setting.
+    helpText: >-
+      CMS recommends states connect to regional CMS HITECH contacts prior to
+      developing HIE funding request. HIE funding requests are complex. Early
+      consultation with CMS facilitates a more efficient approval process. (If
+      there are no HIE activities, skip this section.)
 
 mmis:
-  title: MMIS Overview
-  helpText: >-
-    Briefly summarize planned MMIS funded activities contained within this APD.
-  reminder: >-
-    If there are no MMIS activities, skip this section.
+  instruction:
+    heading: MMIS Overview
+    detail: >-
+      Briefly summarize planned MMIS funded activities contained within this APD.
+    helpText: >-
+      If there are no MMIS activities, skip this section.


### PR DESCRIPTION
Related to #1088.  Demo of how the YAML file might be structured with the proposal from that issue.  Also shows the level of code change involved in addition to the YAML changes.  (Pretty light.)

With this change, the YAML for all of our *subsections* could be switched over to the new `instruction` format - a subsection is inside the collapsible white boxes.  By adding an `instruction` section to the appropriate place in the YAML, the subsection will switch over to using that instead of the old `helpText`/`reminder` - but only for the topmost content.  If there's more than one block of instruction text in the subsection, we'll need to go update the code for those.

The program summary -> program overview subsection YAML was updated to the `instruction` format.  Also, the code was modified to expect the `instruction` format for the other instruction blocks within the subsection.

cc: @jameshupp.  We can pair up sometime to make sure this actually fits with what you intended and makes sense.

### This pull request changes...
- switches some components to use new `instruction` YAML format
- tests intentionally left failing so we don't accidentally merge it

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented

### This feature is done when...
- [ ] Design has approved the experience
- [ ] Product has approved the experience
