### PR TITLE
Highlight navbar items as the user scrolls

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8086,7 +8086,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8107,12 +8108,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8127,17 +8130,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8254,7 +8260,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8266,6 +8273,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8280,6 +8288,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8287,12 +8296,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8311,6 +8322,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8391,7 +8403,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8403,6 +8416,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8488,7 +8502,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8524,6 +8539,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8543,6 +8559,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8586,12 +8603,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -15736,6 +15755,16 @@
         "velocity-react": "^1.4.1"
       }
     },
+    "react-waypoint": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/react-waypoint/-/react-waypoint-9.0.1.tgz",
+      "integrity": "sha512-AdP1EhU5fOFne1aEfZPv2AhVC+cGJ3TxITOnZM9tBBlXOOhz3lXtTSHdicRCY+2VBqerT6zD1tAtp89Mng+Chg==",
+      "requires": {
+        "consolidated-events": "^1.1.0 || ^2.0.0",
+        "prop-types": "^15.0.0",
+        "react-is": "^16.6.3"
+      }
+    },
     "react-with-direction": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/react-with-direction/-/react-with-direction-1.3.0.tgz",
@@ -16284,6 +16313,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
+    },
+    "reselect": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
     },
     "resolve": {
       "version": "1.10.0",

--- a/web/package.json
+++ b/web/package.json
@@ -87,8 +87,10 @@
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",
     "react-table": "^6.8.6",
+    "react-waypoint": "^9.0.1",
     "redux": "^4.0.1",
     "redux-thunk": "^2.3.0",
+    "reselect": "^4.0.0",
     "updeep": "^1.0.0",
     "zxcvbn": "^4.4.2"
   },

--- a/web/src/actions/apd.test.js
+++ b/web/src/actions/apd.test.js
@@ -346,7 +346,7 @@ describe('apd actions', () => {
     });
   });
 
-  describe('fetch APD data if needed (async)', async () => {
+  describe('fetch APD data if needed (async)', () => {
     it('fetches data if it is not already loaded', async () => {
       const store = mockStore({
         apd: {

--- a/web/src/actions/navigation.js
+++ b/web/src/actions/navigation.js
@@ -1,0 +1,24 @@
+export const NAVIGATION_SCROLL_TO_WAYPOINT = Symbol(
+  'navigation : scroll to waypoint'
+);
+
+let jumping = false;
+
+export const jumpTo = waypoint => dispatch => {
+  if (waypoint) {
+    jumping = true;
+    setTimeout(() => {
+      jumping = false;
+    }, 100);
+    dispatch({ type: NAVIGATION_SCROLL_TO_WAYPOINT, data: waypoint });
+  }
+};
+
+export const scrollTo = waypoint => dispatch => {
+  if (!jumping && waypoint) {
+    dispatch({
+      type: NAVIGATION_SCROLL_TO_WAYPOINT,
+      data: waypoint
+    });
+  }
+};

--- a/web/src/actions/navigation.test.js
+++ b/web/src/actions/navigation.test.js
@@ -1,0 +1,84 @@
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import { NAVIGATION_SCROLL_TO_WAYPOINT, jumpTo, scrollTo } from './navigation';
+
+const mockStore = configureStore([thunk]);
+
+describe('navigation actions', () => {
+  describe('jumpTo sends a waypoint update action', () => {
+    it('...if there is a waypoint id', () => {
+      const store = mockStore();
+
+      store.dispatch(jumpTo('foo'));
+
+      expect(store.getActions()).toEqual([
+        {
+          type: NAVIGATION_SCROLL_TO_WAYPOINT,
+          data: 'foo'
+        }
+      ]);
+    });
+
+    it('...not if there is no waypoint id', () => {
+      const store = mockStore();
+
+      store.dispatch(jumpTo());
+
+      expect(store.getActions()).toEqual([]);
+
+      // wait until the jumping timer has passed before continuing the tests,
+      // or else it might muck things up
+      return new Promise(resolve => {
+        setTimeout(() => resolve(), 150);
+      });
+    });
+  });
+
+  describe('scrollTo sends a waypoint update action', () => {
+    it('...if there is a waypoint id', () => {
+      const store = mockStore();
+
+      store.dispatch(scrollTo('bar'));
+
+      expect(store.getActions()).toEqual([
+        {
+          type: NAVIGATION_SCROLL_TO_WAYPOINT,
+          data: 'bar'
+        }
+      ]);
+    });
+
+    it('...not if there is no waypoint id', () => {
+      const store = mockStore();
+
+      store.dispatch(scrollTo());
+
+      expect(store.getActions()).toEqual([]);
+    });
+
+    it('...not if jumpTo was called recently', () => {
+      const store = mockStore();
+
+      store.dispatch(jumpTo('one'));
+      store.dispatch(scrollTo('two'));
+
+      expect(store.getActions()).toEqual([
+        { type: NAVIGATION_SCROLL_TO_WAYPOINT, data: 'one' }
+      ]);
+
+      return new Promise(resolve => {
+        setTimeout(() => {
+          store.dispatch(scrollTo('three'));
+
+          expect(store.getActions()).toEqual([
+            { type: NAVIGATION_SCROLL_TO_WAYPOINT, data: 'one' },
+            { type: NAVIGATION_SCROLL_TO_WAYPOINT, data: 'three' }
+          ]);
+
+          resolve();
+        }, 150);
+      });
+    });
+  });
+});

--- a/web/src/components/ApdStateProfile.js
+++ b/web/src/components/ApdStateProfile.js
@@ -3,26 +3,28 @@ import React from 'react';
 import { Section, Subsection } from './Section';
 import MedicaidOffice from '../containers/ApdStateProfileMedicaidOffice';
 import KeyPersonnel from '../containers/ApdStateKeyPersonnel';
+import Waypoint from '../containers/ConnectedWaypoint';
 
 const ApdStateProfile = () => (
-  <Section
-    isNumbered
-    id="apd-state-profile"
-    resource="apd.stateProfile"
-  >
-    <Subsection
-      id="apd-state-profile-office"
-      resource="apd.stateProfile.directorAndAddress"
-    >
-      <MedicaidOffice />
-    </Subsection>
-    <Subsection
-      id="apd-state-profile-key-personnel"
-      resource="apd.stateProfile.keyPersonnel"
-    >
-      <KeyPersonnel />
-    </Subsection>
-  </Section>
+  <Waypoint id="apd-state-profile-overview">
+    <Section isNumbered id="apd-state-profile" resource="apd.stateProfile">
+      <Waypoint id="apd-state-profile-office" />
+      <Subsection
+        id="apd-state-profile-office"
+        resource="apd.stateProfile.directorAndAddress"
+      >
+        <MedicaidOffice />
+      </Subsection>
+
+      <Waypoint id="apd-state-profile-key-personnel" />
+      <Subsection
+        id="apd-state-profile-key-personnel"
+        resource="apd.stateProfile.keyPersonnel"
+      >
+        <KeyPersonnel />
+      </Subsection>
+    </Section>
+  </Waypoint>
 );
 
 export default ApdStateProfile;

--- a/web/src/components/ProposedBudget.js
+++ b/web/src/components/ProposedBudget.js
@@ -2,34 +2,38 @@ import React from 'react';
 
 import { Section, Subsection } from './Section';
 import BudgetSummary from '../containers/BudgetSummary';
+import Waypoint from '../containers/ConnectedWaypoint';
 import IncentivePayments from '../containers/IncentivePayments';
 import QuarterlyBudgetSummary from '../containers/QuarterlyBudgetSummary';
 
 const ProposedBudget = () => (
-  <Section
-    isNumbered
-    id="budget"
-    resource="proposedBudget"
-  >
-    <Subsection
-      id="budget-summary-table"
-      resource="proposedBudget.summaryBudget"
-    >
-      <BudgetSummary />
-    </Subsection>
-    <Subsection
-      id="budget-federal-by-quarter"
-      resource="proposedBudget.quarterlyBudget"
-    >
-      <QuarterlyBudgetSummary />
-    </Subsection>
-    <Subsection
-      id="budget-incentive-by-quarter"
-      resource="proposedBudget.paymentsByFFYQuarter"
-    >
-      <IncentivePayments />
-    </Subsection>
-  </Section>
+  <Waypoint id="budget-overview">
+    <Section isNumbered id="budget" resource="proposedBudget">
+      <Waypoint id="budget-summary-table" />
+      <Subsection
+        id="budget-summary-table"
+        resource="proposedBudget.summaryBudget"
+      >
+        <BudgetSummary />
+      </Subsection>
+
+      <Waypoint id="budget-federal-by-quarter" />
+      <Subsection
+        id="budget-federal-by-quarter"
+        resource="proposedBudget.quarterlyBudget"
+      >
+        <QuarterlyBudgetSummary />
+      </Subsection>
+
+      <Waypoint id="budget-incentive-by-quarter" />
+      <Subsection
+        id="budget-incentive-by-quarter"
+        resource="proposedBudget.paymentsByFFYQuarter"
+      >
+        <IncentivePayments />
+      </Subsection>
+    </Section>
+  </Waypoint>
 );
 
 export default ProposedBudget;

--- a/web/src/components/Section.js
+++ b/web/src/components/Section.js
@@ -1,13 +1,14 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
+import { Waypoint } from 'react-waypoint';
 
 import Collapsible from './Collapsible';
 import Instruction from './Instruction';
+import { scrollTo } from '../actions/navigation';
 import { t } from '../i18n';
 
-const SectionTitle = ({ children }) => (
-  <h2>{children}</h2>
-);
+const SectionTitle = ({ children }) => <h2>{children}</h2>;
 
 SectionTitle.propTypes = {
   children: PropTypes.node.isRequired
@@ -19,60 +20,96 @@ SectionDesc.propTypes = {
   children: PropTypes.node.isRequired
 };
 
-const Section = ({ children, id, isNumbered, resource }) => {
-  const title = t([resource, 'title'], { defaultValue: false });
-  const helptext = t([resource, 'helpText'], { defaultValue: false });
+class SectionPlain extends Component {
+  hitWaypoint = id => () => {
+    const { hasOverview, scrollTo: action } = this.props;
+    action(hasOverview ? `${id}-overview` : id);
+  };
 
-  return (
-    <section
-      id={id}
-      className={isNumbered && 'numbered-section'}
-    >
-      <h2 className="ds-h2">{title}</h2>
-      <span className="ds-text--lead">{helptext}</span>
-      {children}
-    </section>
-  );
-};
+  render() {
+    const { children, id, isNumbered, resource } = this.props;
+    const title = t([resource, 'title'], { defaultValue: false });
+    const helptext = t([resource, 'helpText'], { defaultValue: false });
 
-Section.propTypes = {
+    return (
+      <section id={id} className={isNumbered && 'numbered-section'}>
+        <Waypoint onEnter={this.hitWaypoint(id)} bottomOffset="90%" />
+        <h2 className="ds-h2">{title}</h2>
+        <span className="ds-text--lead">{helptext}</span>
+        {children}
+      </section>
+    );
+  }
+}
+
+SectionPlain.propTypes = {
   children: PropTypes.node.isRequired,
+  hasOverview: PropTypes.bool,
   id: PropTypes.string,
   resource: PropTypes.string,
-  isNumbered: PropTypes.bool
+  isNumbered: PropTypes.bool,
+  scrollTo: PropTypes.func.isRequired
 };
 
-Section.defaultProps = {
+SectionPlain.defaultProps = {
+  hasOverview: true,
   id: null,
   resource: null,
   isNumbered: false
 };
 
-const Subsection = ({ children, id, nested, open, resource }) => {
-  const title = t([resource, 'title'], { defaultValue: '' });
+class SubsectionPlain extends Component {
+  hitWaypoint = id => () => {
+    const { hasWaypoint, scrollTo: action } = this.props;
+    if (hasWaypoint) {
+      action(id);
+    }
+  };
 
-  return (
-    <Collapsible id={id} title={title} open={open} nested={nested}>
-      <Instruction source={`${resource}.instruction`} />
-      {children}
-    </Collapsible>
-  );
-};
+  render() {
+    const { children, id, nested, open, resource } = this.props;
+    const title = t([resource, 'title'], { defaultValue: '' });
 
-Subsection.propTypes = {
+    return (
+      <Fragment>
+        <Waypoint onEnter={this.hitWaypoint(id)} bottomOffset="90%" />
+        <Collapsible id={id} title={title} open={open} nested={nested}>
+          <Instruction source={`${resource}.instruction`} />
+          {children}
+        </Collapsible>
+      </Fragment>
+    );
+  }
+}
+
+SubsectionPlain.propTypes = {
   children: PropTypes.node.isRequired,
+  hasWaypoint: PropTypes.bool,
   id: PropTypes.string,
   nested: PropTypes.bool,
   open: PropTypes.bool,
-  resource: PropTypes.string
+  resource: PropTypes.string,
+  scrollTo: PropTypes.func.isRequired
 };
 
-Subsection.defaultProps = {
+SubsectionPlain.defaultProps = {
   resource: null,
+  hasWaypoint: true,
   id: null,
   nested: false,
   open: false
 };
 
+const Section = connect(
+  null,
+  { scrollTo }
+)(SectionPlain);
+
+const Subsection = connect(
+  null,
+  { scrollTo }
+)(SubsectionPlain);
+
 export default Section;
+
 export { Section, SectionDesc, SectionTitle, Subsection };

--- a/web/src/components/Section.js
+++ b/web/src/components/Section.js
@@ -1,10 +1,7 @@
 import PropTypes from 'prop-types';
-import React, { Component, Fragment } from 'react';
-import { connect } from 'react-redux';
-import { Waypoint } from 'react-waypoint';
+import React, { Fragment } from 'react';
 
 import Instruction from './Instruction';
-import { scrollTo } from '../actions/navigation';
 import { t } from '../i18n';
 
 const SectionTitle = ({ children }) => <h2>{children}</h2>;
@@ -19,107 +16,65 @@ SectionDesc.propTypes = {
   children: PropTypes.node.isRequired
 };
 
-class SectionPlain extends Component {
-  hitWaypoint = id => () => {
-    const { hasOverview, scrollTo: action } = this.props;
-    action(hasOverview ? `${id}-overview` : id);
-  };
+const Section = ({ children, id, isNumbered, resource }) => {
+  const title = t([resource, 'title'], { defaultValue: false });
+  const helptext = t([resource, 'helpText'], { defaultValue: false });
 
-  render() {
-    const { children, id, isNumbered, resource } = this.props;
-    const title = t([resource, 'title'], { defaultValue: false });
-    const helptext = t([resource, 'helpText'], { defaultValue: false });
-
-    return (
-      <section id={id} className={isNumbered && 'numbered-section'}>
-        <Waypoint onEnter={this.hitWaypoint(id)} bottomOffset="90%" />
-        <h2 className="ds-h2">{title}</h2>
-        <span className="ds-text--lead">{helptext}</span>
-        {children}
-      </section>
-    );
-  }
-}
-
-SectionPlain.propTypes = {
-  children: PropTypes.node.isRequired,
-  hasOverview: PropTypes.bool,
-  id: PropTypes.string,
-  resource: PropTypes.string,
-  isNumbered: PropTypes.bool,
-  scrollTo: PropTypes.func.isRequired
+  return (
+    <section id={id} className={isNumbered && 'numbered-section'}>
+      <h2 className="ds-h2">{title}</h2>
+      <span className="ds-text--lead">{helptext}</span>
+      {children}
+    </section>
+  );
 };
 
-SectionPlain.defaultProps = {
-  hasOverview: true,
+Section.propTypes = {
+  children: PropTypes.node.isRequired,
+  id: PropTypes.string,
+  resource: PropTypes.string,
+  isNumbered: PropTypes.bool
+};
+
+Section.defaultProps = {
   id: null,
   resource: null,
   isNumbered: false
 };
 
-class SubsectionPlain extends Component {
-  hitWaypoint = id => () => {
-    const { hasWaypoint, scrollTo: action } = this.props;
-    if (hasWaypoint) {
-      action(id);
-    }
-  };
+const Subsection = ({ children, id, nested, resource }) => {
+  const title = t([resource, 'title'], { defaultValue: '' });
 
-  render() {
-    const { children, id, nested, resource } = this.props;
-    const title = t([resource, 'title'], { defaultValue: '' });
+  return (
+    <Fragment>
+      {!nested && (
+        <h3 id={id} className="subsection--title ds-h3">
+          {title}
+        </h3>
+      )}
+      {nested && (
+        <h4 id={id} className="ds-h3">
+          {title}
+        </h4>
+      )}
+      <Instruction source={`${resource}.instruction`} />
+      {children}
+    </Fragment>
+  );
+};
 
-    return (
-      <Fragment>
-        <Waypoint onEnter={this.hitWaypoint(id)} bottomOffset="90%" />
-        {!nested &&
-          <h3
-            id={id}
-            className='subsection--title ds-h3'
-          >
-            {title}
-          </h3>
-        }
-        {nested &&
-          <h4
-            id={id}
-            className='ds-h3'
-          >
-            {title}
-          </h4>
-        }
-        <Instruction source={`${resource}.instruction`} />
-        {children}
-      </Fragment>
-    );
-  }
-}
-
-SubsectionPlain.propTypes = {
+Subsection.propTypes = {
   children: PropTypes.node.isRequired,
-  hasWaypoint: PropTypes.bool,
   id: PropTypes.string,
   nested: PropTypes.bool,
-  resource: PropTypes.string,
-  scrollTo: PropTypes.func.isRequired
+  resource: PropTypes.string
 };
 
-SubsectionPlain.defaultProps = {
+Subsection.defaultProps = {
   resource: null,
-  hasWaypoint: true,
   id: null,
-  nested: false,
+  nested: false
 };
-
-const Section = connect(
-  null,
-  { scrollTo }
-)(SectionPlain);
-
-const Subsection = connect(
-  null,
-  { scrollTo }
-)(SubsectionPlain);
 
 export default Section;
 

--- a/web/src/components/__snapshots__/ProposedBudget.test.js.snap
+++ b/web/src/components/__snapshots__/ProposedBudget.test.js.snap
@@ -1,31 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ProposedBudget component renders correctly 1`] = `
-<Section
-  id="budget"
-  isNumbered={true}
-  resource="proposedBudget"
+<Connect(ConnectedWaypoint)
+  id="budget-overview"
 >
-  <Subsection
-    id="budget-summary-table"
-    nested={false}
-    resource="proposedBudget.summaryBudget"
+  <Section
+    id="budget"
+    isNumbered={true}
+    resource="proposedBudget"
   >
-    <Connect(BudgetSummary) />
-  </Subsection>
-  <Subsection
-    id="budget-federal-by-quarter"
-    nested={false}
-    resource="proposedBudget.quarterlyBudget"
-  >
-    <Connect(QuarterlyBudgetSummary) />
-  </Subsection>
-  <Subsection
-    id="budget-incentive-by-quarter"
-    nested={false}
-    resource="proposedBudget.paymentsByFFYQuarter"
-  >
-    <Connect(IncentivePayments) />
-  </Subsection>
-</Section>
+    <Connect(ConnectedWaypoint)
+      id="budget-summary-table"
+    />
+    <Subsection
+      id="budget-summary-table"
+      nested={false}
+      resource="proposedBudget.summaryBudget"
+    >
+      <Connect(BudgetSummary) />
+    </Subsection>
+    <Connect(ConnectedWaypoint)
+      id="budget-federal-by-quarter"
+    />
+    <Subsection
+      id="budget-federal-by-quarter"
+      nested={false}
+      resource="proposedBudget.quarterlyBudget"
+    >
+      <Connect(QuarterlyBudgetSummary) />
+    </Subsection>
+    <Connect(ConnectedWaypoint)
+      id="budget-incentive-by-quarter"
+    />
+    <Subsection
+      id="budget-incentive-by-quarter"
+      nested={false}
+      resource="proposedBudget.paymentsByFFYQuarter"
+    >
+      <Connect(IncentivePayments) />
+    </Subsection>
+  </Section>
+</Connect(ConnectedWaypoint)>
 `;

--- a/web/src/containers/ApdPreviousActivityTableTotal.js
+++ b/web/src/containers/ApdPreviousActivityTableTotal.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 
 import Dollars from '../components/Dollars';
 import { TABLE_HEADERS } from '../constants';
+import { selectPreviousActivityExpensesTotals } from '../reducers/apd.selectors';
 
 const ApdPreviousActivityTableMMIS = ({ totals }) => {
   const years = Object.keys(totals);
@@ -76,36 +77,9 @@ ApdPreviousActivityTableMMIS.propTypes = {
   totals: PropTypes.object.isRequired
 };
 
-const mapStateToProps = ({
-  apd: {
-    data: { previousActivityExpenses }
-  }
-}) => {
-  const totals = Object.entries(previousActivityExpenses).reduce(
-    (acc, [ffy, expenses]) => ({
-      ...acc,
-      [ffy]: {
-        actual:
-          expenses.hithie.federalActual +
-          [90, 75, 50].reduce(
-            (sum, ffp) => sum + expenses.mmis[ffp].federalActual,
-            0
-          ),
-        approved:
-          expenses.hithie.totalApproved * 0.9 +
-          [90, 75, 50].reduce(
-            (sum, ffp) => sum + (expenses.mmis[ffp].totalApproved * ffp) / 100,
-            0
-          )
-      }
-    }),
-    {}
-  );
-
-  return {
-    totals
-  };
-};
+const mapStateToProps = state => ({
+  totals: selectPreviousActivityExpensesTotals(state)
+});
 
 export default connect(
   mapStateToProps,

--- a/web/src/containers/ApdSummary.js
+++ b/web/src/containers/ApdSummary.js
@@ -38,12 +38,12 @@ class ApdSummary extends Component {
     } = this.props;
 
     return (
-      <Section
-        isNumbered
-        id="apd-summary"
-        resource="apd"
-      >
-        <Subsection id="apd-summary-overview" resource="apd.overview">
+      <Section hasOverview={false} isNumbered id="apd-summary" resource="apd">
+        <Subsection
+          hasWaypoint={false}
+          id="apd-summary-overview"
+          resource="apd.overview"
+        >
           <div className="mb3">
             {yearOptions.map(option => (
               <label key={option} className="mr1">

--- a/web/src/containers/ApdSummary.js
+++ b/web/src/containers/ApdSummary.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
+import Waypoint from './ConnectedWaypoint';
 import { updateApd as updateApdAction } from '../actions/apd';
 import { RichText } from '../components/Inputs';
 import Instruction from '../components/Instruction';
@@ -38,59 +39,57 @@ class ApdSummary extends Component {
     } = this.props;
 
     return (
-      <Section hasOverview={false} isNumbered id="apd-summary" resource="apd">
-        <Subsection
-          hasWaypoint={false}
-          id="apd-summary-overview"
-          resource="apd.overview"
-        >
-          <div className="mb3">
-            {yearOptions.map(option => (
-              <label key={option} className="mr1">
-                <input
-                  type="checkbox"
-                  value={option}
-                  checked={years.includes(option)}
-                  onChange={this.handleYears}
-                />
-                {option}
-              </label>
-            ))}
-          </div>
-          <div className="mb3">
-            <Instruction source="apd.introduction.instruction" />
-            <RichText
-              content={programOverview}
-              onSync={this.syncRichText('programOverview')}
-              editorClassName="rte-textarea-l"
-            />
-          </div>
-          <div className="mb3">
-            <Instruction source="apd.hit.instruction" />
-            <RichText
-              content={narrativeHIT}
-              onSync={this.syncRichText('narrativeHIT')}
-              editorClassName="rte-textarea-l"
-            />
-          </div>
-          <div className="mb3">
-            <Instruction source="apd.hie.instruction" />
-            <RichText
-              content={narrativeHIE}
-              onSync={this.syncRichText('narrativeHIE')}
-              editorClassName="rte-textarea-l"
-            />
-          </div>
-          <div>
-            <Instruction source="apd.mmis.instruction" />
-            <RichText
-              content={narrativeMMIS}
-              onSync={this.syncRichText('narrativeMMIS')}
-              editorClassName="rte-textarea-l"
-            />
-          </div>
-        </Subsection>
-      </Section>
+      <Waypoint id="apd-summary">
+        <Section isNumbered id="apd-summary" resource="apd">
+          <Subsection id="apd-summary-overview" resource="apd.overview">
+            <div className="mb3">
+              {yearOptions.map(option => (
+                <label key={option} className="mr1">
+                  <input
+                    type="checkbox"
+                    value={option}
+                    checked={years.includes(option)}
+                    onChange={this.handleYears}
+                  />
+                  {option}
+                </label>
+              ))}
+            </div>
+            <div className="mb3">
+              <Instruction source="apd.introduction.instruction" />
+              <RichText
+                content={programOverview}
+                onSync={this.syncRichText('programOverview')}
+                editorClassName="rte-textarea-l"
+              />
+            </div>
+            <div className="mb3">
+              <Instruction source="apd.hit.instruction" />
+              <RichText
+                content={narrativeHIT}
+                onSync={this.syncRichText('narrativeHIT')}
+                editorClassName="rte-textarea-l"
+              />
+            </div>
+            <div className="mb3">
+              <Instruction source="apd.hie.instruction" />
+              <RichText
+                content={narrativeHIE}
+                onSync={this.syncRichText('narrativeHIE')}
+                editorClassName="rte-textarea-l"
+              />
+            </div>
+            <div>
+              <Instruction source="apd.mmis.instruction" />
+              <RichText
+                content={narrativeMMIS}
+                onSync={this.syncRichText('narrativeMMIS')}
+                editorClassName="rte-textarea-l"
+              />
+            </div>
+          </Subsection>
+        </Section>
+      </Waypoint>
     );
   }
 }

--- a/web/src/containers/AssurancesAndCompliance.js
+++ b/web/src/containers/AssurancesAndCompliance.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
+import Waypoint from './ConnectedWaypoint';
 import { updateApd as updateApdAction } from '../actions/apd';
 import { Textarea } from '../components/Inputs';
 import Btn from '../components/Btn';
@@ -55,67 +56,67 @@ class AssurancesAndCompliance extends Component {
     const { sections: apdSections } = this.props;
 
     return (
-      <Section
-        isNumbered
-        id="assurances-compliance"
-        resource="assurancesAndCompliance"
-        hasOverview={false}
-      >
-        <Subsection
-          hasWaypoint={false}
-          id="assurances-compliance-fed-citations"
-          resource="assurancesAndCompliance.citations"
+      <Waypoint id="assurances-compliance">
+        <Section
+          isNumbered
+          id="assurances-compliance"
+          resource="assurancesAndCompliance"
         >
-          {Object.entries(regLinks).map(([name, regulations]) => (
-            <div key={name} className="mb3">
-              <h3>{t(`assurancesAndCompliance.headings.${name}`)}</h3>
-              {apdSections[name].map(
-                ({ title, checked, explanation }, index) => (
-                  <div key={title} className="mt2">
-                    <div className="mb1 flex items-end justify-between">
-                      <LinkOrText link={regulations[title]} title={title} />
-                      <div>
-                        <Btn
-                          kind="outline"
-                          size="small"
-                          extraCss={`h5 ${checked ? 'bg-black white' : ''}`}
-                          onClick={this.handleCheckChange(name, index, true)}
-                        >
-                          {yes}
-                        </Btn>{' '}
-                        <Btn
-                          kind="outline"
-                          size="small"
-                          extraCss={`h5 ${checked ? '' : 'bg-black white'}`}
-                          onClick={this.handleCheckChange(name, index, false)}
-                        >
-                          {no}
-                        </Btn>
+          <Subsection
+            id="assurances-compliance-fed-citations"
+            resource="assurancesAndCompliance.citations"
+          >
+            {Object.entries(regLinks).map(([name, regulations]) => (
+              <div key={name} className="mb3">
+                <h3>{t(`assurancesAndCompliance.headings.${name}`)}</h3>
+                {apdSections[name].map(
+                  ({ title, checked, explanation }, index) => (
+                    <div key={title} className="mt2">
+                      <div className="mb1 flex items-end justify-between">
+                        <LinkOrText link={regulations[title]} title={title} />
+                        <div>
+                          <Btn
+                            kind="outline"
+                            size="small"
+                            extraCss={`h5 ${checked ? 'bg-black white' : ''}`}
+                            onClick={this.handleCheckChange(name, index, true)}
+                          >
+                            {yes}
+                          </Btn>{' '}
+                          <Btn
+                            kind="outline"
+                            size="small"
+                            extraCss={`h5 ${checked ? '' : 'bg-black white'}`}
+                            onClick={this.handleCheckChange(name, index, false)}
+                          >
+                            {no}
+                          </Btn>
+                        </div>
                       </div>
+                      {checked ? (
+                        <hr className="my2 border-grey" />
+                      ) : (
+                        <div>
+                          <Textarea
+                            name={namify(name, title)}
+                            label={`Explanation for why you do not comply with ${title}`}
+                            placeholder="Please explain..."
+                            hideLabel
+                            value={explanation}
+                            onChange={this.handleExplanationChange(name, index)}
+                            className="m0 textarea textarea-sm"
+                            rows="3"
+                          />
+                        </div>
+                      )}
                     </div>
-                    {checked ? (
-                      <hr className="my2 border-grey" />
-                    ) : (
-                      <div>
-                        <Textarea
-                          name={namify(name, title)}
-                          label={`Explanation for why you do not comply with ${title}`}
-                          placeholder="Please explain..."
-                          hideLabel
-                          value={explanation}
-                          onChange={this.handleExplanationChange(name, index)}
-                          className="m0 textarea textarea-sm"
-                          rows="3"
-                        />
-                      </div>
-                    )}
-                  </div>
-                )
-              )}
-            </div>
-          ))}
-        </Subsection>
-      </Section>
+                  )
+                )}
+              </div>
+            ))}
+          </Subsection>
+        </Section>
+      </Waypoint>
     );
   }
 }

--- a/web/src/containers/AssurancesAndCompliance.js
+++ b/web/src/containers/AssurancesAndCompliance.js
@@ -59,8 +59,10 @@ class AssurancesAndCompliance extends Component {
         isNumbered
         id="assurances-compliance"
         resource="assurancesAndCompliance"
+        hasOverview={false}
       >
         <Subsection
+          hasWaypoint={false}
           id="assurances-compliance-fed-citations"
           resource="assurancesAndCompliance.citations"
         >

--- a/web/src/containers/BudgetSummary.js
+++ b/web/src/containers/BudgetSummary.js
@@ -3,7 +3,7 @@ import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 
 import Dollars from '../components/Dollars';
-import { ACTIVITY_FUNDING_SOURCES } from '../util';
+import { selectBudgetActivitiesByFundingSource } from '../reducers/budget.selectors';
 
 const categoryLookup = {
   statePersonnel: 'Project state staff',
@@ -239,23 +239,11 @@ BudgetSummary.propTypes = {
   years: PropTypes.array.isRequired
 };
 
-const mapStateToProps = ({ apd, budget }) => {
-  const activities = ACTIVITY_FUNDING_SOURCES.reduce(
-    (obj, source) => ({
-      ...obj,
-      [source.toLowerCase()]: budget.activityTotals.filter(
-        a => a.fundingSource === source
-      )
-    }),
-    {}
-  );
-
-  return {
-    activities,
-    data: budget,
-    years: apd.data.years
-  };
-};
+const mapStateToProps = state => ({
+  activities: selectBudgetActivitiesByFundingSource(state),
+  data: state.budget,
+  years: state.apd.data.years
+});
 
 export default connect(mapStateToProps)(BudgetSummary);
 

--- a/web/src/containers/ConnectedWaypoint.js
+++ b/web/src/containers/ConnectedWaypoint.js
@@ -1,0 +1,42 @@
+import PropTypes from 'prop-types';
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
+import { Waypoint } from 'react-waypoint';
+
+import { scrollTo } from '../actions/navigation';
+
+class ConnectedWaypoint extends Component {
+  hitWaypoint = id => () => {
+    const { scrollTo: action } = this.props;
+    action(id);
+  };
+
+  render() {
+    const { children, id } = this.props;
+    return (
+      <Fragment>
+        <Waypoint onEnter={this.hitWaypoint(id)} bottomOffset="90%" />
+        {children}
+      </Fragment>
+    );
+  }
+}
+
+ConnectedWaypoint.propTypes = {
+  children: PropTypes.node,
+  id: PropTypes.string.isRequired,
+  scrollTo: PropTypes.func.isRequired
+};
+
+ConnectedWaypoint.defaultProps = {
+  children: null
+};
+
+const mapDispatchToProps = { scrollTo };
+
+export default connect(
+  null,
+  mapDispatchToProps
+)(ConnectedWaypoint);
+
+export { mapDispatchToProps, ConnectedWaypoint as plain };

--- a/web/src/containers/ConnectedWaypoint.test.js
+++ b/web/src/containers/ConnectedWaypoint.test.js
@@ -1,0 +1,47 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import sinon from 'sinon';
+
+import { plain as Waypoint, mapDispatchToProps } from './ConnectedWaypoint';
+
+import { scrollTo } from '../actions/navigation';
+
+describe('connected waypoint higher-order component', () => {
+  const props = {
+    id: 'id',
+    scrollTo: sinon.spy()
+  };
+
+  beforeEach(() => {
+    props.scrollTo.resetHistory();
+  });
+
+  describe('renders correctly', () => {
+    test('without children', () => {
+      expect(shallow(<Waypoint {...props} />)).toMatchSnapshot();
+    });
+
+    test('with children', () => {
+      expect(
+        shallow(
+          <Waypoint {...props}>
+            <div>Hello, I am child</div>
+          </Waypoint>
+        )
+      ).toMatchSnapshot();
+    });
+  });
+
+  test('dispatches on entering waypoint', () => {
+    shallow(<Waypoint {...props} />)
+      .find('Waypoint')
+      .at(0)
+      .prop('onEnter')('this is some html');
+
+    expect(props.scrollTo.calledWith('id'));
+  });
+
+  test('maps dispatch to props', () => {
+    expect(mapDispatchToProps).toEqual({ scrollTo });
+  });
+});

--- a/web/src/containers/ExecutiveSummary.js
+++ b/web/src/containers/ExecutiveSummary.js
@@ -7,15 +7,13 @@ import { expandActivitySection } from '../actions/activities';
 import Dollars from '../components/Dollars';
 import { Section, Subsection } from '../components/Section';
 import { t } from '../i18n';
+import { selectApdYears } from '../reducers/apd.selectors';
+import { selectBudgetExecutiveSummary } from '../reducers/budget.selectors';
 
 const ExecutiveSummary = ({ data, years, expandSection }) => (
-  <Section
-    isNumbered
-    id="executive-summary"
-    resource="executiveSummary"
-  >
+  <Section isNumbered id="executive-summary" resource="executiveSummary">
     <Subsection
-      id="executive-summary-overview"
+      id="executive-summary-summary"
       resource="executiveSummary.summary"
     >
       {data.map((d, i) => (
@@ -76,44 +74,10 @@ ExecutiveSummary.propTypes = {
   expandSection: PropTypes.func.isRequired
 };
 
-const mapStateToProps = ({
-  activities: { byKey },
-  apd: {
-    data: { years }
-  },
-  budget
-}) => {
-  const data = Object.entries(byKey).map(([key, { name, descShort }]) => {
-    const activityCosts = budget.activities[key].costsByFFY;
-
-    return {
-      key,
-      name,
-      descShort,
-      totals: years.reduce(
-        (acc, year) => ({ ...acc, [year]: activityCosts[year].total }),
-        {}
-      ),
-      combined: activityCosts.total.total
-    };
-  });
-
-  data.push({
-    key: 'all',
-    name: 'Total Cost',
-    descShort: null,
-    totals: years.reduce(
-      (acc, year) => ({ ...acc, [year]: budget.combined[year].total }),
-      {}
-    ),
-    combined: budget.combined.total.total
-  });
-
-  return {
-    data,
-    years
-  };
-};
+const mapStateToProps = state => ({
+  data: selectBudgetExecutiveSummary(state),
+  years: selectApdYears(state)
+});
 
 const mapDispatchToProps = {
   expandSection: expandActivitySection

--- a/web/src/containers/ExecutiveSummary.js
+++ b/web/src/containers/ExecutiveSummary.js
@@ -3,6 +3,7 @@ import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 
 import ExecutiveSummaryBudget from './ExecutiveSummaryBudget';
+import Waypoint from './ConnectedWaypoint';
 import { expandActivitySection } from '../actions/activities';
 import Dollars from '../components/Dollars';
 import { Section, Subsection } from '../components/Section';
@@ -11,61 +12,66 @@ import { selectApdYears } from '../reducers/apd.selectors';
 import { selectBudgetExecutiveSummary } from '../reducers/budget.selectors';
 
 const ExecutiveSummary = ({ data, years, expandSection }) => (
-  <Section isNumbered id="executive-summary" resource="executiveSummary">
-    <Subsection
-      id="executive-summary-summary"
-      resource="executiveSummary.summary"
-    >
-      {data.map((d, i) => (
-        <div
-          key={d.key}
-          className="mb2 md-flex items-center alert alert-success"
-        >
-          <div className="p2 sm-m0 flex-auto">
-            {d.key !== 'all' ? (
-              <Fragment>
-                <div className="h5">
-                  {t('activities.namePrefixAndNum', { number: i + 1 })}
+  <Waypoint id="executive-summary-overview">
+    <Section isNumbered id="executive-summary" resource="executiveSummary">
+      <Waypoint id="executive-summary-summary" />
+      <Subsection
+        id="executive-summary-summary"
+        resource="executiveSummary.summary"
+      >
+        {data.map((d, i) => (
+          <div
+            key={d.key}
+            className="mb2 md-flex items-center alert alert-success"
+          >
+            <div className="p2 sm-m0 flex-auto">
+              {d.key !== 'all' ? (
+                <Fragment>
+                  <div className="h5">
+                    {t('activities.namePrefixAndNum', { number: i + 1 })}
+                  </div>
+                  <a
+                    href={`#activity-${d.key}`}
+                    className="h3 bold black"
+                    onClick={() => expandSection(d.key)}
+                  >
+                    {d.name || t('activities.noNameYet')}
+                  </a>
+                </Fragment>
+              ) : (
+                <div className="h3 bold">{d.name}</div>
+              )}
+              {d.descShort && <div>{d.descShort}</div>}
+            </div>
+            <div className="md-flex md-col-7">
+              {years.map(year => (
+                <div key={year} className="px2 py3 flex-auto">
+                  <div className="h5">{t('ffy', { year })}</div>
+                  <div className="h3 mono bold">
+                    <Dollars>{d.totals[year]}</Dollars>
+                  </div>
                 </div>
-                <a
-                  href={`#activity-${d.key}`}
-                  className="h3 bold black"
-                  onClick={() => expandSection(d.key)}
-                >
-                  {d.name || t('activities.noNameYet')}
-                </a>
-              </Fragment>
-            ) : (
-              <div className="h3 bold">{d.name}</div>
-            )}
-            {d.descShort && <div>{d.descShort}</div>}
-          </div>
-          <div className="md-flex md-col-7">
-            {years.map(year => (
-              <div key={year} className="px2 py3 flex-auto">
-                <div className="h5">{t('ffy', { year })}</div>
+              ))}
+              <div className="px2 py3 flex-auto">
+                <div className="h5">{t('executiveSummary.total')}</div>
                 <div className="h3 mono bold">
-                  <Dollars>{d.totals[year]}</Dollars>
+                  <Dollars>{d.combined}</Dollars>
                 </div>
-              </div>
-            ))}
-            <div className="px2 py3 flex-auto">
-              <div className="h5">{t('executiveSummary.total')}</div>
-              <div className="h3 mono bold">
-                <Dollars>{d.combined}</Dollars>
               </div>
             </div>
           </div>
-        </div>
-      ))}
-    </Subsection>
-    <Subsection
-      id="executive-summary-budget-table"
-      resource="executiveSummary.budgetTable"
-    >
-      <ExecutiveSummaryBudget />
-    </Subsection>
-  </Section>
+        ))}
+      </Subsection>
+
+      <Waypoint id="executive-summary-budget-table" />
+      <Subsection
+        id="executive-summary-budget-table"
+        resource="executiveSummary.budgetTable"
+      >
+        <ExecutiveSummaryBudget />
+      </Subsection>
+    </Section>
+  </Waypoint>
 );
 
 ExecutiveSummary.propTypes = {

--- a/web/src/containers/IncentivePayments.js
+++ b/web/src/containers/IncentivePayments.js
@@ -6,6 +6,11 @@ import { updateApd as updateApdAction } from '../actions/apd';
 import Dollars from '../components/Dollars';
 import { Input, DollarInput } from '../components/Inputs';
 import { t } from '../i18n';
+import {
+  selectApdYears,
+  selectIncentivePayments,
+  selectIncentivePaymentTotals
+} from '../reducers/apd.selectors';
 import { INCENTIVE_ENTRIES } from '../util';
 import { formatNum } from '../util/formats';
 
@@ -31,69 +36,65 @@ class IncentivePayments extends Component {
 
     return (
       <Fragment>
-        {years.map(( year ) => (
-        <Fragment key={year}>
-          <h3 id={thId(year)}>
-            {t('ffy', { year })}
-          </h3>
-          <table className="table-cms table-fixed">
-            <thead>
-              <tr>
-                <th id={thId('null2')} />
-                <Fragment key={year}>
-                  {QUARTERS.map(q => (
-                    <th key={q} className="right-align" id={thId(year, q)}>
-                      {t('table.quarter', { q })}
+        {years.map(year => (
+          <Fragment key={year}>
+            <h3 id={thId(year)}>{t('ffy', { year })}</h3>
+            <table className="table-cms table-fixed">
+              <thead>
+                <tr>
+                  <th id={thId('null2')} />
+                  <Fragment key={year}>
+                    {QUARTERS.map(q => (
+                      <th key={q} className="right-align" id={thId(year, q)}>
+                        {t('table.quarter', { q })}
+                      </th>
+                    ))}
+                    <th className="right-align" id={thId(year, 'subtotal')}>
+                      {t('table.subtotal')}
                     </th>
-                  ))}
-                  <th
-                    className="right-align"
-                    id={thId(year, 'subtotal')}
-                  >
-                    {t('table.subtotal')}
-                  </th>
-                </Fragment>
-              </tr>
-            </thead>
-            <tbody>
-              {INCENTIVE_ENTRIES.map(({ id, name, type }, i) => {
-                const InputComponent = type === 'amount' ? DollarInput : Input;
+                  </Fragment>
+                </tr>
+              </thead>
+              <tbody>
+                {INCENTIVE_ENTRIES.map(({ id, name, type }, i) => {
+                  const InputComponent =
+                    type === 'amount' ? DollarInput : Input;
 
-                return (
-                  <tr key={id}>
-                    <td
-                      className={`align-middle ${i % 2 === 0 ? 'bold' : ''}`}
-                      headers="incentive-payments-table-fynull1 incentive-payments-table-fynull2"
-                    >
-                      {name}
-                    </td>
-                    <Fragment key={year}>
-                      {QUARTERS.map(q => (
-                        <td key={q} headers={tdHdrs(year, q)}>
-                          <InputComponent
-                            name={`${id}-payments-${year}-q${q}`}
-                            label={`${id} payments for ${year}, quarter ${q}`}
-                            wrapperClass="m0"
-                            className="m0 input input-condensed mono right-align"
-                            value={data[id][year][q] || ''}
-                            onChange={this.handleChange(id, year, q)}
-                            hideLabel
-                          />
-                        </td>
-                      ))}
+                  return (
+                    <tr key={id}>
                       <td
-                        className="bold mono right-align align-middle"
-                        headers={tdHdrs(year, 'subtotal')}
+                        className={`align-middle ${i % 2 === 0 ? 'bold' : ''}`}
+                        headers="incentive-payments-table-fynull1 incentive-payments-table-fynull2"
                       >
-                        {formatNumber(type, totals[id].byYear[year])}
+                        {name}
                       </td>
-                    </Fragment>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </Fragment>
+                      <Fragment key={year}>
+                        {QUARTERS.map(q => (
+                          <td key={q} headers={tdHdrs(year, q)}>
+                            <InputComponent
+                              name={`${id}-payments-${year}-q${q}`}
+                              label={`${id} payments for ${year}, quarter ${q}`}
+                              wrapperClass="m0"
+                              className="m0 input input-condensed mono right-align"
+                              value={data[id][year][q] || ''}
+                              onChange={this.handleChange(id, year, q)}
+                              hideLabel
+                            />
+                          </td>
+                        ))}
+                        <td
+                          className="bold mono right-align align-middle"
+                          headers={tdHdrs(year, 'subtotal')}
+                        >
+                          {formatNumber(type, totals[id].byYear[year])}
+                        </td>
+                      </Fragment>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </Fragment>
         ))}
       </Fragment>
     );
@@ -107,27 +108,11 @@ IncentivePayments.propTypes = {
   years: PropTypes.array.isRequired
 };
 
-const addObjVals = obj => Object.values(obj).reduce((a, b) => +a + +b, 0);
-
-/* eslint-disable no-param-reassign */
-const getTotals = (data, years) =>
-  INCENTIVE_ENTRIES.reduce((obj, entry) => {
-    const datum = data[entry.id];
-    const byYear = years.reduce((obj2, yr) => {
-      obj2[yr] = addObjVals(datum[yr]);
-      return obj2;
-    }, {});
-
-    obj[entry.id] = { byYear, allYears: addObjVals(byYear) };
-    return obj;
-  }, {});
-
-const mapStateToProps = ({ apd }) => {
-  const { incentivePayments: data, years } = apd.data;
-  const totals = getTotals(data, years);
-
-  return { data, totals, years };
-};
+const mapStateToProps = state => ({
+  data: selectIncentivePayments(state),
+  totals: selectIncentivePaymentTotals(state),
+  years: selectApdYears(state)
+});
 
 const mapDispatchToProps = { updateApd: updateApdAction };
 

--- a/web/src/containers/PreviousActivities.js
+++ b/web/src/containers/PreviousActivities.js
@@ -8,42 +8,44 @@ import { Section, Subsection } from '../components/Section';
 import ApdPreviousActivityTableHI from './ApdPreviousActivityTable';
 import ApdPreviousActivityTableMMIS from './ApdPreviousActivityTableMMIS';
 import ApdPreviousActivityTableTotal from './ApdPreviousActivityTableTotal';
+import Waypoint from './ConnectedWaypoint';
 import { t } from '../i18n';
 
 const PreviousActivities = ({ previousActivitySummary, updateApd }) => (
-  <Section
-    isNumbered
-    id="prev-activities"
-    resource="previousActivities"
-  >
-    <Subsection
-      id="prev-activities-outline"
-      resource="previousActivities.outline"
-    >
-      <div className="mb-tiny bold">
-        {t('previousActivities.outline.instruction.label')}
-      </div>
-      <RichText
-        content={previousActivitySummary}
-        onSync={html => updateApd({ previousActivitySummary: html })}
-        editorClassName="rte-textarea-l"
-      />
-    </Subsection>
-    <Subsection
-      id="prev-activities-table"
-      resource="previousActivities.actualExpenses"
-    >
-      <div className="mb3">
-        <ApdPreviousActivityTableHI />
-      </div>
-      <div className="mb3">
-        <ApdPreviousActivityTableMMIS />
-      </div>
-      <div className="mb3">
-        <ApdPreviousActivityTableTotal />
-      </div>
-    </Subsection>
-  </Section>
+  <Waypoint id="prev-activities-overview">
+    <Section isNumbered id="prev-activities" resource="previousActivities">
+      <Waypoint id="prev-activities-outline" />
+      <Subsection
+        id="prev-activities-outline"
+        resource="previousActivities.outline"
+      >
+        <div className="mb-tiny bold">
+          {t('previousActivities.outline.instruction.label')}
+        </div>
+        <RichText
+          content={previousActivitySummary}
+          onSync={html => updateApd({ previousActivitySummary: html })}
+          editorClassName="rte-textarea-l"
+        />
+      </Subsection>
+
+      <Waypoint id="prev-activities-table" />
+      <Subsection
+        id="prev-activities-table"
+        resource="previousActivities.actualExpenses"
+      >
+        <div className="mb3">
+          <ApdPreviousActivityTableHI />
+        </div>
+        <div className="mb3">
+          <ApdPreviousActivityTableMMIS />
+        </div>
+        <div className="mb3">
+          <ApdPreviousActivityTableTotal />
+        </div>
+      </Subsection>
+    </Section>
+  </Waypoint>
 );
 
 PreviousActivities.propTypes = {

--- a/web/src/containers/ScheduleSummary.js
+++ b/web/src/containers/ScheduleSummary.js
@@ -5,14 +5,20 @@ import ReactTable from 'react-table';
 
 import { t } from '../i18n';
 import { Section, Subsection } from '../components/Section';
+import { selectActivitySchedule } from '../reducers/activities.selectors';
 
 const ScheduleSummary = ({ tableData }) => (
   <Section
+    hasOverview={false}
     isNumbered
     id="schedule-summary"
     resource="scheduleSummary"
   >
-    <Subsection id="schedule-summary-table" resource="scheduleSummary.main">
+    <Subsection
+      hasWaypoint={false}
+      id="schedule-summary-table"
+      resource="scheduleSummary.main"
+    >
       {tableData.data.length === 0 ? (
         <div className="p1 h6 alert">{t('scheduleSummary.noDataMessage')}</div>
       ) : (
@@ -38,18 +44,8 @@ ScheduleSummary.propTypes = {
 
 const Cell = row => row.value || 'N/A';
 
-const mapStateToProps = ({ activities }) => {
-  const data = [];
-
-  Object.values(activities.byKey).forEach(activity => {
-    activity.schedule.forEach(milestone => {
-      data.push({
-        ...milestone,
-        activityName: activity.name,
-        startDate: activity.plannedStartDate
-      });
-    });
-  });
+const mapStateToProps = state => {
+  const data = selectActivitySchedule(state);
 
   const columns = [
     {

--- a/web/src/containers/ScheduleSummary.js
+++ b/web/src/containers/ScheduleSummary.js
@@ -4,34 +4,30 @@ import { connect } from 'react-redux';
 import ReactTable from 'react-table';
 
 import { t } from '../i18n';
+import Waypoint from './ConnectedWaypoint';
 import { Section, Subsection } from '../components/Section';
 import { selectActivitySchedule } from '../reducers/activities.selectors';
 
 const ScheduleSummary = ({ tableData }) => (
-  <Section
-    hasOverview={false}
-    isNumbered
-    id="schedule-summary"
-    resource="scheduleSummary"
-  >
-    <Subsection
-      hasWaypoint={false}
-      id="schedule-summary-table"
-      resource="scheduleSummary.main"
-    >
-      {tableData.data.length === 0 ? (
-        <div className="p1 h6 alert">{t('scheduleSummary.noDataMessage')}</div>
-      ) : (
-        <ReactTable
-          showPagination={false}
-          resizable={false}
-          minRows={0}
-          className="h6 -striped"
-          {...tableData}
-        />
-      )}
-    </Subsection>
-  </Section>
+  <Waypoint id="schedule-summary">
+    <Section isNumbered id="schedule-summary" resource="scheduleSummary">
+      <Subsection id="schedule-summary-table" resource="scheduleSummary.main">
+        {tableData.data.length === 0 ? (
+          <div className="p1 h6 alert">
+            {t('scheduleSummary.noDataMessage')}
+          </div>
+        ) : (
+          <ReactTable
+            showPagination={false}
+            resizable={false}
+            minRows={0}
+            className="h6 -striped"
+            {...tableData}
+          />
+        )}
+      </Subsection>
+    </Section>
+  </Waypoint>
 );
 
 ScheduleSummary.propTypes = {

--- a/web/src/containers/Sidebar.js
+++ b/web/src/containers/Sidebar.js
@@ -13,9 +13,6 @@ import { selectActivitiesSidebar } from '../reducers/activities.selectors';
 import { selectActiveSection } from '../reducers/navigation';
 
 class Sidebar extends Component {
-  state = { selectedId: 'apd-state-profile-overview' };
-
-  // handleSelectClick = id => this.setState({ selectedId: id });
   handleSelectClick = id => {
     const { jumpTo: action } = this.props;
     action(id);
@@ -232,6 +229,7 @@ class Sidebar extends Component {
 Sidebar.propTypes = {
   activities: PropTypes.array.isRequired,
   activeSection: PropTypes.string.isRequired,
+  jumpTo: PropTypes.func.isRequired,
   place: PropTypes.object.isRequired,
   printApd: PropTypes.func.isRequired,
   saveApdToAPI: PropTypes.func.isRequired

--- a/web/src/containers/Sidebar.js
+++ b/web/src/containers/Sidebar.js
@@ -6,13 +6,20 @@ import VerticalNav from '@cmsgov/design-system-core/dist/components/VerticalNav/
 
 import { t } from '../i18n';
 import { saveApd } from '../actions/apd';
+import { jumpTo } from '../actions/navigation';
 import { printApd } from '../actions/print';
 import Btn from '../components/Btn';
+import { selectActivitiesSidebar } from '../reducers/activities.selectors';
+import { selectActiveSection } from '../reducers/navigation';
 
 class Sidebar extends Component {
   state = { selectedId: 'apd-state-profile-overview' };
 
-  handleSelectClick = id => this.setState({ selectedId: id });
+  // handleSelectClick = id => this.setState({ selectedId: id });
+  handleSelectClick = id => {
+    const { jumpTo: action } = this.props;
+    action(id);
+  };
 
   createActivityItems = activities => {
     const activityItems = activities.map((a, i) => ({
@@ -162,14 +169,14 @@ class Sidebar extends Component {
         defaultCollapsed: true,
         items: [
           {
-            id: 'exec-summary-overview',
+            id: 'executive-summary-overview',
             url: '#executive-summary',
             label: 'Overview',
             onClick: (evt, id) => this.handleSelectClick(id)
           },
           {
-            id: 'executive-summary-overview',
-            url: '#executive-summary-overview',
+            id: 'executive-summary-summary',
+            url: '#executive-summary-summary',
             label: t('executiveSummary.summary.title'),
             onClick: (evt, id) => this.handleSelectClick(id)
           },
@@ -183,7 +190,7 @@ class Sidebar extends Component {
       }
     ];
 
-    const { selectedId } = this.state;
+    const { activeSection } = this.props;
 
     return (
       <div className="ds-l-col--3 bg-white">
@@ -202,7 +209,7 @@ class Sidebar extends Component {
                 {t('title', { year: '2018' })}
               </h1>
             </div>
-            <VerticalNav selectedId={selectedId} items={links} />
+            <VerticalNav selectedId={activeSection} items={links} />
             <div className="ds-u-margin-top--2">
               <Btn onClick={() => saveApdToAPI()}>
                 {t('sidebar.saveApdButtonText')}
@@ -224,20 +231,19 @@ class Sidebar extends Component {
 
 Sidebar.propTypes = {
   activities: PropTypes.array.isRequired,
+  activeSection: PropTypes.string.isRequired,
   place: PropTypes.object.isRequired,
   printApd: PropTypes.func.isRequired,
   saveApdToAPI: PropTypes.func.isRequired
 };
 
-const mapStateToProps = ({ activities: { byKey, allKeys } }) => ({
-  activities: allKeys.map(key => ({
-    key,
-    anchor: `activity-${key}`,
-    name: byKey[key].name
-  }))
+const mapStateToProps = state => ({
+  activities: selectActivitiesSidebar(state),
+  activeSection: selectActiveSection(state)
 });
 
 const mapDispatchToProps = {
+  jumpTo,
   printApd,
   saveApdToAPI: saveApd
 };

--- a/web/src/containers/Sidebar.test.js
+++ b/web/src/containers/Sidebar.test.js
@@ -8,6 +8,7 @@ import {
   mapDispatchToProps
 } from './Sidebar';
 import { saveApd } from '../actions/apd';
+import { jumpTo } from '../actions/navigation';
 import { printApd } from '../actions/print';
 
 describe('Sidebar component', () => {
@@ -16,6 +17,8 @@ describe('Sidebar component', () => {
       { anchor: '#key1', key: 'key 1' },
       { anchor: '#key2', key: 'key 2' }
     ],
+    activeSection: 'some section',
+    jumpTo: sinon.spy(),
     place: { id: 'place id', name: 'place name' },
     printApd: sinon.spy(),
     saveApdToAPI: sinon.spy()
@@ -50,6 +53,9 @@ describe('Sidebar component', () => {
       activities: {
         byKey: { key1: { name: 'activity 1' }, key2: { name: 'activity 2' } },
         allKeys: ['key1', 'key2']
+      },
+      navigation: {
+        activeSection: 'where the runners are'
       }
     };
 
@@ -65,12 +71,14 @@ describe('Sidebar component', () => {
           anchor: 'activity-key2',
           name: 'activity 2'
         }
-      ]
+      ],
+      activeSection: 'where the runners are'
     });
   });
 
   test('maps dispatch to props', () => {
     expect(mapDispatchToProps).toEqual({
+      jumpTo,
       printApd,
       saveApdToAPI: saveApd
     });

--- a/web/src/containers/StateDashboard.js
+++ b/web/src/containers/StateDashboard.js
@@ -9,6 +9,7 @@ import TopBtns from './TopBtns';
 import { createApd, deleteApd, selectApd } from '../actions/apd';
 import { Section } from '../components/Section';
 import { t } from '../i18n';
+import { selectApdDashboard, selectApds } from '../reducers/apd.selectors';
 
 const Loading = () => (
   <div className="h2 p0 pb3 center">
@@ -107,16 +108,10 @@ StateDashboard.propTypes = {
   selectApd: PropType.func.isRequired
 };
 
-const mapStateToProps = ({
-  apd: { byId, fetching },
-  user: {
-    data: { state }
-  }
-}) => ({
-  // Be explicit about which APD properties we need
-  apds: Object.values(byId).map(({ id, years }) => ({ id, years })),
-  fetching,
-  state
+const mapStateToProps = state => ({
+  apds: selectApdDashboard(state),
+  fetching: selectApds(state).fetching,
+  state: state.user.data.state
 });
 
 const mapDispatchToProps = {

--- a/web/src/containers/__snapshots__/ApdSummary.test.js.snap
+++ b/web/src/containers/__snapshots__/ApdSummary.test.js.snap
@@ -1,110 +1,114 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`apd summary component renders correctly 1`] = `
-<Section
+<Connect(ConnectedWaypoint)
   id="apd-summary"
-  isNumbered={true}
-  resource="apd"
 >
-  <Subsection
-    id="apd-summary-overview"
-    nested={false}
-    resource="apd.overview"
+  <Section
+    id="apd-summary"
+    isNumbered={true}
+    resource="apd"
   >
-    <div
-      className="mb3"
+    <Subsection
+      id="apd-summary-overview"
+      nested={false}
+      resource="apd.overview"
     >
-      <label
-        className="mr1"
-        key="1"
+      <div
+        className="mb3"
       >
-        <input
-          checked={true}
-          onChange={[Function]}
-          type="checkbox"
-          value="1"
-        />
-        1
-      </label>
-      <label
-        className="mr1"
-        key="2"
+        <label
+          className="mr1"
+          key="1"
+        >
+          <input
+            checked={true}
+            onChange={[Function]}
+            type="checkbox"
+            value="1"
+          />
+          1
+        </label>
+        <label
+          className="mr1"
+          key="2"
+        >
+          <input
+            checked={true}
+            onChange={[Function]}
+            type="checkbox"
+            value="2"
+          />
+          2
+        </label>
+        <label
+          className="mr1"
+          key="3"
+        >
+          <input
+            checked={false}
+            onChange={[Function]}
+            type="checkbox"
+            value="3"
+          />
+          3
+        </label>
+      </div>
+      <div
+        className="mb3"
       >
-        <input
-          checked={true}
-          onChange={[Function]}
-          type="checkbox"
-          value="2"
+        <Instruction
+          args={null}
+          reverse={false}
+          source="apd.introduction.instruction"
         />
-        2
-      </label>
-      <label
-        className="mr1"
-        key="3"
+        <RichText
+          content="about the program"
+          editorClassName="rte-textarea-l"
+          onSync={[Function]}
+        />
+      </div>
+      <div
+        className="mb3"
       >
-        <input
-          checked={false}
-          onChange={[Function]}
-          type="checkbox"
-          value="3"
+        <Instruction
+          args={null}
+          reverse={false}
+          source="apd.hit.instruction"
         />
-        3
-      </label>
-    </div>
-    <div
-      className="mb3"
-    >
-      <Instruction
-        args={null}
-        reverse={false}
-        source="apd.introduction.instruction"
-      />
-      <RichText
-        content="about the program"
-        editorClassName="rte-textarea-l"
-        onSync={[Function]}
-      />
-    </div>
-    <div
-      className="mb3"
-    >
-      <Instruction
-        args={null}
-        reverse={false}
-        source="apd.hit.instruction"
-      />
-      <RichText
-        content="about hit"
-        editorClassName="rte-textarea-l"
-        onSync={[Function]}
-      />
-    </div>
-    <div
-      className="mb3"
-    >
-      <Instruction
-        args={null}
-        reverse={false}
-        source="apd.hie.instruction"
-      />
-      <RichText
-        content="about hie"
-        editorClassName="rte-textarea-l"
-        onSync={[Function]}
-      />
-    </div>
-    <div>
-      <Instruction
-        args={null}
-        reverse={false}
-        source="apd.mmis.instruction"
-      />
-      <RichText
-        content="about mmis"
-        editorClassName="rte-textarea-l"
-        onSync={[Function]}
-      />
-    </div>
-  </Subsection>
-</Section>
+        <RichText
+          content="about hit"
+          editorClassName="rte-textarea-l"
+          onSync={[Function]}
+        />
+      </div>
+      <div
+        className="mb3"
+      >
+        <Instruction
+          args={null}
+          reverse={false}
+          source="apd.hie.instruction"
+        />
+        <RichText
+          content="about hie"
+          editorClassName="rte-textarea-l"
+          onSync={[Function]}
+        />
+      </div>
+      <div>
+        <Instruction
+          args={null}
+          reverse={false}
+          source="apd.mmis.instruction"
+        />
+        <RichText
+          content="about mmis"
+          editorClassName="rte-textarea-l"
+          onSync={[Function]}
+        />
+      </div>
+    </Subsection>
+  </Section>
+</Connect(ConnectedWaypoint)>
 `;

--- a/web/src/containers/__snapshots__/AssurancesAndCompliance.test.js.snap
+++ b/web/src/containers/__snapshots__/AssurancesAndCompliance.test.js.snap
@@ -13,606 +13,610 @@ exports[`assurances and compliance component LinkOrText component renders correc
 `;
 
 exports[`assurances and compliance component main component renders correctly 1`] = `
-<Section
+<Connect(ConnectedWaypoint)
   id="assurances-compliance"
-  isNumbered={true}
-  resource="assurancesAndCompliance"
 >
-  <Subsection
-    id="assurances-compliance-fed-citations"
-    nested={false}
-    resource="assurancesAndCompliance.citations"
+  <Section
+    id="assurances-compliance"
+    isNumbered={true}
+    resource="assurancesAndCompliance"
   >
-    <div
-      className="mb3"
-      key="procurement"
+    <Subsection
+      id="assurances-compliance-fed-citations"
+      nested={false}
+      resource="assurancesAndCompliance.citations"
     >
-      <h3>
-        Procurement Standards (Competition / Sole Source)
-      </h3>
       <div
-        className="mt2"
-        key="42 CFR Part 495.348"
+        className="mb3"
+        key="procurement"
       >
+        <h3>
+          Procurement Standards (Competition / Sole Source)
+        </h3>
         <div
-          className="mb1 flex items-end justify-between"
+          className="mt2"
+          key="42 CFR Part 495.348"
         >
-          <LinkOrText
-            link="https://www.ecfr.gov/cgi-bin/text-idx?SID=60f02a079c6f091871999372387e5750&mc=true&node=se42.5.495_1348&rgn=div8"
-            title="42 CFR Part 495.348"
-          />
+          <div
+            className="mb1 flex items-end justify-between"
+          >
+            <LinkOrText
+              link="https://www.ecfr.gov/cgi-bin/text-idx?SID=60f02a079c6f091871999372387e5750&mc=true&node=se42.5.495_1348&rgn=div8"
+              title="42 CFR Part 495.348"
+            />
+            <div>
+              <Btn
+                extraCss="h5 "
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                Yes
+              </Btn>
+               
+              <Btn
+                extraCss="h5 bg-black white"
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                No
+              </Btn>
+            </div>
+          </div>
           <div>
-            <Btn
-              extraCss="h5 "
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              Yes
-            </Btn>
-             
-            <Btn
-              extraCss="h5 bg-black white"
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              No
-            </Btn>
+            <InputHolder
+              className="m0 textarea textarea-sm"
+              hideLabel={true}
+              label="Explanation for why you do not comply with 42 CFR Part 495.348"
+              name="explanation-procurement-42_CFR_Part_495.348"
+              onChange={[Function]}
+              placeholder="Please explain..."
+              rows="3"
+              type="text"
+              value=""
+              wrapperClass=""
+            />
           </div>
         </div>
-        <div>
-          <InputHolder
-            className="m0 textarea textarea-sm"
-            hideLabel={true}
-            label="Explanation for why you do not comply with 42 CFR Part 495.348"
-            name="explanation-procurement-42_CFR_Part_495.348"
-            onChange={[Function]}
-            placeholder="Please explain..."
-            rows="3"
-            type="text"
-            value=""
-            wrapperClass=""
+        <div
+          className="mt2"
+          key="SMM Section 11267"
+        >
+          <div
+            className="mb1 flex items-end justify-between"
+          >
+            <LinkOrText
+              link="https://www.cms.gov/Regulations-and-Guidance/Guidance/Manuals/Paper-Based-Manuals-Items/CMS021927.html"
+              title="SMM Section 11267"
+            />
+            <div>
+              <Btn
+                extraCss="h5 bg-black white"
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                Yes
+              </Btn>
+               
+              <Btn
+                extraCss="h5 "
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                No
+              </Btn>
+            </div>
+          </div>
+          <hr
+            className="my2 border-grey"
+          />
+        </div>
+        <div
+          className="mt2"
+          key="45 CFR Part 95.615"
+        >
+          <div
+            className="mb1 flex items-end justify-between"
+          >
+            <LinkOrText
+              link="https://www.ecfr.gov/cgi-bin/text-idx?SID=2cfd59b6ec7c0a6adf749237ebbd1ba1&mc=true&node=se45.1.95_1615&rgn=div8"
+              title="45 CFR Part 95.615"
+            />
+            <div>
+              <Btn
+                extraCss="h5 bg-black white"
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                Yes
+              </Btn>
+               
+              <Btn
+                extraCss="h5 "
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                No
+              </Btn>
+            </div>
+          </div>
+          <hr
+            className="my2 border-grey"
+          />
+        </div>
+        <div
+          className="mt2"
+          key="45 CFR Part 75.326"
+        >
+          <div
+            className="mb1 flex items-end justify-between"
+          >
+            <LinkOrText
+              link={null}
+              title="45 CFR Part 75.326"
+            />
+            <div>
+              <Btn
+                extraCss="h5 bg-black white"
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                Yes
+              </Btn>
+               
+              <Btn
+                extraCss="h5 "
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                No
+              </Btn>
+            </div>
+          </div>
+          <hr
+            className="my2 border-grey"
           />
         </div>
       </div>
       <div
-        className="mt2"
-        key="SMM Section 11267"
+        className="mb3"
+        key="recordsAccess"
       >
+        <h3>
+          Access to Records, Reporting and Agency Attestations
+        </h3>
         <div
-          className="mb1 flex items-end justify-between"
+          className="mt2"
+          key="42 CFR Part 495.350"
         >
-          <LinkOrText
-            link="https://www.cms.gov/Regulations-and-Guidance/Guidance/Manuals/Paper-Based-Manuals-Items/CMS021927.html"
-            title="SMM Section 11267"
-          />
+          <div
+            className="mb1 flex items-end justify-between"
+          >
+            <LinkOrText
+              link="https://www.ecfr.gov/cgi-bin/text-idx?SID=8c677ad13ab6c202c5ae1ee1c1c0b487&mc=true&node=se42.5.495_1350&rgn=div8"
+              title="42 CFR Part 495.350"
+            />
+            <div>
+              <Btn
+                extraCss="h5 "
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                Yes
+              </Btn>
+               
+              <Btn
+                extraCss="h5 bg-black white"
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                No
+              </Btn>
+            </div>
+          </div>
           <div>
-            <Btn
-              extraCss="h5 bg-black white"
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              Yes
-            </Btn>
-             
-            <Btn
-              extraCss="h5 "
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              No
-            </Btn>
+            <InputHolder
+              className="m0 textarea textarea-sm"
+              hideLabel={true}
+              label="Explanation for why you do not comply with 42 CFR Part 495.350"
+              name="explanation-recordsAccess-42_CFR_Part_495.350"
+              onChange={[Function]}
+              placeholder="Please explain..."
+              rows="3"
+              type="text"
+              value="some words"
+              wrapperClass=""
+            />
           </div>
         </div>
-        <hr
-          className="my2 border-grey"
-        />
-      </div>
-      <div
-        className="mt2"
-        key="45 CFR Part 95.615"
-      >
         <div
-          className="mb1 flex items-end justify-between"
+          className="mt2"
+          key="42 CFR Part 495.352"
         >
-          <LinkOrText
-            link="https://www.ecfr.gov/cgi-bin/text-idx?SID=2cfd59b6ec7c0a6adf749237ebbd1ba1&mc=true&node=se45.1.95_1615&rgn=div8"
-            title="45 CFR Part 95.615"
+          <div
+            className="mb1 flex items-end justify-between"
+          >
+            <LinkOrText
+              link="https://www.ecfr.gov/cgi-bin/text-idx?SID=8c677ad13ab6c202c5ae1ee1c1c0b487&mc=true&node=se42.5.495_1352&rgn=div8"
+              title="42 CFR Part 495.352"
+            />
+            <div>
+              <Btn
+                extraCss="h5 bg-black white"
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                Yes
+              </Btn>
+               
+              <Btn
+                extraCss="h5 "
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                No
+              </Btn>
+            </div>
+          </div>
+          <hr
+            className="my2 border-grey"
           />
+        </div>
+        <div
+          className="mt2"
+          key="42 CFR Part 495.346"
+        >
+          <div
+            className="mb1 flex items-end justify-between"
+          >
+            <LinkOrText
+              link="https://www.ecfr.gov/cgi-bin/text-idx?SID=8c677ad13ab6c202c5ae1ee1c1c0b487&mc=true&node=se42.5.495_1346&rgn=div8"
+              title="42 CFR Part 495.346"
+            />
+            <div>
+              <Btn
+                extraCss="h5 bg-black white"
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                Yes
+              </Btn>
+               
+              <Btn
+                extraCss="h5 "
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                No
+              </Btn>
+            </div>
+          </div>
+          <hr
+            className="my2 border-grey"
+          />
+        </div>
+        <div
+          className="mt2"
+          key="42 CFR Part 433.112(b)(5) - (9)"
+        >
+          <div
+            className="mb1 flex items-end justify-between"
+          >
+            <LinkOrText
+              link="https://www.ecfr.gov/cgi-bin/text-idx?SID=8c677ad13ab6c202c5ae1ee1c1c0b487&mc=true&node=se42.4.433_1112&rgn=div8"
+              title="42 CFR Part 433.112(b)(5) - (9)"
+            />
+            <div>
+              <Btn
+                extraCss="h5 bg-black white"
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                Yes
+              </Btn>
+               
+              <Btn
+                extraCss="h5 "
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                No
+              </Btn>
+            </div>
+          </div>
+          <hr
+            className="my2 border-grey"
+          />
+        </div>
+        <div
+          className="mt2"
+          key="45 CFR Part 95.615"
+        >
+          <div
+            className="mb1 flex items-end justify-between"
+          >
+            <LinkOrText
+              link="https://www.ecfr.gov/cgi-bin/text-idx?SID=2cfd59b6ec7c0a6adf749237ebbd1ba1&mc=true&node=se45.1.95_1615&rgn=div8"
+              title="45 CFR Part 95.615"
+            />
+            <div>
+              <Btn
+                extraCss="h5 "
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                Yes
+              </Btn>
+               
+              <Btn
+                extraCss="h5 bg-black white"
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                No
+              </Btn>
+            </div>
+          </div>
           <div>
-            <Btn
-              extraCss="h5 bg-black white"
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              Yes
-            </Btn>
-             
-            <Btn
-              extraCss="h5 "
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              No
-            </Btn>
+            <InputHolder
+              className="m0 textarea textarea-sm"
+              hideLabel={true}
+              label="Explanation for why you do not comply with 45 CFR Part 95.615"
+              name="explanation-recordsAccess-45_CFR_Part_95.615"
+              onChange={[Function]}
+              placeholder="Please explain..."
+              rows="3"
+              type="text"
+              value="other words"
+              wrapperClass=""
+            />
           </div>
         </div>
-        <hr
-          className="my2 border-grey"
-        />
-      </div>
-      <div
-        className="mt2"
-        key="45 CFR Part 75.326"
-      >
         <div
-          className="mb1 flex items-end justify-between"
+          className="mt2"
+          key="SMM Section 11267"
         >
-          <LinkOrText
-            link={null}
-            title="45 CFR Part 75.326"
-          />
-          <div>
-            <Btn
-              extraCss="h5 bg-black white"
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              Yes
-            </Btn>
-             
-            <Btn
-              extraCss="h5 "
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              No
-            </Btn>
+          <div
+            className="mb1 flex items-end justify-between"
+          >
+            <LinkOrText
+              link="https://www.cms.gov/Regulations-and-Guidance/Guidance/Manuals/Paper-Based-Manuals-Items/CMS021927.html"
+              title="SMM Section 11267"
+            />
+            <div>
+              <Btn
+                extraCss="h5 bg-black white"
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                Yes
+              </Btn>
+               
+              <Btn
+                extraCss="h5 "
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                No
+              </Btn>
+            </div>
           </div>
-        </div>
-        <hr
-          className="my2 border-grey"
-        />
-      </div>
-    </div>
-    <div
-      className="mb3"
-      key="recordsAccess"
-    >
-      <h3>
-        Access to Records, Reporting and Agency Attestations
-      </h3>
-      <div
-        className="mt2"
-        key="42 CFR Part 495.350"
-      >
-        <div
-          className="mb1 flex items-end justify-between"
-        >
-          <LinkOrText
-            link="https://www.ecfr.gov/cgi-bin/text-idx?SID=8c677ad13ab6c202c5ae1ee1c1c0b487&mc=true&node=se42.5.495_1350&rgn=div8"
-            title="42 CFR Part 495.350"
-          />
-          <div>
-            <Btn
-              extraCss="h5 "
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              Yes
-            </Btn>
-             
-            <Btn
-              extraCss="h5 bg-black white"
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              No
-            </Btn>
-          </div>
-        </div>
-        <div>
-          <InputHolder
-            className="m0 textarea textarea-sm"
-            hideLabel={true}
-            label="Explanation for why you do not comply with 42 CFR Part 495.350"
-            name="explanation-recordsAccess-42_CFR_Part_495.350"
-            onChange={[Function]}
-            placeholder="Please explain..."
-            rows="3"
-            type="text"
-            value="some words"
-            wrapperClass=""
-          />
-        </div>
-      </div>
-      <div
-        className="mt2"
-        key="42 CFR Part 495.352"
-      >
-        <div
-          className="mb1 flex items-end justify-between"
-        >
-          <LinkOrText
-            link="https://www.ecfr.gov/cgi-bin/text-idx?SID=8c677ad13ab6c202c5ae1ee1c1c0b487&mc=true&node=se42.5.495_1352&rgn=div8"
-            title="42 CFR Part 495.352"
-          />
-          <div>
-            <Btn
-              extraCss="h5 bg-black white"
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              Yes
-            </Btn>
-             
-            <Btn
-              extraCss="h5 "
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              No
-            </Btn>
-          </div>
-        </div>
-        <hr
-          className="my2 border-grey"
-        />
-      </div>
-      <div
-        className="mt2"
-        key="42 CFR Part 495.346"
-      >
-        <div
-          className="mb1 flex items-end justify-between"
-        >
-          <LinkOrText
-            link="https://www.ecfr.gov/cgi-bin/text-idx?SID=8c677ad13ab6c202c5ae1ee1c1c0b487&mc=true&node=se42.5.495_1346&rgn=div8"
-            title="42 CFR Part 495.346"
-          />
-          <div>
-            <Btn
-              extraCss="h5 bg-black white"
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              Yes
-            </Btn>
-             
-            <Btn
-              extraCss="h5 "
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              No
-            </Btn>
-          </div>
-        </div>
-        <hr
-          className="my2 border-grey"
-        />
-      </div>
-      <div
-        className="mt2"
-        key="42 CFR Part 433.112(b)(5) - (9)"
-      >
-        <div
-          className="mb1 flex items-end justify-between"
-        >
-          <LinkOrText
-            link="https://www.ecfr.gov/cgi-bin/text-idx?SID=8c677ad13ab6c202c5ae1ee1c1c0b487&mc=true&node=se42.4.433_1112&rgn=div8"
-            title="42 CFR Part 433.112(b)(5) - (9)"
-          />
-          <div>
-            <Btn
-              extraCss="h5 bg-black white"
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              Yes
-            </Btn>
-             
-            <Btn
-              extraCss="h5 "
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              No
-            </Btn>
-          </div>
-        </div>
-        <hr
-          className="my2 border-grey"
-        />
-      </div>
-      <div
-        className="mt2"
-        key="45 CFR Part 95.615"
-      >
-        <div
-          className="mb1 flex items-end justify-between"
-        >
-          <LinkOrText
-            link="https://www.ecfr.gov/cgi-bin/text-idx?SID=2cfd59b6ec7c0a6adf749237ebbd1ba1&mc=true&node=se45.1.95_1615&rgn=div8"
-            title="45 CFR Part 95.615"
-          />
-          <div>
-            <Btn
-              extraCss="h5 "
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              Yes
-            </Btn>
-             
-            <Btn
-              extraCss="h5 bg-black white"
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              No
-            </Btn>
-          </div>
-        </div>
-        <div>
-          <InputHolder
-            className="m0 textarea textarea-sm"
-            hideLabel={true}
-            label="Explanation for why you do not comply with 45 CFR Part 95.615"
-            name="explanation-recordsAccess-45_CFR_Part_95.615"
-            onChange={[Function]}
-            placeholder="Please explain..."
-            rows="3"
-            type="text"
-            value="other words"
-            wrapperClass=""
+          <hr
+            className="my2 border-grey"
           />
         </div>
       </div>
       <div
-        className="mt2"
-        key="SMM Section 11267"
+        className="mb3"
+        key="softwareRights"
       >
+        <h3>
+          Software & Ownership Rights, Federal Licenses, Information Safeguarding, HIPAA compliance, and progress reports
+        </h3>
         <div
-          className="mb1 flex items-end justify-between"
+          className="mt2"
+          key="42 CFR Part 495.360"
         >
-          <LinkOrText
-            link="https://www.cms.gov/Regulations-and-Guidance/Guidance/Manuals/Paper-Based-Manuals-Items/CMS021927.html"
-            title="SMM Section 11267"
-          />
-          <div>
-            <Btn
-              extraCss="h5 bg-black white"
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              Yes
-            </Btn>
-             
-            <Btn
-              extraCss="h5 "
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              No
-            </Btn>
+          <div
+            className="mb1 flex items-end justify-between"
+          >
+            <LinkOrText
+              link={null}
+              title="42 CFR Part 495.360"
+            />
+            <div>
+              <Btn
+                extraCss="h5 bg-black white"
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                Yes
+              </Btn>
+               
+              <Btn
+                extraCss="h5 "
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                No
+              </Btn>
+            </div>
           </div>
+          <hr
+            className="my2 border-grey"
+          />
         </div>
-        <hr
-          className="my2 border-grey"
-        />
+        <div
+          className="mt2"
+          key="45 CFR Part 95.617"
+        >
+          <div
+            className="mb1 flex items-end justify-between"
+          >
+            <LinkOrText
+              link={null}
+              title="45 CFR Part 95.617"
+            />
+            <div>
+              <Btn
+                extraCss="h5 bg-black white"
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                Yes
+              </Btn>
+               
+              <Btn
+                extraCss="h5 "
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                No
+              </Btn>
+            </div>
+          </div>
+          <hr
+            className="my2 border-grey"
+          />
+        </div>
+        <div
+          className="mt2"
+          key="42 CFR Part 431.300"
+        >
+          <div
+            className="mb1 flex items-end justify-between"
+          >
+            <LinkOrText
+              link="https://www.ecfr.gov/cgi-bin/text-idx?SID=8c677ad13ab6c202c5ae1ee1c1c0b487&mc=true&node=se42.4.431_1300&rgn=div8"
+              title="42 CFR Part 431.300"
+            />
+            <div>
+              <Btn
+                extraCss="h5 bg-black white"
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                Yes
+              </Btn>
+               
+              <Btn
+                extraCss="h5 "
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                No
+              </Btn>
+            </div>
+          </div>
+          <hr
+            className="my2 border-grey"
+          />
+        </div>
+        <div
+          className="mt2"
+          key="42 CFR Part 433.112"
+        >
+          <div
+            className="mb1 flex items-end justify-between"
+          >
+            <LinkOrText
+              link="https://www.ecfr.gov/cgi-bin/text-idx?SID=8c677ad13ab6c202c5ae1ee1c1c0b487&mc=true&node=se42.4.433_1112&rgn=div8"
+              title="42 CFR Part 433.112"
+            />
+            <div>
+              <Btn
+                extraCss="h5 bg-black white"
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                Yes
+              </Btn>
+               
+              <Btn
+                extraCss="h5 "
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                No
+              </Btn>
+            </div>
+          </div>
+          <hr
+            className="my2 border-grey"
+          />
+        </div>
       </div>
-    </div>
-    <div
-      className="mb3"
-      key="softwareRights"
-    >
-      <h3>
-        Software & Ownership Rights, Federal Licenses, Information Safeguarding, HIPAA compliance, and progress reports
-      </h3>
       <div
-        className="mt2"
-        key="42 CFR Part 495.360"
+        className="mb3"
+        key="security"
       >
+        <h3>
+          Security and interface requirements to be employed for all state HIT systems
+        </h3>
         <div
-          className="mb1 flex items-end justify-between"
+          className="mt2"
+          key="45 CFR 164 Securities and Privacy"
         >
-          <LinkOrText
-            link={null}
-            title="42 CFR Part 495.360"
-          />
-          <div>
-            <Btn
-              extraCss="h5 bg-black white"
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              Yes
-            </Btn>
-             
-            <Btn
-              extraCss="h5 "
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              No
-            </Btn>
+          <div
+            className="mb1 flex items-end justify-between"
+          >
+            <LinkOrText
+              link="https://www.ecfr.gov/cgi-bin/text-idx?SID=2cfd59b6ec7c0a6adf749237ebbd1ba1&mc=true&tpl=/ecfrbrowse/Title45/45cfr164_main_02.tpl"
+              title="45 CFR 164 Securities and Privacy"
+            />
+            <div>
+              <Btn
+                extraCss="h5 bg-black white"
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                Yes
+              </Btn>
+               
+              <Btn
+                extraCss="h5 "
+                kind="outline"
+                onClick={[Function]}
+                size="small"
+              >
+                No
+              </Btn>
+            </div>
           </div>
-        </div>
-        <hr
-          className="my2 border-grey"
-        />
-      </div>
-      <div
-        className="mt2"
-        key="45 CFR Part 95.617"
-      >
-        <div
-          className="mb1 flex items-end justify-between"
-        >
-          <LinkOrText
-            link={null}
-            title="45 CFR Part 95.617"
+          <hr
+            className="my2 border-grey"
           />
-          <div>
-            <Btn
-              extraCss="h5 bg-black white"
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              Yes
-            </Btn>
-             
-            <Btn
-              extraCss="h5 "
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              No
-            </Btn>
-          </div>
         </div>
-        <hr
-          className="my2 border-grey"
-        />
       </div>
-      <div
-        className="mt2"
-        key="42 CFR Part 431.300"
-      >
-        <div
-          className="mb1 flex items-end justify-between"
-        >
-          <LinkOrText
-            link="https://www.ecfr.gov/cgi-bin/text-idx?SID=8c677ad13ab6c202c5ae1ee1c1c0b487&mc=true&node=se42.4.431_1300&rgn=div8"
-            title="42 CFR Part 431.300"
-          />
-          <div>
-            <Btn
-              extraCss="h5 bg-black white"
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              Yes
-            </Btn>
-             
-            <Btn
-              extraCss="h5 "
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              No
-            </Btn>
-          </div>
-        </div>
-        <hr
-          className="my2 border-grey"
-        />
-      </div>
-      <div
-        className="mt2"
-        key="42 CFR Part 433.112"
-      >
-        <div
-          className="mb1 flex items-end justify-between"
-        >
-          <LinkOrText
-            link="https://www.ecfr.gov/cgi-bin/text-idx?SID=8c677ad13ab6c202c5ae1ee1c1c0b487&mc=true&node=se42.4.433_1112&rgn=div8"
-            title="42 CFR Part 433.112"
-          />
-          <div>
-            <Btn
-              extraCss="h5 bg-black white"
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              Yes
-            </Btn>
-             
-            <Btn
-              extraCss="h5 "
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              No
-            </Btn>
-          </div>
-        </div>
-        <hr
-          className="my2 border-grey"
-        />
-      </div>
-    </div>
-    <div
-      className="mb3"
-      key="security"
-    >
-      <h3>
-        Security and interface requirements to be employed for all state HIT systems
-      </h3>
-      <div
-        className="mt2"
-        key="45 CFR 164 Securities and Privacy"
-      >
-        <div
-          className="mb1 flex items-end justify-between"
-        >
-          <LinkOrText
-            link="https://www.ecfr.gov/cgi-bin/text-idx?SID=2cfd59b6ec7c0a6adf749237ebbd1ba1&mc=true&tpl=/ecfrbrowse/Title45/45cfr164_main_02.tpl"
-            title="45 CFR 164 Securities and Privacy"
-          />
-          <div>
-            <Btn
-              extraCss="h5 bg-black white"
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              Yes
-            </Btn>
-             
-            <Btn
-              extraCss="h5 "
-              kind="outline"
-              onClick={[Function]}
-              size="small"
-            >
-              No
-            </Btn>
-          </div>
-        </div>
-        <hr
-          className="my2 border-grey"
-        />
-      </div>
-    </div>
-  </Subsection>
-</Section>
+    </Subsection>
+  </Section>
+</Connect(ConnectedWaypoint)>
 `;

--- a/web/src/containers/__snapshots__/ConnectedWaypoint.test.js.snap
+++ b/web/src/containers/__snapshots__/ConnectedWaypoint.test.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`connected waypoint higher-order component renders correctly with children 1`] = `
+<Fragment>
+  <Waypoint
+    bottomOffset="90%"
+    debug={false}
+    fireOnRapidScroll={true}
+    horizontal={false}
+    onEnter={[Function]}
+    onLeave={[Function]}
+    onPositionChange={[Function]}
+    topOffset="0px"
+  />
+  <div>
+    Hello, I am child
+  </div>
+</Fragment>
+`;
+
+exports[`connected waypoint higher-order component renders correctly without children 1`] = `
+<Fragment>
+  <Waypoint
+    bottomOffset="90%"
+    debug={false}
+    fireOnRapidScroll={true}
+    horizontal={false}
+    onEnter={[Function]}
+    onLeave={[Function]}
+    onPositionChange={[Function]}
+    topOffset="0px"
+  />
+</Fragment>
+`;

--- a/web/src/containers/__snapshots__/ExecutiveSummary.test.js.snap
+++ b/web/src/containers/__snapshots__/ExecutiveSummary.test.js.snap
@@ -1,247 +1,257 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`executive summary component renders correctly 1`] = `
-<Section
-  id="executive-summary"
-  isNumbered={true}
-  resource="executiveSummary"
+<Connect(ConnectedWaypoint)
+  id="executive-summary-overview"
 >
-  <Subsection
-    id="executive-summary-overview"
-    nested={false}
-    resource="executiveSummary.summary"
+  <Section
+    id="executive-summary"
+    isNumbered={true}
+    resource="executiveSummary"
   >
-    <div
-      className="mb2 md-flex items-center alert alert-success"
-      key="a1"
+    <Connect(ConnectedWaypoint)
+      id="executive-summary-summary"
+    />
+    <Subsection
+      id="executive-summary-summary"
+      nested={false}
+      resource="executiveSummary.summary"
     >
       <div
-        className="p2 sm-m0 flex-auto"
+        className="mb2 md-flex items-center alert alert-success"
+        key="a1"
       >
         <div
-          className="h5"
+          className="p2 sm-m0 flex-auto"
         >
-          Activity 1
+          <div
+            className="h5"
+          >
+            Activity 1
+          </div>
+          <a
+            className="h3 bold black"
+            href="#activity-a1"
+            onClick={[Function]}
+          >
+            activity 1
+          </a>
+          <div>
+            first activity
+          </div>
         </div>
-        <a
-          className="h3 bold black"
-          href="#activity-a1"
-          onClick={[Function]}
+        <div
+          className="md-flex md-col-7"
         >
-          activity 1
-        </a>
-        <div>
-          first activity
+          <div
+            className="px2 py3 flex-auto"
+            key="1"
+          >
+            <div
+              className="h5"
+            >
+              FFY 1
+            </div>
+            <div
+              className="h3 mono bold"
+            >
+              <Dollars>
+                250
+              </Dollars>
+            </div>
+          </div>
+          <div
+            className="px2 py3 flex-auto"
+            key="2"
+          >
+            <div
+              className="h5"
+            >
+              FFY 2
+            </div>
+            <div
+              className="h3 mono bold"
+            >
+              <Dollars>
+                700
+              </Dollars>
+            </div>
+          </div>
+          <div
+            className="px2 py3 flex-auto"
+          >
+            <div
+              className="h5"
+            >
+              Total
+            </div>
+            <div
+              className="h3 mono bold"
+            >
+              <Dollars>
+                950
+              </Dollars>
+            </div>
+          </div>
         </div>
       </div>
       <div
-        className="md-flex md-col-7"
+        className="mb2 md-flex items-center alert alert-success"
+        key="a2"
       >
         <div
-          className="px2 py3 flex-auto"
-          key="1"
+          className="p2 sm-m0 flex-auto"
         >
           <div
             className="h5"
           >
-            FFY 1
+            Activity 2
           </div>
-          <div
-            className="h3 mono bold"
+          <a
+            className="h3 bold black"
+            href="#activity-a2"
+            onClick={[Function]}
           >
-            <Dollars>
-              250
-            </Dollars>
+            activity 2
+          </a>
+          <div>
+            second activity
           </div>
         </div>
         <div
-          className="px2 py3 flex-auto"
-          key="2"
+          className="md-flex md-col-7"
         >
           <div
-            className="h5"
+            className="px2 py3 flex-auto"
+            key="1"
           >
-            FFY 2
+            <div
+              className="h5"
+            >
+              FFY 1
+            </div>
+            <div
+              className="h3 mono bold"
+            >
+              <Dollars>
+                300
+              </Dollars>
+            </div>
           </div>
           <div
-            className="h3 mono bold"
+            className="px2 py3 flex-auto"
+            key="2"
           >
-            <Dollars>
-              700
-            </Dollars>
+            <div
+              className="h5"
+            >
+              FFY 2
+            </div>
+            <div
+              className="h3 mono bold"
+            >
+              <Dollars>
+                10
+              </Dollars>
+            </div>
           </div>
-        </div>
-        <div
-          className="px2 py3 flex-auto"
-        >
           <div
-            className="h5"
+            className="px2 py3 flex-auto"
           >
-            Total
-          </div>
-          <div
-            className="h3 mono bold"
-          >
-            <Dollars>
-              950
-            </Dollars>
+            <div
+              className="h5"
+            >
+              Total
+            </div>
+            <div
+              className="h3 mono bold"
+            >
+              <Dollars>
+                310
+              </Dollars>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-    <div
-      className="mb2 md-flex items-center alert alert-success"
-      key="a2"
+      <div
+        className="mb2 md-flex items-center alert alert-success"
+        key="all"
+      >
+        <div
+          className="p2 sm-m0 flex-auto"
+        >
+          <div
+            className="h3 bold"
+          >
+            Total Cost
+          </div>
+        </div>
+        <div
+          className="md-flex md-col-7"
+        >
+          <div
+            className="px2 py3 flex-auto"
+            key="1"
+          >
+            <div
+              className="h5"
+            >
+              FFY 1
+            </div>
+            <div
+              className="h3 mono bold"
+            >
+              <Dollars>
+                550
+              </Dollars>
+            </div>
+          </div>
+          <div
+            className="px2 py3 flex-auto"
+            key="2"
+          >
+            <div
+              className="h5"
+            >
+              FFY 2
+            </div>
+            <div
+              className="h3 mono bold"
+            >
+              <Dollars>
+                710
+              </Dollars>
+            </div>
+          </div>
+          <div
+            className="px2 py3 flex-auto"
+          >
+            <div
+              className="h5"
+            >
+              Total
+            </div>
+            <div
+              className="h3 mono bold"
+            >
+              <Dollars>
+                1260
+              </Dollars>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Subsection>
+    <Connect(ConnectedWaypoint)
+      id="executive-summary-budget-table"
+    />
+    <Subsection
+      id="executive-summary-budget-table"
+      nested={false}
+      resource="executiveSummary.budgetTable"
     >
-      <div
-        className="p2 sm-m0 flex-auto"
-      >
-        <div
-          className="h5"
-        >
-          Activity 2
-        </div>
-        <a
-          className="h3 bold black"
-          href="#activity-a2"
-          onClick={[Function]}
-        >
-          activity 2
-        </a>
-        <div>
-          second activity
-        </div>
-      </div>
-      <div
-        className="md-flex md-col-7"
-      >
-        <div
-          className="px2 py3 flex-auto"
-          key="1"
-        >
-          <div
-            className="h5"
-          >
-            FFY 1
-          </div>
-          <div
-            className="h3 mono bold"
-          >
-            <Dollars>
-              300
-            </Dollars>
-          </div>
-        </div>
-        <div
-          className="px2 py3 flex-auto"
-          key="2"
-        >
-          <div
-            className="h5"
-          >
-            FFY 2
-          </div>
-          <div
-            className="h3 mono bold"
-          >
-            <Dollars>
-              10
-            </Dollars>
-          </div>
-        </div>
-        <div
-          className="px2 py3 flex-auto"
-        >
-          <div
-            className="h5"
-          >
-            Total
-          </div>
-          <div
-            className="h3 mono bold"
-          >
-            <Dollars>
-              310
-            </Dollars>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="mb2 md-flex items-center alert alert-success"
-      key="all"
-    >
-      <div
-        className="p2 sm-m0 flex-auto"
-      >
-        <div
-          className="h3 bold"
-        >
-          Total Cost
-        </div>
-      </div>
-      <div
-        className="md-flex md-col-7"
-      >
-        <div
-          className="px2 py3 flex-auto"
-          key="1"
-        >
-          <div
-            className="h5"
-          >
-            FFY 1
-          </div>
-          <div
-            className="h3 mono bold"
-          >
-            <Dollars>
-              550
-            </Dollars>
-          </div>
-        </div>
-        <div
-          className="px2 py3 flex-auto"
-          key="2"
-        >
-          <div
-            className="h5"
-          >
-            FFY 2
-          </div>
-          <div
-            className="h3 mono bold"
-          >
-            <Dollars>
-              710
-            </Dollars>
-          </div>
-        </div>
-        <div
-          className="px2 py3 flex-auto"
-        >
-          <div
-            className="h5"
-          >
-            Total
-          </div>
-          <div
-            className="h3 mono bold"
-          >
-            <Dollars>
-              1260
-            </Dollars>
-          </div>
-        </div>
-      </div>
-    </div>
-  </Subsection>
-  <Subsection
-    id="executive-summary-budget-table"
-    nested={false}
-    resource="executiveSummary.budgetTable"
-  >
-    <Connect(ExecutiveSummaryBudget) />
-  </Subsection>
-</Section>
+      <Connect(ExecutiveSummaryBudget) />
+    </Subsection>
+  </Section>
+</Connect(ConnectedWaypoint)>
 `;

--- a/web/src/containers/__snapshots__/PreviousActivities.test.js.snap
+++ b/web/src/containers/__snapshots__/PreviousActivities.test.js.snap
@@ -1,47 +1,57 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`previous activities component renders correctly if data is not loaded 1`] = `
-<Section
-  id="prev-activities"
-  isNumbered={true}
-  resource="previousActivities"
+<Connect(ConnectedWaypoint)
+  id="prev-activities-overview"
 >
-  <Subsection
-    id="prev-activities-outline"
-    nested={false}
-    resource="previousActivities.outline"
+  <Section
+    id="prev-activities"
+    isNumbered={true}
+    resource="previousActivities"
   >
-    <div
-      className="mb-tiny bold"
-    >
-      Previous Activities Summary
-    </div>
-    <RichText
-      content="previous"
-      editorClassName="rte-textarea-l"
-      onSync={[Function]}
+    <Connect(ConnectedWaypoint)
+      id="prev-activities-outline"
     />
-  </Subsection>
-  <Subsection
-    id="prev-activities-table"
-    nested={false}
-    resource="previousActivities.actualExpenses"
-  >
-    <div
-      className="mb3"
+    <Subsection
+      id="prev-activities-outline"
+      nested={false}
+      resource="previousActivities.outline"
     >
-      <Connect(ApdPreviousActivityTable) />
-    </div>
-    <div
-      className="mb3"
+      <div
+        className="mb-tiny bold"
+      >
+        Previous Activities Summary
+      </div>
+      <RichText
+        content="previous"
+        editorClassName="rte-textarea-l"
+        onSync={[Function]}
+      />
+    </Subsection>
+    <Connect(ConnectedWaypoint)
+      id="prev-activities-table"
+    />
+    <Subsection
+      id="prev-activities-table"
+      nested={false}
+      resource="previousActivities.actualExpenses"
     >
-      <Connect(ApdPreviousActivityTableMMIS) />
-    </div>
-    <div
-      className="mb3"
-    >
-      <Connect(ApdPreviousActivityTableMMIS) />
-    </div>
-  </Subsection>
-</Section>
+      <div
+        className="mb3"
+      >
+        <Connect(ApdPreviousActivityTable) />
+      </div>
+      <div
+        className="mb3"
+      >
+        <Connect(ApdPreviousActivityTableMMIS) />
+      </div>
+      <div
+        className="mb3"
+      >
+        <Connect(ApdPreviousActivityTableMMIS) />
+      </div>
+    </Subsection>
+  </Section>
+</Connect(ConnectedWaypoint)>
 `;

--- a/web/src/containers/__snapshots__/ScheduleSummary.test.js.snap
+++ b/web/src/containers/__snapshots__/ScheduleSummary.test.js.snap
@@ -1,213 +1,221 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`schedule summary component renders correctly 1`] = `
-<Section
+<Connect(ConnectedWaypoint)
   id="schedule-summary"
-  isNumbered={true}
-  resource="scheduleSummary"
 >
-  <Subsection
-    id="schedule-summary-table"
-    nested={false}
-    resource="scheduleSummary.main"
+  <Section
+    id="schedule-summary"
+    isNumbered={true}
+    resource="scheduleSummary"
   >
-    <ReactTable
-      AggregatedComponent={[Function]}
-      ExpanderComponent={[Function]}
-      FilterComponent={[Function]}
-      LoadingComponent={[Function]}
-      NoDataComponent={[Function]}
-      PadRowComponent={[Function]}
-      PaginationComponent={[Function]}
-      PivotValueComponent={[Function]}
-      ResizerComponent={[Function]}
-      TableComponent={[Function]}
-      TbodyComponent={[Function]}
-      TdComponent={[Function]}
-      TfootComponent={[Function]}
-      ThComponent={[Function]}
-      TheadComponent={[Function]}
-      TrComponent={[Function]}
-      TrGroupComponent={[Function]}
-      aggregatedKey="_aggregated"
-      className="h6 -striped"
-      collapseOnDataChange={true}
-      collapseOnPageChange={true}
-      collapseOnSortingChange={true}
-      column={
-        Object {
-          "Aggregated": undefined,
-          "Cell": undefined,
-          "Expander": undefined,
-          "Filter": undefined,
-          "Footer": undefined,
-          "Header": undefined,
-          "Pivot": undefined,
-          "PivotValue": undefined,
-          "Placeholder": undefined,
-          "aggregate": undefined,
-          "className": "",
-          "filterAll": false,
-          "filterMethod": undefined,
-          "filterable": undefined,
-          "footerClassName": "",
-          "footerStyle": Object {},
-          "getFooterProps": [Function],
-          "getHeaderProps": [Function],
-          "getProps": [Function],
-          "headerClassName": "",
-          "headerStyle": Object {},
-          "minResizeWidth": 11,
-          "minWidth": 100,
-          "resizable": undefined,
-          "show": true,
-          "sortMethod": undefined,
-          "sortable": undefined,
-          "style": Object {},
+    <Subsection
+      id="schedule-summary-table"
+      nested={false}
+      resource="scheduleSummary.main"
+    >
+      <ReactTable
+        AggregatedComponent={[Function]}
+        ExpanderComponent={[Function]}
+        FilterComponent={[Function]}
+        LoadingComponent={[Function]}
+        NoDataComponent={[Function]}
+        PadRowComponent={[Function]}
+        PaginationComponent={[Function]}
+        PivotValueComponent={[Function]}
+        ResizerComponent={[Function]}
+        TableComponent={[Function]}
+        TbodyComponent={[Function]}
+        TdComponent={[Function]}
+        TfootComponent={[Function]}
+        ThComponent={[Function]}
+        TheadComponent={[Function]}
+        TrComponent={[Function]}
+        TrGroupComponent={[Function]}
+        aggregatedKey="_aggregated"
+        className="h6 -striped"
+        collapseOnDataChange={true}
+        collapseOnPageChange={true}
+        collapseOnSortingChange={true}
+        column={
+          Object {
+            "Aggregated": undefined,
+            "Cell": undefined,
+            "Expander": undefined,
+            "Filter": undefined,
+            "Footer": undefined,
+            "Header": undefined,
+            "Pivot": undefined,
+            "PivotValue": undefined,
+            "Placeholder": undefined,
+            "aggregate": undefined,
+            "className": "",
+            "filterAll": false,
+            "filterMethod": undefined,
+            "filterable": undefined,
+            "footerClassName": "",
+            "footerStyle": Object {},
+            "getFooterProps": [Function],
+            "getHeaderProps": [Function],
+            "getProps": [Function],
+            "headerClassName": "",
+            "headerStyle": Object {},
+            "minResizeWidth": 11,
+            "minWidth": 100,
+            "resizable": undefined,
+            "show": true,
+            "sortMethod": undefined,
+            "sortable": undefined,
+            "style": Object {},
+          }
         }
-      }
-      columns={
-        Array [
-          Object {
-            "accessor": "accessor 1",
-            "cell": [Function],
-            "header": "Header 1",
-          },
-          Object {
-            "accessor": "accessor 2",
-            "cell": [Function],
-            "header": "Header 2",
-          },
-          Object {
-            "accessor": "accessor 3",
-            "cell": [Function],
-            "header": "Header 3",
-          },
-        ]
-      }
-      data={
-        Array [
-          Object {
-            "accessor 1": "value 1.1",
-            "accessor 2": "value 1.2",
-            "accessor 3": "value 1.3",
-          },
-          Object {
-            "accessor 1": "value 2.1",
-            "accessor 2": "value 2.2",
-            "accessor 3": "value 2.3",
-          },
-        ]
-      }
-      defaultExpanded={Object {}}
-      defaultFilterMethod={[Function]}
-      defaultFiltered={Array []}
-      defaultPage={0}
-      defaultPageSize={20}
-      defaultResized={Array []}
-      defaultSortDesc={false}
-      defaultSortMethod={[Function]}
-      defaultSorted={
-        Array [
-          Object {
-            "desc": false,
-            "id": "accessor 2",
-          },
-        ]
-      }
-      expanderDefaults={
-        Object {
-          "filterable": false,
-          "resizable": false,
-          "sortable": false,
-          "width": 35,
+        columns={
+          Array [
+            Object {
+              "accessor": "accessor 1",
+              "cell": [Function],
+              "header": "Header 1",
+            },
+            Object {
+              "accessor": "accessor 2",
+              "cell": [Function],
+              "header": "Header 2",
+            },
+            Object {
+              "accessor": "accessor 3",
+              "cell": [Function],
+              "header": "Header 3",
+            },
+          ]
         }
-      }
-      filterable={false}
-      freezeWhenExpanded={false}
-      getLoadingProps={[Function]}
-      getNoDataProps={[Function]}
-      getPaginationProps={[Function]}
-      getProps={[Function]}
-      getResizerProps={[Function]}
-      getTableProps={[Function]}
-      getTbodyProps={[Function]}
-      getTdProps={[Function]}
-      getTfootProps={[Function]}
-      getTfootTdProps={[Function]}
-      getTfootTrProps={[Function]}
-      getTheadFilterProps={[Function]}
-      getTheadFilterThProps={[Function]}
-      getTheadFilterTrProps={[Function]}
-      getTheadGroupProps={[Function]}
-      getTheadGroupThProps={[Function]}
-      getTheadGroupTrProps={[Function]}
-      getTheadProps={[Function]}
-      getTheadThProps={[Function]}
-      getTheadTrProps={[Function]}
-      getTrGroupProps={[Function]}
-      getTrProps={[Function]}
-      groupedByPivotKey="_groupedByPivot"
-      indexKey="_index"
-      loading={false}
-      loadingText="Loading..."
-      minRows={0}
-      multiSort={true}
-      nestingLevelKey="_nestingLevel"
-      nextText="Next"
-      noDataText="No rows found"
-      ofText="of"
-      onFetchData={[Function]}
-      originalKey="_original"
-      pageJumpText="jump to page"
-      pageSizeOptions={
-        Array [
-          5,
-          10,
-          20,
-          25,
-          50,
-          100,
-        ]
-      }
-      pageText="Page"
-      pivotDefaults={Object {}}
-      pivotIDKey="_pivotID"
-      pivotValKey="_pivotVal"
-      previousText="Previous"
-      resizable={false}
-      resolveData={[Function]}
-      rowsSelectorText="rows per page"
-      rowsText="rows"
-      showPageJump={true}
-      showPageSizeOptions={true}
-      showPagination={false}
-      showPaginationBottom={true}
-      showPaginationTop={false}
-      sortable={true}
-      style={Object {}}
-      subRowsKey="_subRows"
-    />
-  </Subsection>
-</Section>
+        data={
+          Array [
+            Object {
+              "accessor 1": "value 1.1",
+              "accessor 2": "value 1.2",
+              "accessor 3": "value 1.3",
+            },
+            Object {
+              "accessor 1": "value 2.1",
+              "accessor 2": "value 2.2",
+              "accessor 3": "value 2.3",
+            },
+          ]
+        }
+        defaultExpanded={Object {}}
+        defaultFilterMethod={[Function]}
+        defaultFiltered={Array []}
+        defaultPage={0}
+        defaultPageSize={20}
+        defaultResized={Array []}
+        defaultSortDesc={false}
+        defaultSortMethod={[Function]}
+        defaultSorted={
+          Array [
+            Object {
+              "desc": false,
+              "id": "accessor 2",
+            },
+          ]
+        }
+        expanderDefaults={
+          Object {
+            "filterable": false,
+            "resizable": false,
+            "sortable": false,
+            "width": 35,
+          }
+        }
+        filterable={false}
+        freezeWhenExpanded={false}
+        getLoadingProps={[Function]}
+        getNoDataProps={[Function]}
+        getPaginationProps={[Function]}
+        getProps={[Function]}
+        getResizerProps={[Function]}
+        getTableProps={[Function]}
+        getTbodyProps={[Function]}
+        getTdProps={[Function]}
+        getTfootProps={[Function]}
+        getTfootTdProps={[Function]}
+        getTfootTrProps={[Function]}
+        getTheadFilterProps={[Function]}
+        getTheadFilterThProps={[Function]}
+        getTheadFilterTrProps={[Function]}
+        getTheadGroupProps={[Function]}
+        getTheadGroupThProps={[Function]}
+        getTheadGroupTrProps={[Function]}
+        getTheadProps={[Function]}
+        getTheadThProps={[Function]}
+        getTheadTrProps={[Function]}
+        getTrGroupProps={[Function]}
+        getTrProps={[Function]}
+        groupedByPivotKey="_groupedByPivot"
+        indexKey="_index"
+        loading={false}
+        loadingText="Loading..."
+        minRows={0}
+        multiSort={true}
+        nestingLevelKey="_nestingLevel"
+        nextText="Next"
+        noDataText="No rows found"
+        ofText="of"
+        onFetchData={[Function]}
+        originalKey="_original"
+        pageJumpText="jump to page"
+        pageSizeOptions={
+          Array [
+            5,
+            10,
+            20,
+            25,
+            50,
+            100,
+          ]
+        }
+        pageText="Page"
+        pivotDefaults={Object {}}
+        pivotIDKey="_pivotID"
+        pivotValKey="_pivotVal"
+        previousText="Previous"
+        resizable={false}
+        resolveData={[Function]}
+        rowsSelectorText="rows per page"
+        rowsText="rows"
+        showPageJump={true}
+        showPageSizeOptions={true}
+        showPagination={false}
+        showPaginationBottom={true}
+        showPaginationTop={false}
+        sortable={true}
+        style={Object {}}
+        subRowsKey="_subRows"
+      />
+    </Subsection>
+  </Section>
+</Connect(ConnectedWaypoint)>
 `;
 
 exports[`schedule summary component renders correctly with no data 1`] = `
-<Section
+<Connect(ConnectedWaypoint)
   id="schedule-summary"
-  isNumbered={true}
-  resource="scheduleSummary"
 >
-  <Subsection
-    id="schedule-summary-table"
-    nested={false}
-    resource="scheduleSummary.main"
+  <Section
+    id="schedule-summary"
+    isNumbered={true}
+    resource="scheduleSummary"
   >
-    <div
-      className="p1 h6 alert"
+    <Subsection
+      id="schedule-summary-table"
+      nested={false}
+      resource="scheduleSummary.main"
     >
-      There are no milestones scheduled.
-    </div>
-  </Subsection>
-</Section>
+      <div
+        className="p1 h6 alert"
+      >
+        There are no milestones scheduled.
+      </div>
+    </Subsection>
+  </Section>
+</Connect(ConnectedWaypoint)>
 `;

--- a/web/src/containers/__snapshots__/Sidebar.test.js.snap
+++ b/web/src/containers/__snapshots__/Sidebar.test.js.snap
@@ -168,16 +168,16 @@ exports[`Sidebar component renders correctly 1`] = `
               "id": "executive-summary",
               "items": Array [
                 Object {
-                  "id": "exec-summary-overview",
+                  "id": "executive-summary-overview",
                   "label": "Overview",
                   "onClick": [Function],
                   "url": "#executive-summary",
                 },
                 Object {
-                  "id": "executive-summary-overview",
+                  "id": "executive-summary-summary",
                   "label": "Executive Summary of Activities",
                   "onClick": [Function],
-                  "url": "#executive-summary-overview",
+                  "url": "#executive-summary-summary",
                 },
                 Object {
                   "id": "executive-summary-budget-table",
@@ -190,7 +190,7 @@ exports[`Sidebar component renders correctly 1`] = `
             },
           ]
         }
-        selectedId="apd-state-profile-overview"
+        selectedId="some section"
       />
       <div
         className="ds-u-margin-top--2"

--- a/web/src/containers/activity/All.js
+++ b/web/src/containers/activity/All.js
@@ -4,33 +4,39 @@ import { connect } from 'react-redux';
 
 import EntryBasic from './EntryBasic';
 import EntryDetails from './EntryDetails';
+import Waypoint from '../ConnectedWaypoint';
 import { addActivity as addActivityAction } from '../../actions/activities';
 import Btn from '../../components/Btn';
 import { Section, Subsection } from '../../components/Section';
 import { t } from '../../i18n';
 
 const All = ({ activityKeys, addActivity }) => (
-  <Section isNumbered id="activities" resource="activities">
-    <Subsection id="activities-list" resource="activities.list" open>
-      {activityKeys.length === 0 ? (
-        <div className="mb2 p1 h6 alert">
-          {t('activities.noActivityMessage')}
-        </div>
-      ) : (
-        <div className="mb3">
-          {activityKeys.map((key, idx) => (
-            <EntryBasic key={key} aKey={key} num={idx + 1} />
-          ))}
-        </div>
-      )}
-      <Btn extraCss="visibility--screen" onClick={addActivity}>
-        {t('activities.addActivityButtonText')}
-      </Btn>
-    </Subsection>
-    {activityKeys.map((key, idx) => (
-      <EntryDetails key={key} aKey={key} num={idx + 1} />
-    ))}
-  </Section>
+  <Waypoint id="activities-overview">
+    <Section isNumbered id="activities" resource="activities">
+      <Waypoint id="activities-list" />
+      <Subsection id="activities-list" resource="activities.list" open>
+        {activityKeys.length === 0 ? (
+          <div className="mb2 p1 h6 alert">
+            {t('activities.noActivityMessage')}
+          </div>
+        ) : (
+          <div className="mb3">
+            {activityKeys.map((key, idx) => (
+              <EntryBasic key={key} aKey={key} num={idx + 1} />
+            ))}
+          </div>
+        )}
+        <Btn extraCss="visibility--screen" onClick={addActivity}>
+          {t('activities.addActivityButtonText')}
+        </Btn>
+      </Subsection>
+      {activityKeys.map((key, idx) => (
+        <Waypoint id={key}>
+          <EntryDetails key={key} aKey={key} num={idx + 1} />
+        </Waypoint>
+      ))}
+    </Section>
+  </Waypoint>
 );
 
 All.propTypes = {

--- a/web/src/containers/activity/All.js
+++ b/web/src/containers/activity/All.js
@@ -10,11 +10,7 @@ import { Section, Subsection } from '../../components/Section';
 import { t } from '../../i18n';
 
 const All = ({ activityKeys, addActivity }) => (
-  <Section
-    isNumbered
-    id="activities"
-    resource="activities"
-  >
+  <Section isNumbered id="activities" resource="activities">
     <Subsection id="activities-list" resource="activities.list" open>
       {activityKeys.length === 0 ? (
         <div className="mb2 p1 h6 alert">

--- a/web/src/containers/activity/CostAllocateFFP.js
+++ b/web/src/containers/activity/CostAllocateFFP.js
@@ -7,6 +7,7 @@ import Dollars from '../../components/Dollars';
 import { DollarInput } from '../../components/Inputs';
 import Select from '../../components/Select';
 import { t } from '../../i18n';
+import { makeSelectCostAllocateFFP } from '../../reducers/activities.selectors';
 
 class CostAllocateFFP extends Component {
   handleOther = year => e => {
@@ -95,30 +96,10 @@ CostAllocateFFP.propTypes = {
   updateActivity: PropTypes.func.isRequired
 };
 
-export const mapStateToProps = (
-  { activities: { byKey }, budget },
-  { aKey }
-) => {
-  const activity = byKey[aKey];
-  const { costAllocation } = activity;
-  const { costsByFFY } = budget.activities[aKey];
-
-  const byYearData = Object.entries(costsByFFY)
-    .filter(([year]) => year !== 'total')
-    .map(([year, costs]) => {
-      const { ffp } = costAllocation[year];
-      const ffpSelectVal = `${ffp.federal}-${ffp.state}`;
-
-      return {
-        year,
-        total: costs.total,
-        medicaidShare: costs.medicaidShare,
-        ffpSelectVal,
-        allocations: { federal: costs.federal, state: costs.state }
-      };
-    });
-
-  return { byYearData, costAllocation };
+export const makeMapStateToProps = () => {
+  const selectCostAllocateFFP = makeSelectCostAllocateFFP();
+  const mapStateToProps = (state, props) => selectCostAllocateFFP(state, props);
+  return mapStateToProps;
 };
 
 export const mapDispatchToProps = {
@@ -127,6 +108,6 @@ export const mapDispatchToProps = {
 
 export { CostAllocateFFP as CostAllocateFFPRaw };
 export default connect(
-  mapStateToProps,
+  makeMapStateToProps,
   mapDispatchToProps
 )(CostAllocateFFP);

--- a/web/src/containers/activity/CostAllocateFFP.test.js
+++ b/web/src/containers/activity/CostAllocateFFP.test.js
@@ -4,7 +4,7 @@ import React from 'react';
 
 import {
   CostAllocateFFPRaw as CostAllocateFFP,
-  mapStateToProps,
+  makeMapStateToProps,
   mapDispatchToProps
 } from './CostAllocateFFP';
 import { updateActivity } from '../../actions/activities';
@@ -128,6 +128,8 @@ describe('the CostAllocateFFP component', () => {
   });
 
   test('maps redux state to component props', () => {
+    const mapStateToProps = makeMapStateToProps();
+
     expect(mapStateToProps(state, { aKey: 'key' })).toEqual({
       byYearData: [
         {

--- a/web/src/containers/activity/CostAllocateFFPQuarterly.js
+++ b/web/src/containers/activity/CostAllocateFFPQuarterly.js
@@ -6,6 +6,7 @@ import { updateActivity } from '../../actions/activities';
 import Dollars from '../../components/Dollars';
 import { PercentInput } from '../../components/Inputs';
 import { t } from '../../i18n';
+import { makeSelectCostAllocateFFPBudget } from '../../reducers/activities.selectors';
 import { formatPerc } from '../../util/formats';
 
 const QUARTERS = [1, 2, 3, 4];
@@ -38,17 +39,13 @@ class CostAllocateFFPQuarterly extends Component {
 
     return (
       <div>
-        {years.map((year) => (
-        <div>
-            <h3>
-              {t('ffy', { year })}
-            </h3>
+        {years.map(year => (
+          <div>
+            <h3>{t('ffy', { year })}</h3>
             <table className="table-cms table-fixed">
               <thead>
                 <tr>
-                  <th
-                    id="act_qbudget_null1"
-                  />
+                  <th id="act_qbudget_null1" />
                   <Fragment key={year}>
                     {QUARTERS.map(q => (
                       <th
@@ -93,9 +90,7 @@ class CostAllocateFFPQuarterly extends Component {
                               wrapperClass="m0"
                               className="m0 input input-condensed mono right-align"
                               onChange={this.handleChange(year, q, name)}
-                              value={
-                                quarterlyFFP[year][q][name].percent * 100
-                              }
+                              value={quarterlyFFP[year][q][name].percent * 100}
                               hideLabel
                             />
                           </td>
@@ -121,7 +116,7 @@ class CostAllocateFFPQuarterly extends Component {
                             headers={`act_qbudget_fy${year} act_qbudget_fy${year}_q${q}`}
                           >
                             <Dollars>
-                              {quarterlyFFP[year].subtotal[name].dollars}
+                              {quarterlyFFP[year][q][name].dollars}
                             </Dollars>
                           </td>
                         ))}
@@ -147,7 +142,7 @@ class CostAllocateFFPQuarterly extends Component {
                         headers={`act_qbudget_fy${year} act_qbudget_fy${year}_q${q}`}
                       >
                         <Dollars>
-                          {quarterlyFFP[year].subtotal.combined.dollars}
+                          {quarterlyFFP[year][q].combined.dollars}
                         </Dollars>
                       </td>
                     ))}
@@ -165,16 +160,12 @@ class CostAllocateFFPQuarterly extends Component {
             </table>
           </div>
         ))}
-        <h3>
-          {`Total FFY ${years[0]} - ${years[years.length-1]}`}
-        </h3>
+        <h3>{`Total FFY ${years[0]} - ${years[years.length - 1]}`}</h3>
         <table className="table-cms table-fixed table-fit-contents">
           <thead>
             <tr>
-              <th/>
-              <th>
-                Total
-              </th>
+              <th />
+              <th>Total</th>
             </tr>
           </thead>
           <tbody>
@@ -186,24 +177,16 @@ class CostAllocateFFPQuarterly extends Component {
                     name === 'combined' ? 'bold' : ''
                   }`}
                 >
-                  <th>
-                    {EXPENSE_NAME_DISPLAY[name]}
-                  </th>
-                  <td
-                    className="bold mono right-align"
-                  >
+                  <th>{EXPENSE_NAME_DISPLAY[name]}</th>
+                  <td className="bold mono right-align">
                     <Dollars>{quarterlyFFP.total[name]}</Dollars>
                   </td>
                 </tr>
               </Fragment>
             ))}
             <tr>
-              <th>
-                {EXPENSE_NAME_DISPLAY.combined}
-              </th>
-              <td
-                className="bold mono right-align"
-              >
+              <th>{EXPENSE_NAME_DISPLAY.combined}</th>
+              <td className="bold mono right-align">
                 <Dollars>{quarterlyFFP.total.combined}</Dollars>
               </td>
             </tr>
@@ -221,18 +204,16 @@ CostAllocateFFPQuarterly.propTypes = {
   update: PropTypes.func.isRequired
 };
 
-const mapStateToProps = ({ apd, budget: { activities } }, { aKey }) => {
-  const budget = activities[aKey];
-
-  return {
-    quarterlyFFP: budget ? budget.quarterlyFFP : null,
-    years: apd.data.years
-  };
+const makeMapStateToProps = () => {
+  const selectCostAllocateFFPBudget = makeSelectCostAllocateFFPBudget();
+  const mapStateToProps = (state, props) =>
+    selectCostAllocateFFPBudget(state, props);
+  return mapStateToProps;
 };
 
 const mapDispatchToProps = { update: updateActivity };
 
 export default connect(
-  mapStateToProps,
+  makeMapStateToProps,
   mapDispatchToProps
 )(CostAllocateFFPQuarterly);

--- a/web/src/containers/activity/Description.js
+++ b/web/src/containers/activity/Description.js
@@ -6,6 +6,7 @@ import { updateActivity as updateActivityAction } from '../../actions/activities
 import { RichText, Textarea } from '../../components/Inputs';
 import Instruction from '../../components/Instruction';
 import { Subsection } from '../../components/Section';
+import { selectActivityByKey } from '../../reducers/activities.selectors';
 
 const Description = props => {
   const { activity, updateActivity } = props;
@@ -63,8 +64,8 @@ Description.propTypes = {
   updateActivity: PropTypes.func.isRequired
 };
 
-const mapStateToProps = ({ activities: { byKey } }, { aKey }) => ({
-  activity: byKey[aKey]
+const mapStateToProps = (state, props) => ({
+  activity: selectActivityByKey(state, props)
 });
 
 const mapDispatchToProps = {

--- a/web/src/containers/activity/EntryBasic.js
+++ b/web/src/containers/activity/EntryBasic.js
@@ -8,6 +8,7 @@ import {
 } from '../../actions/activities';
 import DeleteButton from '../../components/DeleteConfirm';
 import { Input } from '../../components/Inputs';
+import { selectActivityByKey } from '../../reducers/activities.selectors';
 import { ACTIVITY_FUNDING_SOURCES } from '../../util';
 
 class EntryBasic extends Component {
@@ -70,8 +71,8 @@ EntryBasic.propTypes = {
   updateActivity: PropTypes.func.isRequired
 };
 
-const mapStateToProps = ({ activities: { byKey } }, props) => ({
-  activity: byKey[props.aKey]
+const mapStateToProps = (state, props) => ({
+  activity: selectActivityByKey(state, props)
 });
 
 const mapDispatchToProps = {

--- a/web/src/containers/activity/EntryDetails.js
+++ b/web/src/containers/activity/EntryDetails.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { Waypoint } from 'react-waypoint';
 
 import ContractorResources from './ContractorResources';
 import CostAllocate from './CostAllocate';
@@ -14,7 +13,6 @@ import {
   removeActivity as removeActivityAction,
   toggleActivitySection
 } from '../../actions/activities';
-import { scrollTo } from '../../actions/navigation';
 import Collapsible from '../../components/Collapsible';
 import DeleteButton from '../../components/DeleteConfirm';
 import { t } from '../../i18n';
@@ -42,37 +40,35 @@ class EntryDetails extends Component {
     toggleSection(key);
   };
 
-  hitWaypoint = id => () => {
-    const { scrollTo: action } = this.props;
-    action(id);
-  };
-
   render() {
-    const { activity, aKey, expanded, num, removeActivity } = this.props;
-    const title = makeTitle(activity, num);
+    const {
+      activity: { name },
+      aKey,
+      expanded,
+      num,
+      removeActivity
+    } = this.props;
+    const title = makeTitle(name, num);
 
     return (
-      <Fragment>
-        <Waypoint onEnter={this.hitWaypoint(aKey)} bottomOffset="90%" />
-        <Collapsible
-          id={`activity-${aKey}`}
-          title={title}
-          btnBgColor="blue"
-          btnColor="white"
-          open={expanded}
-          onChange={this.handleChange(aKey)}
-        >
-          {components.map((Comp, i) => (
-            <Comp key={i} aKey={aKey} />
-          ))}
-          {num > 1 && (
-            <DeleteButton
-              remove={() => removeActivity(aKey)}
-              resource="activities.delete"
-            />
-          )}
-        </Collapsible>
-      </Fragment>
+      <Collapsible
+        id={`activity-${aKey}`}
+        title={title}
+        btnBgColor="blue"
+        btnColor="white"
+        open={expanded}
+        onChange={this.handleChange(aKey)}
+      >
+        {components.map((Comp, i) => (
+          <Comp key={i} aKey={aKey} />
+        ))}
+        {num > 1 && (
+          <DeleteButton
+            remove={() => removeActivity(aKey)}
+            resource="activities.delete"
+          />
+        )}
+      </Collapsible>
     );
   }
 }
@@ -83,7 +79,6 @@ EntryDetails.propTypes = {
   expanded: PropTypes.bool.isRequired,
   num: PropTypes.number.isRequired,
   removeActivity: PropTypes.func.isRequired,
-  scrollTo: PropTypes.func.isRequired,
   toggleSection: PropTypes.func.isRequired
 };
 
@@ -96,11 +91,10 @@ export const mapStateToProps = ({ activities: { byKey } }, { aKey }) => {
 
 export const mapDispatchToProps = {
   removeActivity: removeActivityAction,
-  scrollTo,
   toggleSection: toggleActivitySection
 };
 
-export { EntryDetails as EntryDetailsRaw };
+export { EntryDetails as plain };
 export default connect(
   mapStateToProps,
   mapDispatchToProps

--- a/web/src/containers/activity/EntryDetails.js
+++ b/web/src/containers/activity/EntryDetails.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
+import { Waypoint } from 'react-waypoint';
 
 import ContractorResources from './ContractorResources';
 import CostAllocate from './CostAllocate';
@@ -13,6 +14,7 @@ import {
   removeActivity as removeActivityAction,
   toggleActivitySection
 } from '../../actions/activities';
+import { scrollTo } from '../../actions/navigation';
 import Collapsible from '../../components/Collapsible';
 import DeleteButton from '../../components/DeleteConfirm';
 import { t } from '../../i18n';
@@ -40,52 +42,62 @@ class EntryDetails extends Component {
     toggleSection(key);
   };
 
+  hitWaypoint = id => () => {
+    const { scrollTo: action } = this.props;
+    action(id);
+  };
+
   render() {
-    const { aKey, expanded, num, removeActivity, title } = this.props;
+    const { activity, aKey, expanded, num, removeActivity } = this.props;
+    const title = makeTitle(activity, num);
 
     return (
-      <Collapsible
-        id={`activity-${aKey}`}
-        title={title}
-        bgColor="blue-light"
-        btnBgColor="blue"
-        btnColor="white"
-        open={expanded}
-        onChange={this.handleChange(aKey)}
-      >
-        {components.map((Comp, i) => (
-          <Comp key={i} aKey={aKey} />
-        ))}
-        {num > 1 && (
-          <DeleteButton
-            remove={() => removeActivity(aKey)}
-            resource="activities.delete"
-          />
-        )}
-      </Collapsible>
+      <Fragment>
+        <Waypoint onEnter={this.hitWaypoint(aKey)} bottomOffset="90%" />
+        <Collapsible
+          id={`activity-${aKey}`}
+          title={title}
+          bgColor="blue-light"
+          btnBgColor="blue"
+          btnColor="white"
+          open={expanded}
+          onChange={this.handleChange(aKey)}
+        >
+          {components.map((Comp, i) => (
+            <Comp key={i} aKey={aKey} />
+          ))}
+          {num > 1 && (
+            <DeleteButton
+              remove={() => removeActivity(aKey)}
+              resource="activities.delete"
+            />
+          )}
+        </Collapsible>
+      </Fragment>
     );
   }
 }
 
 EntryDetails.propTypes = {
+  activity: PropTypes.object.isRequired,
   aKey: PropTypes.string.isRequired,
   expanded: PropTypes.bool.isRequired,
   num: PropTypes.number.isRequired,
   removeActivity: PropTypes.func.isRequired,
-  title: PropTypes.string.isRequired,
+  scrollTo: PropTypes.func.isRequired,
   toggleSection: PropTypes.func.isRequired
 };
 
-export const mapStateToProps = ({ activities: { byKey } }, { aKey, num }) => {
+export const mapStateToProps = ({ activities: { byKey } }, { aKey }) => {
   const activity = byKey[aKey];
   const { expanded } = activity.meta;
-  const title = `${t('activities.header')} › ${makeTitle(activity, num)}`;
 
-  return { expanded, title };
+  return { activity, expanded };
 };
 
 export const mapDispatchToProps = {
   removeActivity: removeActivityAction,
+  scrollTo,
   toggleSection: toggleActivitySection
 };
 

--- a/web/src/containers/activity/EntryDetails.test.js
+++ b/web/src/containers/activity/EntryDetails.test.js
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import React from 'react';
 
 import {
-  EntryDetailsRaw as EntryDetails,
+  plain as EntryDetails,
   mapStateToProps,
   mapDispatchToProps
 } from './EntryDetails';
@@ -14,11 +14,13 @@ import {
 
 describe('the (Activity) EntryDetails component', () => {
   const props = {
+    activity: {
+      name: 'activity name'
+    },
     aKey: 'activity-key',
     expanded: false,
     num: 3,
     removeActivity: sinon.stub(),
-    title: 'Activity title',
     toggleSection: sinon.stub()
   };
 
@@ -42,24 +44,26 @@ describe('the (Activity) EntryDetails component', () => {
   });
 
   test('maps redux state to component props', () => {
+    const activity = {
+      fundingSource: 'FUNDING!',
+      meta: { expanded: 'bloop' },
+      name: 'activity name'
+    };
+
     expect(
       mapStateToProps(
         {
           activities: {
             byKey: {
-              key: {
-                fundingSource: 'FUNDING!',
-                meta: { expanded: 'bloop' },
-                name: 'activity name'
-              }
+              key: activity
             }
           }
         },
         { aKey: 'key', num: 3 }
       )
     ).toEqual({
-      expanded: 'bloop',
-      title: 'Program Activities › Activity 3: activity name (FUNDING!)'
+      activity,
+      expanded: 'bloop'
     });
   });
 

--- a/web/src/containers/activity/StandardsAndConditions.js
+++ b/web/src/containers/activity/StandardsAndConditions.js
@@ -7,6 +7,7 @@ import { Textarea } from '../../components/Inputs';
 import Instruction from '../../components/Instruction';
 import { Subsection } from '../../components/Section';
 import { t } from '../../i18n';
+import { selectActivityByKey } from '../../reducers/activities.selectors';
 import { STANDARDS } from '../../util';
 
 class StandardsAndConditions extends Component {
@@ -52,8 +53,8 @@ StandardsAndConditions.propTypes = {
   updateActivity: PropTypes.func.isRequired
 };
 
-const mapStateToProps = ({ activities: { byKey } }, { aKey }) => ({
-  activity: byKey[aKey]
+const mapStateToProps = (state, props) => ({
+  activity: selectActivityByKey(state, props)
 });
 
 const mapDispatchToProps = {

--- a/web/src/containers/activity/__snapshots__/All.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/All.test.js.snap
@@ -1,59 +1,78 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`the Activities component renders correctly 1`] = `
-<Section
-  id="activities"
-  isNumbered={true}
-  resource="activities"
+<Connect(ConnectedWaypoint)
+  id="activities-overview"
 >
-  <Subsection
-    id="activities-list"
-    nested={false}
-    open={true}
-    resource="activities.list"
+  <Section
+    id="activities"
+    isNumbered={true}
+    resource="activities"
   >
-    <div
-      className="mb3"
+    <Connect(ConnectedWaypoint)
+      id="activities-list"
+    />
+    <Subsection
+      id="activities-list"
+      nested={false}
+      open={true}
+      resource="activities.list"
     >
-      <Connect(EntryBasic)
+      <div
+        className="mb3"
+      >
+        <Connect(EntryBasic)
+          aKey="1"
+          key="1"
+          num={1}
+        />
+        <Connect(EntryBasic)
+          aKey="2"
+          key="2"
+          num={2}
+        />
+        <Connect(EntryBasic)
+          aKey="3"
+          key="3"
+          num={3}
+        />
+      </div>
+      <Btn
+        extraCss="visibility--screen"
+        kind="primary"
+        onClick={[Function]}
+        size={null}
+      >
+        Add activity
+      </Btn>
+    </Subsection>
+    <Connect(ConnectedWaypoint)
+      id="1"
+    >
+      <Connect(EntryDetails)
         aKey="1"
         key="1"
         num={1}
       />
-      <Connect(EntryBasic)
+    </Connect(ConnectedWaypoint)>
+    <Connect(ConnectedWaypoint)
+      id="2"
+    >
+      <Connect(EntryDetails)
         aKey="2"
         key="2"
         num={2}
       />
-      <Connect(EntryBasic)
+    </Connect(ConnectedWaypoint)>
+    <Connect(ConnectedWaypoint)
+      id="3"
+    >
+      <Connect(EntryDetails)
         aKey="3"
         key="3"
         num={3}
       />
-    </div>
-    <Btn
-      extraCss="visibility--screen"
-      kind="primary"
-      onClick={[Function]}
-      size={null}
-    >
-      Add activity
-    </Btn>
-  </Subsection>
-  <Connect(EntryDetails)
-    aKey="1"
-    key="1"
-    num={1}
-  />
-  <Connect(EntryDetails)
-    aKey="2"
-    key="2"
-    num={2}
-  />
-  <Connect(EntryDetails)
-    aKey="3"
-    key="3"
-    num={3}
-  />
-</Section>
+    </Connect(ConnectedWaypoint)>
+  </Section>
+</Connect(ConnectedWaypoint)>
 `;

--- a/web/src/containers/activity/__snapshots__/EntryDetails.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/EntryDetails.test.js.snap
@@ -10,7 +10,7 @@ exports[`the (Activity) EntryDetails component renders correctly 1`] = `
   onChange={[Function]}
   open={false}
   sticky={true}
-  title="Activity title"
+  title="Activity 3"
 >
   <Connect(Description)
     aKey="activity-key"

--- a/web/src/reducers/activities.selectors.js
+++ b/web/src/reducers/activities.selectors.js
@@ -1,0 +1,76 @@
+import { createSelector } from 'reselect';
+import { selectApdData } from './apd.selectors';
+
+export const selectActivityKeys = ({ activities: { allKeys } }) => allKeys;
+
+export const selectActivitiesByKey = ({ activities: { byKey } }) => byKey;
+
+export const selectActivityByKey = ({ activities: { byKey } }, { aKey }) =>
+  byKey[aKey];
+
+const selectBudgetForActivity = ({ budget }, { aKey }) =>
+  budget.activities[aKey];
+
+export const makeSelectCostAllocateFFP = () =>
+  createSelector(
+    [selectActivityByKey, selectBudgetForActivity],
+    (activity, budget) => {
+      const { costAllocation } = activity;
+      const { costsByFFY } = budget;
+
+      const byYearData = Object.entries(costsByFFY)
+        .filter(([year]) => year !== 'total')
+        .map(([year, costs]) => {
+          const { ffp } = costAllocation[year];
+          const ffpSelectVal = `${ffp.federal}-${ffp.state}`;
+
+          return {
+            year,
+            total: costs.total,
+            medicaidShare: costs.medicaidShare,
+            ffpSelectVal,
+            allocations: { federal: costs.federal, state: costs.state }
+          };
+        });
+
+      return { byYearData, costAllocation };
+    }
+  );
+
+export const makeSelectCostAllocateFFPBudget = () =>
+  createSelector(
+    [selectApdData, selectBudgetForActivity],
+    (apd, budget) => ({
+      quarterlyFFP: budget ? budget.quarterlyFFP : null,
+      years: apd.years
+    })
+  );
+
+export const selectActivitySchedule = createSelector(
+  [selectActivitiesByKey],
+  byKey => {
+    const data = [];
+
+    Object.values(byKey).forEach(activity => {
+      activity.schedule.forEach(milestone => {
+        data.push({
+          ...milestone,
+          activityName: activity.name,
+          startDate: activity.plannedStartDate
+        });
+      });
+    });
+
+    return data;
+  }
+);
+
+export const selectActivitiesSidebar = createSelector(
+  [selectActivityKeys, selectActivitiesByKey],
+  (allKeys, byKey) =>
+    allKeys.map(key => ({
+      key,
+      anchor: `activity-${key}`,
+      name: byKey[key].name
+    }))
+);

--- a/web/src/reducers/apd.selectors.js
+++ b/web/src/reducers/apd.selectors.js
@@ -1,0 +1,69 @@
+import { createSelector } from 'reselect';
+import { INCENTIVE_ENTRIES } from '../util';
+
+export const selectApds = ({ apd }) => apd;
+
+export const selectApdData = ({ apd: { data } }) => data;
+
+export const selectApdYears = ({
+  apd: {
+    data: { years }
+  }
+}) => years;
+
+export const selectPreviousActivityExpensesTotals = createSelector(
+  [selectApdData],
+  ({ previousActivityExpenses }) =>
+    Object.entries(previousActivityExpenses).reduce(
+      (acc, [ffy, expenses]) => ({
+        ...acc,
+        [ffy]: {
+          actual:
+            expenses.hithie.federalActual +
+            [90, 75, 50].reduce(
+              (sum, ffp) => sum + expenses.mmis[ffp].federalActual,
+              0
+            ),
+          approved:
+            expenses.hithie.totalApproved * 0.9 +
+            [90, 75, 50].reduce(
+              (sum, ffp) =>
+                sum + (expenses.mmis[ffp].totalApproved * ffp) / 100,
+              0
+            )
+        }
+      }),
+      {}
+    )
+);
+
+const addObjVals = obj => Object.values(obj).reduce((a, b) => +a + +b, 0);
+
+export const selectIncentivePayments = ({
+  apd: {
+    data: { incentivePayments }
+  }
+}) => incentivePayments;
+
+export const selectIncentivePaymentTotals = createSelector(
+  [selectApdData],
+  ({ incentivePayments, years }) => {
+    const totals = INCENTIVE_ENTRIES.reduce((obj, entry) => {
+      const datum = incentivePayments[entry.id];
+      const byYear = years.reduce((obj2, yr) => {
+        obj2[yr] = addObjVals(datum[yr]);
+        return obj2;
+      }, {});
+
+      obj[entry.id] = { byYear, allYears: addObjVals(byYear) };
+      return obj;
+    }, {});
+
+    return totals;
+  }
+);
+
+export const selectApdDashboard = createSelector(
+  [selectApds],
+  ({ byId }) => Object.values(byId).map(({ id, years }) => ({ id, years }))
+);

--- a/web/src/reducers/budget.selectors.js
+++ b/web/src/reducers/budget.selectors.js
@@ -1,0 +1,56 @@
+import { createSelector } from 'reselect';
+import { selectActivitiesByKey } from './activities.selectors';
+import { selectApdData } from './apd.selectors';
+import { ACTIVITY_FUNDING_SOURCES } from '../util';
+
+const selectBudget = ({ budget }) => budget;
+
+export const selectBudgetActivitiesByFundingSource = createSelector(
+  [selectBudget],
+  budget => {
+    const activities = ACTIVITY_FUNDING_SOURCES.reduce(
+      (obj, source) => ({
+        ...obj,
+        [source.toLowerCase()]: budget.activityTotals.filter(
+          a => a.fundingSource === source
+        )
+      }),
+      {}
+    );
+
+    return activities;
+  }
+);
+
+export const selectBudgetExecutiveSummary = createSelector(
+  [selectApdData, selectActivitiesByKey, selectBudget],
+  ({ years }, byKey, budget) => {
+    const data = Object.entries(byKey).map(([key, { name, descShort }]) => {
+      const activityCosts = budget.activities[key].costsByFFY;
+
+      return {
+        key,
+        name,
+        descShort,
+        totals: years.reduce(
+          (acc, year) => ({ ...acc, [year]: activityCosts[year].total }),
+          {}
+        ),
+        combined: activityCosts.total.total
+      };
+    });
+
+    data.push({
+      key: 'all',
+      name: 'Total Cost',
+      descShort: null,
+      totals: years.reduce(
+        (acc, year) => ({ ...acc, [year]: budget.combined[year].total }),
+        {}
+      ),
+      combined: budget.combined.total.total
+    });
+
+    return data;
+  }
+);

--- a/web/src/reducers/index.js
+++ b/web/src/reducers/index.js
@@ -7,19 +7,22 @@ import apd from './apd';
 import auth from './auth';
 import budget from './budget';
 import dirty from './dirty';
+import navigation from './navigation';
 import notification from './notification';
 import user from './user';
 
-const rootReducer = history => combineReducers({
-  activities,
-  admin,
-  apd,
-  auth,
-  budget,
-  dirty,
-  notification,
-  user,
-  router: connectRouter(history)
-});
+const rootReducer = history =>
+  combineReducers({
+    activities,
+    admin,
+    apd,
+    auth,
+    budget,
+    dirty,
+    navigation,
+    notification,
+    user,
+    router: connectRouter(history)
+  });
 
 export default rootReducer;

--- a/web/src/reducers/index.test.js
+++ b/web/src/reducers/index.test.js
@@ -10,6 +10,7 @@ describe('root reducer', () => {
       'auth',
       'budget',
       'dirty',
+      'navigation',
       'notification',
       'user',
       'router'

--- a/web/src/reducers/navigation.js
+++ b/web/src/reducers/navigation.js
@@ -1,0 +1,17 @@
+import { NAVIGATION_SCROLL_TO_WAYPOINT } from '../actions/navigation';
+
+const initialState = {
+  activeSection: null
+};
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case NAVIGATION_SCROLL_TO_WAYPOINT:
+      return { ...state, activeSection: action.data };
+    default:
+      return state;
+  }
+};
+
+export const selectActiveSection = ({ navigation: { activeSection } }) =>
+  activeSection;

--- a/web/src/reducers/navigation.test.js
+++ b/web/src/reducers/navigation.test.js
@@ -1,0 +1,30 @@
+import { NAVIGATION_SCROLL_TO_WAYPOINT } from '../actions/navigation';
+import reducer, { selectActiveSection } from './navigation';
+
+describe('navigation reducer', () => {
+  it('has an initial state', () => {
+    expect(reducer(undefined, {})).toEqual({ activeSection: null });
+  });
+
+  it('handles waypoint updates', () => {
+    const state = {
+      activeSection: 'old'
+    };
+
+    expect(
+      reducer(state, { type: NAVIGATION_SCROLL_TO_WAYPOINT, data: 'new' })
+    ).toEqual({
+      activeSection: 'new'
+    });
+  });
+
+  describe('selectors...', () => {
+    it('selects the current active section', () => {
+      const state = {
+        navigation: { activeSection: 'inactive... just kidding' }
+      };
+
+      expect(selectActiveSection(state)).toEqual('inactive... just kidding');
+    });
+  });
+});


### PR DESCRIPTION
Adds waypoints before all `<Section>` and `<Subsection>` elements and updates the active navigation section as they come into view, where "in view" is defined as 90% from the bottom of the screen.  The 90% is kind of arbitrary, but simply "on the screen" ends up with an aggressive battle over what thing is currently selected when multiple things are on the screen.  E.g., should the nav bar change as soon as another section scrolls into view from the bottom, even though 90% of the screen is occupied by the current section?

I think 👆 that is a tough design question.  What are the conditions to set a section as the active one?

Into the dev weeds, because this generates state changes as the user scrolls, I noticed a lot of performance problems.  It turns out some of our `mapStateToProps` functions are doing data calculation and mutation, which means they get executed every time the state changes.  That was contributing to our performance problems because it meant some of the budget data was being recomputed on every keypress (😬), but then it got worse because it was also happening on scroll (😬😬😬😬😬).  This PR also adds the [reselect](https://npm.im/reselect) library to create memoized state selectors for the `mapStateToProps` functions that do calculation/mutation.

Reselect creates a function that remembers its last arguments and return value.  If the arguments don't change, then it just returns the previous return value.  By narrowing which piece of the app state the function relies on, reselect can memoize based on just that piece of state, rather than the whole state.  It can also memoize on props, so you can create a function that is only executed once until its relevant pieces of data are changed.

### This pull request changes...
- highlights the navbar as the user scrolls
- memoizes mutating state-to-props mapping functions for performance gains

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [x] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This feature is done when...
- [ ] Design has approved the experience
- [x] Product has approved the experience
