### PR TITLE
Deploy error fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,10 +367,12 @@ jobs:
             # or a non-zero if there were changes, so stop this step gracefully
             # if there were no changes in the api directory. Compare to
             # one commit back, which is before the current merge commit.
+            set +e
             git diff HEAD~1 --relative=api --name-only --exit-code > /dev/null
             if [ $? -eq "0" ]; then
               circleci-agent step halt
             fi
+            set -e
       - run:
           name: deploy to production
           working_directory: ~/project/bin/prod-deploy
@@ -412,10 +414,12 @@ jobs:
             # or a non-zero if there were changes, so stop this step gracefully
             # if there were no changes in the web directory. Compare to one
             # commit back, which is before the current merge commit.
+            set +e
             git diff HEAD~1 --relative=web --name-only --exit-code > /dev/null
             if [ $? -eq "0" ]; then
               circleci-agent step halt
             fi
+            set -e
       - run:
           name: sync to s3
           command: |


### PR DESCRIPTION
CircleCI immediately fails a build if any command during any step exits with a nonzero code. Our build relies on the output of `git diff --exit-code` to determine which parts of the app have changed in order to know which parts to deploy.  A nonzero exit code indicates that a path has changed and should be deployed, but CircleCI was immediately failing the build.

### This pull request changes...
- runs `set +e` before the `git diff`, indicating to continue running in spite of nonzero exit codes
- run `set -e` after the `git diff` to restore CircleCI's normal behavior

### This pull request is ready to merge when...
- [ ] This code has been reviewed by someone other than the original author