### PR TITLE
Implement new tables for program summary federal FFY share

### DIFF
--- a/web/src/containers/QuarterlyBudgetSummary.js
+++ b/web/src/containers/QuarterlyBudgetSummary.js
@@ -27,7 +27,7 @@ const QuarterlyBudgetSummary = ({ budget, years }) => {
             className="mb3"
           >
             <h3 className="ds-h3">{sourceDisplay}</h3>
-            {years.map((year, i) => (
+            {years.map((year) => (
             <table className="table-cms">
               <colgroup>
                 <col className="table-cms--col-header__fixed-width" />
@@ -67,11 +67,11 @@ const QuarterlyBudgetSummary = ({ budget, years }) => {
                   <tr
                     key={name}
                   >
-                    <td
+                    <th
                       headers={`quarterly-budget-summary-${source}-null1 quarterly-budget-summary-${source}-null2`}
                     >
                       {EXPENSE_NAME_DISPLAY[name]}
-                    </td>
+                    </th>
                     {QUARTERS.map(q => (
                       <td
                         className={`mono right-align nowrap ${
@@ -111,11 +111,11 @@ const QuarterlyBudgetSummary = ({ budget, years }) => {
               <tbody>
               {Object.keys(EXPENSE_NAME_DISPLAY).map(name => (
                 <tr>
-                  <td
+                  <th
                     headers={`quarterly-budget-summary-${source}-total`}
                   >
                     {EXPENSE_NAME_DISPLAY[name]}
-                  </td>
+                  </th>
                   <td
                     className="bold mono right-align nowrap"
                     headers={`quarterly-budget-summary-${source}-total2 quarterly-budget-summary-${source}-total`}

--- a/web/src/containers/QuarterlyBudgetSummary.js
+++ b/web/src/containers/QuarterlyBudgetSummary.js
@@ -29,6 +29,13 @@ const QuarterlyBudgetSummary = ({ budget, years }) => {
             <h3 className="ds-h3">{sourceDisplay}</h3>
             {years.map((year, i) => (
             <table className="table-cms">
+              <colgroup>
+                <col className="table-cms--col-header__fixed-width" />
+                <col />
+                <col />
+                <col />
+                <col />
+              </colgroup>
               <thead>
                 <tr>
                   <th
@@ -59,7 +66,6 @@ const QuarterlyBudgetSummary = ({ budget, years }) => {
                 {Object.keys(EXPENSE_NAME_DISPLAY).map(name => (
                   <tr
                     key={name}
-                    className={`${name === 'combined' ? 'bold' : ''}`}
                   >
                     <td
                       headers={`quarterly-budget-summary-${source}-null1 quarterly-budget-summary-${source}-null2`}
@@ -78,7 +84,7 @@ const QuarterlyBudgetSummary = ({ budget, years }) => {
                       </td>
                     ))}
                     <td
-                      className="bold mono right-align nowrap"
+                      className="mono right-align nowrap"
                       headers={`quarterly-budget-summary-${source}-fy-${year} quarterly-budget-summary-${source}-fy-${year}-subtotal`}
                     >
                       <Dollars>{data[year].subtotal[name]}</Dollars>
@@ -88,7 +94,14 @@ const QuarterlyBudgetSummary = ({ budget, years }) => {
               </tbody>
             </table>
             ))}
-            <table className="table-cms">
+            <table className="table-cms table-cms__totals">
+              <colgroup>
+                <col className="table-cms--col-header__fixed-width" />
+                <col />
+                <col />
+                <col />
+                <col />
+              </colgroup>
               <thead>
                 <tr>
                   <th id={`quarterly-budget-summary-${source}-total`}>Total {sourceDisplay}</th>

--- a/web/src/containers/QuarterlyBudgetSummary.js
+++ b/web/src/containers/QuarterlyBudgetSummary.js
@@ -7,14 +7,11 @@ import { t } from '../i18n';
 
 const FUNDING_SOURCES = [['hitAndHie', 'HIT and HIE'], ['mmis', 'MMIS']];
 const QUARTERS = [1, 2, 3, 4];
-const COLORS = ['teal', 'green', 'yellow'];
 const EXPENSE_NAME_DISPLAY = {
   state: t('proposedBudget.quarterlyBudget.expenseNames.state'),
   contractors: t('proposedBudget.quarterlyBudget.expenseNames.contractor'),
   combined: t('proposedBudget.quarterlyBudget.expenseNames.combined')
 };
-
-const color = idx => `bg-${COLORS[idx] || 'gray'}`;
 
 const QuarterlyBudgetSummary = ({ budget, years }) => {
   // wait until budget is loaded
@@ -30,44 +27,20 @@ const QuarterlyBudgetSummary = ({ budget, years }) => {
             className="mb3 table-frozen-wrapper table-frozen-wide-header"
           >
             <h3 className="mt0">{sourceDisplay}</h3>
-            <div className="overflow-x table-frozen-scroller">
-              <table
-                className="table-cms table-frozen-left-pane"
-                aria-hidden="true"
-              >
-                <thead>
-                  <tr>
-                    <th className="table-frozen-null-cell">--</th>
-                  </tr>
-                  <tr>
-                    <th className="table-frozen-null-cell">--</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {Object.keys(EXPENSE_NAME_DISPLAY).map(name => (
-                    <tr
-                      key={name}
-                      className={`${name === 'combined' ? 'bold' : ''}`}
-                    >
-                      <td>{EXPENSE_NAME_DISPLAY[name]}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-              <table className="table-cms table-frozen-data">
+            <div className="overflow-x">
+              {years.map((year, i) => (
+              <table className="table-cms">
                 <thead>
                   <tr>
                     <th id={`quarterly-budget-summary-${source}-null1`} />
-                    {years.map((year, i) => (
                       <th
                         key={year}
-                        className={`center ${color(i)}`}
+                        className="center"
                         colSpan="5"
                         id={`quarterly-budget-summary-${source}-fy-${year}`}
                       >
                         {t('ffy', { year })}
                       </th>
-                    ))}
                     <th
                       className="center"
                       id={`quarterly-budget-summary-${source}-total`}
@@ -77,8 +50,6 @@ const QuarterlyBudgetSummary = ({ budget, years }) => {
                   </tr>
                   <tr>
                     <th id={`quarterly-budget-summary-${source}-null2`} />
-                    {years.map((year, i) => (
-                      <Fragment key={year}>
                         {QUARTERS.map(q => (
                           <th
                             key={q}
@@ -89,15 +60,12 @@ const QuarterlyBudgetSummary = ({ budget, years }) => {
                           </th>
                         ))}
                         <th
-                          className={`right-align ${color(i)}-light`}
+                          className="right-align"
                           id={`quarterly-budget-summary-${source}-fy-${year}-subtotal`}
                         >
                           {t('table.subtotal')}
                         </th>
-                      </Fragment>
-                    ))}
                     <th
-                      className="bg-gray-light"
                       id={`quarterly-budget-summary-${source}-total2`}
                     />
                   </tr>
@@ -113,12 +81,10 @@ const QuarterlyBudgetSummary = ({ budget, years }) => {
                       >
                         {EXPENSE_NAME_DISPLAY[name]}
                       </td>
-                      {years.map((year, i) => (
-                        <Fragment key={year}>
                           {QUARTERS.map(q => (
                             <td
                               className={`mono right-align nowrap ${
-                                name === 'combined' ? `${color(i)}-light` : ''
+                                name === 'combined'
                               }`}
                               key={q}
                               headers={`quarterly-budget-summary-${source}-fy-${year} quarterly-budget-summary-${source}-fy-${year}-q${q}`}
@@ -127,17 +93,13 @@ const QuarterlyBudgetSummary = ({ budget, years }) => {
                             </td>
                           ))}
                           <td
-                            className={`bold mono right-align nowrap ${color(
-                              i
-                            )}-light`}
+                            className="bold mono right-align nowrap"
                             headers={`quarterly-budget-summary-${source}-fy-${year} quarterly-budget-summary-${source}-fy-${year}-subtotal`}
                           >
                             <Dollars>{data[year].subtotal[name]}</Dollars>
                           </td>
-                        </Fragment>
-                      ))}
                       <td
-                        className="bold mono right-align nowrap bg-gray-light"
+                        className="bold mono right-align nowrap"
                         headers={`quarterly-budget-summary-${source}-total2 quarterly-budget-summary-${source}-total`}
                       >
                         <Dollars>{data.total[name]}</Dollars>
@@ -146,6 +108,7 @@ const QuarterlyBudgetSummary = ({ budget, years }) => {
                   ))}
                 </tbody>
               </table>
+              ))}
             </div>
           </div>
         );

--- a/web/src/containers/QuarterlyBudgetSummary.js
+++ b/web/src/containers/QuarterlyBudgetSummary.js
@@ -18,102 +18,106 @@ const QuarterlyBudgetSummary = ({ budget, years }) => {
   if (!years.length) return null;
 
   return (
-    <div>
+    <Fragment>
       {FUNDING_SOURCES.map(([source, sourceDisplay]) => {
         const data = budget[source];
         return (
           <div
             key={source}
-            className="mb3 table-frozen-wrapper table-frozen-wide-header"
+            className="mb3"
           >
-            <h3 className="mt0">{sourceDisplay}</h3>
-            <div className="overflow-x">
-              {years.map((year, i) => (
-              <table className="table-cms">
-                <thead>
-                  <tr>
-                    <th id={`quarterly-budget-summary-${source}-null1`} />
-                      <th
-                        key={year}
-                        className="center"
-                        colSpan="5"
-                        id={`quarterly-budget-summary-${source}-fy-${year}`}
-                      >
-                        {t('ffy', { year })}
-                      </th>
+            <h3 className="ds-h3">{sourceDisplay}</h3>
+            {years.map((year, i) => (
+            <table className="table-cms">
+              <thead>
+                <tr>
+                  <th
+                    key={year}
+                    className="center"
+                    id={`quarterly-budget-summary-${source}-fy-${year}`}
+                  >
+                    {t('ffy', { year })}
+                  </th>
+                  {QUARTERS.map(q => (
                     <th
+                      key={q}
                       className="center"
-                      id={`quarterly-budget-summary-${source}-total`}
+                      id={`quarterly-budget-summary-${source}-fy-${year}-q${q}`}
                     >
-                      {t('table.total')}
+                      {t('table.quarter', { q })}
                     </th>
-                  </tr>
-                  <tr>
-                    <th id={`quarterly-budget-summary-${source}-null2`} />
-                        {QUARTERS.map(q => (
-                          <th
-                            key={q}
-                            className="center"
-                            id={`quarterly-budget-summary-${source}-fy-${year}-q${q}`}
-                          >
-                            {t('table.quarter', { q })}
-                          </th>
-                        ))}
-                        <th
-                          className="right-align"
-                          id={`quarterly-budget-summary-${source}-fy-${year}-subtotal`}
-                        >
-                          {t('table.subtotal')}
-                        </th>
-                    <th
-                      id={`quarterly-budget-summary-${source}-total2`}
-                    />
-                  </tr>
-                </thead>
-                <tbody>
-                  {Object.keys(EXPENSE_NAME_DISPLAY).map(name => (
-                    <tr
-                      key={name}
-                      className={`${name === 'combined' ? 'bold' : ''}`}
-                    >
-                      <td
-                        headers={`quarterly-budget-summary-${source}-null1 quarterly-budget-summary-${source}-null2`}
-                      >
-                        {EXPENSE_NAME_DISPLAY[name]}
-                      </td>
-                          {QUARTERS.map(q => (
-                            <td
-                              className={`mono right-align nowrap ${
-                                name === 'combined'
-                              }`}
-                              key={q}
-                              headers={`quarterly-budget-summary-${source}-fy-${year} quarterly-budget-summary-${source}-fy-${year}-q${q}`}
-                            >
-                              <Dollars>{data[year][q][name]}</Dollars>
-                            </td>
-                          ))}
-                          <td
-                            className="bold mono right-align nowrap"
-                            headers={`quarterly-budget-summary-${source}-fy-${year} quarterly-budget-summary-${source}-fy-${year}-subtotal`}
-                          >
-                            <Dollars>{data[year].subtotal[name]}</Dollars>
-                          </td>
-                      <td
-                        className="bold mono right-align nowrap"
-                        headers={`quarterly-budget-summary-${source}-total2 quarterly-budget-summary-${source}-total`}
-                      >
-                        <Dollars>{data.total[name]}</Dollars>
-                      </td>
-                    </tr>
                   ))}
-                </tbody>
-              </table>
+                  <th
+                    className="right-align"
+                    id={`quarterly-budget-summary-${source}-fy-${year}-subtotal`}
+                  >
+                    {t('table.subtotal')}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {Object.keys(EXPENSE_NAME_DISPLAY).map(name => (
+                  <tr
+                    key={name}
+                    className={`${name === 'combined' ? 'bold' : ''}`}
+                  >
+                    <td
+                      headers={`quarterly-budget-summary-${source}-null1 quarterly-budget-summary-${source}-null2`}
+                    >
+                      {EXPENSE_NAME_DISPLAY[name]}
+                    </td>
+                    {QUARTERS.map(q => (
+                      <td
+                        className={`mono right-align nowrap ${
+                          name === 'combined'
+                        }`}
+                        key={q}
+                        headers={`quarterly-budget-summary-${source}-fy-${year} quarterly-budget-summary-${source}-fy-${year}-q${q}`}
+                      >
+                        <Dollars>{data[year][q][name]}</Dollars>
+                      </td>
+                    ))}
+                    <td
+                      className="bold mono right-align nowrap"
+                      headers={`quarterly-budget-summary-${source}-fy-${year} quarterly-budget-summary-${source}-fy-${year}-subtotal`}
+                    >
+                      <Dollars>{data[year].subtotal[name]}</Dollars>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            ))}
+            <table className="table-cms">
+              <thead>
+                <tr>
+                  <th id={`quarterly-budget-summary-${source}-total`}>Total {sourceDisplay}</th>
+                  <th id={`quarterly-budget-summary-${source}-null1`}/>
+                </tr>
+              </thead>
+              <tbody>
+              {Object.keys(EXPENSE_NAME_DISPLAY).map(name => (
+                <tr>
+                  <td
+                    headers={`quarterly-budget-summary-${source}-total`}
+                  >
+                    {EXPENSE_NAME_DISPLAY[name]}
+                  </td>
+                  <td
+                    className="bold mono right-align nowrap"
+                    headers={`quarterly-budget-summary-${source}-total2 quarterly-budget-summary-${source}-total`}
+                  >
+                    <Dollars>{data.total[name]}</Dollars>
+                  </td>
+                </tr>
               ))}
-            </div>
+              </tbody>
+            </table>
           </div>
         );
+
       })}
-    </div>
+    </Fragment>
   );
 };
 

--- a/web/src/containers/__snapshots__/QuarterlyBudgetSummary.test.js.snap
+++ b/web/src/containers/__snapshots__/QuarterlyBudgetSummary.test.js.snap
@@ -1,990 +1,1050 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`quarterly budget summary component renders correctly if data is loaded 1`] = `
-<div>
+<Fragment>
   <div
-    className="mb3 table-frozen-wrapper table-frozen-wide-header"
+    className="mb3"
     key="hitAndHie"
   >
     <h3
-      className="mt0"
+      className="ds-h3"
     >
       HIT and HIE
     </h3>
-    <div
-      className="overflow-x table-frozen-scroller"
+    <table
+      className="table-cms"
     >
-      <table
-        aria-hidden="true"
-        className="table-cms table-frozen-left-pane"
-      >
-        <thead>
-          <tr>
-            <th
-              className="table-frozen-null-cell"
-            >
-              --
-            </th>
-          </tr>
-          <tr>
-            <th
-              className="table-frozen-null-cell"
-            >
-              --
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            className=""
-            key="state"
+      <colgroup>
+        <col
+          className="table-cms--col-header__fixed-width"
+        />
+        <col />
+        <col />
+        <col />
+        <col />
+      </colgroup>
+      <thead>
+        <tr>
+          <th
+            className="center"
+            id="quarterly-budget-summary-hitAndHie-fy-1"
+            key="1"
           >
-            <td>
-              In-House Costs
-            </td>
-          </tr>
-          <tr
-            className=""
-            key="contractors"
+            FFY 1
+          </th>
+          <th
+            className="center"
+            id="quarterly-budget-summary-hitAndHie-fy-1-q1"
+            key="1"
           >
-            <td>
-              Private Contractor Costs
-            </td>
-          </tr>
-          <tr
-            className="bold"
-            key="combined"
+            Q1
+          </th>
+          <th
+            className="center"
+            id="quarterly-budget-summary-hitAndHie-fy-1-q2"
+            key="2"
           >
-            <td>
-              Total Enhanced FFP
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <table
-        className="table-cms table-frozen-data"
-      >
-        <thead>
-          <tr>
-            <th
-              id="quarterly-budget-summary-hitAndHie-null1"
-            />
-            <th
-              className="center bg-teal"
-              colSpan="5"
-              id="quarterly-budget-summary-hitAndHie-fy-1"
-              key="1"
-            >
-              FFY 1
-            </th>
-            <th
-              className="center bg-green"
-              colSpan="5"
-              id="quarterly-budget-summary-hitAndHie-fy-2"
-              key="2"
-            >
-              FFY 2
-            </th>
-            <th
-              className="center"
-              id="quarterly-budget-summary-hitAndHie-total"
-            >
-              Total
-            </th>
-          </tr>
-          <tr>
-            <th
-              id="quarterly-budget-summary-hitAndHie-null2"
-            />
-            <th
-              className="center"
-              id="quarterly-budget-summary-hitAndHie-fy-1-q1"
-              key="1"
-            >
-              Q1
-            </th>
-            <th
-              className="center"
-              id="quarterly-budget-summary-hitAndHie-fy-1-q2"
-              key="2"
-            >
-              Q2
-            </th>
-            <th
-              className="center"
-              id="quarterly-budget-summary-hitAndHie-fy-1-q3"
-              key="3"
-            >
-              Q3
-            </th>
-            <th
-              className="center"
-              id="quarterly-budget-summary-hitAndHie-fy-1-q4"
-              key="4"
-            >
-              Q4
-            </th>
-            <th
-              className="right-align bg-teal-light"
-              id="quarterly-budget-summary-hitAndHie-fy-1-subtotal"
-            >
-              Subtotal
-            </th>
-            <th
-              className="center"
-              id="quarterly-budget-summary-hitAndHie-fy-2-q1"
-              key="1"
-            >
-              Q1
-            </th>
-            <th
-              className="center"
-              id="quarterly-budget-summary-hitAndHie-fy-2-q2"
-              key="2"
-            >
-              Q2
-            </th>
-            <th
-              className="center"
-              id="quarterly-budget-summary-hitAndHie-fy-2-q3"
-              key="3"
-            >
-              Q3
-            </th>
-            <th
-              className="center"
-              id="quarterly-budget-summary-hitAndHie-fy-2-q4"
-              key="4"
-            >
-              Q4
-            </th>
-            <th
-              className="right-align bg-green-light"
-              id="quarterly-budget-summary-hitAndHie-fy-2-subtotal"
-            >
-              Subtotal
-            </th>
-            <th
-              className="bg-gray-light"
-              id="quarterly-budget-summary-hitAndHie-total2"
-            />
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            className=""
-            key="state"
+            Q2
+          </th>
+          <th
+            className="center"
+            id="quarterly-budget-summary-hitAndHie-fy-1-q3"
+            key="3"
           >
-            <td
-              headers="quarterly-budget-summary-hitAndHie-null1 quarterly-budget-summary-hitAndHie-null2"
-            >
-              In-House Costs
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-q1"
-              key="1"
-            >
-              <Dollars>
-                3
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-q2"
-              key="2"
-            >
-              <Dollars>
-                6
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-q3"
-              key="3"
-            >
-              <Dollars>
-                9
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-q4"
-              key="4"
-            >
-              <Dollars>
-                12
-              </Dollars>
-            </td>
-            <td
-              className="bold mono right-align nowrap bg-teal-light"
-              headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-subtotal"
-            >
-              <Dollars>
-                15
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-q1"
-              key="1"
-            >
-              <Dollars>
-                103
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-q2"
-              key="2"
-            >
-              <Dollars>
-                106
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-q3"
-              key="3"
-            >
-              <Dollars>
-                109
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-q4"
-              key="4"
-            >
-              <Dollars>
-                112
-              </Dollars>
-            </td>
-            <td
-              className="bold mono right-align nowrap bg-green-light"
-              headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-subtotal"
-            >
-              <Dollars>
-                115
-              </Dollars>
-            </td>
-            <td
-              className="bold mono right-align nowrap bg-gray-light"
-              headers="quarterly-budget-summary-hitAndHie-total2 quarterly-budget-summary-hitAndHie-total"
-            >
-              <Dollars>
-                3002
-              </Dollars>
-            </td>
-          </tr>
-          <tr
-            className=""
-            key="contractors"
+            Q3
+          </th>
+          <th
+            className="center"
+            id="quarterly-budget-summary-hitAndHie-fy-1-q4"
+            key="4"
           >
-            <td
-              headers="quarterly-budget-summary-hitAndHie-null1 quarterly-budget-summary-hitAndHie-null2"
-            >
-              Private Contractor Costs
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-q1"
-              key="1"
-            >
-              <Dollars>
-                2
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-q2"
-              key="2"
-            >
-              <Dollars>
-                5
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-q3"
-              key="3"
-            >
-              <Dollars>
-                8
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-q4"
-              key="4"
-            >
-              <Dollars>
-                11
-              </Dollars>
-            </td>
-            <td
-              className="bold mono right-align nowrap bg-teal-light"
-              headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-subtotal"
-            >
-              <Dollars>
-                14
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-q1"
-              key="1"
-            >
-              <Dollars>
-                102
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-q2"
-              key="2"
-            >
-              <Dollars>
-                105
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-q3"
-              key="3"
-            >
-              <Dollars>
-                108
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-q4"
-              key="4"
-            >
-              <Dollars>
-                111
-              </Dollars>
-            </td>
-            <td
-              className="bold mono right-align nowrap bg-green-light"
-              headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-subtotal"
-            >
-              <Dollars>
-                114
-              </Dollars>
-            </td>
-            <td
-              className="bold mono right-align nowrap bg-gray-light"
-              headers="quarterly-budget-summary-hitAndHie-total2 quarterly-budget-summary-hitAndHie-total"
-            >
-              <Dollars>
-                3001
-              </Dollars>
-            </td>
-          </tr>
-          <tr
-            className="bold"
-            key="combined"
+            Q4
+          </th>
+          <th
+            className="right-align"
+            id="quarterly-budget-summary-hitAndHie-fy-1-subtotal"
           >
-            <td
-              headers="quarterly-budget-summary-hitAndHie-null1 quarterly-budget-summary-hitAndHie-null2"
-            >
-              Total Enhanced FFP
-            </td>
-            <td
-              className="mono right-align nowrap bg-teal-light"
-              headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-q1"
-              key="1"
-            >
-              <Dollars>
-                1
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap bg-teal-light"
-              headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-q2"
-              key="2"
-            >
-              <Dollars>
-                4
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap bg-teal-light"
-              headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-q3"
-              key="3"
-            >
-              <Dollars>
-                7
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap bg-teal-light"
-              headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-q4"
-              key="4"
-            >
-              <Dollars>
-                10
-              </Dollars>
-            </td>
-            <td
-              className="bold mono right-align nowrap bg-teal-light"
-              headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-subtotal"
-            >
-              <Dollars>
-                13
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap bg-green-light"
-              headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-q1"
-              key="1"
-            >
-              <Dollars>
-                101
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap bg-green-light"
-              headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-q2"
-              key="2"
-            >
-              <Dollars>
-                104
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap bg-green-light"
-              headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-q3"
-              key="3"
-            >
-              <Dollars>
-                107
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap bg-green-light"
-              headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-q4"
-              key="4"
-            >
-              <Dollars>
-                110
-              </Dollars>
-            </td>
-            <td
-              className="bold mono right-align nowrap bg-green-light"
-              headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-subtotal"
-            >
-              <Dollars>
-                113
-              </Dollars>
-            </td>
-            <td
-              className="bold mono right-align nowrap bg-gray-light"
-              headers="quarterly-budget-summary-hitAndHie-total2 quarterly-budget-summary-hitAndHie-total"
-            >
-              <Dollars>
-                3000
-              </Dollars>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+            Subtotal
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          key="state"
+        >
+          <th
+            headers="quarterly-budget-summary-hitAndHie-null1 quarterly-budget-summary-hitAndHie-null2"
+          >
+            In-House Costs
+          </th>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-q1"
+            key="1"
+          >
+            <Dollars>
+              3
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-q2"
+            key="2"
+          >
+            <Dollars>
+              6
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-q3"
+            key="3"
+          >
+            <Dollars>
+              9
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-q4"
+            key="4"
+          >
+            <Dollars>
+              12
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap"
+            headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-subtotal"
+          >
+            <Dollars>
+              15
+            </Dollars>
+          </td>
+        </tr>
+        <tr
+          key="contractors"
+        >
+          <th
+            headers="quarterly-budget-summary-hitAndHie-null1 quarterly-budget-summary-hitAndHie-null2"
+          >
+            Private Contractor Costs
+          </th>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-q1"
+            key="1"
+          >
+            <Dollars>
+              2
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-q2"
+            key="2"
+          >
+            <Dollars>
+              5
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-q3"
+            key="3"
+          >
+            <Dollars>
+              8
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-q4"
+            key="4"
+          >
+            <Dollars>
+              11
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap"
+            headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-subtotal"
+          >
+            <Dollars>
+              14
+            </Dollars>
+          </td>
+        </tr>
+        <tr
+          key="combined"
+        >
+          <th
+            headers="quarterly-budget-summary-hitAndHie-null1 quarterly-budget-summary-hitAndHie-null2"
+          >
+            Total Enhanced FFP
+          </th>
+          <td
+            className="mono right-align nowrap true"
+            headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-q1"
+            key="1"
+          >
+            <Dollars>
+              1
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap true"
+            headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-q2"
+            key="2"
+          >
+            <Dollars>
+              4
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap true"
+            headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-q3"
+            key="3"
+          >
+            <Dollars>
+              7
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap true"
+            headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-q4"
+            key="4"
+          >
+            <Dollars>
+              10
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap"
+            headers="quarterly-budget-summary-hitAndHie-fy-1 quarterly-budget-summary-hitAndHie-fy-1-subtotal"
+          >
+            <Dollars>
+              13
+            </Dollars>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <table
+      className="table-cms"
+    >
+      <colgroup>
+        <col
+          className="table-cms--col-header__fixed-width"
+        />
+        <col />
+        <col />
+        <col />
+        <col />
+      </colgroup>
+      <thead>
+        <tr>
+          <th
+            className="center"
+            id="quarterly-budget-summary-hitAndHie-fy-2"
+            key="2"
+          >
+            FFY 2
+          </th>
+          <th
+            className="center"
+            id="quarterly-budget-summary-hitAndHie-fy-2-q1"
+            key="1"
+          >
+            Q1
+          </th>
+          <th
+            className="center"
+            id="quarterly-budget-summary-hitAndHie-fy-2-q2"
+            key="2"
+          >
+            Q2
+          </th>
+          <th
+            className="center"
+            id="quarterly-budget-summary-hitAndHie-fy-2-q3"
+            key="3"
+          >
+            Q3
+          </th>
+          <th
+            className="center"
+            id="quarterly-budget-summary-hitAndHie-fy-2-q4"
+            key="4"
+          >
+            Q4
+          </th>
+          <th
+            className="right-align"
+            id="quarterly-budget-summary-hitAndHie-fy-2-subtotal"
+          >
+            Subtotal
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          key="state"
+        >
+          <th
+            headers="quarterly-budget-summary-hitAndHie-null1 quarterly-budget-summary-hitAndHie-null2"
+          >
+            In-House Costs
+          </th>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-q1"
+            key="1"
+          >
+            <Dollars>
+              103
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-q2"
+            key="2"
+          >
+            <Dollars>
+              106
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-q3"
+            key="3"
+          >
+            <Dollars>
+              109
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-q4"
+            key="4"
+          >
+            <Dollars>
+              112
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap"
+            headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-subtotal"
+          >
+            <Dollars>
+              115
+            </Dollars>
+          </td>
+        </tr>
+        <tr
+          key="contractors"
+        >
+          <th
+            headers="quarterly-budget-summary-hitAndHie-null1 quarterly-budget-summary-hitAndHie-null2"
+          >
+            Private Contractor Costs
+          </th>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-q1"
+            key="1"
+          >
+            <Dollars>
+              102
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-q2"
+            key="2"
+          >
+            <Dollars>
+              105
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-q3"
+            key="3"
+          >
+            <Dollars>
+              108
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-q4"
+            key="4"
+          >
+            <Dollars>
+              111
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap"
+            headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-subtotal"
+          >
+            <Dollars>
+              114
+            </Dollars>
+          </td>
+        </tr>
+        <tr
+          key="combined"
+        >
+          <th
+            headers="quarterly-budget-summary-hitAndHie-null1 quarterly-budget-summary-hitAndHie-null2"
+          >
+            Total Enhanced FFP
+          </th>
+          <td
+            className="mono right-align nowrap true"
+            headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-q1"
+            key="1"
+          >
+            <Dollars>
+              101
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap true"
+            headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-q2"
+            key="2"
+          >
+            <Dollars>
+              104
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap true"
+            headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-q3"
+            key="3"
+          >
+            <Dollars>
+              107
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap true"
+            headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-q4"
+            key="4"
+          >
+            <Dollars>
+              110
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap"
+            headers="quarterly-budget-summary-hitAndHie-fy-2 quarterly-budget-summary-hitAndHie-fy-2-subtotal"
+          >
+            <Dollars>
+              113
+            </Dollars>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <table
+      className="table-cms table-cms__totals"
+    >
+      <colgroup>
+        <col
+          className="table-cms--col-header__fixed-width"
+        />
+        <col />
+        <col />
+        <col />
+        <col />
+      </colgroup>
+      <thead>
+        <tr>
+          <th
+            id="quarterly-budget-summary-hitAndHie-total"
+          >
+            Total 
+            HIT and HIE
+          </th>
+          <th
+            id="quarterly-budget-summary-hitAndHie-null1"
+          />
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th
+            headers="quarterly-budget-summary-hitAndHie-total"
+          >
+            In-House Costs
+          </th>
+          <td
+            className="bold mono right-align nowrap"
+            headers="quarterly-budget-summary-hitAndHie-total2 quarterly-budget-summary-hitAndHie-total"
+          >
+            <Dollars>
+              3002
+            </Dollars>
+          </td>
+        </tr>
+        <tr>
+          <th
+            headers="quarterly-budget-summary-hitAndHie-total"
+          >
+            Private Contractor Costs
+          </th>
+          <td
+            className="bold mono right-align nowrap"
+            headers="quarterly-budget-summary-hitAndHie-total2 quarterly-budget-summary-hitAndHie-total"
+          >
+            <Dollars>
+              3001
+            </Dollars>
+          </td>
+        </tr>
+        <tr>
+          <th
+            headers="quarterly-budget-summary-hitAndHie-total"
+          >
+            Total Enhanced FFP
+          </th>
+          <td
+            className="bold mono right-align nowrap"
+            headers="quarterly-budget-summary-hitAndHie-total2 quarterly-budget-summary-hitAndHie-total"
+          >
+            <Dollars>
+              3000
+            </Dollars>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
   <div
-    className="mb3 table-frozen-wrapper table-frozen-wide-header"
+    className="mb3"
     key="mmis"
   >
     <h3
-      className="mt0"
+      className="ds-h3"
     >
       MMIS
     </h3>
-    <div
-      className="overflow-x table-frozen-scroller"
+    <table
+      className="table-cms"
     >
-      <table
-        aria-hidden="true"
-        className="table-cms table-frozen-left-pane"
-      >
-        <thead>
-          <tr>
-            <th
-              className="table-frozen-null-cell"
-            >
-              --
-            </th>
-          </tr>
-          <tr>
-            <th
-              className="table-frozen-null-cell"
-            >
-              --
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            className=""
-            key="state"
+      <colgroup>
+        <col
+          className="table-cms--col-header__fixed-width"
+        />
+        <col />
+        <col />
+        <col />
+        <col />
+      </colgroup>
+      <thead>
+        <tr>
+          <th
+            className="center"
+            id="quarterly-budget-summary-mmis-fy-1"
+            key="1"
           >
-            <td>
-              In-House Costs
-            </td>
-          </tr>
-          <tr
-            className=""
-            key="contractors"
+            FFY 1
+          </th>
+          <th
+            className="center"
+            id="quarterly-budget-summary-mmis-fy-1-q1"
+            key="1"
           >
-            <td>
-              Private Contractor Costs
-            </td>
-          </tr>
-          <tr
-            className="bold"
-            key="combined"
+            Q1
+          </th>
+          <th
+            className="center"
+            id="quarterly-budget-summary-mmis-fy-1-q2"
+            key="2"
           >
-            <td>
-              Total Enhanced FFP
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <table
-        className="table-cms table-frozen-data"
-      >
-        <thead>
-          <tr>
-            <th
-              id="quarterly-budget-summary-mmis-null1"
-            />
-            <th
-              className="center bg-teal"
-              colSpan="5"
-              id="quarterly-budget-summary-mmis-fy-1"
-              key="1"
-            >
-              FFY 1
-            </th>
-            <th
-              className="center bg-green"
-              colSpan="5"
-              id="quarterly-budget-summary-mmis-fy-2"
-              key="2"
-            >
-              FFY 2
-            </th>
-            <th
-              className="center"
-              id="quarterly-budget-summary-mmis-total"
-            >
-              Total
-            </th>
-          </tr>
-          <tr>
-            <th
-              id="quarterly-budget-summary-mmis-null2"
-            />
-            <th
-              className="center"
-              id="quarterly-budget-summary-mmis-fy-1-q1"
-              key="1"
-            >
-              Q1
-            </th>
-            <th
-              className="center"
-              id="quarterly-budget-summary-mmis-fy-1-q2"
-              key="2"
-            >
-              Q2
-            </th>
-            <th
-              className="center"
-              id="quarterly-budget-summary-mmis-fy-1-q3"
-              key="3"
-            >
-              Q3
-            </th>
-            <th
-              className="center"
-              id="quarterly-budget-summary-mmis-fy-1-q4"
-              key="4"
-            >
-              Q4
-            </th>
-            <th
-              className="right-align bg-teal-light"
-              id="quarterly-budget-summary-mmis-fy-1-subtotal"
-            >
-              Subtotal
-            </th>
-            <th
-              className="center"
-              id="quarterly-budget-summary-mmis-fy-2-q1"
-              key="1"
-            >
-              Q1
-            </th>
-            <th
-              className="center"
-              id="quarterly-budget-summary-mmis-fy-2-q2"
-              key="2"
-            >
-              Q2
-            </th>
-            <th
-              className="center"
-              id="quarterly-budget-summary-mmis-fy-2-q3"
-              key="3"
-            >
-              Q3
-            </th>
-            <th
-              className="center"
-              id="quarterly-budget-summary-mmis-fy-2-q4"
-              key="4"
-            >
-              Q4
-            </th>
-            <th
-              className="right-align bg-green-light"
-              id="quarterly-budget-summary-mmis-fy-2-subtotal"
-            >
-              Subtotal
-            </th>
-            <th
-              className="bg-gray-light"
-              id="quarterly-budget-summary-mmis-total2"
-            />
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            className=""
-            key="state"
+            Q2
+          </th>
+          <th
+            className="center"
+            id="quarterly-budget-summary-mmis-fy-1-q3"
+            key="3"
           >
-            <td
-              headers="quarterly-budget-summary-mmis-null1 quarterly-budget-summary-mmis-null2"
-            >
-              In-House Costs
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-q1"
-              key="1"
-            >
-              <Dollars>
-                203
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-q2"
-              key="2"
-            >
-              <Dollars>
-                206
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-q3"
-              key="3"
-            >
-              <Dollars>
-                209
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-q4"
-              key="4"
-            >
-              <Dollars>
-                212
-              </Dollars>
-            </td>
-            <td
-              className="bold mono right-align nowrap bg-teal-light"
-              headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-subtotal"
-            >
-              <Dollars>
-                215
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-q1"
-              key="1"
-            >
-              <Dollars>
-                1103
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-q2"
-              key="2"
-            >
-              <Dollars>
-                1106
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-q3"
-              key="3"
-            >
-              <Dollars>
-                1109
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-q4"
-              key="4"
-            >
-              <Dollars>
-                1112
-              </Dollars>
-            </td>
-            <td
-              className="bold mono right-align nowrap bg-green-light"
-              headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-subtotal"
-            >
-              <Dollars>
-                1115
-              </Dollars>
-            </td>
-            <td
-              className="bold mono right-align nowrap bg-gray-light"
-              headers="quarterly-budget-summary-mmis-total2 quarterly-budget-summary-mmis-total"
-            >
-              <Dollars>
-                4002
-              </Dollars>
-            </td>
-          </tr>
-          <tr
-            className=""
-            key="contractors"
+            Q3
+          </th>
+          <th
+            className="center"
+            id="quarterly-budget-summary-mmis-fy-1-q4"
+            key="4"
           >
-            <td
-              headers="quarterly-budget-summary-mmis-null1 quarterly-budget-summary-mmis-null2"
-            >
-              Private Contractor Costs
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-q1"
-              key="1"
-            >
-              <Dollars>
-                202
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-q2"
-              key="2"
-            >
-              <Dollars>
-                205
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-q3"
-              key="3"
-            >
-              <Dollars>
-                208
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-q4"
-              key="4"
-            >
-              <Dollars>
-                211
-              </Dollars>
-            </td>
-            <td
-              className="bold mono right-align nowrap bg-teal-light"
-              headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-subtotal"
-            >
-              <Dollars>
-                214
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-q1"
-              key="1"
-            >
-              <Dollars>
-                1102
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-q2"
-              key="2"
-            >
-              <Dollars>
-                1105
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-q3"
-              key="3"
-            >
-              <Dollars>
-                1108
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap "
-              headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-q4"
-              key="4"
-            >
-              <Dollars>
-                1111
-              </Dollars>
-            </td>
-            <td
-              className="bold mono right-align nowrap bg-green-light"
-              headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-subtotal"
-            >
-              <Dollars>
-                1114
-              </Dollars>
-            </td>
-            <td
-              className="bold mono right-align nowrap bg-gray-light"
-              headers="quarterly-budget-summary-mmis-total2 quarterly-budget-summary-mmis-total"
-            >
-              <Dollars>
-                4001
-              </Dollars>
-            </td>
-          </tr>
-          <tr
-            className="bold"
-            key="combined"
+            Q4
+          </th>
+          <th
+            className="right-align"
+            id="quarterly-budget-summary-mmis-fy-1-subtotal"
           >
-            <td
-              headers="quarterly-budget-summary-mmis-null1 quarterly-budget-summary-mmis-null2"
-            >
-              Total Enhanced FFP
-            </td>
-            <td
-              className="mono right-align nowrap bg-teal-light"
-              headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-q1"
-              key="1"
-            >
-              <Dollars>
-                201
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap bg-teal-light"
-              headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-q2"
-              key="2"
-            >
-              <Dollars>
-                204
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap bg-teal-light"
-              headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-q3"
-              key="3"
-            >
-              <Dollars>
-                207
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap bg-teal-light"
-              headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-q4"
-              key="4"
-            >
-              <Dollars>
-                210
-              </Dollars>
-            </td>
-            <td
-              className="bold mono right-align nowrap bg-teal-light"
-              headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-subtotal"
-            >
-              <Dollars>
-                213
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap bg-green-light"
-              headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-q1"
-              key="1"
-            >
-              <Dollars>
-                1101
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap bg-green-light"
-              headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-q2"
-              key="2"
-            >
-              <Dollars>
-                1104
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap bg-green-light"
-              headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-q3"
-              key="3"
-            >
-              <Dollars>
-                1107
-              </Dollars>
-            </td>
-            <td
-              className="mono right-align nowrap bg-green-light"
-              headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-q4"
-              key="4"
-            >
-              <Dollars>
-                1110
-              </Dollars>
-            </td>
-            <td
-              className="bold mono right-align nowrap bg-green-light"
-              headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-subtotal"
-            >
-              <Dollars>
-                1113
-              </Dollars>
-            </td>
-            <td
-              className="bold mono right-align nowrap bg-gray-light"
-              headers="quarterly-budget-summary-mmis-total2 quarterly-budget-summary-mmis-total"
-            >
-              <Dollars>
-                4000
-              </Dollars>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
+            Subtotal
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          key="state"
+        >
+          <th
+            headers="quarterly-budget-summary-mmis-null1 quarterly-budget-summary-mmis-null2"
+          >
+            In-House Costs
+          </th>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-q1"
+            key="1"
+          >
+            <Dollars>
+              203
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-q2"
+            key="2"
+          >
+            <Dollars>
+              206
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-q3"
+            key="3"
+          >
+            <Dollars>
+              209
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-q4"
+            key="4"
+          >
+            <Dollars>
+              212
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap"
+            headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-subtotal"
+          >
+            <Dollars>
+              215
+            </Dollars>
+          </td>
+        </tr>
+        <tr
+          key="contractors"
+        >
+          <th
+            headers="quarterly-budget-summary-mmis-null1 quarterly-budget-summary-mmis-null2"
+          >
+            Private Contractor Costs
+          </th>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-q1"
+            key="1"
+          >
+            <Dollars>
+              202
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-q2"
+            key="2"
+          >
+            <Dollars>
+              205
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-q3"
+            key="3"
+          >
+            <Dollars>
+              208
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-q4"
+            key="4"
+          >
+            <Dollars>
+              211
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap"
+            headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-subtotal"
+          >
+            <Dollars>
+              214
+            </Dollars>
+          </td>
+        </tr>
+        <tr
+          key="combined"
+        >
+          <th
+            headers="quarterly-budget-summary-mmis-null1 quarterly-budget-summary-mmis-null2"
+          >
+            Total Enhanced FFP
+          </th>
+          <td
+            className="mono right-align nowrap true"
+            headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-q1"
+            key="1"
+          >
+            <Dollars>
+              201
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap true"
+            headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-q2"
+            key="2"
+          >
+            <Dollars>
+              204
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap true"
+            headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-q3"
+            key="3"
+          >
+            <Dollars>
+              207
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap true"
+            headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-q4"
+            key="4"
+          >
+            <Dollars>
+              210
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap"
+            headers="quarterly-budget-summary-mmis-fy-1 quarterly-budget-summary-mmis-fy-1-subtotal"
+          >
+            <Dollars>
+              213
+            </Dollars>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <table
+      className="table-cms"
+    >
+      <colgroup>
+        <col
+          className="table-cms--col-header__fixed-width"
+        />
+        <col />
+        <col />
+        <col />
+        <col />
+      </colgroup>
+      <thead>
+        <tr>
+          <th
+            className="center"
+            id="quarterly-budget-summary-mmis-fy-2"
+            key="2"
+          >
+            FFY 2
+          </th>
+          <th
+            className="center"
+            id="quarterly-budget-summary-mmis-fy-2-q1"
+            key="1"
+          >
+            Q1
+          </th>
+          <th
+            className="center"
+            id="quarterly-budget-summary-mmis-fy-2-q2"
+            key="2"
+          >
+            Q2
+          </th>
+          <th
+            className="center"
+            id="quarterly-budget-summary-mmis-fy-2-q3"
+            key="3"
+          >
+            Q3
+          </th>
+          <th
+            className="center"
+            id="quarterly-budget-summary-mmis-fy-2-q4"
+            key="4"
+          >
+            Q4
+          </th>
+          <th
+            className="right-align"
+            id="quarterly-budget-summary-mmis-fy-2-subtotal"
+          >
+            Subtotal
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          key="state"
+        >
+          <th
+            headers="quarterly-budget-summary-mmis-null1 quarterly-budget-summary-mmis-null2"
+          >
+            In-House Costs
+          </th>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-q1"
+            key="1"
+          >
+            <Dollars>
+              1103
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-q2"
+            key="2"
+          >
+            <Dollars>
+              1106
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-q3"
+            key="3"
+          >
+            <Dollars>
+              1109
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-q4"
+            key="4"
+          >
+            <Dollars>
+              1112
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap"
+            headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-subtotal"
+          >
+            <Dollars>
+              1115
+            </Dollars>
+          </td>
+        </tr>
+        <tr
+          key="contractors"
+        >
+          <th
+            headers="quarterly-budget-summary-mmis-null1 quarterly-budget-summary-mmis-null2"
+          >
+            Private Contractor Costs
+          </th>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-q1"
+            key="1"
+          >
+            <Dollars>
+              1102
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-q2"
+            key="2"
+          >
+            <Dollars>
+              1105
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-q3"
+            key="3"
+          >
+            <Dollars>
+              1108
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap false"
+            headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-q4"
+            key="4"
+          >
+            <Dollars>
+              1111
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap"
+            headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-subtotal"
+          >
+            <Dollars>
+              1114
+            </Dollars>
+          </td>
+        </tr>
+        <tr
+          key="combined"
+        >
+          <th
+            headers="quarterly-budget-summary-mmis-null1 quarterly-budget-summary-mmis-null2"
+          >
+            Total Enhanced FFP
+          </th>
+          <td
+            className="mono right-align nowrap true"
+            headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-q1"
+            key="1"
+          >
+            <Dollars>
+              1101
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap true"
+            headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-q2"
+            key="2"
+          >
+            <Dollars>
+              1104
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap true"
+            headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-q3"
+            key="3"
+          >
+            <Dollars>
+              1107
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap true"
+            headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-q4"
+            key="4"
+          >
+            <Dollars>
+              1110
+            </Dollars>
+          </td>
+          <td
+            className="mono right-align nowrap"
+            headers="quarterly-budget-summary-mmis-fy-2 quarterly-budget-summary-mmis-fy-2-subtotal"
+          >
+            <Dollars>
+              1113
+            </Dollars>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <table
+      className="table-cms table-cms__totals"
+    >
+      <colgroup>
+        <col
+          className="table-cms--col-header__fixed-width"
+        />
+        <col />
+        <col />
+        <col />
+        <col />
+      </colgroup>
+      <thead>
+        <tr>
+          <th
+            id="quarterly-budget-summary-mmis-total"
+          >
+            Total 
+            MMIS
+          </th>
+          <th
+            id="quarterly-budget-summary-mmis-null1"
+          />
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th
+            headers="quarterly-budget-summary-mmis-total"
+          >
+            In-House Costs
+          </th>
+          <td
+            className="bold mono right-align nowrap"
+            headers="quarterly-budget-summary-mmis-total2 quarterly-budget-summary-mmis-total"
+          >
+            <Dollars>
+              4002
+            </Dollars>
+          </td>
+        </tr>
+        <tr>
+          <th
+            headers="quarterly-budget-summary-mmis-total"
+          >
+            Private Contractor Costs
+          </th>
+          <td
+            className="bold mono right-align nowrap"
+            headers="quarterly-budget-summary-mmis-total2 quarterly-budget-summary-mmis-total"
+          >
+            <Dollars>
+              4001
+            </Dollars>
+          </td>
+        </tr>
+        <tr>
+          <th
+            headers="quarterly-budget-summary-mmis-total"
+          >
+            Total Enhanced FFP
+          </th>
+          <td
+            className="bold mono right-align nowrap"
+            headers="quarterly-budget-summary-mmis-total2 quarterly-budget-summary-mmis-total"
+          >
+            <Dollars>
+              4000
+            </Dollars>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
-</div>
+</Fragment>
 `;
 
 exports[`quarterly budget summary component renders correctly if data is not loaded 1`] = `""`;

--- a/web/src/styles/scss/tables.scss
+++ b/web/src/styles/scss/tables.scss
@@ -2,6 +2,12 @@
 
 .table-cms {
   font-size: 12px;
+  &.table-cms__totals {
+    width: 40%; // roughly equal to full tables' cells?
+  }
+  &.centered-headers th {
+    text-align: center;
+  }
   th {
     background-color: $color-primary-alt-light;
     font-weight: normal;
@@ -16,11 +22,12 @@
     &:first-child {
       border-left: none;
     }
-  }
-  &.centered-headers th {
-    text-align: center;
+
   }
   + .table-cms:not(.table-frozen-data){
     margin-top: $spacer-2;
+  }
+  .table-cms--col-header__fixed-width {
+    width: 175px; // set these so that the totals tables in each section will have the same col width as other tables
   }
 }

--- a/web/src/styles/scss/tables.scss
+++ b/web/src/styles/scss/tables.scss
@@ -3,7 +3,7 @@
 .table-cms {
   font-size: 12px;
   &.table-cms__totals {
-    width: 40%; // roughly equal to full tables' cells?
+    width: 42%; // roughly equal to full tables' cells; temp fix before switching font to courier
   }
   &.centered-headers th {
     text-align: center;
@@ -28,6 +28,6 @@
     margin-top: $spacer-2;
   }
   .table-cms--col-header__fixed-width {
-    width: 175px; // set these so that the totals tables in each section will have the same col width as other tables
+    width: 175px; // so totals tables have the same col width as other tables
   }
 }


### PR DESCRIPTION
Implements the second set of tables in #1394. 

Looks like:
<img width="684" alt="Screen Shot 2019-04-18 at 5 14 06 PM" src="https://user-images.githubusercontent.com/509309/56396876-417fe900-61fe-11e9-91e0-98e0f020fb4a.png">


### This pull request changes...
- Breaks apart fiscal years and totals

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This feature is done when...
- [ ] Design has approved the experience
- [ ] Product has approved the experience
