### PR TITLE
Get rid of double lines

### DIFF
--- a/web/src/styles/scss/print.scss
+++ b/web/src/styles/scss/print.scss
@@ -82,9 +82,11 @@
     color: black !important;
     border: 1px solid black;
   }
+
   .form-and-review-list,
   div.form--with-reviews {
     border-bottom: none;
+  }
   
   .public-DraftEditor-content {
     border: 0;

--- a/web/src/styles/scss/print.scss
+++ b/web/src/styles/scss/print.scss
@@ -83,6 +83,10 @@
     color: black !important;
     border: 1px solid black;
   }
+  .form-and-review-list,
+  div.form--with-reviews {
+    border-bottom: none;
+  }
 }
 
 @media screen {


### PR DESCRIPTION
Review components look like they have double lines because those lines are supposed to be around a button. That we're hiding in print. Fix it.