### PR TITLE
Clarify what Payment and Count are

### DIFF
--- a/web/src/i18n/locales/en/proposedBudget.yaml
+++ b/web/src/i18n/locales/en/proposedBudget.yaml
@@ -21,5 +21,6 @@ paymentsByFFYQuarter:
   title: Incentive Payments by FFY Quarter
   helpText: >-
     Use this table to capture incentive payments for Eligible Hospitals (EHs) and
-    Eligible Professionals (EPs). Provide the amount paid (Payments) and number
-    of payments (Count) by quarter. The table will calculate yearly totals automatically.
+    Eligible Professionals (EPs). Provide the total amount paid (Payments) and the
+    number of providers who received payments (Count) for each quarter. The table will
+    calculate yearly totals automatically.

--- a/web/src/i18n/locales/en/proposedBudget.yaml
+++ b/web/src/i18n/locales/en/proposedBudget.yaml
@@ -21,5 +21,5 @@ paymentsByFFYQuarter:
   title: Incentive Payments by FFY Quarter
   helpText: >-
     Use this table to capture incentive payments for Eligible Hospitals (EHs) and
-    Eligible Professionals (EPs). Provide payments and counts, and the table will
-    calculate totals automatically.
+    Eligible Professionals (EPs). Provide the amount paid (Payments) and number
+    of payments (Count) by quarter. The table will calculate yearly totals automatically.


### PR DESCRIPTION
Addresses #1164.

I went back and forth on this for a bit, trying to figure out how to say `EH Payments` differently in the table, but I think it works way better to change the instruction copy. Now it explains those words more clearly; the words are unchanged. (This has the bonus benefit of not requiring any code, which changing table headers would have required. I don't really like that setup fwiw.) I also got a bit more specific about "calculate"; the previous wording made it seem like `payments` may mean amount per payment.

No need for an accessibility audit, as this only changes text that was confusing in the first place.

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)

### This feature is done when...
- [ ] Design has approved the experience
- [ ] Product has approved the experience