### PR TITLE
Some API cleanup

### DIFF
--- a/api/auth/session.js
+++ b/api/auth/session.js
@@ -13,6 +13,11 @@ const TOKEN_ISSUER = 'CMS eAPD API';
  *                                   cookies; primary for unit testing
  */
 const loadSession = (req, cookie) => {
+  if (!cookie) {
+    logger.silly(req, 'no auth cookie, skip validation');
+    return {};
+  }
+
   try {
     logger.silly(req, 'verifying JWT auth token');
     const valid = jwt.verify(cookie, process.env.SESSION_SECRET, {
@@ -88,7 +93,7 @@ module.exports = ({ Cookies = defaultCookies } = {}) => {
               expiresIn: `${process.env.SESSION_LIFETIME_MINUTES}m`
             }
           ),
-          { httpOnly: true }
+          { httpOnly: true, overwrite: true }
         );
       } else {
         // Else, write a cookie with an immediate expiration

--- a/api/auth/session.test.js
+++ b/api/auth/session.test.js
@@ -146,7 +146,8 @@ tap.test('session functions', async tests => {
 
         test.ok(
           cookies.set.calledWith('token', sinon.match.string, {
-            httpOnly: true
+            httpOnly: true,
+            overwrite: true
           }),
           'sets the cookie'
         );
@@ -187,7 +188,8 @@ tap.test('session functions', async tests => {
 
           test.ok(
             cookies.set.calledWith('token', sinon.match.string, {
-              httpOnly: true
+              httpOnly: true,
+              overwrite: true
             }),
             'sets the cookie'
           );

--- a/api/main.js
+++ b/api/main.js
@@ -27,6 +27,14 @@ if (process.env.PROXY_TRUST !== 'false') {
   );
 }
 
+// This endpoint doesn't do anything, but lets us verify that the server is
+// online without triggering any other processing - e.g., no authentication,
+// no cookie/token processing, etc.
+logger.silly('setting up heartbeat endpoint');
+server.get('/heartbeat', (_, res) => {
+  res.status(204).end();
+});
+
 server.use((req, res, next) => {
   req.id = uuid();
   req.meta = {};

--- a/api/routes/apds/get.js
+++ b/api/routes/apds/get.js
@@ -28,7 +28,7 @@ module.exports = (app, ApdModel = defaultApdModel) => {
         }));
 
       logger.silly(req, `got apds:`);
-      logger.silly(req, apds);
+      logger.silly(req, apds.map(({ id, name }) => ({ id, name })));
       return res.send(apds);
     } catch (e) {
       logger.error(req, e);
@@ -53,8 +53,10 @@ module.exports = (app, ApdModel = defaultApdModel) => {
       })).toJSON();
 
       if (apds.length) {
-        logger.silly(req, `got apds:`);
-        logger.silly(req, apds[0]);
+        logger.silly(
+          req,
+          `got single apd, id=${apds[0].id}, name="${apds[0].name}"`
+        );
         return res.send(apds[0]);
       }
 

--- a/api/routes/auth/activities/index.js
+++ b/api/routes/auth/activities/index.js
@@ -8,8 +8,13 @@ module.exports = (app, ActivityModel = defaultActivityModel) => {
     logger.silly(req, 'handling GET /auth/activities');
     try {
       const activities = await ActivityModel.fetchAll();
-      logger.silly(req, 'got activities:');
-      logger.silly(req, activities);
+      logger.silly(
+        req,
+        `got all the activities: ${activities
+          .toJSON()
+          .reduce((acc, { name }) => [...acc, name], [])
+          .join(', ')}`
+      );
       res.send(activities.toJSON());
     } catch (e) {
       logger.error(req, e);

--- a/api/routes/auth/activities/index.test.js
+++ b/api/routes/auth/activities/index.test.js
@@ -63,7 +63,11 @@ tap.test('auth activities GET endpoint', async endpointTest => {
 
     handlerTest.test('sends back a list of activities', async validTest => {
       const toJSON = sinon.stub();
-      toJSON.returns('json stuff');
+      toJSON.returns([
+        { name: 'auth activity 1' },
+        { name: 'auth activity 2' },
+        { name: 'auth activity 3' }
+      ]);
       const activities = { toJSON };
       ActivityModel.fetchAll.resolves(activities);
 
@@ -71,7 +75,11 @@ tap.test('auth activities GET endpoint', async endpointTest => {
 
       validTest.ok(res.status.notCalled, 'HTTP status is not explicitly set');
       validTest.ok(
-        res.send.calledWith('json stuff'),
+        res.send.calledWith([
+          { name: 'auth activity 1' },
+          { name: 'auth activity 2' },
+          { name: 'auth activity 3' }
+        ]),
         'body is JSON-ified activities'
       );
     });

--- a/api/routes/auth/roles/get.js
+++ b/api/routes/auth/roles/get.js
@@ -10,8 +10,13 @@ module.exports = (app, RoleModel = defaultRoleModel) => {
       const roles = await RoleModel.fetchAll({
         withRelated: RoleModel.withRelated
       });
-      logger.silly(req, 'got all the roles');
-      logger.silly(req, roles);
+      logger.silly(
+        req,
+        `got all the roles: ${roles
+          .toJSON()
+          .reduce((acc, { name }) => [...acc, name], [])
+          .join(', ')}`
+      );
       res.send(roles.toJSON());
     } catch (e) {
       logger.error(req, e);

--- a/api/routes/auth/roles/get.test.js
+++ b/api/routes/auth/roles/get.test.js
@@ -66,7 +66,13 @@ tap.test('auth roles GET endpoint', async endpointTest => {
 
     handlerTest.test('sends back a list of roles', async validTest => {
       RoleModel.fetchAll.resolves({
-        toJSON: sinon.stub().returns('roles as json')
+        toJSON: sinon
+          .stub()
+          .returns([
+            { name: 'auth role 1' },
+            { name: 'auth role 2' },
+            { name: 'auth role 3' }
+          ])
       });
 
       await handler({}, res);
@@ -79,7 +85,11 @@ tap.test('auth roles GET endpoint', async endpointTest => {
       );
       validTest.ok(res.status.notCalled, 'HTTP status is not explicitly set');
       validTest.ok(
-        res.send.calledWith('roles as json'),
+        res.send.calledWith([
+          { name: 'auth role 1' },
+          { name: 'auth role 2' },
+          { name: 'auth role 3' }
+        ]),
         'body is JSON-ified roles'
       );
     });

--- a/api/routes/users/get.js
+++ b/api/routes/users/get.js
@@ -6,7 +6,16 @@ const allUsersHandler = async (req, res, UserModel) => {
   logger.silly(req, 'handling GET /users route');
   try {
     const users = await UserModel.fetchAll();
-    logger.silly(req, 'sending users', users.toJSON());
+    logger.silly(
+      req,
+      'sending users',
+      users
+        .toJSON()
+        .map(
+          ({ id, email, name, state, role }) =>
+            `id: ${id}, email: ${email}, name: ${name}, state: ${state}, auth role: ${role}`
+        )
+    );
     res.send(users.toJSON());
   } catch (e) {
     logger.error(req, e);

--- a/api/routes/users/get.test.js
+++ b/api/routes/users/get.test.js
@@ -69,14 +69,44 @@ tap.test('user GET endpoint', async endpointTest => {
 
     handlerTest.test('sends back a list of users', async validTest => {
       UserModel.fetchAll.resolves({
-        toJSON: sinon.stub().returns('object-as-json')
+        toJSON: sinon.stub().returns([
+          {
+            id: 1,
+            email: 'user@one.com',
+            name: 'User 1',
+            state: 'us1',
+            role: 'role 1'
+          },
+          {
+            id: 2,
+            email: 'user@two.net',
+            name: 'User 2',
+            state: 'us2',
+            role: 'role 2'
+          }
+        ])
       });
 
       await handler({}, res);
 
       validTest.ok(res.status.notCalled, 'HTTP status is not explicitly set');
       validTest.ok(
-        res.send.calledWith('object-as-json'),
+        res.send.calledWith([
+          {
+            id: 1,
+            email: 'user@one.com',
+            name: 'User 1',
+            state: 'us1',
+            role: 'role 1'
+          },
+          {
+            id: 2,
+            email: 'user@two.net',
+            name: 'User 2',
+            state: 'us2',
+            role: 'role 2'
+          }
+        ]),
         'body is set to the list of users'
       );
     });


### PR DESCRIPTION
### This pull request changes...
- explicitly overwrites cookies; this shouldn't affect anything but let's just be safe
- tightens up logging so there's less trash in the console, should make reading the `silly` logs a lot easier
- adds a `/heartbeat` endpoint that does nothing, terminates immediately, and precedes all other endpoint processing (so it doesn't log anything or trigger authentication processing); perfect for a health check, which AWS triggers every 30 seconds and is seriously polluting the logs 😜 

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented