### PR TITLE
lots of little adjustments to copy

### DIFF
--- a/api/routes/openAPI/__snapshots__/get.endpoint.js.snap
+++ b/api/routes/openAPI/__snapshots__/get.endpoint.js.snap
@@ -1838,7 +1838,7 @@ Object {
                         "type": "string",
                       },
                       "position": Object {
-                        "description": "User's position in the state's Medicaid program",
+                        "description": "User's position in the state’s Medicaid program",
                         "type": "string",
                       },
                       "role": Object {
@@ -2017,7 +2017,7 @@ Object {
                       "type": "string",
                     },
                     "position": Object {
-                      "description": "User's position in the state's Medicaid program",
+                      "description": "User's position in the state’s Medicaid program",
                       "type": "string",
                     },
                     "role": Object {

--- a/api/routes/users/openAPI.js
+++ b/api/routes/users/openAPI.js
@@ -25,7 +25,7 @@ const userObjectSchema = {
     },
     position: {
       type: 'string',
-      description: "User's position in the state's Medicaid program"
+      description: "User's position in the state’s Medicaid program"
     },
     state: {
       type: 'string',

--- a/bin/cascade-delete-apd.js
+++ b/bin/cascade-delete-apd.js
@@ -89,6 +89,6 @@ if (/^\d+$/.test(id)) {
 
   <id> - Required. To delete a single APD, use the APD
          numeric ID.  To delete all APDs for a given
-         state, use the state's two-letter ID.
+         state, use the state’s two-letter ID.
   `);
 }

--- a/web/src/containers/BudgetSummary.js
+++ b/web/src/containers/BudgetSummary.js
@@ -6,9 +6,9 @@ import Dollars from '../components/Dollars';
 import { selectBudgetActivitiesByFundingSource } from '../reducers/budget.selectors';
 
 const categoryLookup = {
-  statePersonnel: 'Project state staff',
-  expenses: 'Non-personnel',
-  contractors: 'Contracted resources',
+  statePersonnel: 'Project State Staff',
+  expenses: 'Non-Personnel',
+  contractors: 'Contracted Resources',
   combined: 'Subtotal'
 };
 
@@ -79,19 +79,19 @@ const HeaderRow = ({ yr }) => {
         className="ds-u-text-align--center"
         id={`summary-budget-fy-${yr}-total`}
       >
-        Medicaid total
+        Medicaid Total
       </th>
       <th
         className="ds-u-text-align--center"
         id={`summary-budget-fy-${yr}-federal`}
       >
-        Federal total
+        Federal Total
       </th>
       <th
         className="ds-u-text-align--center"
         id={`summary-budget-fy-${yr}-state`}
       >
-        State total
+        State Total
       </th>
     </tr>
   );
@@ -103,7 +103,7 @@ HeaderRow.propTypes = {
 
 const BudgetSummary = ({ activities, data, years }) => (
   <Fragment>
-    <h3 className="ds-h3">HIT activities</h3>
+    <h3 className="ds-h3">HIT Activities</h3>
     {[...years, 'total'].map(yr => (
       <table className="table-cms" key={yr}>
         <thead>
@@ -115,7 +115,7 @@ const BudgetSummary = ({ activities, data, years }) => (
       </table>
     ))}
 
-    <h3 className="ds-h3">HIE activities</h3>
+    <h3 className="ds-h3">HIE Activities</h3>
     {[...years, 'total'].map(yr => (
       <table className="table-cms" key={yr}>
         <thead>
@@ -127,7 +127,7 @@ const BudgetSummary = ({ activities, data, years }) => (
       </table>
     ))}
 
-    <h3 className="ds-h3">MMIS activities</h3>
+    <h3 className="ds-h3">MMIS Activities</h3>
     {[...years, 'total'].map(yr => (
       <table className="table-cms" key={yr}>
         <thead>
@@ -139,7 +139,7 @@ const BudgetSummary = ({ activities, data, years }) => (
       </table>
     ))}
 
-    <h3 className="ds-h3">Project activities totals</h3>
+    <h3 className="ds-h3">Project Activities Totals</h3>
     <table className="table-cms">
       <thead>
         <tr>
@@ -148,19 +148,19 @@ const BudgetSummary = ({ activities, data, years }) => (
             className="ds-u-text-align--center"
             id="summary-budget-total-medicaid"
           >
-            Medicaid total
+            Medicaid Total
           </th>
           <th
             className="ds-u-text-align--center"
             id="summary-budget-total-federal"
           >
-            Federal total
+            Federal Total
           </th>
           <th
             className="ds-u-text-align--center"
             id="summary-budget-total-state"
           >
-            State total
+            State Total
           </th>
         </tr>
       </thead>

--- a/web/src/containers/__snapshots__/BudgetSummary.test.js.snap
+++ b/web/src/containers/__snapshots__/BudgetSummary.test.js.snap
@@ -27,7 +27,7 @@ exports[`budget summary component data row group renders 1`] = `
       ]
     }
     key="contractors"
-    title="Contracted resources"
+    title="Contracted Resources"
     year="1448"
   />
   <DataRow
@@ -41,7 +41,7 @@ exports[`budget summary component data row group renders 1`] = `
       ]
     }
     key="expenses"
-    title="Non-personnel"
+    title="Non-Personnel"
     year="1448"
   />
   <DataRow
@@ -55,7 +55,7 @@ exports[`budget summary component data row group renders 1`] = `
       ]
     }
     key="statePersonnel"
-    title="Project state staff"
+    title="Project State Staff"
     year="1448"
   />
 </Fragment>
@@ -155,19 +155,19 @@ exports[`budget summary component header row renders 1`] = `
     className="ds-u-text-align--center"
     id="summary-budget-fy-1-total"
   >
-    Medicaid total
+    Medicaid Total
   </th>
   <th
     className="ds-u-text-align--center"
     id="summary-budget-fy-1-federal"
   >
-    Federal total
+    Federal Total
   </th>
   <th
     className="ds-u-text-align--center"
     id="summary-budget-fy-1-state"
   >
-    State total
+    State Total
   </th>
 </tr>
 `;
@@ -177,7 +177,7 @@ exports[`budget summary component renders correctly 1`] = `
   <h3
     className="ds-h3"
   >
-    HIT activities
+    HIT Activities
   </h3>
   <table
     className="table-cms"
@@ -245,7 +245,7 @@ exports[`budget summary component renders correctly 1`] = `
   <h3
     className="ds-h3"
   >
-    HIE activities
+    HIE Activities
   </h3>
   <table
     className="table-cms"
@@ -313,7 +313,7 @@ exports[`budget summary component renders correctly 1`] = `
   <h3
     className="ds-h3"
   >
-    MMIS activities
+    MMIS Activities
   </h3>
   <table
     className="table-cms"
@@ -381,7 +381,7 @@ exports[`budget summary component renders correctly 1`] = `
   <h3
     className="ds-h3"
   >
-    Project activities totals
+    Project Activities Totals
   </h3>
   <table
     className="table-cms"
@@ -395,19 +395,19 @@ exports[`budget summary component renders correctly 1`] = `
           className="ds-u-text-align--center"
           id="summary-budget-total-medicaid"
         >
-          Medicaid total
+          Medicaid Total
         </th>
         <th
           className="ds-u-text-align--center"
           id="summary-budget-total-federal"
         >
-          Federal total
+          Federal Total
         </th>
         <th
           className="ds-u-text-align--center"
           id="summary-budget-total-state"
         >
-          State total
+          State Total
         </th>
       </tr>
     </thead>

--- a/web/src/containers/__snapshots__/ExecutiveSummaryBudget.test.js.snap
+++ b/web/src/containers/__snapshots__/ExecutiveSummaryBudget.test.js.snap
@@ -110,7 +110,7 @@ exports[`executive summary budget component renders correctly with data 1`] = `
             className="right-align"
             id="program-budget-table-combined-total"
           >
-            Medicaid total
+            Medicaid Total
           </th>
         </tr>
       </thead>
@@ -330,7 +330,7 @@ exports[`executive summary budget component renders correctly with data 1`] = `
             className="right-align"
             id="program-budget-table-mmisTotal-total"
           >
-            Medicaid total
+            Medicaid Total
           </th>
         </tr>
       </thead>

--- a/web/src/i18n/locales/en/activities/costAllocate.yaml
+++ b/web/src/i18n/locales/en/activities/costAllocate.yaml
@@ -41,8 +41,8 @@ ffp:
     other: Other Funding Amount
     fedStateSplit: Federal-State Split
 quarterly:
-  title: Breakout of federal share by quarter
   instruction:
+    heading: Breakout of federal share by quarter
     detail: >-
       Indicate allocations of state personnel & contract resources in current FFY
       by quarter.
@@ -54,7 +54,7 @@ otherFunding:
   instruction:
     heading: Other funding description
     detail: >-
-      Write a high level description to describe funding used to support this activity.
+      Write a high level description of funding used to support this activity.
       (Review Letter 10‐016 for examples of grants for inclusion.)
     helpText: >-
       Ensure new grants are included, and remove expired grants.

--- a/web/src/i18n/locales/en/apd/apd.yaml
+++ b/web/src/i18n/locales/en/apd/apd.yaml
@@ -28,13 +28,13 @@ hie:
     heading: HIE Overview
     detail: >-
       Summarize planned HIE-funded activities within this APD.
-      
+
       If there are no HIE activities, enter “No HIE activities.”
 
 
       [ol]
-      Description of the state's HIE approach (statewide, sub-state
-      health information office (HIOs), etc.);
+      Description of the state’s HIE approach (statewide, sub-state
+      health information organization (HIO), etc.);
 
       Anticipated risks and mitigation strategies;
 
@@ -44,7 +44,7 @@ hie:
       [/ol]
     helpText: >-
       CMS recommends that states connect with regional CMS HITECH contacts prior to
-      developing HIE funding request. HIE funding requests are complex. Early
+      developing an HIE funding request. HIE funding requests are complex. Early
       consultation with CMS facilitates a more efficient approval process.
 
 mmis:
@@ -52,5 +52,5 @@ mmis:
     heading: MMIS Overview
     detail: >-
       Briefly summarize planned MMIS-funded activities contained within this APD.
-      
+
       If there are no MMIS activities, enter “No MMIS activities.”

--- a/web/src/i18n/locales/en/apd/stateProfile.yaml
+++ b/web/src/i18n/locales/en/apd/stateProfile.yaml
@@ -36,6 +36,10 @@ keyPersonnel:
       Activities instead. CMS seeks to ensure  state teams are adequately resourced,
       but does not require states to provide key vendor personnel to satisfy this
       requirement.
+
+      Key personnel costs are included within Activity #1, Program Administration. 
+      These costs are HIT costs shared at the 90-10 rate. Quarterly adjustments for
+      personnel costs under Activity #1 will apply to all key personnel costs.
   contact: 'Contact #{{number}}'
   labels:
     name: Name

--- a/web/src/i18n/locales/en/certifyAndSubmit.yaml
+++ b/web/src/i18n/locales/en/certifyAndSubmit.yaml
@@ -30,7 +30,7 @@ certify:
           through the app with a link to respond.
 
           If you would like to check the status of your request
-          or start a new document, please go to your state's
+          or start a new document, please go to your state’s
           dashboard.
 withdraw:
   prompt:

--- a/web/src/i18n/locales/en/executiveSummary.yaml
+++ b/web/src/i18n/locales/en/executiveSummary.yaml
@@ -23,4 +23,4 @@ budgetTable:
   mmisTotal: MMIS (Total)
   fedShare: Federal
   stateShare: State
-  grandTotal: Medicaid total
+  grandTotal: Medicaid Total


### PR DESCRIPTION
Closes #1599

Might close #1177, depends on someone’s interpretation, I’ll leave that to the rest of the team.

- This addresses a number of minor typos and stylistic errors I noticed while I was updating the content style guide per #1180.
- This also adds information about Key Personnel being 90-10 HIT expenses for #1177.

This is ready to merge when nothing breaks and product says the content is clearer than it was before on key personnel. It can certainly use additional work but I want it to be more clear rather than less.