### PR TITLE
Tweaks for legends and fieldsets in print

### DIFF
--- a/web/src/styles/scss/print.scss
+++ b/web/src/styles/scss/print.scss
@@ -20,7 +20,8 @@
 
   table,
   figure,
-  textarea {
+  textarea,
+  fieldset {
     page-break-inside: avoid;
   }
 
@@ -39,6 +40,12 @@
   .ds-l-col--9 {
     width: 100%!important;
     min-width: 100%!important;
+  }
+
+  fieldset,
+  .ds-c-label {
+    width: 100% !important;
+    max-width: 100%;
   }
 
   .accordian {


### PR DESCRIPTION
Don't break inside fieldsets.

Legends should be 100% width.