### PR TITLE
Adding the CMS COR

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -31,6 +31,7 @@
     "Heather Battaglia",
     "Ronald Bronson",
     "Nicole Fenton",
+    "Eghosa Guobadia",
     "James Hupp",
     "Meghana Khandekar",
     "Jerome Lee",


### PR DESCRIPTION
Work doesn't continue without our CMS COR. I would like to add Eg to our list of contributors, but would be OK if we created a "Special Thanks" somewhere in the app as an alternative.

### This pull request changes...
- No visible changes. Only updates contributors.

### This feature is done when...
- [ ] Dev is sure this doesn't crash the app
- [x] Someone on product (other than me) has approved this change
