### PR TITLE
Fix 404 on routes other than /

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,7 @@
     "storybook": "start-storybook -p 9001 -c .storybook",
     "build-storybook": "build-storybook -c .storybook -o .storybook-dist/public",
     "make-state-icons": "babel-node scripts/stateIcons.js",
-    "scaffold": "mkdir -p dist && cp src/index.html dist/ && cp -r src/static dist/",
+    "scaffold": "mkdir -p dist && cp src/index.html dist/ && cp ../Staticfile dist/ && cp -r src/static dist/",
     "build": "npm run scaffold && NODE_ENV=production webpack -p",
     "lint": "eslint 'src/**/*.js'",
     "start": "webpack-dev-server --config webpack.config.dev.js",


### PR DESCRIPTION
I removed the part of our deploy that copied the Staticfile configuration into our distributable package.  For some reason I thought we weren't using it anymore, but that's not right.  😬  This PR puts it back.

### This pull request changes...
- locations other than `/` will work again

- [ ] Product has approved the experience
