### PR TITLE
Update section 8 (executive summary), activity summary with design system

### DIFF
--- a/web/src/components/Dollars.js
+++ b/web/src/components/Dollars.js
@@ -45,11 +45,15 @@ const formatLong = num => formats.long(num);
  * "only-screen" and contains the potentially truncated dollar value. The other
  * has a class of "only-print" and contains the full dollar value.
  */
-const Dollars = ({ children }) => {
+const Dollars = ({ children, long }) => {
   const num = parseFloat(children);
 
   if (Number.isNaN(num) || !Number.isFinite(num)) {
     return <Fragment>--</Fragment>;
+  }
+
+  if (long) {
+    return <span>{formatLong(num)}</span>;
   }
 
   return (
@@ -63,7 +67,13 @@ const Dollars = ({ children }) => {
 Dollars.propTypes = {
   /** The number, either as a numeric type or a parseable string, to display as
    * dollars. */
-  children: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired
+  children: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+    .isRequired,
+  long: PropTypes.bool
+};
+
+Dollars.defaultProps = {
+  long: false
 };
 
 export default Dollars;

--- a/web/src/components/Dollars.test.js
+++ b/web/src/components/Dollars.test.js
@@ -29,6 +29,10 @@ describe('Dollars formatting container', () => {
     });
   });
 
+  test('prints full numbers if long prop is set', () => {
+    expect(render(<Dollars long>2857298672</Dollars>)).toMatchSnapshot();
+  });
+
   test('prints full numbers below $100,000', () => {
     expect(render(<Dollars>50000</Dollars>)).toMatchSnapshot();
   });

--- a/web/src/components/__snapshots__/Dollars.test.js.snap
+++ b/web/src/components/__snapshots__/Dollars.test.js.snap
@@ -15,6 +15,12 @@ exports[`Dollars formatting container prints full numbers below $100,000 1`] = `
 </Fragment>
 `;
 
+exports[`Dollars formatting container prints full numbers if long prop is set 1`] = `
+<span>
+  $2,857,298,672
+</span>
+`;
+
 exports[`Dollars formatting container prints truncated numbers above $100,000 1`] = `
 <Fragment>
   <span

--- a/web/src/containers/ExecutiveSummary.js
+++ b/web/src/containers/ExecutiveSummary.js
@@ -1,6 +1,6 @@
 import { Review } from '@cmsgov/design-system-core';
 import PropTypes from 'prop-types';
-import React, { PureComponent } from 'react';
+import React, { Fragment, PureComponent } from 'react';
 import { connect } from 'react-redux';
 
 import ExecutiveSummaryBudget from './ExecutiveSummaryBudget';
@@ -35,24 +35,35 @@ class ExecutiveSummary extends PureComponent {
           >
             {data.map((activity, i) => (
               <Review
-                heading={`Activity ${i + 1}: ${activity.name ||
-                  t('activities.noNameYet')}`}
+                key={activity.key}
+                heading={
+                  <Fragment>
+                    Activity {i + 1}:{' '}
+                    <a
+                      href={`#activity-${activity.key}`}
+                      onClick={this.jump(activity.key)}
+                    >
+                      {activity.name || t('activities.noNameYet')}
+                    </a>
+                  </Fragment>
+                }
+                headingLevel={4}
                 editHref={`#activity-${activity.key}`}
-                onEditClick={this.jump(`#activity-${activity.key}`)}
+                onEditClick={this.jump(activity.key)}
                 className={i === data.length - 1 ? 'ds-u-border-bottom--0' : ''}
               >
                 {activity.summary && <p>{activity.summary}</p>}
 
                 <ul className="ds-c-list--bare">
                   <li>
-                    <strong>Date:</strong>
+                    <strong>Date:</strong> {activity.dateRange}
                   </li>
                   <li>
                     <strong>Total cost of activity:</strong>{' '}
                     <Dollars long>{activity.combined}</Dollars>
                   </li>
                   <li>
-                    <strong>Medicaid share:</strong>
+                    <strong>Medicaid share:</strong>{' '}
                     <Dollars long>{activity.medicaid}</Dollars> (
                     <Dollars long>{activity.federal}</Dollars> Federal share)
                   </li>
@@ -102,7 +113,7 @@ class ExecutiveSummary extends PureComponent {
 ExecutiveSummary.propTypes = {
   data: PropTypes.array.isRequired,
   jumpTo: PropTypes.func.isRequired,
-  total: PropTypes.number.isRequired,
+  total: PropTypes.object.isRequired,
   years: PropTypes.array.isRequired
 };
 

--- a/web/src/containers/ExecutiveSummary.js
+++ b/web/src/containers/ExecutiveSummary.js
@@ -71,7 +71,11 @@ class ExecutiveSummary extends PureComponent {
               </Review>
             ))}
             <hr className="ds-u-border--dark ds-u-margin--0" />
-            <Review heading="Total cost" className="ds-u-border--0">
+            <Review
+              heading="Total cost"
+              headingLevel={4}
+              className="ds-u-border--0"
+            >
               <p>
                 Verify that this information is correct.{' '}
                 <a href="#activities" onClick={this.jump('activities')}>

--- a/web/src/containers/ExecutiveSummary.js
+++ b/web/src/containers/ExecutiveSummary.js
@@ -1,5 +1,6 @@
+import { Review } from '@cmsgov/design-system-core';
 import PropTypes from 'prop-types';
-import React, { Fragment } from 'react';
+import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 
 import ExecutiveSummaryBudget from './ExecutiveSummaryBudget';
@@ -8,85 +9,112 @@ import { expandActivitySection } from '../actions/activities';
 import Dollars from '../components/Dollars';
 import { Section, Subsection } from '../components/Section';
 import { t } from '../i18n';
+
+import { jumpTo } from '../actions/navigation';
 import { selectApdYears } from '../reducers/apd.selectors';
-import { selectBudgetExecutiveSummary } from '../reducers/budget.selectors';
+import {
+  selectBudgetExecutiveSummary,
+  selectBudgetGrandTotal
+} from '../reducers/budget.selectors';
 
-const ExecutiveSummary = ({ data, years, expandSection }) => (
-  <Waypoint id="executive-summary-overview">
-    <Section isNumbered id="executive-summary" resource="executiveSummary">
-      <Waypoint id="executive-summary-summary" />
-      <Subsection
-        id="executive-summary-summary"
-        resource="executiveSummary.summary"
-      >
-        {data.map((d, i) => (
-          <div
-            key={d.key}
-            className="mb2 md-flex items-center alert alert-success"
+class ExecutiveSummary extends PureComponent {
+  jump = to => () => {
+    const { jumpTo: action } = this.props;
+    action(to);
+  };
+
+  render() {
+    const { data, total, years } = this.props;
+    return (
+      <Waypoint id="executive-summary-overview">
+        <Section isNumbered id="executive-summary" resource="executiveSummary">
+          <Waypoint id="executive-summary-summary" />
+          <Subsection
+            id="executive-summary-summary"
+            resource="executiveSummary.summary"
           >
-            <div className="p2 sm-m0 flex-auto">
-              {d.key !== 'all' ? (
-                <Fragment>
-                  <div className="h5">
-                    {t('activities.namePrefixAndNum', { number: i + 1 })}
-                  </div>
-                  <a
-                    href={`#activity-${d.key}`}
-                    className="h3 bold black"
-                    onClick={() => expandSection(d.key)}
-                  >
-                    {d.name || t('activities.noNameYet')}
-                  </a>
-                </Fragment>
-              ) : (
-                <div className="h3 bold">{d.name}</div>
-              )}
-              {d.descShort && <div>{d.descShort}</div>}
-            </div>
-            <div className="md-flex md-col-7">
-              {years.map(year => (
-                <div key={year} className="px2 py3 flex-auto">
-                  <div className="h5">{t('ffy', { year })}</div>
-                  <div className="h3 mono bold">
-                    <Dollars>{d.totals[year]}</Dollars>
-                  </div>
-                </div>
-              ))}
-              <div className="px2 py3 flex-auto">
-                <div className="h5">{t('executiveSummary.total')}</div>
-                <div className="h3 mono bold">
-                  <Dollars>{d.combined}</Dollars>
-                </div>
-              </div>
-            </div>
-          </div>
-        ))}
-      </Subsection>
+            {data.map((activity, i) => (
+              <Review
+                heading={`Activity ${i + 1}: ${activity.name ||
+                  t('activities.noNameYet')}`}
+                editHref={`#activity-${activity.key}`}
+                onEditClick={this.jump(`#activity-${activity.key}`)}
+                className={i === data.length - 1 ? 'ds-u-border-bottom--0' : ''}
+              >
+                {activity.summary && <p>{activity.summary}</p>}
 
-      <Waypoint id="executive-summary-budget-table" />
-      <Subsection
-        id="executive-summary-budget-table"
-        resource="executiveSummary.budgetTable"
-      >
-        <ExecutiveSummaryBudget />
-      </Subsection>
-    </Section>
-  </Waypoint>
-);
+                <ul className="ds-c-list--bare">
+                  <li>
+                    <strong>Date:</strong>
+                  </li>
+                  <li>
+                    <strong>Total cost of activity:</strong>{' '}
+                    <Dollars long>{activity.combined}</Dollars>
+                  </li>
+                  <li>
+                    <strong>Medicaid share:</strong>
+                    <Dollars long>{activity.medicaid}</Dollars> (
+                    <Dollars long>{activity.federal}</Dollars> Federal share)
+                  </li>
+                </ul>
+              </Review>
+            ))}
+            <hr className="ds-u-border--dark ds-u-margin--0" />
+            <Review heading="Total cost" className="ds-u-border--0">
+              <p>
+                Verify that this information is correct.{' '}
+                <a href="#activities" onClick={this.jump('activities')}>
+                  Edit activities above
+                </a>{' '}
+                to make changes.
+              </p>
+              <ul className="ds-c-list--bare">
+                <li>
+                  <strong>Federal Fiscal Years requested:</strong> FFY{' '}
+                  {years.join(', ')}
+                </li>
+                <li>
+                  <strong>Medicaid share:</strong>{' '}
+                  <Dollars long>{total.medicaid}</Dollars> (
+                  <Dollars long>{total.federal}</Dollars> Federal share)
+                </li>
+                <li>
+                  <strong>Total funding request:</strong>{' '}
+                  <Dollars long>{total.combined}</Dollars>
+                </li>
+              </ul>
+            </Review>
+          </Subsection>
+
+          <Waypoint id="executive-summary-budget-table" />
+          <Subsection
+            id="executive-summary-budget-table"
+            resource="executiveSummary.budgetTable"
+          >
+            <ExecutiveSummaryBudget />
+          </Subsection>
+        </Section>
+      </Waypoint>
+    );
+  }
+}
 
 ExecutiveSummary.propTypes = {
   data: PropTypes.array.isRequired,
-  years: PropTypes.array.isRequired,
-  expandSection: PropTypes.func.isRequired
+  jumpTo: PropTypes.func.isRequired,
+  total: PropTypes.number.isRequired,
+  years: PropTypes.array.isRequired
 };
 
 const mapStateToProps = state => ({
   data: selectBudgetExecutiveSummary(state),
+  total: selectBudgetGrandTotal(state),
   years: selectApdYears(state)
 });
 
 const mapDispatchToProps = {
-  expandSection: expandActivitySection
+  expandSection: expandActivitySection,
+  jumpTo
 };
 
 export default connect(

--- a/web/src/containers/ExecutiveSummary.test.js
+++ b/web/src/containers/ExecutiveSummary.test.js
@@ -29,6 +29,7 @@ describe('executive summary component', () => {
         medicaid: 2150
       }
     ],
+    jumpTo: jest.fn(),
     total: {
       combined: 10,
       federal: 20,
@@ -51,6 +52,10 @@ describe('executive summary component', () => {
           a1: {
             key: 'a1',
             name: 'activity 1',
+            // Hiram Revels is seated to the United States Senate
+            plannedEndDate: '1870-02-25',
+            // Shirley Chisholm is seated to the United States House of Representatives
+            plannedStartDate: '1969-01-03',
             summary: 'first activity'
           },
           a2: {
@@ -90,6 +95,7 @@ describe('executive summary component', () => {
       data: [
         {
           key: 'a1',
+          dateRange: '1/3/1969 - 2/25/1870',
           name: 'activity 1',
           summary: 'first activity',
           combined: 950,
@@ -98,6 +104,7 @@ describe('executive summary component', () => {
         },
         {
           key: 'a2',
+          dateRange: 'Dates not set',
           name: 'activity 2',
           summary: 'second activity',
           combined: 310,

--- a/web/src/containers/ExecutiveSummary.test.js
+++ b/web/src/containers/ExecutiveSummary.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-import sinon from 'sinon';
 
 import {
   plain as ExecutiveSummary,
@@ -8,6 +7,7 @@ import {
   mapDispatchToProps
 } from './ExecutiveSummary';
 import { expandActivitySection } from '../actions/activities';
+import { jumpTo } from '../actions/navigation';
 
 describe('executive summary component', () => {
   const props = {
@@ -15,25 +15,25 @@ describe('executive summary component', () => {
       {
         key: 'a1',
         name: 'activity 1',
-        descShort: 'first activity',
-        totals: { '1': 250, '2': 700 },
-        combined: 950
+        summary: 'first activity',
+        combined: 950,
+        federal: 1050,
+        medicaid: 1150
       },
       {
         key: 'a2',
         name: 'activity 2',
-        descShort: 'second activity',
-        totals: { '1': 300, '2': 10 },
-        combined: 310
-      },
-      {
-        key: 'all',
-        name: 'Total Cost',
-        descShort: null,
-        totals: { '1': 550, '2': 710 },
-        combined: 1260
+        summary: 'second activity',
+        combined: 310,
+        federal: 2050,
+        medicaid: 2150
       }
     ],
+    total: {
+      combined: 10,
+      federal: 20,
+      medicaid: 30
+    },
     years: ['1', '2']
   };
 
@@ -44,21 +44,6 @@ describe('executive summary component', () => {
     expect(component).toMatchSnapshot();
   });
 
-  test('dispatches an action to expand', () => {
-    const expandSectionProp = sinon.spy();
-    const component = shallow(
-      <ExecutiveSummary {...props} expandSection={expandSectionProp} />
-    );
-
-    // clicking the first link should expand the first activity
-    component
-      .find('a')
-      .at(0)
-      .simulate('click');
-
-    expect(expandSectionProp.calledWith('a1'));
-  });
-
   test('maps state to props', () => {
     const state = {
       activities: {
@@ -66,12 +51,12 @@ describe('executive summary component', () => {
           a1: {
             key: 'a1',
             name: 'activity 1',
-            descShort: 'first activity'
+            summary: 'first activity'
           },
           a2: {
             key: 'a2',
             name: 'activity 2',
-            descShort: 'second activity'
+            summary: 'second activity'
           }
         }
       },
@@ -82,21 +67,21 @@ describe('executive summary component', () => {
             costsByFFY: {
               '1': { total: 250 },
               '2': { total: 700 },
-              total: { total: 950 }
+              total: { federal: 1050, medicaidShare: 1150, total: 950 }
             }
           },
           a2: {
             costsByFFY: {
               '1': { total: 300 },
               '2': { total: 10 },
-              total: { total: 310 }
+              total: { federal: 410, medicaidShare: 510, total: 310 }
             }
           }
         },
         combined: {
           '1': { total: 550 },
           '2': { total: 710 },
-          total: { total: 1260 }
+          total: { federal: 1360, medicaid: 1460, total: 1260 }
         }
       }
     };
@@ -106,32 +91,33 @@ describe('executive summary component', () => {
         {
           key: 'a1',
           name: 'activity 1',
-          descShort: 'first activity',
-          totals: { '1': 250, '2': 700 },
-          combined: 950
+          summary: 'first activity',
+          combined: 950,
+          federal: 1050,
+          medicaid: 1150
         },
         {
           key: 'a2',
           name: 'activity 2',
-          descShort: 'second activity',
-          totals: { '1': 300, '2': 10 },
-          combined: 310
-        },
-        {
-          key: 'all',
-          name: 'Total Cost',
-          descShort: null,
-          totals: { '1': 550, '2': 710 },
-          combined: 1260
+          summary: 'second activity',
+          combined: 310,
+          federal: 410,
+          medicaid: 510
         }
       ],
+      total: {
+        combined: 1260,
+        federal: 1360,
+        medicaid: 1460
+      },
       years: ['1', '2']
     });
   });
 
   test('maps dispatch to props', () => {
     expect(mapDispatchToProps).toEqual({
-      expandSection: expandActivitySection
+      expandSection: expandActivitySection,
+      jumpTo
     });
   });
 });

--- a/web/src/containers/__snapshots__/ApdPreviousActivityTable.test.js.snap
+++ b/web/src/containers/__snapshots__/ApdPreviousActivityTable.test.js.snap
@@ -155,7 +155,9 @@ exports[`apd previous activity table, mmis component renders correctly 1`] = `
             <td
               headers="prev_act_hithie_row_1 prev_act_hithie_federal prev_act_hithie_total_approved"
             >
-              <Dollars>
+              <Dollars
+                long={false}
+              >
                 18
               </Dollars>
             </td>
@@ -200,7 +202,9 @@ exports[`apd previous activity table, mmis component renders correctly 1`] = `
             <td
               headers="prev_act_hithie_row_2 prev_act_hithie_federal prev_act_hithie_total_approved"
             >
-              <Dollars>
+              <Dollars
+                long={false}
+              >
                 180
               </Dollars>
             </td>

--- a/web/src/containers/__snapshots__/ApdPreviousActivityTableMMIS.test.js.snap
+++ b/web/src/containers/__snapshots__/ApdPreviousActivityTableMMIS.test.js.snap
@@ -156,7 +156,9 @@ exports[`apd previous activity table, mmis component renders correctly 1`] = `
             <td
               headers="prev_act_mmis_row_1 prev_act_mmis90_federal prev_act_mmis90_federal_approved"
             >
-              <Dollars>
+              <Dollars
+                long={false}
+              >
                 18
               </Dollars>
             </td>
@@ -201,7 +203,9 @@ exports[`apd previous activity table, mmis component renders correctly 1`] = `
             <td
               headers="prev_act_mmis_row_2 prev_act_mmis90_federal prev_act_mmis90_federal_approved"
             >
-              <Dollars>
+              <Dollars
+                long={false}
+              >
                 180
               </Dollars>
             </td>
@@ -375,7 +379,9 @@ exports[`apd previous activity table, mmis component renders correctly 1`] = `
             <td
               headers="prev_act_mmis_row_1 prev_act_mmis75_federal prev_act_mmis75_federal_approved"
             >
-              <Dollars>
+              <Dollars
+                long={false}
+              >
                 30
               </Dollars>
             </td>
@@ -420,7 +426,9 @@ exports[`apd previous activity table, mmis component renders correctly 1`] = `
             <td
               headers="prev_act_mmis_row_2 prev_act_mmis75_federal prev_act_mmis75_federal_approved"
             >
-              <Dollars>
+              <Dollars
+                long={false}
+              >
                 300
               </Dollars>
             </td>
@@ -594,7 +602,9 @@ exports[`apd previous activity table, mmis component renders correctly 1`] = `
             <td
               headers="prev_act_mmis_row_1 prev_act_mmis50_federal prev_act_mmis50_federal_approved"
             >
-              <Dollars>
+              <Dollars
+                long={false}
+              >
                 30
               </Dollars>
             </td>
@@ -639,7 +649,9 @@ exports[`apd previous activity table, mmis component renders correctly 1`] = `
             <td
               headers="prev_act_mmis_row_2 prev_act_mmis50_federal prev_act_mmis50_federal_approved"
             >
-              <Dollars>
+              <Dollars
+                long={false}
+              >
                 300
               </Dollars>
             </td>

--- a/web/src/containers/__snapshots__/ApdPreviousActivityTableTotal.test.js.snap
+++ b/web/src/containers/__snapshots__/ApdPreviousActivityTableTotal.test.js.snap
@@ -78,14 +78,18 @@ exports[`apd previous activity table, grand total component renders correctly 1`
             <td
               headers="prev_act_total_row_1 prev_act_total_approved"
             >
-              <Dollars>
+              <Dollars
+                long={false}
+              >
                 1878
               </Dollars>
             </td>
             <td
               headers="prev_act_total_row_1 prev_act_total_actual"
             >
-              <Dollars>
+              <Dollars
+                long={false}
+              >
                 1090
               </Dollars>
             </td>
@@ -102,14 +106,18 @@ exports[`apd previous activity table, grand total component renders correctly 1`
             <td
               headers="prev_act_total_row_2 prev_act_total_approved"
             >
-              <Dollars>
+              <Dollars
+                long={false}
+              >
                 4380
               </Dollars>
             </td>
             <td
               headers="prev_act_total_row_2 prev_act_total_actual"
             >
-              <Dollars>
+              <Dollars
+                long={false}
+              >
                 3900
               </Dollars>
             </td>

--- a/web/src/containers/__snapshots__/BudgetSummary.test.js.snap
+++ b/web/src/containers/__snapshots__/BudgetSummary.test.js.snap
@@ -72,7 +72,9 @@ exports[`budget summary component data row renders with data 1`] = `
     className="font-family--mono right-align"
     headers="summary-budget-fy-year summary-budget-fy-year-total"
   >
-    <Dollars>
+    <Dollars
+      long={false}
+    >
       1000
     </Dollars>
   </td>
@@ -80,7 +82,9 @@ exports[`budget summary component data row renders with data 1`] = `
     className="font-family--mono right-align"
     headers="summary-budget-fy-year summary-budget-fy-year-federal"
   >
-    <Dollars>
+    <Dollars
+      long={false}
+    >
       1
     </Dollars>
   </td>
@@ -88,7 +92,9 @@ exports[`budget summary component data row renders with data 1`] = `
     className="font-family--mono right-align"
     headers="summary-budget-fy-year summary-budget-fy-year-state"
   >
-    <Dollars>
+    <Dollars
+      long={false}
+    >
       2
     </Dollars>
   </td>
@@ -106,7 +112,9 @@ exports[`budget summary component data row renders with no data 1`] = `
     className="font-family--mono right-align"
     headers="summary-budget-fy-year summary-budget-fy-year-total"
   >
-    <Dollars>
+    <Dollars
+      long={false}
+    >
       0
     </Dollars>
   </td>
@@ -114,7 +122,9 @@ exports[`budget summary component data row renders with no data 1`] = `
     className="font-family--mono right-align"
     headers="summary-budget-fy-year summary-budget-fy-year-federal"
   >
-    <Dollars>
+    <Dollars
+      long={false}
+    >
       0
     </Dollars>
   </td>
@@ -122,7 +132,9 @@ exports[`budget summary component data row renders with no data 1`] = `
     className="font-family--mono right-align"
     headers="summary-budget-fy-year summary-budget-fy-year-state"
   >
-    <Dollars>
+    <Dollars
+      long={false}
+    >
       0
     </Dollars>
   </td>
@@ -413,7 +425,9 @@ exports[`budget summary component renders correctly 1`] = `
           className="font-family--mono right-align"
           headers="summary-budget-total-medicaid"
         >
-          <Dollars>
+          <Dollars
+            long={false}
+          >
             1000
           </Dollars>
         </td>
@@ -421,7 +435,9 @@ exports[`budget summary component renders correctly 1`] = `
           className="font-family--mono right-align"
           headers="summary-budget-total-federal"
         >
-          <Dollars>
+          <Dollars
+            long={false}
+          >
             1
           </Dollars>
         </td>
@@ -429,7 +445,9 @@ exports[`budget summary component renders correctly 1`] = `
           className="font-family--mono right-align"
           headers="summary-budget-total-state"
         >
-          <Dollars>
+          <Dollars
+            long={false}
+          >
             2
           </Dollars>
         </td>
@@ -447,7 +465,9 @@ exports[`budget summary component renders correctly 1`] = `
           className="font-family--mono right-align"
           headers="summary-budget-total-medicaid"
         >
-          <Dollars>
+          <Dollars
+            long={false}
+          >
             2000
           </Dollars>
         </td>
@@ -455,7 +475,9 @@ exports[`budget summary component renders correctly 1`] = `
           className="font-family--mono right-align"
           headers="summary-budget-total-federal"
         >
-          <Dollars>
+          <Dollars
+            long={false}
+          >
             10
           </Dollars>
         </td>
@@ -463,7 +485,9 @@ exports[`budget summary component renders correctly 1`] = `
           className="font-family--mono right-align"
           headers="summary-budget-total-state"
         >
-          <Dollars>
+          <Dollars
+            long={false}
+          >
             20
           </Dollars>
         </td>

--- a/web/src/containers/__snapshots__/ExecutiveSummary.test.js.snap
+++ b/web/src/containers/__snapshots__/ExecutiveSummary.test.js.snap
@@ -154,6 +154,7 @@ exports[`executive summary component renders correctly 1`] = `
         className="ds-u-border--0"
         editText="Edit"
         heading="Total cost"
+        headingLevel={4}
       >
         <p>
           Verify that this information is correct.

--- a/web/src/containers/__snapshots__/ExecutiveSummary.test.js.snap
+++ b/web/src/containers/__snapshots__/ExecutiveSummary.test.js.snap
@@ -17,230 +17,164 @@ exports[`executive summary component renders correctly 1`] = `
       nested={false}
       resource="executiveSummary.summary"
     >
-      <div
-        className="mb2 md-flex items-center alert alert-success"
-        key="a1"
+      <Review
+        className=""
+        editHref="#activity-a1"
+        editText="Edit"
+        heading="Activity 1: activity 1"
+        onEditClick={[Function]}
       >
-        <div
-          className="p2 sm-m0 flex-auto"
+        <p>
+          first activity
+        </p>
+        <ul
+          className="ds-c-list--bare"
         >
-          <div
-            className="h5"
-          >
-            Activity 1
-          </div>
+          <li>
+            <strong>
+              Date:
+            </strong>
+          </li>
+          <li>
+            <strong>
+              Total cost of activity:
+            </strong>
+             
+            <Dollars
+              long={true}
+            >
+              950
+            </Dollars>
+          </li>
+          <li>
+            <strong>
+              Medicaid share:
+            </strong>
+            <Dollars
+              long={true}
+            >
+              1150
+            </Dollars>
+             (
+            <Dollars
+              long={true}
+            >
+              1050
+            </Dollars>
+             Federal share)
+          </li>
+        </ul>
+      </Review>
+      <Review
+        className="ds-u-border-bottom--0"
+        editHref="#activity-a2"
+        editText="Edit"
+        heading="Activity 2: activity 2"
+        onEditClick={[Function]}
+      >
+        <p>
+          second activity
+        </p>
+        <ul
+          className="ds-c-list--bare"
+        >
+          <li>
+            <strong>
+              Date:
+            </strong>
+          </li>
+          <li>
+            <strong>
+              Total cost of activity:
+            </strong>
+             
+            <Dollars
+              long={true}
+            >
+              310
+            </Dollars>
+          </li>
+          <li>
+            <strong>
+              Medicaid share:
+            </strong>
+            <Dollars
+              long={true}
+            >
+              2150
+            </Dollars>
+             (
+            <Dollars
+              long={true}
+            >
+              2050
+            </Dollars>
+             Federal share)
+          </li>
+        </ul>
+      </Review>
+      <hr
+        className="ds-u-border--dark ds-u-margin--0"
+      />
+      <Review
+        className="ds-u-border--0"
+        editText="Edit"
+        heading="Total cost"
+      >
+        <p>
+          Verify that this information is correct.
+           
           <a
-            className="h3 bold black"
-            href="#activity-a1"
+            href="#activities"
             onClick={[Function]}
           >
-            activity 1
+            Edit activities above
           </a>
-          <div>
-            first activity
-          </div>
-        </div>
-        <div
-          className="md-flex md-col-7"
+           
+          to make changes.
+        </p>
+        <ul
+          className="ds-c-list--bare"
         >
-          <div
-            className="px2 py3 flex-auto"
-            key="1"
-          >
-            <div
-              className="h5"
+          <li>
+            <strong>
+              Federal Fiscal Years requested:
+            </strong>
+             FFY
+             
+            1, 2
+          </li>
+          <li>
+            <strong>
+              Medicaid share:
+            </strong>
+             
+            <Dollars
+              long={true}
             >
-              FFY 1
-            </div>
-            <div
-              className="h3 mono bold"
+              30
+            </Dollars>
+             (
+            <Dollars
+              long={true}
             >
-              <Dollars>
-                250
-              </Dollars>
-            </div>
-          </div>
-          <div
-            className="px2 py3 flex-auto"
-            key="2"
-          >
-            <div
-              className="h5"
+              20
+            </Dollars>
+             Federal share)
+          </li>
+          <li>
+            <strong>
+              Total funding request:
+            </strong>
+             
+            <Dollars
+              long={true}
             >
-              FFY 2
-            </div>
-            <div
-              className="h3 mono bold"
-            >
-              <Dollars>
-                700
-              </Dollars>
-            </div>
-          </div>
-          <div
-            className="px2 py3 flex-auto"
-          >
-            <div
-              className="h5"
-            >
-              Total
-            </div>
-            <div
-              className="h3 mono bold"
-            >
-              <Dollars>
-                950
-              </Dollars>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        className="mb2 md-flex items-center alert alert-success"
-        key="a2"
-      >
-        <div
-          className="p2 sm-m0 flex-auto"
-        >
-          <div
-            className="h5"
-          >
-            Activity 2
-          </div>
-          <a
-            className="h3 bold black"
-            href="#activity-a2"
-            onClick={[Function]}
-          >
-            activity 2
-          </a>
-          <div>
-            second activity
-          </div>
-        </div>
-        <div
-          className="md-flex md-col-7"
-        >
-          <div
-            className="px2 py3 flex-auto"
-            key="1"
-          >
-            <div
-              className="h5"
-            >
-              FFY 1
-            </div>
-            <div
-              className="h3 mono bold"
-            >
-              <Dollars>
-                300
-              </Dollars>
-            </div>
-          </div>
-          <div
-            className="px2 py3 flex-auto"
-            key="2"
-          >
-            <div
-              className="h5"
-            >
-              FFY 2
-            </div>
-            <div
-              className="h3 mono bold"
-            >
-              <Dollars>
-                10
-              </Dollars>
-            </div>
-          </div>
-          <div
-            className="px2 py3 flex-auto"
-          >
-            <div
-              className="h5"
-            >
-              Total
-            </div>
-            <div
-              className="h3 mono bold"
-            >
-              <Dollars>
-                310
-              </Dollars>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        className="mb2 md-flex items-center alert alert-success"
-        key="all"
-      >
-        <div
-          className="p2 sm-m0 flex-auto"
-        >
-          <div
-            className="h3 bold"
-          >
-            Total Cost
-          </div>
-        </div>
-        <div
-          className="md-flex md-col-7"
-        >
-          <div
-            className="px2 py3 flex-auto"
-            key="1"
-          >
-            <div
-              className="h5"
-            >
-              FFY 1
-            </div>
-            <div
-              className="h3 mono bold"
-            >
-              <Dollars>
-                550
-              </Dollars>
-            </div>
-          </div>
-          <div
-            className="px2 py3 flex-auto"
-            key="2"
-          >
-            <div
-              className="h5"
-            >
-              FFY 2
-            </div>
-            <div
-              className="h3 mono bold"
-            >
-              <Dollars>
-                710
-              </Dollars>
-            </div>
-          </div>
-          <div
-            className="px2 py3 flex-auto"
-          >
-            <div
-              className="h5"
-            >
-              Total
-            </div>
-            <div
-              className="h3 mono bold"
-            >
-              <Dollars>
-                1260
-              </Dollars>
-            </div>
-          </div>
-        </div>
-      </div>
+              10
+            </Dollars>
+          </li>
+        </ul>
+      </Review>
     </Subsection>
     <Connect(ConnectedWaypoint)
       id="executive-summary-budget-table"

--- a/web/src/containers/__snapshots__/ExecutiveSummary.test.js.snap
+++ b/web/src/containers/__snapshots__/ExecutiveSummary.test.js.snap
@@ -21,7 +21,22 @@ exports[`executive summary component renders correctly 1`] = `
         className=""
         editHref="#activity-a1"
         editText="Edit"
-        heading="Activity 1: activity 1"
+        heading={
+          <React.Fragment>
+            Activity 
+            1
+            :
+             
+            <a
+              href="#activity-a1"
+              onClick={[Function]}
+            >
+              activity 1
+            </a>
+          </React.Fragment>
+        }
+        headingLevel={4}
+        key="a1"
         onEditClick={[Function]}
       >
         <p>
@@ -34,6 +49,7 @@ exports[`executive summary component renders correctly 1`] = `
             <strong>
               Date:
             </strong>
+             
           </li>
           <li>
             <strong>
@@ -50,6 +66,7 @@ exports[`executive summary component renders correctly 1`] = `
             <strong>
               Medicaid share:
             </strong>
+             
             <Dollars
               long={true}
             >
@@ -69,7 +86,22 @@ exports[`executive summary component renders correctly 1`] = `
         className="ds-u-border-bottom--0"
         editHref="#activity-a2"
         editText="Edit"
-        heading="Activity 2: activity 2"
+        heading={
+          <React.Fragment>
+            Activity 
+            2
+            :
+             
+            <a
+              href="#activity-a2"
+              onClick={[Function]}
+            >
+              activity 2
+            </a>
+          </React.Fragment>
+        }
+        headingLevel={4}
+        key="a2"
         onEditClick={[Function]}
       >
         <p>
@@ -82,6 +114,7 @@ exports[`executive summary component renders correctly 1`] = `
             <strong>
               Date:
             </strong>
+             
           </li>
           <li>
             <strong>
@@ -98,6 +131,7 @@ exports[`executive summary component renders correctly 1`] = `
             <strong>
               Medicaid share:
             </strong>
+             
             <Dollars
               long={true}
             >

--- a/web/src/containers/__snapshots__/ExecutiveSummaryBudget.test.js.snap
+++ b/web/src/containers/__snapshots__/ExecutiveSummaryBudget.test.js.snap
@@ -5,7 +5,9 @@ exports[`executive summary budget component DollarCell renders correctly 1`] = `
   className="mono right-align"
   headers="one two three"
 >
-  <Dollars>
+  <Dollars
+    long={false}
+  >
     32.57
   </Dollars>
 </td>
@@ -16,7 +18,9 @@ exports[`executive summary budget component DollarCell renders correctly 2`] = `
   className="mono right-align"
   headers="one two three"
 >
-  <Dollars>
+  <Dollars
+    long={false}
+  >
     75.23
   </Dollars>
 </td>

--- a/web/src/containers/__snapshots__/IncentivePayments.test.js.snap
+++ b/web/src/containers/__snapshots__/IncentivePayments.test.js.snap
@@ -118,7 +118,9 @@ exports[`incentive payments component renders correctly 1`] = `
         <td
           className="mono right-align align-middle"
         >
-          <Dollars>
+          <Dollars
+            long={false}
+          >
             10
           </Dollars>
         </td>
@@ -262,7 +264,9 @@ exports[`incentive payments component renders correctly 1`] = `
         <td
           className="mono right-align align-middle"
         >
-          <Dollars>
+          <Dollars
+            long={false}
+          >
             74
           </Dollars>
         </td>
@@ -456,7 +460,9 @@ exports[`incentive payments component renders correctly 1`] = `
         <td
           className="mono right-align align-middle"
         >
-          <Dollars>
+          <Dollars
+            long={false}
+          >
             26
           </Dollars>
         </td>
@@ -600,7 +606,9 @@ exports[`incentive payments component renders correctly 1`] = `
         <td
           className="mono right-align align-middle"
         >
-          <Dollars>
+          <Dollars
+            long={false}
+          >
             90
           </Dollars>
         </td>

--- a/web/src/containers/__snapshots__/QuarterlyBudgetSummary.test.js.snap
+++ b/web/src/containers/__snapshots__/QuarterlyBudgetSummary.test.js.snap
@@ -79,7 +79,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="1"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               3
             </Dollars>
           </td>
@@ -87,7 +89,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="2"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               6
             </Dollars>
           </td>
@@ -95,7 +99,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="3"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               9
             </Dollars>
           </td>
@@ -103,14 +109,18 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="4"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               12
             </Dollars>
           </td>
           <td
             className="mono right-align nowrap"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               15
             </Dollars>
           </td>
@@ -127,7 +137,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="1"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               2
             </Dollars>
           </td>
@@ -135,7 +147,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="2"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               5
             </Dollars>
           </td>
@@ -143,7 +157,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="3"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               8
             </Dollars>
           </td>
@@ -151,14 +167,18 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="4"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               11
             </Dollars>
           </td>
           <td
             className="mono right-align nowrap"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               14
             </Dollars>
           </td>
@@ -175,7 +195,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="1"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               1
             </Dollars>
           </td>
@@ -183,7 +205,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="2"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               4
             </Dollars>
           </td>
@@ -191,7 +215,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="3"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               7
             </Dollars>
           </td>
@@ -199,14 +225,18 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="4"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               10
             </Dollars>
           </td>
           <td
             className="mono right-align nowrap"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               13
             </Dollars>
           </td>
@@ -281,7 +311,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="1"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               103
             </Dollars>
           </td>
@@ -289,7 +321,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="2"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               106
             </Dollars>
           </td>
@@ -297,7 +331,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="3"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               109
             </Dollars>
           </td>
@@ -305,14 +341,18 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="4"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               112
             </Dollars>
           </td>
           <td
             className="mono right-align nowrap"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               115
             </Dollars>
           </td>
@@ -329,7 +369,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="1"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               102
             </Dollars>
           </td>
@@ -337,7 +379,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="2"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               105
             </Dollars>
           </td>
@@ -345,7 +389,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="3"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               108
             </Dollars>
           </td>
@@ -353,14 +399,18 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="4"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               111
             </Dollars>
           </td>
           <td
             className="mono right-align nowrap"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               114
             </Dollars>
           </td>
@@ -377,7 +427,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="1"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               101
             </Dollars>
           </td>
@@ -385,7 +437,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="2"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               104
             </Dollars>
           </td>
@@ -393,7 +447,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="3"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               107
             </Dollars>
           </td>
@@ -401,14 +457,18 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="4"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               110
             </Dollars>
           </td>
           <td
             className="mono right-align nowrap"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               113
             </Dollars>
           </td>
@@ -443,7 +503,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
           <td
             className="bold mono right-align nowrap"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               3002
             </Dollars>
           </td>
@@ -457,7 +519,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
           <td
             className="bold mono right-align nowrap"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               3001
             </Dollars>
           </td>
@@ -471,7 +535,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
           <td
             className="bold mono right-align nowrap"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               3000
             </Dollars>
           </td>
@@ -556,7 +622,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="1"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               203
             </Dollars>
           </td>
@@ -564,7 +632,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="2"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               206
             </Dollars>
           </td>
@@ -572,7 +642,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="3"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               209
             </Dollars>
           </td>
@@ -580,14 +652,18 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="4"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               212
             </Dollars>
           </td>
           <td
             className="mono right-align nowrap"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               215
             </Dollars>
           </td>
@@ -604,7 +680,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="1"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               202
             </Dollars>
           </td>
@@ -612,7 +690,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="2"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               205
             </Dollars>
           </td>
@@ -620,7 +700,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="3"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               208
             </Dollars>
           </td>
@@ -628,14 +710,18 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="4"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               211
             </Dollars>
           </td>
           <td
             className="mono right-align nowrap"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               214
             </Dollars>
           </td>
@@ -652,7 +738,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="1"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               201
             </Dollars>
           </td>
@@ -660,7 +748,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="2"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               204
             </Dollars>
           </td>
@@ -668,7 +758,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="3"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               207
             </Dollars>
           </td>
@@ -676,14 +768,18 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="4"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               210
             </Dollars>
           </td>
           <td
             className="mono right-align nowrap"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               213
             </Dollars>
           </td>
@@ -758,7 +854,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="1"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               1103
             </Dollars>
           </td>
@@ -766,7 +864,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="2"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               1106
             </Dollars>
           </td>
@@ -774,7 +874,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="3"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               1109
             </Dollars>
           </td>
@@ -782,14 +884,18 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="4"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               1112
             </Dollars>
           </td>
           <td
             className="mono right-align nowrap"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               1115
             </Dollars>
           </td>
@@ -806,7 +912,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="1"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               1102
             </Dollars>
           </td>
@@ -814,7 +922,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="2"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               1105
             </Dollars>
           </td>
@@ -822,7 +932,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="3"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               1108
             </Dollars>
           </td>
@@ -830,14 +942,18 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="4"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               1111
             </Dollars>
           </td>
           <td
             className="mono right-align nowrap"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               1114
             </Dollars>
           </td>
@@ -854,7 +970,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="1"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               1101
             </Dollars>
           </td>
@@ -862,7 +980,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="2"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               1104
             </Dollars>
           </td>
@@ -870,7 +990,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="3"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               1107
             </Dollars>
           </td>
@@ -878,14 +1000,18 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
             className="mono right-align nowrap"
             key="4"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               1110
             </Dollars>
           </td>
           <td
             className="mono right-align nowrap"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               1113
             </Dollars>
           </td>
@@ -920,7 +1046,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
           <td
             className="bold mono right-align nowrap"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               4002
             </Dollars>
           </td>
@@ -934,7 +1062,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
           <td
             className="bold mono right-align nowrap"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               4001
             </Dollars>
           </td>
@@ -948,7 +1078,9 @@ exports[`quarterly budget summary component renders correctly if data is loaded 
           <td
             className="bold mono right-align nowrap"
           >
-            <Dollars>
+            <Dollars
+              long={false}
+            >
               4000
             </Dollars>
           </td>

--- a/web/src/containers/activity/__snapshots__/CostAllocateFFP.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/CostAllocateFFP.test.js.snap
@@ -23,7 +23,9 @@ exports[`the CostAllocateFFP component renders correctly 1`] = `
         <div
           className="h3 bold mono truncate"
         >
-          <Dollars>
+          <Dollars
+            long={false}
+          >
             300
           </Dollars>
         </div>
@@ -43,7 +45,9 @@ exports[`the CostAllocateFFP component renders correctly 1`] = `
         <div
           className="h4 bold mono truncate"
         >
-          <Dollars>
+          <Dollars
+            long={false}
+          >
             290
           </Dollars>
         </div>
@@ -75,7 +79,9 @@ exports[`the CostAllocateFFP component renders correctly 1`] = `
             <div
               className="h4 bold mono truncate"
             >
-              <Dollars>
+              <Dollars
+                long={false}
+              >
                 261
               </Dollars>
             </div>
@@ -89,7 +95,9 @@ exports[`the CostAllocateFFP component renders correctly 1`] = `
             <div
               className="h4 bold mono truncate"
             >
-              <Dollars>
+              <Dollars
+                long={false}
+              >
                 29
               </Dollars>
             </div>
@@ -110,7 +118,9 @@ exports[`the CostAllocateFFP component renders correctly 1`] = `
         <div
           className="h3 bold mono truncate"
         >
-          <Dollars>
+          <Dollars
+            long={false}
+          >
             3000
           </Dollars>
         </div>
@@ -130,7 +140,9 @@ exports[`the CostAllocateFFP component renders correctly 1`] = `
         <div
           className="h4 bold mono truncate"
         >
-          <Dollars>
+          <Dollars
+            long={false}
+          >
             3000
           </Dollars>
         </div>
@@ -162,7 +174,9 @@ exports[`the CostAllocateFFP component renders correctly 1`] = `
             <div
               className="h4 bold mono truncate"
             >
-              <Dollars>
+              <Dollars
+                long={false}
+              >
                 300
               </Dollars>
             </div>
@@ -176,7 +190,9 @@ exports[`the CostAllocateFFP component renders correctly 1`] = `
             <div
               className="h4 bold mono truncate"
             >
-              <Dollars>
+              <Dollars
+                long={false}
+              >
                 2700
               </Dollars>
             </div>

--- a/web/src/reducers/budget.selectors.js
+++ b/web/src/reducers/budget.selectors.js
@@ -1,6 +1,5 @@
 import { createSelector } from 'reselect';
 import { selectActivitiesByKey } from './activities.selectors';
-import { selectApdData } from './apd.selectors';
 import { ACTIVITY_FUNDING_SOURCES } from '../util';
 
 const selectBudget = ({ budget }) => budget;
@@ -23,34 +22,34 @@ export const selectBudgetActivitiesByFundingSource = createSelector(
 );
 
 export const selectBudgetExecutiveSummary = createSelector(
-  [selectApdData, selectActivitiesByKey, selectBudget],
-  ({ years }, byKey, budget) => {
-    const data = Object.entries(byKey).map(([key, { name, descShort }]) => {
+  [selectActivitiesByKey, selectBudget],
+  (byKey, budget) => {
+    const data = Object.entries(byKey).map(([key, { name, summary }]) => {
       const activityCosts = budget.activities[key].costsByFFY;
 
       return {
         key,
         name,
-        descShort,
-        totals: years.reduce(
-          (acc, year) => ({ ...acc, [year]: activityCosts[year].total }),
-          {}
-        ),
-        combined: activityCosts.total.total
+        summary,
+        combined: activityCosts.total.total,
+        federal: activityCosts.total.federal,
+        medicaid: activityCosts.total.medicaidShare
       };
-    });
-
-    data.push({
-      key: 'all',
-      name: 'Total Cost',
-      descShort: null,
-      totals: years.reduce(
-        (acc, year) => ({ ...acc, [year]: budget.combined[year].total }),
-        {}
-      ),
-      combined: budget.combined.total.total
     });
 
     return data;
   }
+);
+
+export const selectBudgetGrandTotal = createSelector(
+  [selectBudget],
+  ({
+    combined: {
+      total: { federal, medicaid, total }
+    }
+  }) => ({
+    combined: total,
+    federal,
+    medicaid
+  })
 );

--- a/web/src/reducers/budget.selectors.js
+++ b/web/src/reducers/budget.selectors.js
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import { createSelector } from 'reselect';
 import { selectActivitiesByKey } from './activities.selectors';
 import { ACTIVITY_FUNDING_SOURCES } from '../util';
@@ -24,18 +25,28 @@ export const selectBudgetActivitiesByFundingSource = createSelector(
 export const selectBudgetExecutiveSummary = createSelector(
   [selectActivitiesByKey, selectBudget],
   (byKey, budget) => {
-    const data = Object.entries(byKey).map(([key, { name, summary }]) => {
-      const activityCosts = budget.activities[key].costsByFFY;
+    const data = Object.entries(byKey).map(
+      ([key, { name, plannedEndDate, plannedStartDate, summary }]) => {
+        const activityCosts = budget.activities[key].costsByFFY;
 
-      return {
-        key,
-        name,
-        summary,
-        combined: activityCosts.total.total,
-        federal: activityCosts.total.federal,
-        medicaid: activityCosts.total.medicaidShare
-      };
-    });
+        let dateRange = 'Dates not set';
+        if (plannedEndDate && plannedStartDate) {
+          dateRange = `${moment(plannedStartDate, 'YYYY-MM-DD').format(
+            'M/D/YYYY'
+          )} - ${moment(plannedEndDate, 'YYYY-MM-DD').format('M/D/YYYY')}`;
+        }
+
+        return {
+          key,
+          dateRange,
+          name,
+          summary,
+          combined: activityCosts.total.total,
+          federal: activityCosts.total.federal,
+          medicaid: activityCosts.total.medicaidShare
+        };
+      }
+    );
 
     return data;
   }

--- a/web/src/styles/scss/overrides.scss
+++ b/web/src/styles/scss/overrides.scss
@@ -1,0 +1,5 @@
+@import '@cmsgov/design-system-support/src/settings/index';
+
+h4.ds-c-review__heading {
+  font-size: $h4-font-size;
+}


### PR DESCRIPTION
This PR does not update the executive summary budget table, only the activity summary view, as designed in #1491.

### This pull request changes...
- closes #1491

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This feature is done when...
- [ ] Design has approved the experience
- [ ] Product has approved the experience
