### PR TITLE
Update production deploy cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -364,7 +364,7 @@ jobs:
           working_directory: ~/project
           command: |
             git diff master --relative=api --name-only --exit-code > /dev/null
-            if [ $? -ne 0 ]; then
+            if [ $? -eq "0" ]; then
               circleci-agent step halt
             fi
       - run:
@@ -403,7 +403,7 @@ jobs:
           name: make sure the frontend changed
           command: |
             git diff master --relative=web --name-only --exit-code > /dev/null
-            if [ $? -ne 0 ]; thenqgit
+            if [ $? -eq "0" ]; thenqgit
               circleci-agent step halt
             fi
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,6 +363,9 @@ jobs:
           name: make sure the backend changed
           working_directory: ~/project
           command: |
+            # git diff --exit-code will exit with a 0 if there were no changes
+            # or a non-zero if there were changes, so stop this step gracefully
+            # if there were no changes in the api directory
             git diff master --relative=api --name-only --exit-code > /dev/null
             if [ $? -eq "0" ]; then
               circleci-agent step halt
@@ -402,8 +405,11 @@ jobs:
       - run:
           name: make sure the frontend changed
           command: |
+            # git diff --exit-code will exit with a 0 if there were no changes
+            # or a non-zero if there were changes, so stop this step gracefully
+            # if there were no changes in the web directory
             git diff master --relative=web --name-only --exit-code > /dev/null
-            if [ $? -eq "0" ]; thenqgit
+            if [ $? -eq "0" ]; then
               circleci-agent step halt
             fi
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,6 +360,14 @@ jobs:
     steps:
       - checkout
       - run:
+          name: make sure the backend changed
+          working_directory: ~/project
+          command: |
+            git diff master --relative=api --name-only --exit-code > /dev/null
+            if [ $? -ne 0 ]; then
+              circleci-agent step halt
+            fi
+      - run:
           name: deploy to production
           working_directory: ~/project/bin/prod-deploy
           command: |
@@ -391,6 +399,13 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/project
+      - run:
+          name: make sure the frontend changed
+          command: |
+            git diff master --relative=web --name-only --exit-code > /dev/null
+            if [ $? -ne 0 ]; thenqgit
+              circleci-agent step halt
+            fi
       - run:
           name: sync to s3
           command: |

--- a/bin/prod-deploy/aws.sh
+++ b/bin/prod-deploy/aws.sh
@@ -35,9 +35,10 @@ function deployAPItoEC2() {
   # Configure AWS CLI with defaults
   configureAWS
 
-  # Get the instance ID of the current API EC2 instance, so we can delete it later
-  PREV_INSTANCE_ID=$(getCurrentTargetGroupInstanceID)
-  echo "• Found previous instance $PREV_INSTANCE_ID"
+  # Get the instance IDs of the current API EC2 production instances, so we can 
+  # delete them later
+  PREV_INSTANCE_INFOS=$(findExistingInstances)
+  echo "• Found previous instances: $PREV_INSTANCE_INFOS"
 
   # Create new EC2 instance
   INSTANCE_ID=$(createNewInstance)
@@ -60,14 +61,13 @@ function deployAPItoEC2() {
   echo "• Waiting for target to be healthy"
   waitForTargetToBeHealthy $INSTANCE_ID
 
-  # Once the new instance is healthy, we can take the old instance out of the
-  # ELB target group.
-  removeInstanceFromTargetGroup $PREV_INSTANCE_ID
-  echo "• Removed previous instance $PREV_INSTANCE_ID from ELB target group"
-
-  # And finally, we terminate it.
-  terminateInstance $PREV_INSTANCE_ID
-  echo "• Terminated previous instance $PREV_INSTANCE_ID"
+  # And finally, we terminate previous instances.
+  while read -r PREV_INSTANCE_INFO; do
+    BITS=(${PREV_INSTANCE_INFO//,/ })
+    PREV_INSTANCE_ID=$(echo ${BITS[0]} | tr -d '"')
+    terminateInstance $PREV_INSTANCE_ID
+    echo "• Terminated previous instance $PREV_INSTANCE_ID"
+  done <<< "$PREV_INSTANCE_INFOS"
 }
 
 # Reads deployment ecosystem data from the environment, builds a PM2
@@ -151,16 +151,15 @@ function createNewInstance() {
     | jq -r -c '.Instances[0].InstanceId'
 }
 
-# Get the EC2 instance ID of the instance currently in the ELB target group.
-# Echos the instance ID.
+# Finds any existing instances for production. Echos a newline-delimited list
+# of instance IDs and names.  E.g.:
 #
-# Expects global environment variables:
-#   AWS_PROD_API_TARGET_GROUP_ARN - The ARN of the target group to check
-function getCurrentTargetGroupInstanceID() {
-  aws elbv2 describe-target-health \
-    --target-group-arn $AWS_PROD_API_TARGET_GROUP_ARN \
-    --query 'TargetHealthDescriptions[*].Target.Id' \
-    | jq -r -c '.[0]'
+# "instance-id-1","instance-name-1"
+# "instance-id-2","instance-name-2"
+function findExistingInstances() {
+  aws ec2 describe-instances \
+    --filter "Name=tag:Name,Values=eapd-prod-auto" \
+    | jq -rc '.Reservations[].Instances[] | [.InstanceId, .Tags[].Value] | @csv'
 }
 
 # Gets the target health for an EC2 instance in an ELB target group
@@ -176,21 +175,6 @@ function getTargetHealth() {
     --target-group-arn $AWS_PROD_API_TARGET_GROUP_ARN \
     --targets Id=$1,Port=$AWS_PROD_API_PORT \
     | jq -r -c '.TargetHealthDescriptions[0].TargetHealth.State'
-}
-
-# Remove an EC2 instance from the ELB target group.
-#
-# $1 - ID of the EC2 instance to remove
-#
-# Expects global environment variables:
-#   AWS_PROD_API_PORT - Port the EC2 instance is listening on
-#   AWS_PROD_API_TARGET_GROUP_ARN - The ARN of the target group to remove the
-#     instance from.
-function removeInstanceFromTargetGroup() {
-  aws elbv2 deregister-targets \
-    --target-group-arn $AWS_PROD_API_TARGET_GROUP_ARN \
-    --targets Id=$1,Port=$AWS_PROD_API_PORT \
-    > /dev/null
 }
 
 # Terminate an EC2 instance


### PR DESCRIPTION
Currently, the production deployment will only successfully cleanup instances that have completed their deployments (i.e., they've been created and added to the load balancer).  However, in the case that a deployment begins while a previous deployment is still ongoing, the latter deployment may fail to clean up the former and we could end up with two active deployments.  This could cause unpredictable behavior if the API changed, as different versions of the API are responding to requests.

### This pull request changes...
- cleans up all previously-existing production instances when the new instance is ready, regardless of their status

### This pull request is ready to merge when...
- [x] This code has been reviewed by someone other than the original author