### PR TITLE
Hush the Github bot

### DIFF
--- a/bin/deploy-pr.sh
+++ b/bin/deploy-pr.sh
@@ -31,6 +31,7 @@ if [ -n "$CI_PULL_REQUESTS" ] && [ "$WEBCHANGES" -ne 0 ]; then
   BUCKET_URI="s3://pr$PRNUM.hitech.eapd.cms.gov"
   BUCKET_POLICY='{"Version":"2012-10-17","Statement":[{"Sid":"PublicReadGetObject","Effect":"Allow","Principal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::'"$BUCKET"'/*"}]}'
   aws s3 mb $BUCKET_URI
+  DEPLOYED_URL="http://$BUCKET.s3-website-us-east-1.amazonaws.com/"
   
   cd web/dist
   for filename in *.*; do
@@ -49,17 +50,17 @@ if [ -n "$CI_PULL_REQUESTS" ] && [ "$WEBCHANGES" -ne 0 ]; then
   aws s3api put-bucket-policy --bucket $BUCKET --policy "$BUCKET_POLICY"
   cd ../..
 
-  # Delete comment on Github, if there's one already
+  # Update the comment on Github, if there's one already.  This way we'll know the bot updated the thing.
   COMMENTS=$(curl -s -u "$GH_BOT_USER:$GH_BOT_PASSWORD" https://api.github.com/repos/18f/cms-hitech-apd/issues/$PRNUM/comments | jq -c -r '.[] | {id:.id,user:.user.login}' | grep "$GH_BOT_USER" || true)
   if [ "$COMMENTS" ]; then
     ID=$(echo "$COMMENTS" | jq -c -r .id)
-    curl -s -u "$GH_BOT_USER:$GH_BOT_PASSWORD" -X DELETE "https://api.github.com/repos/18f/cms-hitech-apd/issues/comments/$ID"
+    # Use $ before the body to use ANSI encoding, which preserves the newlines.
+    # Add the commit SHA so we know it deployed and when.
+    curl -s -u "$GH_BOT_USER:$GH_BOT_PASSWORD" -d $'{"body":"See this pull request in action: '"$DEPLOYED_URL"'\n\n'"$CIRCLE_SHA1"'"}' -H "Content-Type: application/json" -X PATCH "https://api.github.com/repos/18f/cms-hitech-apd/issues/comments/$ID"
+  else
+    # Post a new message if one doesn't already exist.
+    curl -s -u "$GH_BOT_USER:$GH_BOT_PASSWORD" -d '{"body":"See this pull request in action: '"$DEPLOYED_URL"'"}' -H "Content-Type: application/json" -X POST "https://api.github.com/repos/18f/cms-hitech-apd/issues/$PRNUM/comments"
   fi
-
-  # Post again.  This way we'll know the bot updated the thing.
-  URL="http://$BUCKET.s3-website-us-east-1.amazonaws.com/"
-  curl -s -u "$GH_BOT_USER:$GH_BOT_PASSWORD" -d '{"body":"See this pull request in action: '"$URL"'"}' -H "Content-Type: application/json" -X POST "https://api.github.com/repos/18f/cms-hitech-apd/issues/$PRNUM/comments"
-
 
 elif [ "$WEBCHANGES" -eq 0 ]; then
   echo "No changes to /web"


### PR DESCRIPTION
Update the per-PR deployment so that if the PR has already been deployed, the @cms-eapd-bot will update the existing message instead of posting a new one.  The bot also adds the git commit SHA to the message so we'll be able to see when it deployed last, in case of problems.

### This pull request changes...
- the bot shouldn't send as many emails

### This pull request is ready to merge when...
- [ ] This code has been reviewed by someone other than the original author