### PR TITLE
fix summary budget table 'total' header

### DIFF
--- a/web/src/containers/BudgetSummary.js
+++ b/web/src/containers/BudgetSummary.js
@@ -73,7 +73,7 @@ const HeaderRow = ({ yr }) => {
         className="ds-u-font-weight--bold"
         id={`summary-budget-fy-${yr}`}
       >
-        FFY {yr}
+        {yr === 'total' ? 'Total' : `FFY ${yr}`}
       </th>
       <th
         className="ds-u-text-align--center"
@@ -169,7 +169,9 @@ const BudgetSummary = ({ activities, data, years }) => (
           const combined = data.combined[ffy];
           return (
             <tr key={ffy}>
-              <th headers="summary-budget-null1">FFY {ffy}</th>
+              <th headers="summary-budget-null1">
+                {ffy === 'total' ? 'Total' : `FFY ${ffy}`}
+              </th>
               <td
                 className="font-family--mono right-align"
                 headers="summary-budget-total-medicaid"

--- a/web/src/containers/BudgetSummary.test.js
+++ b/web/src/containers/BudgetSummary.test.js
@@ -84,6 +84,7 @@ describe('budget summary component', () => {
 
   test('header row renders', () => {
     expect(shallow(<HeaderRow yr="1" />)).toMatchSnapshot();
+    expect(shallow(<HeaderRow yr="total" />)).toMatchSnapshot();
   });
 
   test('maps state to props', () => {

--- a/web/src/containers/__snapshots__/BudgetSummary.test.js.snap
+++ b/web/src/containers/__snapshots__/BudgetSummary.test.js.snap
@@ -148,8 +148,7 @@ exports[`budget summary component header row renders 1`] = `
     id="summary-budget-fy-1"
     key="1"
   >
-    FFY 
-    1
+    FFY 1
   </th>
   <th
     className="ds-u-text-align--center"
@@ -166,6 +165,36 @@ exports[`budget summary component header row renders 1`] = `
   <th
     className="ds-u-text-align--center"
     id="summary-budget-fy-1-state"
+  >
+    State Total
+  </th>
+</tr>
+`;
+
+exports[`budget summary component header row renders 2`] = `
+<tr>
+  <th
+    className="ds-u-font-weight--bold"
+    id="summary-budget-fy-total"
+    key="total"
+  >
+    Total
+  </th>
+  <th
+    className="ds-u-text-align--center"
+    id="summary-budget-fy-total-total"
+  >
+    Medicaid Total
+  </th>
+  <th
+    className="ds-u-text-align--center"
+    id="summary-budget-fy-total-federal"
+  >
+    Federal Total
+  </th>
+  <th
+    className="ds-u-text-align--center"
+    id="summary-budget-fy-total-state"
   >
     State Total
   </th>
@@ -418,8 +447,7 @@ exports[`budget summary component renders correctly 1`] = `
         <th
           headers="summary-budget-null1"
         >
-          FFY 
-          1
+          FFY 1
         </th>
         <td
           className="font-family--mono right-align"
@@ -458,8 +486,7 @@ exports[`budget summary component renders correctly 1`] = `
         <th
           headers="summary-budget-null1"
         >
-          FFY 
-          2
+          FFY 2
         </th>
         <td
           className="font-family--mono right-align"


### PR DESCRIPTION
The table header described in #1607 is the total across FFYs in the "Summary Budget Table" in the "Proposed Budget" section.  The header was being computed based on the year, but for the total across FFYs, the year field is `total`.  Thus, the header was displaying as `FFY total`.

The fix is to make the header text conditional so that if the year field is `total`, it will display something else.  Because `FFY Total` doesn't really make sense (it isn't a total of a single FFY and there is no FFY called "total"), I changed it to just `Total`.

Since @quarterback is back (:tada:), I'd love feedback on the decision to change `FFY total` to just `total`.  It makes sense to *me*, but who am I but a lowly, humble dev? 😄

#### Before

<img width="189" alt="screenshot showing the original header that says FFY total with improper capitalization" src="https://user-images.githubusercontent.com/1775733/59951702-5451ac80-943f-11e9-85d8-0a60a3f617ec.png">

#### After

<img width="188" alt="screenshot showing the revised header that just says Total" src="https://user-images.githubusercontent.com/1775733/59951710-5c115100-943f-11e9-9eb6-3731d9109ef2.png">

### This pull request changes...
- closes #1607 

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author

### This feature is done when...
- [ ] Design has approved the experience
- [ ] Product has approved the experience
