### PR TITLE
Switch to 18F build of rich text editor

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 
   web:
     build: ./web
-    image: cms-eapd/web:f0bf8811077201803fc022caf480a626
+    image: cms-eapd/web:72dca8688dab13b5770619037bbc59b7
     environment:
       - API_URL=http://localhost:8081
     volumes:
@@ -31,7 +31,7 @@ services:
       - 8080:8001
   
   storybook:
-    image: cms-eapd/web:f0bf8811077201803fc022caf480a626
+    image: cms-eapd/web:72dca8688dab13b5770619037bbc59b7
     volumes:
       - ./web:/app
       - /app/node_modules

--- a/web/.snyk
+++ b/web/.snyk
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.13.5
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-AXIOS-174505:
+    - axios:
+        reason: no fix; does not affect our app
+        expires: '2019-05-25T14:29:57.487Z'
+patch: {}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -6606,9 +6606,9 @@
       "integrity": "sha512-+4hekxc8dTJvKk6usiEsFX9O1uOD9vLZZOs9ZI3RhTe89yNmtazYII/ILDXfbMPfzNaYfX7Gf3zjRm6UUFxqyg=="
     },
     "draftjs-utils": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/draftjs-utils/-/draftjs-utils-0.8.8.tgz",
-      "integrity": "sha1-WDXa7ZX1nT7h+W/cu7mAl3LIZJA="
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/draftjs-utils/-/draftjs-utils-0.9.4.tgz",
+      "integrity": "sha512-KYjABSbGpJrwrwmxVj5UhfV37MF/p0QRxKIyL+/+QOaJ8J9z1FBKxkblThbpR0nJi9lxPQWGg+gh+v0dAsSCCg=="
     },
     "duplexer": {
       "version": "0.1.1",
@@ -8077,7 +8077,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8098,12 +8099,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8118,17 +8121,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8245,7 +8251,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8257,6 +8264,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8271,6 +8279,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8278,12 +8287,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8302,6 +8313,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8382,7 +8394,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8394,6 +8407,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8479,7 +8493,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8515,6 +8530,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8534,6 +8550,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8577,12 +8594,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -15440,13 +15459,14 @@
       }
     },
     "react-draft-wysiwyg": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/react-draft-wysiwyg/-/react-draft-wysiwyg-1.10.7.tgz",
-      "integrity": "sha1-TJrPlRWxJa9rC/qiLXuSgA0ipBg=",
+      "version": "github:18f/react-draft-wysiwyg#2d89041dc5503bd02f73f1b438949175c552a044",
+      "from": "github:18f/react-draft-wysiwyg#2d89041dc5503bd02f73f1b438949175c552a044",
       "requires": {
         "classnames": "^2.2.5",
-        "draftjs-utils": "^0.8.03",
-        "prop-types": "^15.5.10"
+        "draftjs-utils": "^0.9.3",
+        "html-to-draftjs": "^1.4.0",
+        "linkify-it": "^2.0.3",
+        "prop-types": "^15.6.0"
       }
     },
     "react-dropzone": {

--- a/web/package.json
+++ b/web/package.json
@@ -78,7 +78,7 @@
     "react": "^16.8.3",
     "react-dates": "^20.0.0",
     "react-dom": "^16.8.3",
-    "react-draft-wysiwyg": "1.10.7",
+    "react-draft-wysiwyg": "github:18f/react-draft-wysiwyg#2d89041dc5503bd02f73f1b438949175c552a044",
     "react-dropzone": "^4.3.0",
     "react-number-format": "^4.0.6",
     "react-redux": "^6.0.1",


### PR DESCRIPTION
I forked the [react-draft-wysiwyg repo](https://github.com/jpuri/react-draft-wysiwyg) repo and made changes to how it handles click events:

https://github.com/18F/react-draft-wysiwyg/commit/2d89041dc5503bd02f73f1b438949175c552a044

In summary:
- components set their own state on click instead of waiting for a global click event to propagate back to them
- components only subscribe to global click events when necessary, and unsubscribe as soon as possible
- all rich text editor instances share a single global click event instead of each having their own

In dev, this resulted in about a 12x speedup for certain actions.

### This pull request changes...
- switches to 18F build of rich text editor
- closes #1466 

### This pull request is ready to merge when...
- [x] This code has been reviewed by someone other than the original author

### This feature is done when...
- [ ] Product has approved the experience
