### PR TITLE
Un-collapse subsection accordions

### DIFF
--- a/web/src/components/Collapsible.js
+++ b/web/src/components/Collapsible.js
@@ -33,7 +33,7 @@ class Collapsible extends Component {
     const replaceSpaces = / /g;
     const removeColon = /:/g;
     const removeCarat = /›/g;
-    const slug = `${title.replace(replaceSpaces, '-').replace(removeColon, '').replace(removeCarat, '').toLowerCase()}`;
+    const slug = title.replace(replaceSpaces, '-').replace(removeColon, '').replace(removeCarat, '').toLowerCase();
     const contentId = `collapsible-${slug}`;
 
     let btnClass = deline`

--- a/web/src/components/Collapsible.js
+++ b/web/src/components/Collapsible.js
@@ -1,5 +1,4 @@
 import deline from 'deline';
-import kebabCase from 'lodash.kebabcase';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
@@ -31,7 +30,11 @@ class Collapsible extends Component {
     const { open: openState } = this.state;
 
     const isOpen = onChange ? openProp : openState;
-    const contentId = `collapsible-${kebabCase(title)}`;
+    const replaceSpaces = / /g;
+    const removeColon = /:/g;
+    const removeCarat = /›/g;
+    const slug = `${title.replace(replaceSpaces, '-').replace(removeColon, '').replace(removeCarat, '').toLowerCase()}`;
+    const contentId = `collapsible-${slug}`;
 
     let btnClass = deline`
       btn btn-collapse block col-12 py2 sm-px3 h3 sm-h2 line-height-1 left-align

--- a/web/src/components/Collapsible.js
+++ b/web/src/components/Collapsible.js
@@ -50,7 +50,7 @@ class Collapsible extends Component {
     `;
 
     return (
-      <div id={id} className={`mb3 bg-${bgColor} rounded shadow accordian`}>
+      <div id={id} className={`mt3 mb3 bg-${bgColor} rounded shadow accordian`}>
         <button
           type="button"
           className={btnClass}

--- a/web/src/components/Section.js
+++ b/web/src/components/Section.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Fragment } from 'react';
 
-import Collapsible from './Collapsible';
 import Instruction from './Instruction';
 import { t } from '../i18n';
 
@@ -52,10 +51,16 @@ const Subsection = ({ children, id, nested, open, resource }) => {
   const title = t([resource, 'title'], { defaultValue: '' });
 
   return (
-    <Collapsible id={id} title={title} open={open} nested={nested}>
+    <Fragment>
+      <h3
+        id={id}
+        className='subsection--title'
+      >
+        {title}
+      </h3>
       <Instruction source={`${resource}.instruction`} />
       {children}
-    </Collapsible>
+    </Fragment>
   );
 };
 

--- a/web/src/components/Section.js
+++ b/web/src/components/Section.js
@@ -47,17 +47,27 @@ Section.defaultProps = {
   isNumbered: false
 };
 
-const Subsection = ({ children, id, nested, open, resource }) => {
+const Subsection = ({ children, id, nested, resource }) => {
   const title = t([resource, 'title'], { defaultValue: '' });
 
   return (
     <Fragment>
-      <h3
-        id={id}
-        className='subsection--title ds-h3'
-      >
-        {title}
-      </h3>
+      {!nested &&
+        <h3
+          id={id}
+          className='subsection--title ds-h3'
+        >
+          {title}
+        </h3>
+      }
+      {nested &&
+        <h4
+          id={id}
+          className='ds-h3'
+        >
+          {title}
+        </h4>
+      }
       <Instruction source={`${resource}.instruction`} />
       {children}
     </Fragment>
@@ -68,7 +78,6 @@ Subsection.propTypes = {
   children: PropTypes.node.isRequired,
   id: PropTypes.string,
   nested: PropTypes.bool,
-  open: PropTypes.bool,
   resource: PropTypes.string
 };
 
@@ -76,7 +85,6 @@ Subsection.defaultProps = {
   resource: null,
   id: null,
   nested: false,
-  open: false
 };
 
 export default Section;

--- a/web/src/components/Section.js
+++ b/web/src/components/Section.js
@@ -54,7 +54,7 @@ const Subsection = ({ children, id, nested, open, resource }) => {
     <Fragment>
       <h3
         id={id}
-        className='subsection--title'
+        className='subsection--title ds-h3'
       >
         {title}
       </h3>

--- a/web/src/components/__snapshots__/Collapsible.test.js.snap
+++ b/web/src/components/__snapshots__/Collapsible.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Collapsible component renders correctly in the default case 1`] = `
 <div
-  className="mb3 bg-white rounded shadow accordian"
+  className="mt3 mb3 bg-white rounded shadow accordian"
   id={null}
 >
   <button
@@ -57,7 +57,7 @@ exports[`Collapsible component renders correctly in the default case 1`] = `
 
 exports[`Collapsible component renders correctly when open 1`] = `
 <div
-  className="mb3 bg-white rounded shadow accordian"
+  className="mt3 mb3 bg-white rounded shadow accordian"
   id={null}
 >
   <button
@@ -112,7 +112,7 @@ exports[`Collapsible component renders correctly when open 1`] = `
 
 exports[`Collapsible component sets sticky class if enabled 1`] = `
 <div
-  className="mb3 bg-white rounded shadow accordian"
+  className="mt3 mb3 bg-white rounded shadow accordian"
   id={null}
 >
   <button
@@ -167,7 +167,7 @@ exports[`Collapsible component sets sticky class if enabled 1`] = `
 
 exports[`Collapsible component toggles from closed to open 1`] = `
 <div
-  className="mb3 bg-white rounded shadow accordian"
+  className="mt3 mb3 bg-white rounded shadow accordian"
   id={null}
 >
   <button
@@ -222,7 +222,7 @@ exports[`Collapsible component toggles from closed to open 1`] = `
 
 exports[`Collapsible component toggles from open to closed 1`] = `
 <div
-  className="mb3 bg-white rounded shadow accordian"
+  className="mt3 mb3 bg-white rounded shadow accordian"
   id={null}
 >
   <button

--- a/web/src/components/__snapshots__/ProposedBudget.test.js.snap
+++ b/web/src/components/__snapshots__/ProposedBudget.test.js.snap
@@ -9,7 +9,6 @@ exports[`ProposedBudget component renders correctly 1`] = `
   <Subsection
     id="budget-summary-table"
     nested={false}
-    open={false}
     resource="proposedBudget.summaryBudget"
   >
     <Connect(BudgetSummary) />
@@ -17,7 +16,6 @@ exports[`ProposedBudget component renders correctly 1`] = `
   <Subsection
     id="budget-federal-by-quarter"
     nested={false}
-    open={false}
     resource="proposedBudget.quarterlyBudget"
   >
     <Connect(QuarterlyBudgetSummary) />
@@ -25,7 +23,6 @@ exports[`ProposedBudget component renders correctly 1`] = `
   <Subsection
     id="budget-incentive-by-quarter"
     nested={false}
-    open={false}
     resource="proposedBudget.paymentsByFFYQuarter"
   >
     <Connect(IncentivePayments) />

--- a/web/src/components/__snapshots__/Section.test.js.snap
+++ b/web/src/components/__snapshots__/Section.test.js.snap
@@ -49,22 +49,18 @@ exports[`SectionTitle component renders correctly 1`] = `
 `;
 
 exports[`Subsection component renders correctly 1`] = `
-<Collapsible
-  bgColor="white"
-  btnBgColor="white"
-  btnColor="blue"
-  id={null}
-  nested={false}
-  onChange={null}
-  open={false}
-  sticky={true}
-  title="Performance Goals and Benchmarks"
->
+<Fragment>
+  <h3
+    className="subsection--title ds-h3"
+    id={null}
+  >
+    Performance Goals and Benchmarks
+  </h3>
   <Instruction
     args={null}
     reverse={false}
     source="activities.goals.instruction"
   />
   test child
-</Collapsible>
+</Fragment>
 `;

--- a/web/src/containers/__snapshots__/ApdSummary.test.js.snap
+++ b/web/src/containers/__snapshots__/ApdSummary.test.js.snap
@@ -9,7 +9,6 @@ exports[`apd summary component renders correctly 1`] = `
   <Subsection
     id="apd-summary-overview"
     nested={false}
-    open={false}
     resource="apd.overview"
   >
     <div

--- a/web/src/containers/__snapshots__/AssurancesAndCompliance.test.js.snap
+++ b/web/src/containers/__snapshots__/AssurancesAndCompliance.test.js.snap
@@ -21,7 +21,6 @@ exports[`assurances and compliance component main component renders correctly 1`
   <Subsection
     id="assurances-compliance-fed-citations"
     nested={false}
-    open={false}
     resource="assurancesAndCompliance.citations"
   >
     <div

--- a/web/src/containers/__snapshots__/ExecutiveSummary.test.js.snap
+++ b/web/src/containers/__snapshots__/ExecutiveSummary.test.js.snap
@@ -9,7 +9,6 @@ exports[`executive summary component renders correctly 1`] = `
   <Subsection
     id="executive-summary-overview"
     nested={false}
-    open={false}
     resource="executiveSummary.summary"
   >
     <div
@@ -240,7 +239,6 @@ exports[`executive summary component renders correctly 1`] = `
   <Subsection
     id="executive-summary-budget-table"
     nested={false}
-    open={false}
     resource="executiveSummary.budgetTable"
   >
     <Connect(ExecutiveSummaryBudget) />

--- a/web/src/containers/__snapshots__/PreviousActivities.test.js.snap
+++ b/web/src/containers/__snapshots__/PreviousActivities.test.js.snap
@@ -9,7 +9,6 @@ exports[`previous activities component renders correctly if data is not loaded 1
   <Subsection
     id="prev-activities-outline"
     nested={false}
-    open={false}
     resource="previousActivities.outline"
   >
     <div
@@ -26,7 +25,6 @@ exports[`previous activities component renders correctly if data is not loaded 1
   <Subsection
     id="prev-activities-table"
     nested={false}
-    open={false}
     resource="previousActivities.actualExpenses"
   >
     <div

--- a/web/src/containers/__snapshots__/ScheduleSummary.test.js.snap
+++ b/web/src/containers/__snapshots__/ScheduleSummary.test.js.snap
@@ -9,7 +9,6 @@ exports[`schedule summary component renders correctly 1`] = `
   <Subsection
     id="schedule-summary-table"
     nested={false}
-    open={false}
     resource="scheduleSummary.main"
   >
     <ReactTable
@@ -202,7 +201,6 @@ exports[`schedule summary component renders correctly with no data 1`] = `
   <Subsection
     id="schedule-summary-table"
     nested={false}
-    open={false}
     resource="scheduleSummary.main"
   >
     <div

--- a/web/src/containers/activity/EntryDetails.js
+++ b/web/src/containers/activity/EntryDetails.js
@@ -47,7 +47,6 @@ class EntryDetails extends Component {
       <Collapsible
         id={`activity-${aKey}`}
         title={title}
-        bgColor="blue-light"
         btnBgColor="blue"
         btnColor="white"
         open={expanded}

--- a/web/src/containers/activity/__snapshots__/ContractorResources.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/ContractorResources.test.js.snap
@@ -4,7 +4,6 @@ exports[`the ContractorResources component renders correctly 1`] = `
 <Subsection
   id={null}
   nested={true}
-  open={false}
   resource="activities.contractorResources"
 >
   <div

--- a/web/src/containers/activity/__snapshots__/CostAllocate.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/CostAllocate.test.js.snap
@@ -4,7 +4,6 @@ exports[`the CostAllocate component renders correctly 1`] = `
 <Subsection
   id={null}
   nested={true}
-  open={false}
   resource="activities.costAllocate"
 >
   <div

--- a/web/src/containers/activity/__snapshots__/EntryDetails.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/EntryDetails.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`the (Activity) EntryDetails component renders correctly 1`] = `
 <Collapsible
-  bgColor="blue-light"
+  bgColor="white"
   btnBgColor="blue"
   btnColor="white"
   id="activity-activity-key"

--- a/web/src/styles/app/editor.css
+++ b/web/src/styles/app/editor.css
@@ -24,6 +24,7 @@
 
 .rdw-editor-main {
   overflow: inherit;
+  background-color: #fff;
 }
 
 .DraftEditor-root,

--- a/web/src/styles/scss/section.scss
+++ b/web/src/styles/scss/section.scss
@@ -28,7 +28,7 @@ body {
     }
   }
 
-  margin-top: $spacer-2;
+  margin-top: $spacer-6;
   padding-top: $spacer-2;
   padding-left: $number-padding-size;
   border-top: 1px solid $color-gray-dark;
@@ -36,6 +36,5 @@ body {
 
 .subsection--title {
   border-top: 1px solid $color-gray-dark;
-  padding-top: $spacer-3;
-  margin-top: $spacer-5;
+  padding-top: $spacer-2;
 }

--- a/web/src/styles/scss/section.scss
+++ b/web/src/styles/scss/section.scss
@@ -33,3 +33,9 @@ body {
   padding-left: $number-padding-size;
   border-top: 1px solid $color-gray-dark;
 }
+
+.subsection--title {
+  border-top: 1px solid $color-gray-dark;
+  padding-top: $spacer-3;
+  margin-top: $spacer-5;
+}


### PR DESCRIPTION
Closes #1344. No more accordions in sections, yay! I believe the only place the `Collapsible` element is used now is in the Activity section, to collapse activities down to a readable list. 

There is a little weirdness in those Activity sections: the `Collapsible` component passes its children to `Subsection` for reasons I don't entirely understand (I feel like it probably doesn't actually need to, but I'd like to look at this with @mgwalker). Because of this, the headings in those subsections need to be `h4` instead of `h3`. There's a little bit of repetitive code to make this work (by checking whether the subsection has a `nested` property.

<img width="759" alt="Screen Shot 2019-03-21 at 6 33 50 PM" src="https://user-images.githubusercontent.com/509309/54789159-f3c88e80-4c07-11e9-9bc2-9a233e0a0509.png">

### This pull request changes...
- Removes the `Collapsible` component from `Subsection`.
- Applies the correct heading to `Subsection` titles (including taking into account whether they are nested subsections).

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author

### This feature is done when...
- [ ] Design has approved the experience
- [ ] Product has approved the experience
