### PR TITLE
Convert SI prefixes on currency to thousands-scale prefixes

### DIFF
--- a/bin/deploy-pr.sh
+++ b/bin/deploy-pr.sh
@@ -33,7 +33,7 @@ if [ -n "$CI_PULL_REQUESTS" ] && [ "$WEBCHANGES" -ne 0 ]; then
   aws s3 mb $BUCKET_URI
   DEPLOYED_URL="http://$BUCKET.s3-website-us-east-1.amazonaws.com/"
   
-  aws s3 sync web/dist $BUCKET_RUI
+  aws s3 sync web/dist $BUCKET_URI
   aws s3 website $BUCKET_URI --index-document index.html
   aws s3api put-bucket-policy --bucket $BUCKET --policy "$BUCKET_POLICY"
 

--- a/web/src/util/formats.js
+++ b/web/src/util/formats.js
@@ -15,5 +15,15 @@ export const formatPerc = (x, n = 0) => fmt(x, `+.${n}%`);
 export const formatMoney = (x, smN = 0, lgN = 3) => {
   if (!isNumeric(x)) return '--';
   const spec = +x < BIG_NUMBER_THRESHOLD ? `$,.${smN}f` : `$,.${lgN}~s`;
-  return format(spec)(x);
+
+  // d3-format uses SI prefixes, so replace the prefix
+  // with one that makes more sense for currency.
+  //  IN                        OUT
+  //   M -> mega, million -----> M
+  //   G -> giga, billion -----> B
+  //   T -> tera, trillion ----> T
+  //   P -> peta, quadrillion -> Q
+  return format(spec)(x)
+    .replace(/G$/, 'B')
+    .replace(/P$/, 'Q');
 };

--- a/web/src/util/formats.test.js
+++ b/web/src/util/formats.test.js
@@ -23,6 +23,12 @@ describe('formatting util', () => {
     expect(formatMoney(999999)).toEqual('$999,999');
     expect(formatMoney(1234567)).toEqual('$1.23M');
     expect(formatMoney(1200000)).toEqual('$1.2M');
+
+    // Make sure we convert from SI prefixes to currency initialisms
+    expect(formatMoney(1230000000)).toEqual('$1.23B');
+    expect(formatMoney(1230000000000)).toEqual('$1.23T');
+    expect(formatMoney(1230000000000000)).toEqual('$1.23Q');
+
     expect(formatMoney('hello')).toEqual('--');
   });
 


### PR DESCRIPTION
Fixes #1225

### This pull request changes...
- Dollar amounts in the billions or quadrillions will now display the correct suffixes
- `$1.23G` becomes `$1.23T`

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- ~The change has been documented~
  - ~Associated OpenAPI documentation has been updated~

### This feature is done when...
- ~Design has approved the experience~
- [ ] Product has approved the experience
