### PR TITLE
Login consent screen

### DIFF
--- a/web/src/components/ConsentBanner.js
+++ b/web/src/components/ConsentBanner.js
@@ -1,6 +1,6 @@
 import { Button } from '@cmsgov/design-system-core';
 import PropTypes from 'prop-types';
-import React, { PureComponent } from 'react';
+import React, { Fragment, PureComponent } from 'react';
 
 let cookie = name => {
   const cookieMap = (document.cookie || '').split(';').reduce((c, s) => {
@@ -41,82 +41,86 @@ class ConsentBanner extends PureComponent {
     return (
       <div className="card--container">
         <div className="ds-l-container">
-          <div className="ds-l-row">
-            <div className={`ds-l-col--${showDetails ? 2 : 4}`} />
-            {showDetails ? (
-              <div className="ds-l-col--8 ds-u-fill--white ds-u-padding--3 ds-u-radius">
-                <p>
-                  This warning banner provides privacy and security notices
-                  consistent with applicable federal laws, directives, and other
-                  federal guidance for accessing this Government system, which
-                  includes (1) this computer network, (2) all computers
-                  connected to this network, and (3) all devices and storage
-                  media attached to this network or to a computer on this
-                  network.
-                </p>
-                <p>
-                  This system is provided for Government authorized use only.
-                </p>
-                <p>
-                  Unauthorized or improper use of this system is prohibited and
-                  may result in disciplinary action and/or civil and criminal
-                  penalties.
-                </p>
-                <p>
-                  Personal use of social media and networking sites on this
-                  system is limited as to not interfere with official work
-                  duties and is subject to monitoring.
-                </p>
-                <p>
-                  By using this system, you understand and consent to the
-                  following:
-                </p>
-                <ul>
-                  <li>
-                    The Government may monitor, record, and audit your system
-                    usage, including usage of personal devices and email systems
-                    for official duties or to conduct HHS business. Therefore,
-                    you have no reasonable expectation of privacy regarding any
-                    communication or data transiting or stored on this system.
-                    At any time, and for any lawful Government purpose, the
-                    government may monitor, intercept, and search and seize any
-                    communication or data transiting or stored on this system.
-                  </li>
-                  <li>
-                    Any communication or data transiting or stored on this
-                    system may be disclosed or used for any lawful Government
-                    purpose. To continue, you must accept the terms and
-                    conditions. If you decline, your login will automatically be
-                    cancelled.
-                  </li>
-                </ul>
-                <div className="ds-u-text-align--right">
-                  <Button variation="primary" onClick={this.toggleDetails}>
-                    Hide details
-                  </Button>
-                </div>
-              </div>
-            ) : (
-              <div className="ds-l-col--4 ds-u-fill--white ds-u-padding--3 ds-u-radius">
-                <p>
-                  This is a U.S. government service. Your use indicates your
-                  consent to monitoring, recording, and no expectation of
-                  privacy. Misuse is subject to criminal and civil penalties.{' '}
-                  <Button
-                    size="small"
-                    variation="transparent"
-                    onClick={this.toggleDetails}
-                  >
-                    Read more details
-                  </Button>
-                </p>
-                <div className="ds-u-text-align--center">
-                  <Button variation="primary" onClick={this.agreeAndContinue}>
-                    Agree and Continue
-                  </Button>
-                </div>
-              </div>
-            )}
+          <div className="ds-l-row card">
+            <div className="ds-l-col--1 ds-u-margin-left--auto" />
+            <div className="ds-l-col--12 ds-l-sm-col--10 ds-l-lg-col--6">
+              {showDetails ? (
+                <Fragment>
+                  <p>
+                    This warning banner provides privacy and security notices
+                    consistent with applicable federal laws, directives, and
+                    other federal guidance for accessing this Government system,
+                    which includes (1) this computer network, (2) all computers
+                    connected to this network, and (3) all devices and storage
+                    media attached to this network or to a computer on this
+                    network.
+                  </p>
+                  <p>
+                    This system is provided for Government authorized use only.
+                  </p>
+                  <p>
+                    Unauthorized or improper use of this system is prohibited
+                    and may result in disciplinary action and/or civil and
+                    criminal penalties.
+                  </p>
+                  <p>
+                    Personal use of social media and networking sites on this
+                    system is limited as to not interfere with official work
+                    duties and is subject to monitoring.
+                  </p>
+                  <p>
+                    By using this system, you understand and consent to the
+                    following:
+                  </p>
+                  <ul>
+                    <li>
+                      The Government may monitor, record, and audit your system
+                      usage, including usage of personal devices and email
+                      systems for official duties or to conduct HHS business.
+                      Therefore, you have no reasonable expectation of privacy
+                      regarding any communication or data transiting or stored
+                      on this system. At any time, and for any lawful Government
+                      purpose, the government may monitor, intercept, and search
+                      and seize any communication or data transiting or stored
+                      on this system.
+                    </li>
+                    <li>
+                      Any communication or data transiting or stored on this
+                      system may be disclosed or used for any lawful Government
+                      purpose. To continue, you must accept the terms and
+                      conditions. If you decline, your login will automatically
+                      be cancelled.
+                    </li>
+                  </ul>
+                  <div className="ds-u-text-align--right">
+                    <Button variation="primary" onClick={this.toggleDetails}>
+                      Hide details
+                    </Button>
+                  </div>
+                </Fragment>
+              ) : (
+                <Fragment>
+                  <p>
+                    This is a U.S. government service. Your use indicates your
+                    consent to monitoring, recording, and no expectation of
+                    privacy. Misuse is subject to criminal and civil penalties.{' '}
+                    <Button
+                      size="small"
+                      variation="transparent"
+                      onClick={this.toggleDetails}
+                    >
+                      Read more details
+                    </Button>
+                  </p>
+                  <div className="ds-u-text-align--center">
+                    <Button variation="primary" onClick={this.agreeAndContinue}>
+                      Agree and Continue
+                    </Button>
+                  </div>
+                </Fragment>
+              )}
+            </div>
+            <div className="ds-l-col--1 ds-u-margin-right--auto" />
           </div>
         </div>
       </div>

--- a/web/src/components/ConsentBanner.js
+++ b/web/src/components/ConsentBanner.js
@@ -114,7 +114,7 @@ class ConsentBanner extends PureComponent {
                   </p>
                   <div className="ds-u-text-align--center">
                     <Button variation="primary" onClick={this.agreeAndContinue}>
-                      Agree and Continue
+                      Agree and continue
                     </Button>
                   </div>
                 </Fragment>

--- a/web/src/components/ConsentBanner.js
+++ b/web/src/components/ConsentBanner.js
@@ -1,0 +1,131 @@
+import { Button } from '@cmsgov/design-system-core';
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+
+let cookie = name => {
+  const cookieMap = (document.cookie || '').split(';').reduce((c, s) => {
+    const bits = s.trim().split('=');
+    if (bits.length === 2) {
+      return { ...c, [bits[0].trim()]: bits[1].trim() };
+    }
+    return c;
+  }, {});
+
+  cookie = n => cookieMap[n];
+
+  return cookieMap[name];
+};
+
+class ConsentBanner extends PureComponent {
+  state = { showDetails: false };
+
+  agreeAndContinue = () => {
+    const { onAgree } = this.props;
+    document.cookie = 'gov.cms.eapd.hasConsented=true;max-age=259200'; // 3 days
+    onAgree();
+  };
+
+  toggleDetails = () => {
+    this.setState(prev => ({ showDetails: !prev.showDetails }));
+  };
+
+  render() {
+    const { showDetails } = this.state;
+
+    const hasConsented = cookie('gov.cms.eapd.hasConsented');
+    if (hasConsented) {
+      this.agreeAndContinue();
+      return null;
+    }
+
+    return (
+      <div className="card--container">
+        <div className="ds-l-container">
+          <div className="ds-l-row">
+            <div className={`ds-l-col--${showDetails ? 2 : 4}`} />
+            {showDetails ? (
+              <div className="ds-l-col--8 ds-u-fill--white ds-u-padding--3 ds-u-radius">
+                <p>
+                  This warning banner provides privacy and security notices
+                  consistent with applicable federal laws, directives, and other
+                  federal guidance for accessing this Government system, which
+                  includes (1) this computer network, (2) all computers
+                  connected to this network, and (3) all devices and storage
+                  media attached to this network or to a computer on this
+                  network.
+                </p>
+                <p>
+                  This system is provided for Government authorized use only.
+                </p>
+                <p>
+                  Unauthorized or improper use of this system is prohibited and
+                  may result in disciplinary action and/or civil and criminal
+                  penalties.
+                </p>
+                <p>
+                  Personal use of social media and networking sites on this
+                  system is limited as to not interfere with official work
+                  duties and is subject to monitoring.
+                </p>
+                <p>
+                  By using this system, you understand and consent to the
+                  following:
+                </p>
+                <ul>
+                  <li>
+                    The Government may monitor, record, and audit your system
+                    usage, including usage of personal devices and email systems
+                    for official duties or to conduct HHS business. Therefore,
+                    you have no reasonable expectation of privacy regarding any
+                    communication or data transiting or stored on this system.
+                    At any time, and for any lawful Government purpose, the
+                    government may monitor, intercept, and search and seize any
+                    communication or data transiting or stored on this system.
+                  </li>
+                  <li>
+                    Any communication or data transiting or stored on this
+                    system may be disclosed or used for any lawful Government
+                    purpose. To continue, you must accept the terms and
+                    conditions. If you decline, your login will automatically be
+                    cancelled.
+                  </li>
+                </ul>
+                <div className="ds-u-text-align--right">
+                  <Button variation="primary" onClick={this.toggleDetails}>
+                    Hide details
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <div className="ds-l-col--4 ds-u-fill--white ds-u-padding--3 ds-u-radius">
+                <p>
+                  This is a U.S. government service. Your use indicates your
+                  consent to monitoring, recording, and no expectation of
+                  privacy. Misuse is subject to criminal and civil penalties.{' '}
+                  <Button
+                    size="small"
+                    variation="transparent"
+                    onClick={this.toggleDetails}
+                  >
+                    Read more details
+                  </Button>
+                </p>
+                <div className="ds-u-text-align--center">
+                  <Button variation="primary" onClick={this.agreeAndContinue}>
+                    Agree and Continue
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+ConsentBanner.propTypes = {
+  onAgree: PropTypes.func.isRequired
+};
+
+export default ConsentBanner;

--- a/web/src/components/ConsentBanner.test.js
+++ b/web/src/components/ConsentBanner.test.js
@@ -1,0 +1,60 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import sinon from 'sinon';
+
+describe('Consent banner component', () => {
+  let ConsentBanner;
+  const onAgree = sinon.spy();
+
+  beforeEach(() => {
+    jest.resetModules();
+    onAgree.resetHistory();
+    ConsentBanner = require('./ConsentBanner').default; // eslint-disable-line global-require
+  });
+
+  describe('when there is no cookie', () => {
+    test('renders the banner', () => {
+      const component = shallow(<ConsentBanner onAgree={onAgree} />);
+      expect(component).toMatchSnapshot();
+    });
+
+    test('toggles consent details on and off', () => {
+      const component = shallow(<ConsentBanner onAgree={onAgree} />);
+      expect(component).toMatchSnapshot();
+
+      // toggle on the details
+      component
+        .find('Button')
+        .find({ variation: 'transparent' })
+        .simulate('click');
+      expect(component).toMatchSnapshot();
+
+      // toggle them off
+      component.find('Button').simulate('click');
+      expect(component).toMatchSnapshot();
+    });
+
+    test('dismisses on agreement', () => {
+      const component = shallow(<ConsentBanner onAgree={onAgree} />);
+      component
+        .find('Button')
+        .find({ variation: 'primary' })
+        .simulate('click');
+
+      expect(onAgree.calledOnce).toEqual(true);
+    });
+  });
+
+  describe('when there is a consent cookie', () => {
+    beforeEach(() => {
+      document.cookie = 'gov.cms.eapd.hasConsented=true';
+    });
+
+    test('calls onAgree prop and does not render anything', () => {
+      const component = shallow(<ConsentBanner onAgree={onAgree} />);
+
+      expect(component).toMatchSnapshot();
+      expect(onAgree.calledOnce).toEqual(true);
+    });
+  });
+});

--- a/web/src/components/__snapshots__/ConsentBanner.test.js.snap
+++ b/web/src/components/__snapshots__/ConsentBanner.test.js.snap
@@ -38,7 +38,7 @@ exports[`Consent banner component when there is no cookie renders the banner 1`]
             type="button"
             variation="primary"
           >
-            Agree and Continue
+            Agree and continue
           </Button>
         </div>
       </div>
@@ -86,7 +86,7 @@ exports[`Consent banner component when there is no cookie toggles consent detail
             type="button"
             variation="primary"
           >
-            Agree and Continue
+            Agree and continue
           </Button>
         </div>
       </div>
@@ -193,7 +193,7 @@ exports[`Consent banner component when there is no cookie toggles consent detail
             type="button"
             variation="primary"
           >
-            Agree and Continue
+            Agree and continue
           </Button>
         </div>
       </div>

--- a/web/src/components/__snapshots__/ConsentBanner.test.js.snap
+++ b/web/src/components/__snapshots__/ConsentBanner.test.js.snap
@@ -1,0 +1,194 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Consent banner component when there is a consent cookie calls onAgree prop and does not render anything 1`] = `""`;
+
+exports[`Consent banner component when there is no cookie renders the banner 1`] = `
+<div
+  className="card--container"
+>
+  <div
+    className="ds-l-container"
+  >
+    <div
+      className="ds-l-row"
+    >
+      <div
+        className="ds-l-col--4"
+      />
+      <div
+        className="ds-l-col--4 ds-u-fill--white ds-u-padding--3 ds-u-radius"
+      >
+        <p>
+          This is a U.S. government service. Your use indicates your consent to monitoring, recording, and no expectation of privacy. Misuse is subject to criminal and civil penalties.
+           
+          <Button
+            onClick={[Function]}
+            size="small"
+            type="button"
+            variation="transparent"
+          >
+            Read more details
+          </Button>
+        </p>
+        <div
+          className="ds-u-text-align--center"
+        >
+          <Button
+            onClick={[Function]}
+            type="button"
+            variation="primary"
+          >
+            Agree and Continue
+          </Button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Consent banner component when there is no cookie toggles consent details on and off 1`] = `
+<div
+  className="card--container"
+>
+  <div
+    className="ds-l-container"
+  >
+    <div
+      className="ds-l-row"
+    >
+      <div
+        className="ds-l-col--4"
+      />
+      <div
+        className="ds-l-col--4 ds-u-fill--white ds-u-padding--3 ds-u-radius"
+      >
+        <p>
+          This is a U.S. government service. Your use indicates your consent to monitoring, recording, and no expectation of privacy. Misuse is subject to criminal and civil penalties.
+           
+          <Button
+            onClick={[Function]}
+            size="small"
+            type="button"
+            variation="transparent"
+          >
+            Read more details
+          </Button>
+        </p>
+        <div
+          className="ds-u-text-align--center"
+        >
+          <Button
+            onClick={[Function]}
+            type="button"
+            variation="primary"
+          >
+            Agree and Continue
+          </Button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Consent banner component when there is no cookie toggles consent details on and off 2`] = `
+<div
+  className="card--container"
+>
+  <div
+    className="ds-l-container"
+  >
+    <div
+      className="ds-l-row"
+    >
+      <div
+        className="ds-l-col--2"
+      />
+      <div
+        className="ds-l-col--8 ds-u-fill--white ds-u-padding--3 ds-u-radius"
+      >
+        <p>
+          This warning banner provides privacy and security notices consistent with applicable federal laws, directives, and other federal guidance for accessing this Government system, which includes (1) this computer network, (2) all computers connected to this network, and (3) all devices and storage media attached to this network or to a computer on this network.
+        </p>
+        <p>
+          This system is provided for Government authorized use only.
+        </p>
+        <p>
+          Unauthorized or improper use of this system is prohibited and may result in disciplinary action and/or civil and criminal penalties.
+        </p>
+        <p>
+          Personal use of social media and networking sites on this system is limited as to not interfere with official work duties and is subject to monitoring.
+        </p>
+        <p>
+          By using this system, you understand and consent to the following:
+        </p>
+        <ul>
+          <li>
+            The Government may monitor, record, and audit your system usage, including usage of personal devices and email systems for official duties or to conduct HHS business. Therefore, you have no reasonable expectation of privacy regarding any communication or data transiting or stored on this system. At any time, and for any lawful Government purpose, the government may monitor, intercept, and search and seize any communication or data transiting or stored on this system.
+          </li>
+          <li>
+            Any communication or data transiting or stored on this system may be disclosed or used for any lawful Government purpose. To continue, you must accept the terms and conditions. If you decline, your login will automatically be cancelled.
+          </li>
+        </ul>
+        <div
+          className="ds-u-text-align--right"
+        >
+          <Button
+            onClick={[Function]}
+            type="button"
+            variation="primary"
+          >
+            Hide details
+          </Button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Consent banner component when there is no cookie toggles consent details on and off 3`] = `
+<div
+  className="card--container"
+>
+  <div
+    className="ds-l-container"
+  >
+    <div
+      className="ds-l-row"
+    >
+      <div
+        className="ds-l-col--4"
+      />
+      <div
+        className="ds-l-col--4 ds-u-fill--white ds-u-padding--3 ds-u-radius"
+      >
+        <p>
+          This is a U.S. government service. Your use indicates your consent to monitoring, recording, and no expectation of privacy. Misuse is subject to criminal and civil penalties.
+           
+          <Button
+            onClick={[Function]}
+            size="small"
+            type="button"
+            variation="transparent"
+          >
+            Read more details
+          </Button>
+        </p>
+        <div
+          className="ds-u-text-align--center"
+        >
+          <Button
+            onClick={[Function]}
+            type="button"
+            variation="primary"
+          >
+            Agree and Continue
+          </Button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/web/src/components/__snapshots__/ConsentBanner.test.js.snap
+++ b/web/src/components/__snapshots__/ConsentBanner.test.js.snap
@@ -10,13 +10,13 @@ exports[`Consent banner component when there is no cookie renders the banner 1`]
     className="ds-l-container"
   >
     <div
-      className="ds-l-row"
+      className="ds-l-row card"
     >
       <div
-        className="ds-l-col--4"
+        className="ds-l-col--1 ds-u-margin-left--auto"
       />
       <div
-        className="ds-l-col--4 ds-u-fill--white ds-u-padding--3 ds-u-radius"
+        className="ds-l-col--12 ds-l-sm-col--10 ds-l-lg-col--6"
       >
         <p>
           This is a U.S. government service. Your use indicates your consent to monitoring, recording, and no expectation of privacy. Misuse is subject to criminal and civil penalties.
@@ -42,6 +42,9 @@ exports[`Consent banner component when there is no cookie renders the banner 1`]
           </Button>
         </div>
       </div>
+      <div
+        className="ds-l-col--1 ds-u-margin-right--auto"
+      />
     </div>
   </div>
 </div>
@@ -55,13 +58,13 @@ exports[`Consent banner component when there is no cookie toggles consent detail
     className="ds-l-container"
   >
     <div
-      className="ds-l-row"
+      className="ds-l-row card"
     >
       <div
-        className="ds-l-col--4"
+        className="ds-l-col--1 ds-u-margin-left--auto"
       />
       <div
-        className="ds-l-col--4 ds-u-fill--white ds-u-padding--3 ds-u-radius"
+        className="ds-l-col--12 ds-l-sm-col--10 ds-l-lg-col--6"
       >
         <p>
           This is a U.S. government service. Your use indicates your consent to monitoring, recording, and no expectation of privacy. Misuse is subject to criminal and civil penalties.
@@ -87,6 +90,9 @@ exports[`Consent banner component when there is no cookie toggles consent detail
           </Button>
         </div>
       </div>
+      <div
+        className="ds-l-col--1 ds-u-margin-right--auto"
+      />
     </div>
   </div>
 </div>
@@ -100,13 +106,13 @@ exports[`Consent banner component when there is no cookie toggles consent detail
     className="ds-l-container"
   >
     <div
-      className="ds-l-row"
+      className="ds-l-row card"
     >
       <div
-        className="ds-l-col--2"
+        className="ds-l-col--1 ds-u-margin-left--auto"
       />
       <div
-        className="ds-l-col--8 ds-u-fill--white ds-u-padding--3 ds-u-radius"
+        className="ds-l-col--12 ds-l-sm-col--10 ds-l-lg-col--6"
       >
         <p>
           This warning banner provides privacy and security notices consistent with applicable federal laws, directives, and other federal guidance for accessing this Government system, which includes (1) this computer network, (2) all computers connected to this network, and (3) all devices and storage media attached to this network or to a computer on this network.
@@ -143,6 +149,9 @@ exports[`Consent banner component when there is no cookie toggles consent detail
           </Button>
         </div>
       </div>
+      <div
+        className="ds-l-col--1 ds-u-margin-right--auto"
+      />
     </div>
   </div>
 </div>
@@ -156,13 +165,13 @@ exports[`Consent banner component when there is no cookie toggles consent detail
     className="ds-l-container"
   >
     <div
-      className="ds-l-row"
+      className="ds-l-row card"
     >
       <div
-        className="ds-l-col--4"
+        className="ds-l-col--1 ds-u-margin-left--auto"
       />
       <div
-        className="ds-l-col--4 ds-u-fill--white ds-u-padding--3 ds-u-radius"
+        className="ds-l-col--12 ds-l-sm-col--10 ds-l-lg-col--6"
       >
         <p>
           This is a U.S. government service. Your use indicates your consent to monitoring, recording, and no expectation of privacy. Misuse is subject to criminal and civil penalties.
@@ -188,6 +197,9 @@ exports[`Consent banner component when there is no cookie toggles consent detail
           </Button>
         </div>
       </div>
+      <div
+        className="ds-l-col--1 ds-u-margin-right--auto"
+      />
     </div>
   </div>
 </div>

--- a/web/src/containers/Login.js
+++ b/web/src/containers/Login.js
@@ -42,7 +42,12 @@ class Login extends Component {
     }
 
     if (showConsent) {
-      return <ConsentBanner onAgree={this.hideConsent} />;
+      return (
+        <Fragment>
+          <Header />
+          <ConsentBanner onAgree={this.hideConsent} />
+        </Fragment>
+      );
     }
 
     let errorMessage = false;

--- a/web/src/containers/Login.js
+++ b/web/src/containers/Login.js
@@ -4,13 +4,14 @@ import { connect } from 'react-redux';
 import { Redirect } from 'react-router-dom';
 import { TextField } from '@cmsgov/design-system-core';
 
+import ConsentBanner from '../components/ConsentBanner';
 import { login } from '../actions/auth';
 import CardForm from '../components/CardForm';
 import Header from '../components/Header';
 import Password from '../components/PasswordWithMeter';
 
 class Login extends Component {
-  state = { username: '', password: '' };
+  state = { showConsent: true, username: '', password: '' };
 
   handleChange = e => {
     const { name, value } = e.target;
@@ -24,16 +25,24 @@ class Login extends Component {
     action(username, password);
   };
 
+  hideConsent = () => {
+    this.setState({ showConsent: false });
+  };
+
   render() {
     const { authenticated, error, fetching, location } = this.props;
     const { from } = location.state || { from: { pathname: '/' } };
-    const { username, password } = this.state;
+    const { showConsent, username, password } = this.state;
 
     if (authenticated) {
       if (from.pathname !== '/logout') {
         return <Redirect to={from} />;
       }
       return <Redirect to="/" />;
+    }
+
+    if (showConsent) {
+      return <ConsentBanner onAgree={this.hideConsent} />;
     }
 
     let errorMessage = false;

--- a/web/src/containers/Login.test.js
+++ b/web/src/containers/Login.test.js
@@ -39,6 +39,19 @@ describe('login component', () => {
     expect(component).toMatchSnapshot();
   });
 
+  test('renders consent banner initially', () => {
+    const component = shallow(
+      <Login
+        authenticated={false}
+        error=""
+        fetching={false}
+        location={{ state: { from: 'origin' } }}
+        login={() => {}}
+      />
+    );
+    expect(component).toMatchSnapshot();
+  });
+
   test('renders correctly if not logged in', () => {
     const component = shallow(
       <Login
@@ -49,6 +62,9 @@ describe('login component', () => {
         login={() => {}}
       />
     );
+    // clicky the consent banner to get through to the login screen
+    component.find('ConsentBanner').prop('onAgree')();
+
     expect(component).toMatchSnapshot();
 
     component
@@ -71,6 +87,9 @@ describe('login component', () => {
         login={() => {}}
       />
     );
+    // clicky the consent banner to get through to the login screen
+    component.find('ConsentBanner').prop('onAgree')();
+
     expect(component).toMatchSnapshot();
   });
 
@@ -84,6 +103,9 @@ describe('login component', () => {
         login={() => {}}
       />
     );
+    // clicky the consent banner to get through to the login screen
+    component.find('ConsentBanner').prop('onAgree')();
+
     expect(component).toMatchSnapshot();
   });
 
@@ -100,6 +122,8 @@ describe('login component', () => {
         login={loginProp}
       />
     );
+    // clicky the consent banner to get through to the login screen
+    component.find('ConsentBanner').prop('onAgree')();
 
     component
       .find('TextField')

--- a/web/src/containers/__snapshots__/Login.test.js.snap
+++ b/web/src/containers/__snapshots__/Login.test.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`login component renders consent banner initially 1`] = `
+<ConsentBanner
+  onAgree={[Function]}
+/>
+`;
+
 exports[`login component renders correctly if logged in 1`] = `
 <Redirect
   push={false}

--- a/web/src/containers/__snapshots__/Login.test.js.snap
+++ b/web/src/containers/__snapshots__/Login.test.js.snap
@@ -1,9 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`login component renders consent banner initially 1`] = `
-<ConsentBanner
-  onAgree={[Function]}
-/>
+<Fragment>
+  <Connect(Header) />
+  <ConsentBanner
+    onAgree={[Function]}
+  />
+</Fragment>
 `;
 
 exports[`login component renders correctly if logged in 1`] = `


### PR DESCRIPTION
### This pull request changes...
- adds a government IS consent banner before allowing access to the web app
  - Once a user logs in, we store a cookie in their browser that's valid for 3 days and won't show them the consent banner again as long as the cookie is valid.  The cookie expiration is extended when the user logs in again, but not every time they visit the app.
- closes #1424

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This feature is done when...
- [ ] Design has approved the experience
- [ ] Product has approved the experience
