### PR TITLE
Fix legacy collapsible list headers

### DIFF
--- a/web/src/components/CollapsibleList.js
+++ b/web/src/components/CollapsibleList.js
@@ -30,9 +30,7 @@ class ListItem extends Component {
             }`}
             onClick={this.toggle}
           >
-            <header className="flex items-center justify-between">
-              {header}
-            </header>
+            <div className="flex items-center justify-between">{header}</div>
           </button>
           {deleteItem && (
             <button
@@ -50,9 +48,7 @@ class ListItem extends Component {
             className="btn btn-no-focus p1 flex-auto left-align bg-blue-light rounded"
             onClick={this.toggle}
           >
-            <header className="flex items-center justify-between">
-              {header}
-            </header>
+            <div className="flex items-center justify-between">{header}</div>
           </button>
         </div>
         <div className={childClass}>{children}</div>


### PR DESCRIPTION

### This pull request changes...
- Switch `CollapsibleList` toggly things from `<header>` to `<div>` as a quick fix. The whole `CollapsibleList` component will hopefully go away relatively soon.
- fixes #1515 

### This pull request is ready to merge when...
- [ ] This code has been reviewed by someone other than the original author

### This feature is done when...
- [ ] Product has approved the experience
