### PR TITLE
Postinstall hotfix

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -15,7 +15,7 @@
     "test-endpoints": "jest --runInBand '.+\\.endpoint\\.js'",
     "test-specific": "NODE_ENV=test tap --cov --coverage-report=lcov --no-browser --reporter=spec",
     "prettier": "prettier --single-quote --trailing-comma none --write \"**/*.js\"",
-    "postinstall": "sed -i'.backup' -e 's/\\(image: cms-eapd\\/api:\\).*/\\1'`md5 -q package-lock.json`'/g' ../docker-compose.yml && rm ../docker-compose.yml.backup"
+    "postinstall": "sed -i'.backup' -e 's/\\(image: cms-eapd\\/api:\\).*/\\1'`md5 -q package-lock.json`'/g' ../docker-compose.yml && rm ../docker-compose.yml.backup || true"
   },
   "repository": {
     "type": "git",

--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,7 @@
     "test": "jest --collectCoverage",
     "test-watch": "jest --watch",
     "prettier": "prettier --single-quote --trailing-comma none --write \"src/**/*.js\"",
-    "postinstall": "sed -i'.backup' -e 's/\\(image: cms-eapd\\/web:\\).*/\\1'`md5 -q package-lock.json`'/g' ../docker-compose.yml && rm ../docker-compose.yml.backup"
+    "postinstall": "sed -i'.backup' -e 's/\\(image: cms-eapd\\/web:\\).*/\\1'`md5 -q package-lock.json`'/g' ../docker-compose.yml && rm ../docker-compose.yml.backup || true"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Deploy fails because the postinstall step can't find `../docker-compose.yml`.  This hotfix doesn't change that, but instead of failing, it just...  `true`s.

### This pull request changes...
- deploys will work

### This pull request is ready to merge when...
- [ ] This code has been reviewed by someone other than the original author