### PR TITLE
Fix activity names in list headers

### DIFF
--- a/web/src/containers/activity/EntryDetails.js
+++ b/web/src/containers/activity/EntryDetails.js
@@ -17,10 +17,14 @@ import Collapsible from '../../components/Collapsible';
 import DeleteButton from '../../components/DeleteConfirm';
 import { t } from '../../i18n';
 
-const makeTitle = (a, i) => {
+const makeTitle = ({ name, fundingSource }, i) => {
   let title = `${t('activities.namePrefix')} ${i}`;
-  if (a.name) title += `: ${a.name}`;
-  if (a.fundingSource) title += ` (${a.fundingSource})`;
+  if (name) {
+    title += `: ${name}`;
+  }
+  if (fundingSource) {
+    title += ` (${fundingSource})`;
+  }
   return title;
 };
 
@@ -41,14 +45,8 @@ class EntryDetails extends Component {
   };
 
   render() {
-    const {
-      activity: { name },
-      aKey,
-      expanded,
-      num,
-      removeActivity
-    } = this.props;
-    const title = makeTitle(name, num);
+    const { activity, aKey, expanded, num, removeActivity } = this.props;
+    const title = makeTitle(activity, num);
 
     return (
       <Collapsible

--- a/web/src/containers/activity/__snapshots__/EntryDetails.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/EntryDetails.test.js.snap
@@ -10,7 +10,7 @@ exports[`the (Activity) EntryDetails component renders correctly 1`] = `
   onChange={[Function]}
   open={false}
   sticky={true}
-  title="Activity 3"
+  title="Activity 3: activity name"
 >
   <Connect(Description)
     aKey="activity-key"


### PR DESCRIPTION
The helper function that builds up activity names for display expects a whole activity object, but we were only sending it the activity name so it failed and just returned the default name.

### This pull request changes...
- passes the whole activity object so activity names for display are built correctly
- Fixes #1410

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author

### This feature is done when...
- [x] Product has approved the experience
