### PR TITLE
shorter nav headers

### DIFF
--- a/web/src/i18n/locales/en/apd/stateProfile.yaml
+++ b/web/src/i18n/locales/en/apd/stateProfile.yaml
@@ -1,9 +1,9 @@
-title: State Profile Contact Information
+title: Key State Personnel
 helpText: >-
   List relevant state contacts. If this is updating a previously submitted APD,
   the information will be prepopulated. Review to ensure that it is correct.
 directorAndAddress:
-  title: State Medicaid Director and Medicaid Office Address
+  title: State Director and Office Address
   director:
     title: Medicaid director
     labels:
@@ -19,7 +19,7 @@ directorAndAddress:
       state: State
       zip: ZIP Code
 keyPersonnel:
-  title: Key Personnel and Program Management Planning
+  title: Key Personnel and Program Management
   instruction:
     short: >-
       Identify key state staff who will be involved in all activities listed in

--- a/web/src/i18n/locales/en/executiveSummary.yaml
+++ b/web/src/i18n/locales/en/executiveSummary.yaml
@@ -4,7 +4,7 @@ helpText: >-
   provided. Program budget tables are automatically included for review.
 total: Total
 summary:
-  title: Executive Summary of Activities
+  title: Activities Summary
   instruction:
     detail: >-
       Each activity is listed with its total cost and cost per FFY.

--- a/web/src/i18n/locales/en/previousActivities.yaml
+++ b/web/src/i18n/locales/en/previousActivities.yaml
@@ -3,6 +3,11 @@ helpText: >-
   Describe the results of the program’s activities approved in the previous APD.
   This includes both the current status of those activities and the costs associated
   with them.
+actualExpenses:
+  title: Actual Costs
+  instruction:
+    detail: >-
+      Input the most recent approved and actual costs.
 outline:
   title: Prior Activities Overview
   instruction:
@@ -12,8 +17,3 @@ outline:
       Provide a high level description of the activities that are completed, in-progress,
       or on-hold.
     label: Previous Activities Summary
-actualExpenses:
-  title: Actual Costs
-  instruction:
-    detail: >-
-      Input the most recent approved and actual costs.

--- a/web/src/i18n/locales/en/proposedBudget.yaml
+++ b/web/src/i18n/locales/en/proposedBudget.yaml
@@ -10,7 +10,7 @@ summaryBudget:
       The table breaks out the Medicaid share, federal share, and state share. Amounts
       are calculated automatically.
 quarterlyBudget:
-  title: Federal share by FFY Quarter
+  title: Quarterly Federal Share
   instruction:
     detail: >-
       These tables summarize the proposed budget for federal financial participation
@@ -20,7 +20,7 @@ quarterlyBudget:
     contractor: Private Contractor Costs
     combined: Total Enhanced FFP
 paymentsByFFYQuarter:
-  title: Incentive Payments by FFY Quarter
+  title: Estimated Quarterly Incentive Payments
   instruction:
     detail: >-
       Use this table to capture incentive payments for Eligible Hospitals (EHs) and


### PR DESCRIPTION
### what this does
* shortens some titles, which should be reflected in the nav

### what this does not do
* add an `Export` section. Until that experience is settled, there’s not much point in creating a yaml for the content.
* rename the profile info yaml file to more closely reflect the new title. Probably fine, but at some point it might be worth auditing the yaml itself for this, too