### PR TITLE
Suggestion: new ref pattern [skip deploy]

### DIFF
--- a/web/src/components/Header.js
+++ b/web/src/components/Header.js
@@ -19,6 +19,7 @@ class Header extends Component {
     this.state = {
       ariaExpanded: props.ariaExpanded,
     };
+    this.node = React.createRef();
     this.handleOutsideClick = this.handleOutsideClick.bind(this);
   }
 
@@ -27,7 +28,7 @@ class Header extends Component {
   }
 
   handleOutsideClick = e => {
-    if (this.node.contains(e.target)) {
+    if (this.node.current.contains(e.target)) {
       return;
     }
     this.setState({ ariaExpanded: false })
@@ -47,7 +48,7 @@ class Header extends Component {
     const { authenticated, currentUser, isAdmin, showSiteTitle } = this.props;
     const { ariaExpanded } = this.state;
     return (
-      <header ref={node => this.node = node}>
+      <header ref={this.node}>
         <div className="ds-l-container">
           <div className="ds-l-row">
             <div className="ds-l-col--12 ds-l-md-col--4 site-title">


### PR DESCRIPTION
The current `ref` implementation was deprecated for :waves_hands: reasons.  This suggestion updates to the current recommended pattern, which is different because :waves_hands: reasons.