### PR TITLE
Don't allow users to update their own email address

### DIFF
--- a/api/routes/me/__snapshots__/put.endpoint.js.snap
+++ b/api/routes/me/__snapshots__/put.endpoint.js.snap
@@ -28,7 +28,7 @@ Object {
     "id": "mn",
     "name": "Minnesota",
   },
-  "username": "bob@burgers.com",
+  "username": "all-permissions-and-state",
 }
 `;
 
@@ -60,13 +60,7 @@ Object {
     "id": "mn",
     "name": "Minnesota",
   },
-  "username": "bob@burgers.com",
-}
-`;
-
-exports[`/me endpoint | PUT when authenticated rejects when changing email address to something held by another account 1`] = `
-Object {
-  "error": "update-self-email-exists",
+  "username": "all-permissions-and-state",
 }
 `;
 

--- a/api/routes/me/openAPI.js
+++ b/api/routes/me/openAPI.js
@@ -67,7 +67,32 @@ const openAPI = {
     put: {
       tags: ['Users'],
       summary: `Updates the current user's information`,
-      description: `Update information about the current user.  Only the email, name, password, phone, and position fields can be updated.`,
+      description: `Update information about the current user.  Only the name, password, phone, and position fields can be updated.`,
+      requestBody: {
+        description: 'The new values for the apd.  All fields are optional.',
+        required: true,
+        content: jsonResponse({
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+              description: `The user's updated name. Omit to leave unchanged.`
+            },
+            password: {
+              type: 'string',
+              description: `The user's updated password. Omit to leave unchanged.`
+            },
+            phone: {
+              type: 'string',
+              description: `The user's updated phone number. Omit to leave unchanged.`
+            },
+            position: {
+              type: 'string',
+              description: `The user's updated position. Omit to leave unchanged.`
+            }
+          }
+        })
+      },
       responses: {
         200: {
           description: 'The current user',

--- a/api/routes/me/put.endpoint.js
+++ b/api/routes/me/put.endpoint.js
@@ -24,10 +24,6 @@ describe('/me endpoint | PUT', () => {
   describe('when authenticated', () => {
     [
       [
-        'rejects when changing email address to something held by another account',
-        { email: 'no-permissions' }
-      ],
-      [
         'rejects when changing password to something insufficiently complex',
         { password: 'abc123' }
       ],
@@ -65,7 +61,7 @@ describe('/me endpoint | PUT', () => {
       const {
         response: { statusCode },
         body
-      } = await put({ email: 'bob@burgers.com', position: 'cook' });
+      } = await put({ position: 'cook' });
 
       const afterUser = await db('users')
         .where({ id: 2000 })
@@ -73,7 +69,6 @@ describe('/me endpoint | PUT', () => {
 
       expect(afterUser).toMatchObject({
         ...beforeUser,
-        email: 'bob@burgers.com',
         position: 'cook'
       });
       expect(statusCode).toEqual(200);
@@ -111,7 +106,6 @@ describe('/me endpoint | PUT', () => {
       // validate that the state_id and auth_role weren't changed
       expect(afterUser).toMatchObject({
         ...beforeUser,
-        email: 'bob@burgers.com',
         name: 'Bob Belcher',
         password: expect.stringMatching(/.+/),
         position: 'cook',

--- a/api/routes/me/put.js
+++ b/api/routes/me/put.js
@@ -2,7 +2,7 @@ const logger = require('../../logger')('me route put');
 const loggedIn = require('../../middleware').loggedIn;
 const deserializeUser = require('../../auth/serialization').deserializeUser;
 
-const editableFields = ['email', 'name', 'password', 'phone', 'position'];
+const editableFields = ['name', 'password', 'phone', 'position'];
 
 const getUserJSON = user => ({
   // Send back state info and get rid of the model object

--- a/api/routes/me/put.test.js
+++ b/api/routes/me/put.test.js
@@ -107,9 +107,9 @@ tap.test('me PUT endpoint', async endpointTest => {
       });
 
       const fieldsAreUpdated = test => {
-        test.ok(
-          req.user.model.set.calledWith('email', 'new email'),
-          'email is updated'
+        test.notOk(
+          req.user.model.set.calledWith('email'),
+          'email is NOT updated'
         );
         test.ok(
           req.user.model.set.calledWith('name', 'new name'),

--- a/api/routes/openAPI/__snapshots__/get.endpoint.js.snap
+++ b/api/routes/openAPI/__snapshots__/get.endpoint.js.snap
@@ -1663,7 +1663,36 @@ Object {
         ],
       },
       "put": Object {
-        "description": "Update information about the current user.  Only the email, name, password, phone, and position fields can be updated.",
+        "description": "Update information about the current user.  Only the name, password, phone, and position fields can be updated.",
+        "requestBody": Object {
+          "content": Object {
+            "application/json": Object {
+              "schema": Object {
+                "properties": Object {
+                  "name": Object {
+                    "description": "The user's updated name. Omit to leave unchanged.",
+                    "type": "string",
+                  },
+                  "password": Object {
+                    "description": "The user's updated password. Omit to leave unchanged.",
+                    "type": "string",
+                  },
+                  "phone": Object {
+                    "description": "The user's updated phone number. Omit to leave unchanged.",
+                    "type": "string",
+                  },
+                  "position": Object {
+                    "description": "The user's updated position. Omit to leave unchanged.",
+                    "type": "string",
+                  },
+                },
+                "type": "object",
+              },
+            },
+          },
+          "description": "The new values for the apd.  All fields are optional.",
+          "required": true,
+        },
         "responses": Object {
           "200": Object {
             "content": Object {


### PR DESCRIPTION
Closes #1360

### This pull request changes...
- updates the `PUT /me` route to ignore email addresses

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [x] The change has been documented
  - [x] Associated OpenAPI documentation has been updated