### PR TITLE
Create names/tags for our Docker images based on dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,6 +252,7 @@ workflows:
   web:
     jobs:
       - prepare dependencies cache
+      - check docker-compose image tags
       - web dependency vulnerability scan:
           requires:
             - prepare dependencies cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,19 @@ jobs:
           working_directory: ~/project/web
           command: node yaml-tests.js
 
+  check docker-compose image tags:
+    docker:
+      - image: node:10
+    steps:
+      - checkout
+      - run:
+          name: check docker-compose image tags
+          working_directory: ~/project
+          command: |
+            echo "`cat docker-compose.yml | grep -m1 cms-eapd/api: | sed 's/.*image: cms-eapd\/api://'` api/package-lock.json" > hashes.md5
+            echo "`cat docker-compose.yml | grep -m1 cms-eapd/web: | sed 's/.*image: cms-eapd\/web://'` web/package-lock.json" >> hashes.md5
+            md5sum -c hashes.md5
+
   web dependency vulnerability scan:
     docker:
       - image: node:10

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ You can also view the component Storybook at
 
 See the [testing documentation](docs/testing.md) for information about running tests.
 
+Note that our Docker configuration uses named images and tags, which can create
+orphaned images. See the [Docker configuration documentation](docs/docker.md)
+for more information.
+
 ### manually
 
 From your command line, switch to the directory where you put the code and

--- a/api/package.json
+++ b/api/package.json
@@ -14,7 +14,8 @@
     "test": "NODE_ENV=test tap -J --cov --coverage-report=lcov --no-browser --reporter=spec --test-arg=--silent '{,!(node_modules)/**/}*.test.js'",
     "test-endpoints": "jest --runInBand '.+\\.endpoint\\.js'",
     "test-specific": "NODE_ENV=test tap --cov --coverage-report=lcov --no-browser --reporter=spec",
-    "prettier": "prettier --single-quote --trailing-comma none --write \"**/*.js\""
+    "prettier": "prettier --single-quote --trailing-comma none --write \"**/*.js\"",
+    "postinstall": "sed -i'.backup' -e 's/\\(image: cms-eapd\\/api:\\).*/\\1'`md5 -q package-lock.json`'/g' ../docker-compose.yml && rm ../docker-compose.yml.backup"
   },
   "repository": {
     "type": "git",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
 
   web:
     build: ./web
+    image: cms-eapd/web:d7dbc090071212d08c163bb64cbbb191
     environment:
       - API_URL=http://localhost:8081
     volumes:
@@ -30,7 +31,7 @@ services:
       - 8080:8001
   
   storybook:
-    build: ./web
+    image: cms-eapd/web:d7dbc090071212d08c163bb64cbbb191
     volumes:
       - ./web:/app
       - /app/node_modules
@@ -40,6 +41,7 @@ services:
 
   api:
     build: ./api
+    image: cms-eapd/api:82b2ddb685da95663996230ec7c78bba
     depends_on:
       - db
     environment:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,53 @@
+# Docker
+
+Our Docker configuration consists of four containers:
+
+1. PostgreSQL database
+2. API
+3. Web app
+4. Storybook
+
+The PostgreSQL database container is based on the official image from Docker
+Hub, so there is no customization.
+
+### API
+
+The API image is built from the `/api/Dockerfile` config. The API
+`package.json` and `package-lock.json` files are added to the container and
+then `npm ci` is run. This installs packages and versions from the lockfile
+so as to closely mirror the deployed environment. Once built, The image is
+named `cms-eapd/api`. It is then tagged with the MD5 hash of the
+`api/package-lock.json` file. This way, when the `package-lock.json` changes,
+docker-compose will know to rebuild the image.
+
+When started, the container will listen on your local machine's port 8081.
+It uses [nodemon](https://npm.im/nodemon) to watch for file changes and will
+restart the API whenever it detects changes in the API source code.
+
+### Web app and Storybook
+
+The web app image is built from the `/web/Dockerfile` config. The web
+`package.json` and `package-lock.json` files are added to the container and
+then `npm ci` is run. This installs packages and versions from the lockfile
+so as to closely mirror the deployed environment. Once built, The image is
+named `cms-eapd/web`. It is then tagged with the MD5 hash of the
+`web/package-lock.json` file. This way, when the `package-lock.json` changes,
+docker-compose will know to rebuild the image.
+
+The web app and Storybook containers both use the web app image.
+
+When started, the web app container will listen on your local machine's port
+8080, and the Storybook container will listen on port 8082. The web app
+container is using [webpack-dev-server](https://npm.im/webpack-dev-server)
+and the Storybook container is doing whatever magic Storybook does, to watch
+for file changes and will rebuild the web app whenever they detect changes in
+the app source code.
+
+### Updating the image tags
+
+When you install or update dependencies, you will need to make sure the
+`docker-compose.yml` file gets updated with new tags for the API and web app
+images. Simply running `npm install` or `npm ci` in the `/api` or `/web`
+directories will update the `docker-compose.yml` file for you. Note that these
+commands must be run on your local machine, not inside one of the Docker
+containers.

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -8,6 +8,6 @@ WORKDIR /app
 ADD ./package.json .
 ADD ./package-lock.json .
 
-RUN npm install
+RUN npm ci
 
 CMD npm run start -- --public=0.0.0.0:8080

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,8 @@
     "start": "webpack-dev-server --config webpack.config.dev.js",
     "test": "jest --collectCoverage",
     "test-watch": "jest --watch",
-    "prettier": "prettier --single-quote --trailing-comma none --write \"src/**/*.js\""
+    "prettier": "prettier --single-quote --trailing-comma none --write \"src/**/*.js\"",
+    "postinstall": "sed -i'.backup' -e 's/\\(image: cms-eapd\\/web:\\).*/\\1'`md5 -q package-lock.json`'/g' ../docker-compose.yml && rm ../docker-compose.yml.backup"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR gives our web and API Docker images names and tags.  The names are `cms-eapd/web` and `cms-eapd/api`, respectively, and the tags are the MD5 hashes of their respective `package-lock.json` files.  Running `npm install` in either the web or API directories will automatically update the `docker-compose.yml` file with new tags.

Why?

By having named and tagged images, we will be able to more easily switch between branches with different dependencies.  Instead of destroying and rebuilding images every time you switch, you'll be able to switch and just run `docker-compose up` again to switch images.  If the image tag doesn't exist yet, it'll be built and then switched in, but if you already have it, it'll speed things up considerably.

Caveat: to update the tags, you'll need to run `npm install` or `npm ci` locally, not in the Docker container, because the Docker container doesn't have `md5` installed and getting the `docker-compose.yml` file injected into the container is an issue.

Downside: you'll end up with orphaned images over time, so it'll be necessary to periodically run `docker images` and use `docker rmi` to clean up old tags (or `docker image prune` to do it in one step).

### This pull request changes...
- doesn't require destroying and rebuilding images every single time you switch between branches with different dependencies

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
   - going to add a CircleCI test to verify that the tags in `docker-compose.yml` match the MD5 hashes of the two lockfiles
- [x] This code has been reviewed by someone other than the original author
- [x] The change has been documented
   - still need to update the documentation...