### PR TITLE
update activity goals section

### DIFF
--- a/api/seeds/development/apds.js
+++ b/api/seeds/development/apds.js
@@ -748,53 +748,53 @@ exports.seed = async knex => {
     {
       activity_id: activity0,
       description:
-        '<p>Accept attestations for 2018, and modify SLR to meet new spec sheets released by CMS.</p>\n<p></p>\n',
+        'Accept attestations for 2018, and modify SLR to meet new spec sheets released by CMS.',
       objective:
-        '<ol>\n<li>Complete SLR modifications by 11/1/18</li>\n<li>Accept attestations through 4/30/19.</li>\n</ol>\n'
+        '- Complete SLR modifications by 11/1/18\n- Accept attestations through 4/30/19.'
     },
     {
       activity_id: activity0,
       description:
-        '<p>Provide support to EPs and EHs through attestation process.</p>\n',
+        'Provide support to EPs and EHs through attestation process.',
       objective:
-        "<ol>\n<li>Guidance available on Tycho's websites</li>\n<li>Office hours availble for EPs and EHs</li>\n<li>Site visits, as needed, for EPs and EHs</li>\n</ol>\n"
+        "- Guidance available on Tycho's websites\n- Office hours availble for EPs and EHs\n- Site visits, as needed, for EPs and EHs"
     },
     {
       activity_id: activity1,
       description:
-        '<p>Build interface between the MMIS Data Warehouse (DW) and the HIE so that Medicaid claims data can be made available to consumers in their Personal Health Record (PHR) within the HIE.&nbsp;</p>\n',
+        'Build interface between the MMIS Data Warehouse (DW) and the HIE so that Medicaid claims data can be made available to consumers in their Personal Health Record (PHR) within the HIE.',
       objective:
-        '<ol>\n<li>Hire contracted support to build an open API for the DW that the HIE and PHR can consume.</li>\n<li>Provide support for using open API for DW</li>\n</ol>\n'
+        '- Hire contracted support to build an open API for the DW that the HIE and PHR can consume.\n- Provide support for using open API for DW'
     },
     {
       activity_id: activity2,
-      description: '<p>Plan to do a thing.</p>\n',
-      objective: '<p>Do a thing.</p>\n'
+      description: 'Plan to do a thing.',
+      objective: 'Do a thing.'
     },
     {
       activity_id: activity2,
-      description: '<p>Onboard 100 providers.</p>\n',
-      objective: '<p>100 providers onboarded.</p>\n'
+      description: 'Onboard 100 providers.',
+      objective: '100 providers onboarded.'
     },
     {
       activity_id: activity3,
-      description: '<p>Build blue button.</p>\n',
-      objective: '<p>Test blue button with 10 providers.</p>\n'
+      description: 'Build blue button.',
+      objective: 'Test blue button with 10 providers.'
     },
     {
       activity_id: activity4,
-      description: '<p>Identifiy PH needs</p>\n',
-      objective: '<p>Complete a build/implementation plan by Summery 2019</p>\n'
+      description: 'Identifiy PH needs',
+      objective: 'Complete a build/implementation plan by Summery 2019'
     },
     {
       activity_id: activity4,
-      description: '<p>Connect PH systems to HIE</p>\n',
-      objective: '<p>Connect all 3 PH systems to HIE by Fall 2019</p>\n'
+      description: 'Connect PH systems to HIE',
+      objective: 'Connect all 3 PH systems to HIE by Fall 2019'
     },
     {
       activity_id: activity5,
-      description: '<p>Complete MITA 3.0 HITECH portion.</p>\n',
-      objective: '<p>&nbsp;Complete MITA 3.0 HITECH portion by July 2019</p>\n'
+      description: 'Complete MITA 3.0 HITECH portion.',
+      objective: '&nbsp;Complete MITA 3.0 HITECH portion by July 2019'
     }
   ]);
 

--- a/web/src/actions/activities.js
+++ b/web/src/actions/activities.js
@@ -181,11 +181,19 @@ export const removeActivityContractor = (key, contractorKey) => dispatch => {
   dispatch(updateBudget());
 };
 
-export const removeActivityGoal = (key, goalKey) => ({
-  type: REMOVE_ACTIVITY_GOAL,
+export const removeActivityGoal = (
   key,
-  goalKey
-});
+  goalKey,
+  { global = window } = {}
+) => dispatch => {
+  if (global.confirm('Do you really want to delete this activity goal?')) {
+    dispatch({
+      type: REMOVE_ACTIVITY_GOAL,
+      key,
+      goalKey
+    });
+  }
+};
 
 export const removeActivityExpense = (key, expenseKey) => dispatch => {
   dispatch({

--- a/web/src/actions/activities.test.js
+++ b/web/src/actions/activities.test.js
@@ -129,7 +129,11 @@ describe('activities actions', () => {
         expectedActions.push(updatedBudgetAction(state));
       }
 
-      store.dispatch(actions[method]('activity key', 'item key'));
+      store.dispatch(
+        actions[method]('activity key', 'item key', {
+          global: { confirm: sinon.stub().returns(true) }
+        })
+      );
 
       expect(store.getActions()).toEqual(expectedActions);
     });

--- a/web/src/components/Section.js
+++ b/web/src/components/Section.js
@@ -53,7 +53,7 @@ const Subsection = ({ children, id, nested, resource }) => {
         </h3>
       )}
       {nested && (
-        <h4 id={id} className="ds-h3">
+        <h4 id={id} className="ds-h4">
           {title}
         </h4>
       )}

--- a/web/src/containers/activity/Goals.js
+++ b/web/src/containers/activity/Goals.js
@@ -58,8 +58,10 @@ const GoalForm = ({ goal, idx, done, handleChange }) => (
     <TextField
       name="name"
       className="data-entry-box"
-      label="Goal name"
-      hint={t('activities.goals.goal.instruction.detail', {
+      label={t('activities.goals.description.input.label', {
+        defaultValue: ''
+      })}
+      hint={t('activities.goals.description.input.hint', {
         defaultValue: ''
       })}
       value={goal.description}
@@ -69,10 +71,12 @@ const GoalForm = ({ goal, idx, done, handleChange }) => (
     <TextField
       name="milestones"
       className="data-entry-box"
-      label="Benchmarks"
+      label={t('activities.goals.objective.input.label', {
+        defaultValue: 'Benchmarks'
+      })}
       multiline
       rows={6}
-      hint={t('activities.goals.objective.instruction.detail', {
+      hint={t('activities.goals.objective.input.hint', {
         defaultValue: ''
       })}
       value={goal.objective}
@@ -175,7 +179,7 @@ class Goals extends Component {
           className="ds-u-margin-top--4 visibility--screen"
           onClick={this.handleAdd}
         >
-          {t('activities.goals.addGoalButtonText')}
+          Add a goal
         </Button>
         <hr />
       </Subsection>

--- a/web/src/containers/activity/Goals.js
+++ b/web/src/containers/activity/Goals.js
@@ -16,9 +16,9 @@ import { t } from '../../i18n';
 const GoalReview = ({ goal, idx, edit, handleDelete }) => (
   <Review
     heading={
-      <h5 className="ds-h4">
+      <h4 className="ds-h4">
         {idx + 1}. {goal.description}
-      </h5>
+      </h4>
     }
     editHref="#"
     onEditClick={edit}

--- a/web/src/containers/activity/Goals.js
+++ b/web/src/containers/activity/Goals.js
@@ -38,7 +38,9 @@ const GoalReview = ({ goal, idx, edit, handleDelete }) => (
       </div>
     }
   >
-    <p className="ds-u-margin-top--2">Benchmark: {goal.objective}</p>
+    <p className="ds-u-margin-top--2">
+      <strong>Benchmark:</strong> {goal.objective}
+    </p>
   </Review>
 );
 

--- a/web/src/containers/activity/Goals.js
+++ b/web/src/containers/activity/Goals.js
@@ -76,7 +76,7 @@ const GoalForm = ({ goal, idx, done, handleChange }) => (
         defaultValue: ''
       })}
       value={goal.objective}
-      onChange={handleChange('idx', 'objective')}
+      onChange={handleChange(idx, 'objective')}
     />
 
     <Button variation="primary" className="ds-u-margin-top--4" onClick={done}>
@@ -141,11 +141,9 @@ class Goals extends Component {
     addActivityGoal(activityKey);
   };
 
-  handleDelete = goal => this.getDeleter(goal.key)();
-
-  handleSync = (index, field) => html => {
+  handleChange = (index, field) => ({ target: { value } }) => {
     const { activityKey, updateActivity } = this.props;
-    const updates = { goals: { [index]: { [field]: html } } };
+    const updates = { goals: { [index]: { [field]: value } } };
     updateActivity(activityKey, updates);
   };
 
@@ -164,7 +162,7 @@ class Goals extends Component {
                 goal={goal}
                 idx={i}
                 initialExpanded={goal.expanded}
-                handleChange={this.handleSync}
+                handleChange={this.handleChange}
                 handleDelete={
                   goals.length > 1 ? this.getDeleter(goal.key) : null
                 }
@@ -208,3 +206,12 @@ export default connect(
   mapStateToProps,
   mapDispatchToProps
 )(Goals);
+
+export {
+  Goals as plain,
+  Goal,
+  GoalForm,
+  GoalReview,
+  mapStateToProps,
+  mapDispatchToProps
+};

--- a/web/src/containers/activity/Goals.test.js
+++ b/web/src/containers/activity/Goals.test.js
@@ -1,0 +1,273 @@
+import { mount, shallow } from 'enzyme';
+import sinon from 'sinon';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+
+import {
+  plain as Goals,
+  Goal,
+  GoalForm,
+  GoalReview,
+  mapStateToProps,
+  mapDispatchToProps
+} from './Goals';
+import {
+  addActivityGoal,
+  removeActivityGoal,
+  updateActivity
+} from '../../actions/activities';
+
+describe('activity goals subsection', () => {
+  const sandbox = sinon.createSandbox();
+  const dispatchProps = {
+    addActivityGoal: sandbox.spy(),
+    removeActivityGoal: sandbox.spy(),
+    updateActivity: sandbox.spy()
+  };
+
+  beforeEach(() => {
+    sandbox.resetHistory();
+  });
+
+  it('maps dispatch actions to props', () => {
+    expect(mapDispatchToProps).toEqual({
+      addActivityGoal,
+      removeActivityGoal,
+      updateActivity
+    });
+  });
+
+  it('maps appropriate state to props', () => {
+    const state = {
+      activities: {
+        byKey: { 'activity-key': { goals: 'these are goals from state' } }
+      }
+    };
+
+    const ownProps = { aKey: 'activity-key' };
+
+    expect(mapStateToProps(state, ownProps)).toEqual({
+      activityKey: 'activity-key',
+      goals: 'these are goals from state'
+    });
+  });
+
+  describe('the Goals commponent, wrapping all the others', () => {
+    describe('with no goals', () => {
+      const component = shallow(
+        <Goals activityKey="activity-key" goals={[]} {...dispatchProps} />
+      );
+
+      it('renders properly', () => {
+        expect(component).toMatchSnapshot();
+      });
+
+      it('can add a new activity', () => {
+        component.find('Button').simulate('click');
+        expect(
+          dispatchProps.addActivityGoal.calledWith('activity-key')
+        ).toEqual(true);
+      });
+    });
+
+    describe('with one goal', () => {
+      const component = shallow(
+        <Goals
+          activityKey="activity-key"
+          goals={[{ key: 'goal-1', expanded: false }]}
+          {...dispatchProps}
+        />
+      );
+
+      it('renders properly', () => {
+        expect(component).toMatchSnapshot();
+      });
+
+      it('can add a new activity', () => {
+        component.find('Button').simulate('click');
+        expect(
+          dispatchProps.addActivityGoal.calledWith('activity-key')
+        ).toEqual(true);
+      });
+
+      it('cannot delete a goal', () => {
+        expect(
+          component
+            .find('Goal')
+            .first()
+            .prop('handleDelete')
+        ).toEqual(null);
+      });
+    });
+
+    describe('with some goals', () => {
+      const component = shallow(
+        <Goals
+          activityKey="activity-key"
+          goals={[
+            { key: 'goal-1', expanded: false },
+            { key: 'goal-2', expanded: false },
+            { key: 'goal-3', expanded: true }
+          ]}
+          {...dispatchProps}
+        />
+      );
+
+      it('renders properly', () => {
+        expect(component).toMatchSnapshot();
+      });
+
+      it('can add a new activity', () => {
+        component.find('Button').simulate('click');
+        expect(
+          dispatchProps.addActivityGoal.calledWith('activity-key')
+        ).toEqual(true);
+      });
+
+      it('can edit a goal', () => {
+        const firstGoalChanger = component
+          .find('Goal')
+          .first()
+          .prop('handleChange');
+
+        firstGoalChanger(0, 'field name')({ target: { value: 'new value' } });
+
+        expect(
+          dispatchProps.updateActivity.calledWith('activity-key', {
+            goals: { 0: { 'field name': 'new value' } }
+          })
+        ).toEqual(true);
+      });
+
+      it('can delete a goal', () => {
+        const firstGoalDeleter = component
+          .find('Goal')
+          .first()
+          .prop('handleDelete');
+
+        firstGoalDeleter();
+
+        expect(
+          dispatchProps.removeActivityGoal.calledWith('activity-key', 'goal-1')
+        ).toEqual(true);
+      });
+    });
+  });
+
+  describe('the Goal component, wrapper around the form and review', () => {
+    const props = {
+      idx: 0,
+      handleChange: sandbox.spy(),
+      handleDelete: sandbox.spy()
+    };
+
+    describe('with an initially-expanded goal', () => {
+      // need a full DOM mount to support React hooks
+      const component = mount(<Goal goal={{}} initialExpanded {...props} />);
+
+      it('renders correctly', () => {
+        expect(component).toMatchSnapshot();
+      });
+
+      it('collapses when done is called', () => {
+        // act() is a React wrapper around state-changing functions for
+        // testing. https://reactjs.org/docs/test-utils.html#act
+        act(() => {
+          component.find('GoalForm').prop('done')();
+        });
+        component.update();
+        expect(component).toMatchSnapshot();
+      });
+    });
+
+    describe('with an initially-collapsed goal', () => {
+      const component = mount(<Goal goal={{}} {...props} />);
+
+      it('renders correctly', () => {
+        expect(component).toMatchSnapshot();
+      });
+
+      it('expands when edit is called', () => {
+        act(() => {
+          component.find('GoalReview').prop('edit')();
+        });
+        component.update();
+        expect(component).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('the GoalForm component', () => {
+    const done = sinon.spy();
+    const handleChange = sinon.stub();
+
+    // Put these two in the sandbox so they get reset on each test
+    const handleDescriptionChange = sandbox.spy();
+    const handleObjectiveChange = sandbox.spy();
+
+    handleChange.withArgs(0, 'description').returns(handleDescriptionChange);
+    handleChange.withArgs(0, 'objective').returns(handleObjectiveChange);
+
+    const component = shallow(
+      <GoalForm
+        goal={{ description: 'goal name', objective: 'goal benchmarks' }}
+        idx={0}
+        done={done}
+        handleChange={handleChange}
+      />
+    );
+
+    it('renders properly', () => {
+      expect(component).toMatchSnapshot();
+    });
+
+    it('handles editing the name', () => {
+      component
+        .findWhere(c => c.name() === 'TextField' && c.prop('name') === 'name')
+        .simulate('change');
+
+      expect(handleDescriptionChange.calledOnce).toEqual(true);
+    });
+
+    it('handles editing the benchmarks', () => {
+      component
+        .findWhere(
+          c => c.name() === 'TextField' && c.prop('name') === 'milestones'
+        )
+        .simulate('change');
+
+      expect(handleObjectiveChange.calledOnce).toEqual(true);
+    });
+  });
+
+  describe('the GoalReview component', () => {
+    const edit = sandbox.spy();
+    const handleDelete = sandbox.spy();
+
+    it('renders properly without a delete delete', () => {
+      expect(
+        shallow(
+          <GoalReview
+            goal={{ description: 'goal name', objective: 'goal benchmarks' }}
+            idx={0}
+            edit={edit}
+            handleDelete={null}
+          />
+        )
+      ).toMatchSnapshot();
+    });
+
+    it('renders properly with a delete handler', () => {
+      expect(
+        shallow(
+          <GoalReview
+            goal={{ description: 'goal name', objective: 'goal benchmarks' }}
+            idx={0}
+            edit={edit}
+            handleDelete={handleDelete}
+          />
+        )
+      ).toMatchSnapshot();
+    });
+  });
+});

--- a/web/src/containers/activity/Goals.test.js
+++ b/web/src/containers/activity/Goals.test.js
@@ -244,7 +244,7 @@ describe('activity goals subsection', () => {
     const edit = sandbox.spy();
     const handleDelete = sandbox.spy();
 
-    it('renders properly without a delete delete', () => {
+    it('renders properly without a delete handler', () => {
       expect(
         shallow(
           <GoalReview

--- a/web/src/containers/activity/__snapshots__/Goals.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/Goals.test.js.snap
@@ -155,12 +155,12 @@ exports[`activity goals subsection the Goal component, wrapper around the form a
       editHref="#"
       editText="Edit"
       heading={
-        <h5
+        <h4
           className="ds-h4"
         >
           1
           . 
-        </h5>
+        </h4>
       }
       onEditClick={[Function]}
     >
@@ -173,12 +173,12 @@ exports[`activity goals subsection the Goal component, wrapper around the form a
           <h3
             className="ds-c-review__heading ds-text ds-u-margin-bottom--0 ds-u-font-weight--bold ds-u-display--inline-block"
           >
-            <h5
+            <h4
               className="ds-h4"
             >
               1
               . 
-            </h5>
+            </h4>
           </h3>
           <div
             className="ds-c-review__body"
@@ -275,12 +275,12 @@ exports[`activity goals subsection the Goal component, wrapper around the form a
       editHref="#"
       editText="Edit"
       heading={
-        <h5
+        <h4
           className="ds-h4"
         >
           1
           . 
-        </h5>
+        </h4>
       }
       onEditClick={[Function]}
     >
@@ -293,12 +293,12 @@ exports[`activity goals subsection the Goal component, wrapper around the form a
           <h3
             className="ds-c-review__heading ds-text ds-u-margin-bottom--0 ds-u-font-weight--bold ds-u-display--inline-block"
           >
-            <h5
+            <h4
               className="ds-h4"
             >
               1
               . 
-            </h5>
+            </h4>
           </h3>
           <div
             className="ds-c-review__body"
@@ -529,13 +529,13 @@ exports[`activity goals subsection the GoalReview component renders properly wit
   editHref="#"
   editText="Edit"
   heading={
-    <h5
+    <h4
       className="ds-h4"
     >
       1
       . 
       goal name
-    </h5>
+    </h4>
   }
   onEditClick={[Function]}
 >
@@ -551,7 +551,7 @@ exports[`activity goals subsection the GoalReview component renders properly wit
 </Review>
 `;
 
-exports[`activity goals subsection the GoalReview component renders properly without a delete delete 1`] = `
+exports[`activity goals subsection the GoalReview component renders properly without a delete handler 1`] = `
 <Review
   editContent={
     <div
@@ -570,13 +570,13 @@ exports[`activity goals subsection the GoalReview component renders properly wit
   editHref="#"
   editText="Edit"
   heading={
-    <h5
+    <h4
       className="ds-h4"
     >
       1
       . 
       goal name
-    </h5>
+    </h4>
   }
   onEditClick={[Function]}
 >

--- a/web/src/containers/activity/__snapshots__/Goals.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/Goals.test.js.snap
@@ -186,7 +186,10 @@ exports[`activity goals subsection the Goal component, wrapper around the form a
             <p
               className="ds-u-margin-top--2"
             >
-              Benchmark: 
+              <strong>
+                Benchmark:
+              </strong>
+               
             </p>
           </div>
         </div>
@@ -303,7 +306,10 @@ exports[`activity goals subsection the Goal component, wrapper around the form a
             <p
               className="ds-u-margin-top--2"
             >
-              Benchmark: 
+              <strong>
+                Benchmark:
+              </strong>
+               
             </p>
           </div>
         </div>
@@ -536,7 +542,10 @@ exports[`activity goals subsection the GoalReview component renders properly wit
   <p
     className="ds-u-margin-top--2"
   >
-    Benchmark: 
+    <strong>
+      Benchmark:
+    </strong>
+     
     goal benchmarks
   </p>
 </Review>
@@ -574,7 +583,10 @@ exports[`activity goals subsection the GoalReview component renders properly wit
   <p
     className="ds-u-margin-top--2"
   >
-    Benchmark: 
+    <strong>
+      Benchmark:
+    </strong>
+     
     goal benchmarks
   </p>
 </Review>

--- a/web/src/containers/activity/__snapshots__/Goals.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/Goals.test.js.snap
@@ -1,0 +1,695 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`activity goals subsection the Goal component, wrapper around the form and review with an initially-collapsed goal expands when edit is called 1`] = `
+<Goal
+  goal={Object {}}
+  handleChange={[Function]}
+  handleDelete={[Function]}
+  idx={0}
+  initialExpanded={false}
+>
+  <GoalForm
+    done={[Function]}
+    goal={Object {}}
+    handleChange={[Function]}
+    handleDelete={[Function]}
+    idx={0}
+  >
+    <div
+      className="ds-u-padding-bottom--2 ds-u-border-bottom--2"
+    >
+      <TextField
+        className="data-entry-box"
+        hint=""
+        label="Goal name"
+        name="name"
+        type="text"
+      >
+        <div
+          className="ds-u-clearfix data-entry-box"
+        >
+          <FormLabel
+            component="label"
+            fieldId="textfield_3"
+            hint=""
+          >
+            <label
+              className="ds-c-label"
+              htmlFor="textfield_3"
+            >
+              <span
+                className=""
+              >
+                Goal name
+              </span>
+            </label>
+          </FormLabel>
+          <input
+            className="ds-c-field"
+            id="textfield_3"
+            name="name"
+            type="text"
+          />
+        </div>
+      </TextField>
+      <TextField
+        className="data-entry-box"
+        hint="Briefly describe how the state will measure progress toward the identified goal."
+        label="Benchmarks"
+        multiline={true}
+        name="milestones"
+        rows={6}
+        type="text"
+      >
+        <div
+          className="ds-u-clearfix data-entry-box"
+        >
+          <FormLabel
+            component="label"
+            fieldId="textfield_4"
+            hint="Briefly describe how the state will measure progress toward the identified goal."
+          >
+            <label
+              className="ds-c-label"
+              htmlFor="textfield_4"
+            >
+              <span
+                className=""
+              >
+                Benchmarks
+              </span>
+              <span
+                className="ds-c-field__hint"
+              >
+                Briefly describe how the state will measure progress toward the identified goal.
+              </span>
+            </label>
+          </FormLabel>
+          <textarea
+            className="ds-c-field"
+            id="textfield_4"
+            name="milestones"
+            rows={6}
+          />
+        </div>
+      </TextField>
+      <Button
+        className="ds-u-margin-top--4"
+        onClick={[Function]}
+        type="button"
+        variation="primary"
+      >
+        <button
+          className="ds-c-button ds-c-button--primary ds-u-margin-top--4"
+          onClick={[Function]}
+          type="button"
+        >
+          Done
+        </button>
+      </Button>
+    </div>
+  </GoalForm>
+</Goal>
+`;
+
+exports[`activity goals subsection the Goal component, wrapper around the form and review with an initially-collapsed goal renders correctly 1`] = `
+<Goal
+  goal={Object {}}
+  handleChange={[Function]}
+  handleDelete={[Function]}
+  idx={0}
+  initialExpanded={false}
+>
+  <GoalReview
+    edit={[Function]}
+    goal={Object {}}
+    handleDelete={[Function]}
+    idx={0}
+  >
+    <Review
+      editContent={
+        <div
+          className="nowrap"
+        >
+          <Button
+            onClick={[Function]}
+            size="small"
+            type="button"
+            variation="transparent"
+          >
+            Edit
+          </Button>
+          <React.Fragment>
+            |
+            <Button
+              onClick={[Function]}
+              size="small"
+              type="button"
+              variation="transparent"
+            >
+              Remove
+            </Button>
+          </React.Fragment>
+        </div>
+      }
+      editHref="#"
+      editText="Edit"
+      heading={
+        <h5
+          className="ds-h4"
+        >
+          1
+          . 
+        </h5>
+      }
+      onEditClick={[Function]}
+    >
+      <div
+        className="ds-c-review ds-u-border-bottom--2 ds-u-padding-y--2 ds-u-justify-content--between ds-u-display--flex"
+      >
+        <div
+          className="ds-u-margin-right--2"
+        >
+          <h3
+            className="ds-c-review__heading ds-text ds-u-margin-bottom--0 ds-u-font-weight--bold ds-u-display--inline-block"
+          >
+            <h5
+              className="ds-h4"
+            >
+              1
+              . 
+            </h5>
+          </h3>
+          <div
+            className="ds-c-review__body"
+          >
+            <p
+              className="ds-u-margin-top--2"
+            >
+              Benchmark: 
+            </p>
+          </div>
+        </div>
+        <div
+          className="nowrap"
+        >
+          <Button
+            onClick={[Function]}
+            size="small"
+            type="button"
+            variation="transparent"
+          >
+            <button
+              className="ds-c-button ds-c-button--transparent ds-c-button--small"
+              onClick={[Function]}
+              type="button"
+            >
+              Edit
+            </button>
+          </Button>
+          |
+          <Button
+            onClick={[Function]}
+            size="small"
+            type="button"
+            variation="transparent"
+          >
+            <button
+              className="ds-c-button ds-c-button--transparent ds-c-button--small"
+              onClick={[Function]}
+              type="button"
+            >
+              Remove
+            </button>
+          </Button>
+        </div>
+      </div>
+    </Review>
+  </GoalReview>
+</Goal>
+`;
+
+exports[`activity goals subsection the Goal component, wrapper around the form and review with an initially-expanded goal collapses when done is called 1`] = `
+<Goal
+  goal={Object {}}
+  handleChange={[Function]}
+  handleDelete={[Function]}
+  idx={0}
+  initialExpanded={true}
+>
+  <GoalReview
+    edit={[Function]}
+    goal={Object {}}
+    handleDelete={[Function]}
+    idx={0}
+  >
+    <Review
+      editContent={
+        <div
+          className="nowrap"
+        >
+          <Button
+            onClick={[Function]}
+            size="small"
+            type="button"
+            variation="transparent"
+          >
+            Edit
+          </Button>
+          <React.Fragment>
+            |
+            <Button
+              onClick={[Function]}
+              size="small"
+              type="button"
+              variation="transparent"
+            >
+              Remove
+            </Button>
+          </React.Fragment>
+        </div>
+      }
+      editHref="#"
+      editText="Edit"
+      heading={
+        <h5
+          className="ds-h4"
+        >
+          1
+          . 
+        </h5>
+      }
+      onEditClick={[Function]}
+    >
+      <div
+        className="ds-c-review ds-u-border-bottom--2 ds-u-padding-y--2 ds-u-justify-content--between ds-u-display--flex"
+      >
+        <div
+          className="ds-u-margin-right--2"
+        >
+          <h3
+            className="ds-c-review__heading ds-text ds-u-margin-bottom--0 ds-u-font-weight--bold ds-u-display--inline-block"
+          >
+            <h5
+              className="ds-h4"
+            >
+              1
+              . 
+            </h5>
+          </h3>
+          <div
+            className="ds-c-review__body"
+          >
+            <p
+              className="ds-u-margin-top--2"
+            >
+              Benchmark: 
+            </p>
+          </div>
+        </div>
+        <div
+          className="nowrap"
+        >
+          <Button
+            onClick={[Function]}
+            size="small"
+            type="button"
+            variation="transparent"
+          >
+            <button
+              className="ds-c-button ds-c-button--transparent ds-c-button--small"
+              onClick={[Function]}
+              type="button"
+            >
+              Edit
+            </button>
+          </Button>
+          |
+          <Button
+            onClick={[Function]}
+            size="small"
+            type="button"
+            variation="transparent"
+          >
+            <button
+              className="ds-c-button ds-c-button--transparent ds-c-button--small"
+              onClick={[Function]}
+              type="button"
+            >
+              Remove
+            </button>
+          </Button>
+        </div>
+      </div>
+    </Review>
+  </GoalReview>
+</Goal>
+`;
+
+exports[`activity goals subsection the Goal component, wrapper around the form and review with an initially-expanded goal renders correctly 1`] = `
+<Goal
+  goal={Object {}}
+  handleChange={[Function]}
+  handleDelete={[Function]}
+  idx={0}
+  initialExpanded={true}
+>
+  <GoalForm
+    done={[Function]}
+    goal={Object {}}
+    handleChange={[Function]}
+    handleDelete={[Function]}
+    idx={0}
+  >
+    <div
+      className="ds-u-padding-bottom--2 ds-u-border-bottom--2"
+    >
+      <TextField
+        className="data-entry-box"
+        hint=""
+        label="Goal name"
+        name="name"
+        type="text"
+      >
+        <div
+          className="ds-u-clearfix data-entry-box"
+        >
+          <FormLabel
+            component="label"
+            fieldId="textfield_1"
+            hint=""
+          >
+            <label
+              className="ds-c-label"
+              htmlFor="textfield_1"
+            >
+              <span
+                className=""
+              >
+                Goal name
+              </span>
+            </label>
+          </FormLabel>
+          <input
+            className="ds-c-field"
+            id="textfield_1"
+            name="name"
+            type="text"
+          />
+        </div>
+      </TextField>
+      <TextField
+        className="data-entry-box"
+        hint="Briefly describe how the state will measure progress toward the identified goal."
+        label="Benchmarks"
+        multiline={true}
+        name="milestones"
+        rows={6}
+        type="text"
+      >
+        <div
+          className="ds-u-clearfix data-entry-box"
+        >
+          <FormLabel
+            component="label"
+            fieldId="textfield_2"
+            hint="Briefly describe how the state will measure progress toward the identified goal."
+          >
+            <label
+              className="ds-c-label"
+              htmlFor="textfield_2"
+            >
+              <span
+                className=""
+              >
+                Benchmarks
+              </span>
+              <span
+                className="ds-c-field__hint"
+              >
+                Briefly describe how the state will measure progress toward the identified goal.
+              </span>
+            </label>
+          </FormLabel>
+          <textarea
+            className="ds-c-field"
+            id="textfield_2"
+            name="milestones"
+            rows={6}
+          />
+        </div>
+      </TextField>
+      <Button
+        className="ds-u-margin-top--4"
+        onClick={[Function]}
+        type="button"
+        variation="primary"
+      >
+        <button
+          className="ds-c-button ds-c-button--primary ds-u-margin-top--4"
+          onClick={[Function]}
+          type="button"
+        >
+          Done
+        </button>
+      </Button>
+    </div>
+  </GoalForm>
+</Goal>
+`;
+
+exports[`activity goals subsection the GoalForm component renders properly 1`] = `
+<div
+  className="ds-u-padding-bottom--2 ds-u-border-bottom--2"
+>
+  <TextField
+    className="data-entry-box"
+    hint=""
+    label="Goal name"
+    name="name"
+    onChange={[Function]}
+    type="text"
+    value="goal name"
+  />
+  <TextField
+    className="data-entry-box"
+    hint="Briefly describe how the state will measure progress toward the identified goal."
+    label="Benchmarks"
+    multiline={true}
+    name="milestones"
+    onChange={[Function]}
+    rows={6}
+    type="text"
+    value="goal benchmarks"
+  />
+  <Button
+    className="ds-u-margin-top--4"
+    onClick={[Function]}
+    type="button"
+    variation="primary"
+  >
+    Done
+  </Button>
+</div>
+`;
+
+exports[`activity goals subsection the GoalReview component renders properly with a delete handler 1`] = `
+<Review
+  editContent={
+    <div
+      className="nowrap"
+    >
+      <Button
+        onClick={[Function]}
+        size="small"
+        type="button"
+        variation="transparent"
+      >
+        Edit
+      </Button>
+      <React.Fragment>
+        |
+        <Button
+          onClick={[Function]}
+          size="small"
+          type="button"
+          variation="transparent"
+        >
+          Remove
+        </Button>
+      </React.Fragment>
+    </div>
+  }
+  editHref="#"
+  editText="Edit"
+  heading={
+    <h5
+      className="ds-h4"
+    >
+      1
+      . 
+      goal name
+    </h5>
+  }
+  onEditClick={[Function]}
+>
+  <p
+    className="ds-u-margin-top--2"
+  >
+    Benchmark: 
+    goal benchmarks
+  </p>
+</Review>
+`;
+
+exports[`activity goals subsection the GoalReview component renders properly without a delete delete 1`] = `
+<Review
+  editContent={
+    <div
+      className="nowrap"
+    >
+      <Button
+        onClick={[Function]}
+        size="small"
+        type="button"
+        variation="transparent"
+      >
+        Edit
+      </Button>
+    </div>
+  }
+  editHref="#"
+  editText="Edit"
+  heading={
+    <h5
+      className="ds-h4"
+    >
+      1
+      . 
+      goal name
+    </h5>
+  }
+  onEditClick={[Function]}
+>
+  <p
+    className="ds-u-margin-top--2"
+  >
+    Benchmark: 
+    goal benchmarks
+  </p>
+</Review>
+`;
+
+exports[`activity goals subsection the Goals commponent, wrapping all the others with no goals renders properly 1`] = `
+<Subsection
+  id={null}
+  nested={true}
+  resource="activities.goals"
+>
+  <NoDataMsg>
+    Additional costs for this activity are missing.
+  </NoDataMsg>
+  <Button
+    className="ds-u-margin-top--4 visibility--screen"
+    onClick={[Function]}
+    type="button"
+  >
+    Add a goal
+  </Button>
+  <hr />
+</Subsection>
+`;
+
+exports[`activity goals subsection the Goals commponent, wrapping all the others with one goal renders properly 1`] = `
+<Subsection
+  id={null}
+  nested={true}
+  resource="activities.goals"
+>
+  <div
+    className="ds-u-border-top--1"
+  >
+    <Goal
+      goal={
+        Object {
+          "expanded": false,
+          "key": "goal-1",
+        }
+      }
+      handleChange={[Function]}
+      handleDelete={null}
+      idx={0}
+      initialExpanded={false}
+      key="goal-1"
+    />
+  </div>
+  <Button
+    className="ds-u-margin-top--4 visibility--screen"
+    onClick={[Function]}
+    type="button"
+  >
+    Add a goal
+  </Button>
+  <hr />
+</Subsection>
+`;
+
+exports[`activity goals subsection the Goals commponent, wrapping all the others with some goals renders properly 1`] = `
+<Subsection
+  id={null}
+  nested={true}
+  resource="activities.goals"
+>
+  <div
+    className="ds-u-border-top--1"
+  >
+    <Goal
+      goal={
+        Object {
+          "expanded": false,
+          "key": "goal-1",
+        }
+      }
+      handleChange={[Function]}
+      handleDelete={[Function]}
+      idx={0}
+      initialExpanded={false}
+      key="goal-1"
+    />
+    <Goal
+      goal={
+        Object {
+          "expanded": false,
+          "key": "goal-2",
+        }
+      }
+      handleChange={[Function]}
+      handleDelete={[Function]}
+      idx={1}
+      initialExpanded={false}
+      key="goal-2"
+    />
+    <Goal
+      goal={
+        Object {
+          "expanded": true,
+          "key": "goal-3",
+        }
+      }
+      handleChange={[Function]}
+      handleDelete={[Function]}
+      idx={2}
+      initialExpanded={true}
+      key="goal-3"
+    />
+  </div>
+  <Button
+    className="ds-u-margin-top--4 visibility--screen"
+    onClick={[Function]}
+    type="button"
+  >
+    Add a goal
+  </Button>
+  <hr />
+</Subsection>
+`;

--- a/web/src/i18n/locales/en/activities/goals.yaml
+++ b/web/src/i18n/locales/en/activities/goals.yaml
@@ -12,11 +12,14 @@ instruction:
     improved health outcomes for benficiaries, transformation of public health services,
     enabling implementation of other initiatives, etc.
 noDataNotice: There are no goals set for this activity.
-goal:
-  title: 'Goal #{{number}}'
+
+description:
+  input:
+    label: Goal name
+
 objective:
-  title: Benchmarks
-  instruction:
-    detail: >-
+  input:
+    label: Benchmarks
+    hint: >-
       Briefly describe how the state will measure progress toward the identified goal.
-addGoalButtonText: Add a goal
+

--- a/web/src/i18n/locales/en/activities/goals.yaml
+++ b/web/src/i18n/locales/en/activities/goals.yaml
@@ -1,11 +1,12 @@
 title: Performance Goals and Benchmarks
 instruction:
   short: >-
-    Explain the state’s goals for this activity.
+    
   detail: >-
-    Goals are outcomes the state is pursuing through the activity. In addition
-    to listing the goal, briefly describe how each goal relates to the vision
-    identified in the program summary.
+    Explain the state’s goals for this activity. Goals are outcomes the state
+    is pursuing through the activity. In addition to listing the goal, briefly
+    describe how each goal relates to the vision identified in the program
+    summary.
   helpText: >-
     Examples of goals include:
     improved health outcomes for benficiaries, transformation of public health services,
@@ -16,6 +17,6 @@ goal:
 objective:
   title: Benchmarks
   instruction:
-    short: >-
+    detail: >-
       Briefly describe how the state will measure progress toward the identified goal.
 addGoalButtonText: Add a goal

--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -32,7 +32,12 @@ export const setKeyGenerator = fn => {
   generateKey = fn;
 };
 
-const newGoal = () => ({ key: generateKey(), description: '', objective: '' });
+const newGoal = () => ({
+  key: generateKey(),
+  description: '',
+  expanded: true,
+  objective: ''
+});
 
 const newMilestone = (milestone = '', endDate = '') => ({
   key: generateKey(),

--- a/web/src/reducers/activities.test.js
+++ b/web/src/reducers/activities.test.js
@@ -51,7 +51,12 @@ describe('activities reducer', () => {
     years: { '1973': { amt: '', perc: '' }, '1974': { amt: '', perc: '' } }
   });
 
-  const newGoal = keyFn => ({ key: keyFn(), description: '', objective: '' });
+  const newGoal = keyFn => ({
+    key: keyFn(),
+    description: '',
+    expanded: true,
+    objective: ''
+  });
 
   const newExpense = keyFn => ({
     key: keyFn(),

--- a/web/src/styles/index.scss
+++ b/web/src/styles/index.scss
@@ -17,3 +17,7 @@
 @import '/scss/print';
 @import '/scss/save-button';
 @import '/scss/section';
+
+.nowrap {
+  white-space: nowrap;
+}

--- a/web/src/util/serialization/activities.js
+++ b/web/src/util/serialization/activities.js
@@ -175,6 +175,7 @@ export const fromAPI = (activityAPI, years) => {
 
     goals: goals.map(g => ({
       ...replaceNulls(g),
+      expanded: false,
       key: generateKey()
     })),
 

--- a/web/src/util/serialization/activities.test.js
+++ b/web/src/util/serialization/activities.test.js
@@ -202,12 +202,14 @@ describe('APD activity serializer', () => {
           goals: [
             {
               id: 'g1',
+              expanded: false,
               key: expect.stringMatching(/^[a-f0-9]{8}$/),
               description: 'goal 1 description',
               objective: 'goal 1 objective'
             },
             {
               id: 'g2',
+              expanded: false,
               key: expect.stringMatching(/^[a-f0-9]{8}$/),
               description: 'goal 2 description',
               objective: 'goal 2 objective'


### PR DESCRIPTION
### This pull request changes...
- updates activity goals section

  ![image](https://user-images.githubusercontent.com/1775733/58658832-11406580-82e7-11e9-849e-453d42122cdd.png)

  - goals can be removed as long as there is more than one in the list
  - users are prompted for confirmation before goals are deleted
  - new goals are expanded by default

- updates dev seed to remove HTML formatting from goal name and benchmark text
- closes #1453 

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This feature is done when...
- [ ] Design has approved the experience
- [ ] Product has approved the experience
