### PR TITLE
Audit account management actions

### DIFF
--- a/api/audit.js
+++ b/api/audit.js
@@ -37,7 +37,11 @@ module.exports = (action, req) => {
       },
       set: (field, value) => {
         try {
-          data[field] = value;
+          if (field === 'password') {
+            data.password = '<new password>';
+          } else {
+            data[field] = value;
+          }
         } catch (e) {
           logger.error('ERROR SETTING AUDIT VALUE', e);
         }

--- a/api/audit.js
+++ b/api/audit.js
@@ -1,0 +1,65 @@
+const logger = require('./logger')('AUDIT');
+
+const CREATE_ACCOUNT = Symbol('audit: create account');
+const DISABLE_ACCOUNT = Symbol('audit: disable account');
+const ENABLE_ACCOUNT = Symbol('audit: enable account');
+const MODIFY_ACCOUNT = Symbol('audit: modify account');
+const REMOVE_ACCOUNT = Symbol('audit: remove account');
+
+const actionsToProps = {
+  [CREATE_ACCOUNT]: 'createAccount',
+  [DISABLE_ACCOUNT]: 'disableAccount',
+  [ENABLE_ACCOUNT]: 'enableAccount',
+  [MODIFY_ACCOUNT]: 'modifyAccount',
+  [REMOVE_ACCOUNT]: 'removeAccount'
+};
+
+module.exports = (action, req) => {
+  try {
+    if (!actionsToProps[action]) {
+      throw new Error(`don't know how to audit ${action}`);
+    }
+
+    const data = {};
+    let target = {};
+
+    return {
+      log: () => {
+        try {
+          logger.audit(`AUDIT ACTION: ${action.toString()}`, {
+            actor: { id: req.user.id, email: req.user.model.get('email') },
+            action: { [actionsToProps[action]]: data },
+            target
+          });
+        } catch (e) {
+          logger.error('ERROR LOGGING AUDIT', e);
+        }
+      },
+      set: (field, value) => {
+        try {
+          data[field] = value;
+        } catch (e) {
+          logger.error('ERROR SETTING AUDIT VALUE', e);
+        }
+      },
+      target: t => {
+        try {
+          target = t;
+        } catch (e) {
+          logger.error('ERROR SETTING AUDIT TARGET', e);
+        }
+      }
+    };
+  } catch (e) {
+    logger.error('ERROR CREATING AUDITOR', e);
+    throw e;
+  }
+};
+
+module.exports.actions = {
+  CREATE_ACCOUNT,
+  DISABLE_ACCOUNT,
+  ENABLE_ACCOUNT,
+  MODIFY_ACCOUNT,
+  REMOVE_ACCOUNT
+};

--- a/api/audit.js
+++ b/api/audit.js
@@ -27,7 +27,11 @@ module.exports = (action, req) => {
       log: () => {
         try {
           logger.audit(`AUDIT ACTION: ${action.toString()}`, {
-            actor: { id: req.user.id, email: req.user.model.get('email') },
+            actor: {
+              id: req.user.id,
+              email: req.user.model.get('email'),
+              ip: req.ip
+            },
             action: { [actionsToProps[action]]: data },
             target
           });

--- a/api/env.js
+++ b/api/env.js
@@ -9,6 +9,7 @@ const defaults = {
   LOG_LEVEL: 'info',
   LOG_FILE: 'false',
   LOG_CONSOLE: 'true',
+  PROXY_TRUST: 'false',
   STORE_PATH: '',
   STORE_TYPE: 'null' // default to using the /dev/null store
 };
@@ -35,16 +36,19 @@ process.env = Object.assign({}, defaults, upsEnv, process.env);
 
 // Don't require this until process.env is finished setting up, since that
 // defines how the logger works.
-const logger = require('./logger')('env setup')
+const logger = require('./logger')('env setup');
 
 // Convert the SESSION_SECRET from a hex string to a bunch of bytes, if
 // applicable.
 if (process.env.SESSION_SECRET.match(/^[a-f0-9]+$/i)) {
   process.env.SESSION_SECRET = Buffer.from(process.env.SESSION_SECRET, 'hex');
 } else {
-  logger.warn('SESSION_SECRET should be a hex string')
+  logger.warn('SESSION_SECRET should be a hex string');
 }
 
 if (process.env.SESSION_SECRET.length * 8 < 256) {
-  logger.warn(`SESSION_SECRET is ${process.env.SESSION_SECRET.length * 8} bits - should be AT LEAST 256 bits [see: https://tools.ietf.org/html/rfc7518#section-3.2]`)
+  logger.warn(
+    `SESSION_SECRET is ${process.env.SESSION_SECRET.length *
+      8} bits - should be AT LEAST 256 bits [see: https://tools.ietf.org/html/rfc7518#section-3.2]`
+  );
 }

--- a/api/logger.js
+++ b/api/logger.js
@@ -41,6 +41,12 @@ module.exports = name => {
   }
 
   const logger = winston.loggers.get(name);
+
+  // Add an audit log level at 0 priority, so it will always be logged
+  // regardless of the configured logging level.
+  logger.setLevels({ audit: 0, ...winston.config.npm.levels });
+  winston.addColors({ audit: 'red' });
+
   // Override the log function to append request information
   // if it's provided
   logger.log = (level, req, ...args) => {

--- a/api/main.js
+++ b/api/main.js
@@ -16,6 +16,17 @@ const endpointCoverage = require('./endpointCoverageMiddleware');
 const server = express();
 
 endpointCoverage.registerCoverageMiddleware(server);
+
+if (process.env.PROXY_TRUST !== 'false') {
+  // If there is a non-false PROXY_TRUST value, use it. If the value is 'true',
+  // convert to a boolean to trust everything. This will use the left-most
+  // value in X-FORWARDED-FOR as the requestor IP address.
+  server.set(
+    'trust proxy',
+    process.env.PROXY_TRUST === 'true' || process.env.PROXY_TRUST
+  );
+}
+
 server.use((req, res, next) => {
   req.id = uuid();
   req.meta = {};

--- a/api/routes/users/delete.js
+++ b/api/routes/users/delete.js
@@ -1,6 +1,7 @@
 const logger = require('../../logger')('users route get');
 const defaultUserModel = require('../../db').models.user;
 const can = require('../../middleware').can;
+const auditor = require('../../audit');
 
 module.exports = (app, UserModel = defaultUserModel) => {
   logger.silly('setting up DELETE /users/:id route');
@@ -9,6 +10,7 @@ module.exports = (app, UserModel = defaultUserModel) => {
     logger.verbose(req, 'got a request to delete a user', req.params.id);
 
     try {
+      const audit = auditor(auditor.actions.REMOVE_ACCOUNT, req);
       const targetID = Number.parseInt(req.params.id, 10);
       if (Number.isNaN(targetID)) {
         return res.status(400).end();
@@ -31,9 +33,11 @@ module.exports = (app, UserModel = defaultUserModel) => {
         req,
         `request to delete user [${targetUser.get('email')}]`
       );
+      audit.target({ id: targetID, email: targetUser.get('email') });
 
       logger.silly(req, 'destroying user');
       await targetUser.destroy();
+      audit.log();
       logger.silly(req, 'okay, all good');
       return res.status(204).end();
     } catch (e) {

--- a/api/routes/users/post.js
+++ b/api/routes/users/post.js
@@ -1,6 +1,7 @@
 const logger = require('../../logger')('users route post');
 const defaultUserModel = require('../../db').models.user;
 const can = require('../../middleware').can;
+const auditor = require('../../audit');
 
 module.exports = (app, UserModel = defaultUserModel) => {
   logger.silly('setting up POST /users route');
@@ -9,20 +10,27 @@ module.exports = (app, UserModel = defaultUserModel) => {
     logger.silly(req, `attempting to create new user [${req.body.email}]`);
     if (req.body.email && req.body.password) {
       try {
+        const audit = auditor(auditor.actions.CREATE_ACCOUNT, req);
+
         const posted = {
           email: req.body.email,
           password: req.body.password
         };
+        audit.set('email', req.body.email);
+        audit.set('password', '<new password>');
 
         // If these values are not passed in, don't set them at all, even
         // to undefined.  Undefined will make the data model explode.
         if (req.body.name) {
+          audit.set('name', req.body.name);
           posted.name = req.body.name;
         }
         if (req.body.role) {
+          audit.set('auth_role', req.body.role);
           posted.auth_role = req.body.role;
         }
         if (req.body.state) {
+          audit.set('state_id', req.body.state);
           posted.state_id = req.body.state;
         }
 
@@ -39,6 +47,10 @@ module.exports = (app, UserModel = defaultUserModel) => {
         }
 
         await user.save();
+
+        audit.set('id', user.get('id'));
+        audit.log();
+
         logger.silly(req, 'all done');
         return res.status(200).end();
       } catch (e) {

--- a/api/routes/users/post.test.js
+++ b/api/routes/users/post.test.js
@@ -11,6 +11,7 @@ tap.test('user POST endpoint', async endpointTest => {
   };
 
   const User = {
+    get: sandbox.stub(),
     save: sandbox.stub(),
     validate: sandbox.stub()
   };

--- a/api/routes/users/put.js
+++ b/api/routes/users/put.js
@@ -56,9 +56,6 @@ module.exports = (
       ['email', 'name', 'password', 'position', 'phone'].forEach(field => {
         if (req.body[field]) {
           audit.set(field, req.body[field]);
-          if (field === 'password') {
-            audit.set('password', '<new password>');
-          }
           targetUser.set(field, req.body[field]);
         }
       });

--- a/api/routes/users/put.js
+++ b/api/routes/users/put.js
@@ -3,6 +3,7 @@ const defaultRoleModel = require('../../db').models.role;
 const defaultStateModel = require('../../db').models.state;
 const defaultUserModel = require('../../db').models.user;
 const can = require('../../middleware').can;
+const auditor = require('../../audit');
 
 module.exports = (
   app,
@@ -14,6 +15,7 @@ module.exports = (
 ) => {
   logger.silly('setting up PUT /users/:id route');
   app.put('/users/:id', can('add-users'), async (req, res) => {
+    const audit = auditor(auditor.actions.MODIFY_ACCOUNT, req);
     logger.silly(req, 'handling PUT /users/:id route');
     logger.silly(req, `attempting to update user [${req.params.id}]`);
 
@@ -40,6 +42,10 @@ module.exports = (
         );
         return res.status(404).end();
       }
+      audit.target({
+        id: targetUser.get('id'),
+        emmail: targetUser.get('email')
+      });
       logger.verbose(
         req,
         `request to modify user [${targetUser.get('email')}]`
@@ -49,6 +55,10 @@ module.exports = (
       // all willy-nilly.
       ['email', 'name', 'password', 'position', 'phone'].forEach(field => {
         if (req.body[field]) {
+          audit.set(field, req.body[field]);
+          if (field === 'password') {
+            audit.set('password', '<new password>');
+          }
           targetUser.set(field, req.body[field]);
         }
       });
@@ -63,6 +73,7 @@ module.exports = (
         const validStateIDs = validStates.map(state => state.get('id'));
 
         if (validStateIDs.some(role => role === req.body.state)) {
+          audit.set('state_id', req.body.state);
           targetUser.set('state_id', req.body.state);
         } else {
           logger.verbose(`state [${req.body.state}] is invalid`);
@@ -81,6 +92,7 @@ module.exports = (
         const validRoleNames = validRoles.map(role => role.get('name'));
 
         if (validRoleNames.some(role => role === req.body.role)) {
+          audit.set('auth_role', req.body.role);
           targetUser.set('auth_role', req.body.role);
         } else {
           logger.verbose(`role [${req.body.role}] is invalid`);
@@ -93,9 +105,11 @@ module.exports = (
 
       // And provide a way to unset the user's state or role.
       if (req.body.state === '') {
+        audit.set('state_id', null);
         targetUser.set('state_id', null);
       }
       if (req.body.role === '') {
+        audit.set('auth_role', null);
         targetUser.set('auth_role', null);
       }
 
@@ -109,6 +123,7 @@ module.exports = (
       }
 
       await targetUser.save();
+      audit.log();
       logger.silly(req, 'all done');
       return res.status(204).end();
     } catch (e) {

--- a/bin/prod-deploy/aws.sh
+++ b/bin/prod-deploy/aws.sh
@@ -90,7 +90,8 @@ function addEcosystemToUserData() {
         PBKDF2_ITERATIONS: '$AWS_PROD_API_PBKDF2_ITERATIONS',
         PORT: '$AWS_PROD_API_PORT',
         DATABASE_URL: '$AWS_PROD_API_DATABASE_URL',
-        SESSION_SECRET: '$AWS_PROD_API_SESSION_SECRET'
+        SESSION_SECRET: '$AWS_PROD_API_SESSION_SECRET',
+        PROXY_TRUST: 'true'
       },
     },{
       name: 'Database migration',

--- a/web/.snyk
+++ b/web/.snyk
@@ -4,6 +4,6 @@ version: v1.13.5
 ignore:
   SNYK-JS-AXIOS-174505:
     - axios:
-        reason: no fix; does not affect our app
-        expires: '2019-05-25T14:29:57.487Z'
+        reason: no fix yet
+        expires: '2019-06-27T13:08:48.879Z'
 patch: {}


### PR DESCRIPTION
#1507 says we need to audit account creation, modification, enabling, disabling, and deleting.  This PR should satisfy that requirement.  We don't have a distinct method for enabling or disabling accounts, but we can effectively disable account by removing its authorization role and re-enable it by adding a role back to it.  That would be captured by the account modification audit.  There is no auditing for account enable/disable since that't not an explicit action.

### This pull request changes...
- adds an auditor helper
- updates account creation, update, and delete API routes to use auditing
- updates logger to add `audit` log level that cannot be disabled
- closes #1507

![image](https://user-images.githubusercontent.com/1775733/58180196-46a5dd00-7c6f-11e9-9444-e77b6eddba48.png)

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented
  - probably need to put a note about this in the controls spreadsheet?

### This feature is done when...
- [x] Product has approved the experience
