### PR TITLE
Fix pre-deployment "did it change" check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,8 +365,9 @@ jobs:
           command: |
             # git diff --exit-code will exit with a 0 if there were no changes
             # or a non-zero if there were changes, so stop this step gracefully
-            # if there were no changes in the api directory
-            git diff master --relative=api --name-only --exit-code > /dev/null
+            # if there were no changes in the api directory. Compare to
+            # one commit back, which is before the current merge commit.
+            git diff HEAD~1 --relative=api --name-only --exit-code > /dev/null
             if [ $? -eq "0" ]; then
               circleci-agent step halt
             fi
@@ -409,8 +410,9 @@ jobs:
           command: |
             # git diff --exit-code will exit with a 0 if there were no changes
             # or a non-zero if there were changes, so stop this step gracefully
-            # if there were no changes in the web directory
-            git diff master --relative=web --name-only --exit-code > /dev/null
+            # if there were no changes in the web directory. Compare to one
+            # commit back, which is before the current merge commit.
+            git diff HEAD~1 --relative=web --name-only --exit-code > /dev/null
             if [ $? -eq "0" ]; then
               circleci-agent step halt
             fi


### PR DESCRIPTION
Before deploying, we check to see what changed and only deploy the components that need it. E.g., if nothing in the `/api` directory changed, we don't deploy the backend. The problem is that it did a `git diff` against master...  from the master branch. Surprising no one, it always said there were no diffs.

🤦‍♂

This changes it to `git diff HEAD~1` which will compare against the previous commit. This step only ever runs on the master branch, so each commit is a merge commit, and `HEAD~1` will point to the state of the code before the most recent merge.

### This pull request changes...
- took out some dumb, replaced with some common sense

### This pull request is ready to merge when...
- [ ] This code has been reviewed by someone other than the original author