### PR TITLE
Move AWS DB migration step into PM2

### DIFF
--- a/bin/preview-deploy/aws.cleanup.sh
+++ b/bin/preview-deploy/aws.cleanup.sh
@@ -29,8 +29,7 @@ function cleanupPreviewDeploys() {
 # Expects global environment variables:
 #   AWS_PROD_API_REGION - The AWS region to use
 function configureAWS() {
-  # aws configure set default.region $AWS_PROD_API_REGION
-  echo
+  aws configure set default.region $AWS_PROD_API_REGION
 }
 
 # Finds any existing instances for previewing this PR

--- a/bin/prod-deploy/aws.user-data.sh
+++ b/bin/prod-deploy/aws.user-data.sh
@@ -50,10 +50,6 @@ rm seeds/shared/delete-everything.js
 
 npm ci --only=production
 
-# Migrate the database.  The "DB_URL" placeholder below should be replaced by
-# the CI/CD process with the real database URL to use.
-NODE_ENV=production DB_URL=__DB_URL__ npm run migrate
-
 # pm2 wants an ecosystem file that describes the apps to run and sets any
 # environment variables they need.  The environment variables are sensitive,
 # so we won't put them here.  Instead, the CI/CD process should replace the


### PR DESCRIPTION
The database migration wasn't happening. This moves the migration step into PM2 to make sure the environment is setup correctly, instead of having a separate command and environment injection and all that.  (I suspect there was a problem with escaping, and this should fix that.)

### This pull request changes...
- database migrates correctly
- configures AWS region for the cleanup script

### This pull request is ready to merge when...
- [ ] This code has been reviewed by someone other than the original author