### PR TITLE
Language change to reflect APD Portfolio

### DIFF
--- a/web/src/components/__snapshots__/Header.test.js.snap
+++ b/web/src/components/__snapshots__/Header.test.js.snap
@@ -15,7 +15,7 @@ exports[`Header component opens and closes the dropdown when clicked 1`] = `
           replace={false}
           to="/"
         >
-          CMS HITECH APD
+          CMS HITECH eAPD
         </Link>
       </div>
       <div
@@ -187,7 +187,7 @@ exports[`Header component renders correctly when the dropdown is closed and the 
           replace={false}
           to="/"
         >
-          CMS HITECH APD
+          CMS HITECH eAPD
         </Link>
       </div>
       <div

--- a/web/src/containers/__snapshots__/StateDashboardSidebar.test.js.snap
+++ b/web/src/containers/__snapshots__/StateDashboardSidebar.test.js.snap
@@ -26,7 +26,7 @@ exports[`State dashboard sidebar component renders correctly 1`] = `
           Solid
            
           <br />
-           HITECH APD
+           APD Portfolio
         </h1>
       </div>
       <VerticalNav

--- a/web/src/i18n/index.test.js
+++ b/web/src/i18n/index.test.js
@@ -13,7 +13,7 @@ describe('i18n translations', () => {
   beforeEach(() => load());
 
   test('t function', () => {
-    expect(container.t('title', { year: 2018 })).toBe('2018 HITECH APD');
+    expect(container.t('title', { year: 2018 })).toBe('2018 APD Portfolio');
     expect(container.t('nonsense')).toBe('[missing "en.nonsense" translation]');
   });
 

--- a/web/src/i18n/locales/en/app.yaml
+++ b/web/src/i18n/locales/en/app.yaml
@@ -2,8 +2,8 @@
 
 # This is the title displayed in the sidebar.  First is when logged in, second
 # is when logged out.
-title: '{{year}} HITECH APD'
-titleBasic: CMS HITECH APD
+title: '{{year}} APD Portfolio'
+titleBasic: CMS HITECH eAPD
 
 # Top navbar button text
 login: Log in


### PR DESCRIPTION
Changes the sidebar and header to reflect both the eAPD and APD Portfolio (consistent language)

### This pull request changes...
- Sidebar and header language adjustment

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author

### This feature is done when...
- [ ] Design has approved the experience
- [ ] Product has approved the experience
