### PR TITLE
Patch for #1397

### DIFF
--- a/web/src/containers/ApdStateProfileMedicaidOffice.js
+++ b/web/src/containers/ApdStateProfileMedicaidOffice.js
@@ -22,11 +22,10 @@ class ApdStateProfile extends Component {
 
     return (
       <Fragment>
-        <h4 className="ds-h4 ds-u-margin-bottom--0">
-          {t(`${dirTRoot}.title`)}
-        </h4>
-        <fieldset className="ds-u-margin--0 ds-u-padding--0 ds-u-border--0">
-          <legend className="sr-only">medicaid director details</legend>
+        <fieldset>
+          <legend>
+            {t(`${dirTRoot}.title`)}
+          </legend>
           <TextField
             name="apd-state-profile-mdname"
             label={t(`${dirTRoot}.labels.name`)}
@@ -47,11 +46,10 @@ class ApdStateProfile extends Component {
           />
         </fieldset>
 
-        <h4 className="ds-h4 ds-u-margin-bottom--0 ds-u-margin-top--5">
-          {t(`${offTRoot}.title`)}
-        </h4>
-        <fieldset className="ds-u-margin--0 ds-u-padding--0 ds-u-border--0">
-          <legend className="sr-only">medicaid office details</legend>
+        <fieldset>
+          <legend>
+            {t(`${offTRoot}.title`)}
+          </legend>
           <TextField
             name="apd-state-profile-addr1"
             label={t(`${offTRoot}.labels.address1`)}

--- a/web/src/containers/__snapshots__/ApdStateProfileMedicaidOffice.test.js.snap
+++ b/web/src/containers/__snapshots__/ApdStateProfileMedicaidOffice.test.js.snap
@@ -2,18 +2,9 @@
 
 exports[`apd state profile, Medicaid office component renders correctly 1`] = `
 <Fragment>
-  <h4
-    className="ds-h4 ds-u-margin-bottom--0"
-  >
-    Medicaid director
-  </h4>
-  <fieldset
-    className="ds-u-margin--0 ds-u-padding--0 ds-u-border--0"
-  >
-    <legend
-      className="sr-only"
-    >
-      medicaid director details
+  <fieldset>
+    <legend>
+      Medicaid director
     </legend>
     <TextField
       label="Name"
@@ -37,18 +28,9 @@ exports[`apd state profile, Medicaid office component renders correctly 1`] = `
       value="phone"
     />
   </fieldset>
-  <h4
-    className="ds-h4 ds-u-margin-bottom--0 ds-u-margin-top--5"
-  >
-    Medicaid office
-  </h4>
-  <fieldset
-    className="ds-u-margin--0 ds-u-padding--0 ds-u-border--0"
-  >
-    <legend
-      className="sr-only"
-    >
-      medicaid office details
+  <fieldset>
+    <legend>
+      Medicaid office
     </legend>
     <TextField
       label="Address"
@@ -443,18 +425,9 @@ exports[`apd state profile, Medicaid office component renders correctly 1`] = `
 
 exports[`apd state profile, Medicaid office component renders correctly 2`] = `
 <Fragment>
-  <h4
-    className="ds-h4 ds-u-margin-bottom--0"
-  >
-    Medicaid director
-  </h4>
-  <fieldset
-    className="ds-u-margin--0 ds-u-padding--0 ds-u-border--0"
-  >
-    <legend
-      className="sr-only"
-    >
-      medicaid director details
+  <fieldset>
+    <legend>
+      Medicaid director
     </legend>
     <TextField
       label="Name"
@@ -478,18 +451,9 @@ exports[`apd state profile, Medicaid office component renders correctly 2`] = `
       value="phone"
     />
   </fieldset>
-  <h4
-    className="ds-h4 ds-u-margin-bottom--0 ds-u-margin-top--5"
-  >
-    Medicaid office
-  </h4>
-  <fieldset
-    className="ds-u-margin--0 ds-u-padding--0 ds-u-border--0"
-  >
-    <legend
-      className="sr-only"
-    >
-      medicaid office details
+  <fieldset>
+    <legend>
+      Medicaid office
     </legend>
     <TextField
       label="Address"

--- a/web/src/styles/index.scss
+++ b/web/src/styles/index.scss
@@ -4,6 +4,7 @@
 @import '/scss/overrides';
 @import '@cmsgov/design-system-support/src/settings/index';
 
+@import '/scss/forms';
 @import '/scss/password-meter';
 @import '/scss/print';
 @import '/scss/section';

--- a/web/src/styles/scss/forms.scss
+++ b/web/src/styles/scss/forms.scss
@@ -1,0 +1,17 @@
+@import '@cmsgov/design-system-support/src/settings/index';
+
+fieldset {
+  margin: 0;
+  padding: 0;
+  border: 0;
+
+  legend {
+    margin-top: $spacer-3;
+    font-size: $h4-font-size;
+    font-weight: bold;
+  }
+
+  div:first-child label.ds-c-label {
+    margin-top: 0;
+  }
+}

--- a/web/src/styles/scss/forms.scss
+++ b/web/src/styles/scss/forms.scss
@@ -4,14 +4,17 @@ fieldset {
   margin: 0;
   padding: 0;
   border: 0;
+}
 
+/* only legends that are first-level descendents of sections should inherit this style */
+section > fieldset {
   legend {
     margin-top: $spacer-3;
     font-size: $h4-font-size;
     font-weight: bold;
   }
 
-  div:first-child label.ds-c-label {
+  div label.ds-c-label {
     margin-top: 0;
   }
 }


### PR DESCRIPTION
**Note: This PR is against #1397, not `master`**
I started off making suggested changes in the original PR, but realized it was going to be easier to follow my logic if I just opened a patch PR. Feel free to take or leave as much of this as necessary! Essentially, I tried to make this implementation as vanilla as possible so that we can figure out where we need to deviate from the design system. This means that it doesn't match the mocks exactly, but that's actually okay in this case!

### This pull request changes...
- Removes the `h4`s in favor of using the `fieldset` (both are equally semantic in this case), which also removes the need to make the `fieldset` only visible to screen readers
- Adds default styling for `fieldset` and `legend` instead of applying design system utility classes -- this means that when we restyle new sections, they should mostly get the correct styling when they have the correct HTML in place 🤞 

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author