### PR TITLE
HOTFIX - Frontend production deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -400,10 +400,12 @@ jobs:
     docker:
       - image: python:3
     steps:
+      - checkout
       - attach_workspace:
           at: ~/project
       - run:
           name: make sure the frontend changed
+          working_directory: ~/project
           command: |
             # git diff --exit-code will exit with a 0 if there were no changes
             # or a non-zero if there were changes, so stop this step gracefully


### PR DESCRIPTION
Frontend production deployment is broken. The script does a `git` status check to verify that the frontend has changed before deploying it, but it doesn't actually checkout the code first (the deployment step previously only relied on the built frontend which is cached earlier in the CI process, so deployment didn't need the source code).

### This pull request changes...
- checks out the code on frontend deployments so the git status check will work