### PR TITLE
Re-re-stick sidebar

### DIFF
--- a/web/src/containers/Sidebar.js
+++ b/web/src/containers/Sidebar.js
@@ -12,7 +12,7 @@ import { selectActiveSection } from '../reducers/navigation';
 
 class Sidebar extends Component {
   componentDidMount() {
-    stickybits('.site-sidebar__sticky');
+    stickybits('.site-sidebar');
   }
 
   handleSelectClick = id => {


### PR DESCRIPTION
I don't understand why, but moving the sticky to the `<aside>` instead of the `<div>` inside the `aside` made it work again.

### This pull request changes...
- made the sidebar's `<aside>` element sticky instead of the `<div>` inside of the `aside`
- flabbergasted about how CSS works
- closes #1560

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author

### This feature is done when...
- [ ] Product has approved the experience
