### PR TITLE
Remove more backend data validations, to reduce save errors

### DIFF
--- a/api/db/activity/activity.js
+++ b/api/db/activity/activity.js
@@ -116,26 +116,31 @@ module.exports = {
       ]
     },
 
-    async validate({ transacting } = {}) {
+    // TODO: Re-enable these validations.
+    // Name uniqueness and minimum length validation temporarily removed until
+    // we have better frontend support for notifying users why a save failed.
+    // Associated tests are also commented out.
+
+    async validate(/* { transacting } = {} */) {
       logger.silly('validating');
 
-      if (this.hasChanged('name')) {
-        const name = this.attributes.name;
+      // if (this.hasChanged('name')) {
+      //   const name = this.attributes.name;
 
-        if (typeof name !== 'string' || name.length < 1) {
-          logger.verbose('name is not a string or is empty');
-          throw new Error('activity-name-invalid');
-        }
+      //   if (typeof name !== 'string' || name.length < 1) {
+      //     logger.verbose('name is not a string or is empty');
+      //     throw new Error('activity-name-invalid');
+      //   }
 
-        const hasName = await this.where({
-          apd_id: this.attributes.apd_id,
-          name
-        }).fetchAll({ transacting });
-        if (hasName.length) {
-          logger.verbose('another activity already has this name');
-          throw new Error('activity-name-exists');
-        }
-      }
+      //   const hasName = await this.where({
+      //     apd_id: this.attributes.apd_id,
+      //     name
+      //   }).fetchAll({ transacting });
+      //   if (hasName.length) {
+      //     logger.verbose('another activity already has this name');
+      //     throw new Error('activity-name-exists');
+      //   }
+      // }
 
       [
         ['plannedEndDate', 'planned-end-date'],

--- a/api/db/activity/activity.test.js
+++ b/api/db/activity/activity.test.js
@@ -248,102 +248,102 @@ tap.test('activity data model', async activityModelTests => {
         self.where.returns(self);
       });
 
-      validationTests.test(
-        'does not throw if the name has not changed',
-        async test => {
-          self.hasChanged.withArgs('name').returns(false);
+      // validationTests.test(
+      //   'does not throw if the name has not changed',
+      //   async test => {
+      //     self.hasChanged.withArgs('name').returns(false);
 
-          test.resolves(validate(), 'validate resolves');
-        }
-      );
+      //     test.resolves(validate(), 'validate resolves');
+      //   }
+      // );
 
-      validationTests.test(
-        'does not throw if the name has changed, is valid, and is unique',
-        async test => {
-          self.hasChanged.withArgs('name').returns(true);
-          self.attributes.name = 'valid name';
-          self.attributes.apd_id = 'apd id';
-          self.fetchAll.resolves([]);
+      // validationTests.test(
+      //   'does not throw if the name has changed, is valid, and is unique',
+      //   async test => {
+      //     self.hasChanged.withArgs('name').returns(true);
+      //     self.attributes.name = 'valid name';
+      //     self.attributes.apd_id = 'apd id';
+      //     self.fetchAll.resolves([]);
 
-          await validate();
-          test.ok(true, 'validate resolves');
-          test.ok(
-            self.where.calledWith({ apd_id: 'apd id', name: 'valid name' })
-          );
-        }
-      );
+      //     await validate();
+      //     test.ok(true, 'validate resolves');
+      //     test.ok(
+      //       self.where.calledWith({ apd_id: 'apd id', name: 'valid name' })
+      //     );
+      //   }
+      // );
 
-      validationTests.test('throws if the name is null', async test => {
-        self.hasChanged.withArgs('name').returns(true);
-        self.attributes.name = null;
+      // validationTests.test('throws if the name is null', async test => {
+      //   self.hasChanged.withArgs('name').returns(true);
+      //   self.attributes.name = null;
 
-        try {
-          await validate();
-        } catch (e) {
-          test.ok(true, 'rejects on an empty name');
-          test.equal(
-            e.message,
-            'activity-name-invalid',
-            'rejects with the expected message'
-          );
-        }
-      });
+      //   try {
+      //     await validate();
+      //   } catch (e) {
+      //     test.ok(true, 'rejects on an empty name');
+      //     test.equal(
+      //       e.message,
+      //       'activity-name-invalid',
+      //       'rejects with the expected message'
+      //     );
+      //   }
+      // });
 
-      validationTests.test('throws if the name is a number', async test => {
-        self.hasChanged.withArgs('name').returns(true);
-        self.attributes.name = 7;
+      // validationTests.test('throws if the name is a number', async test => {
+      //   self.hasChanged.withArgs('name').returns(true);
+      //   self.attributes.name = 7;
 
-        try {
-          await validate();
-        } catch (e) {
-          test.ok(true, 'rejects on an numeric name');
-          test.equal(
-            e.message,
-            'activity-name-invalid',
-            'rejects with the expected message'
-          );
-        }
-      });
+      //   try {
+      //     await validate();
+      //   } catch (e) {
+      //     test.ok(true, 'rejects on an numeric name');
+      //     test.equal(
+      //       e.message,
+      //       'activity-name-invalid',
+      //       'rejects with the expected message'
+      //     );
+      //   }
+      // });
 
-      validationTests.test(
-        'throws if the name is an empty string',
-        async test => {
-          self.hasChanged.withArgs('name').returns(true);
-          self.attributes.name = '';
+      // validationTests.test(
+      //   'throws if the name is an empty string',
+      //   async test => {
+      //     self.hasChanged.withArgs('name').returns(true);
+      //     self.attributes.name = '';
 
-          try {
-            await validate();
-          } catch (e) {
-            test.ok(true, 'rejects on an empty name');
-            test.equal(
-              e.message,
-              'activity-name-invalid',
-              'rejects with the expected message'
-            );
-          }
-        }
-      );
+      //     try {
+      //       await validate();
+      //     } catch (e) {
+      //       test.ok(true, 'rejects on an empty name');
+      //       test.equal(
+      //         e.message,
+      //         'activity-name-invalid',
+      //         'rejects with the expected message'
+      //       );
+      //     }
+      //   }
+      // );
 
-      validationTests.test('throws if the name already exists', async test => {
-        self.hasChanged.withArgs('name').returns(true);
-        self.attributes.name = 'valid name';
-        self.attributes.apd_id = 'apd id';
-        self.fetchAll.resolves([{ hello: 'world' }]);
+      // validationTests.test('throws if the name already exists', async test => {
+      //   self.hasChanged.withArgs('name').returns(true);
+      //   self.attributes.name = 'valid name';
+      //   self.attributes.apd_id = 'apd id';
+      //   self.fetchAll.resolves([{ hello: 'world' }]);
 
-        try {
-          await validate();
-        } catch (e) {
-          test.ok(true, 'rejects if the name already exists');
-          test.ok(
-            self.where.calledWith({ apd_id: 'apd id', name: 'valid name' })
-          );
-          test.equal(
-            e.message,
-            'activity-name-exists',
-            'rejects with the expected message'
-          );
-        }
-      });
+      //   try {
+      //     await validate();
+      //   } catch (e) {
+      //     test.ok(true, 'rejects if the name already exists');
+      //     test.ok(
+      //       self.where.calledWith({ apd_id: 'apd id', name: 'valid name' })
+      //     );
+      //     test.equal(
+      //       e.message,
+      //       'activity-name-exists',
+      //       'rejects with the expected message'
+      //     );
+      //   }
+      // });
 
       validationTests.test('deletes falsey date attributes', async test => {
         self.attributes.plannedEndDate = false;

--- a/api/db/activity/contractorResource.js
+++ b/api/db/activity/contractorResource.js
@@ -92,12 +92,6 @@ module.exports = {
       );
     },
 
-    async validate() {
-      if (this.attributes.year < 2010 || this.attributes.year > 3000) {
-        throw new Error('year-out-of-range');
-      }
-    },
-
     toJSON() {
       return {
         id: this.get('id'),

--- a/api/db/activity/contractorResource.test.js
+++ b/api/db/activity/contractorResource.test.js
@@ -225,32 +225,6 @@ tap.test(
     );
 
     contractorResourceCostModelTests.test(
-      'validation',
-      async validationTests => {
-        validationTests.test(
-          'fails if the year is too early or too late',
-          async test => {
-            const self = { attributes: { year: 2009 } };
-            test.rejects(
-              cost.validate.bind(self),
-              'rejects if year is too early'
-            );
-            self.attributes.year = 3001;
-            test.rejects(
-              cost.validate.bind(self),
-              'rejects if year is too late'
-            );
-          }
-        );
-
-        validationTests.test('succeeds if year is valid', async test => {
-          const self = { attributes: { year: 2019 } };
-          test.resolves(cost.validate.bind(self), 'resolves if year is valid');
-        });
-      }
-    );
-
-    contractorResourceCostModelTests.test(
       'overrides toJSON method',
       async jsonTests => {
         const self = { get: sinon.stub() };

--- a/api/db/activity/quarterlyFFP.js
+++ b/api/db/activity/quarterlyFFP.js
@@ -24,12 +24,6 @@ module.exports = {
       return out;
     },
 
-    async validate() {
-      if (!this.attributes.year) {
-        throw new Error('invalid-activity-quarterly-ffp');
-      }
-    },
-
     toJSON() {
       return {
         q1: {

--- a/api/db/activity/quarterlyFFP.test.js
+++ b/api/db/activity/quarterlyFFP.test.js
@@ -11,7 +11,6 @@ tap.test('activity quarterly FFP data model', async tests => {
         tableName: 'activity_quarterly_ffp',
         activity: Function,
         format: Function,
-        validate: Function,
         toJSON: Function,
         static: {
           updateableFields: ['q1', 'q2', 'q3', 'q4', 'year']
@@ -76,46 +75,6 @@ tap.test('activity quarterly FFP data model', async tests => {
       );
     }
   );
-
-  tests.test('has validate method', async validationTests => {
-    validationTests.test('throws if year is empty', async test => {
-      test.rejects(
-        quarterlyFFP.validate.bind({
-          attributes: {
-            year: undefined
-          }
-        }),
-        'fails if year is undefined'
-      );
-
-      test.rejects(
-        quarterlyFFP.validate.bind({
-          attributes: {
-            year: null
-          }
-        }),
-        'fails if value is null'
-      );
-
-      test.rejects(
-        quarterlyFFP.validate.bind({
-          attributes: {
-            year: ''
-          }
-        }),
-        'fails if value is empty string'
-      );
-
-      test.resolves(
-        quarterlyFFP.validate.bind({
-          attributes: {
-            year: 2001
-          }
-        }),
-        'passes if at year is not empty'
-      );
-    });
-  });
 
   tests.test('overrides toJSON method', async test => {
     const self = { get: sinon.stub() };

--- a/api/db/activity/statePersonnel.js
+++ b/api/db/activity/statePersonnel.js
@@ -43,15 +43,6 @@ module.exports = {
       return this.belongsTo('apdActivityStatePersonnel', 'personnel_id');
     },
 
-    async validate() {
-      if (this.attributes.fte < 0) {
-        throw new Error('fte-out-of-range');
-      }
-      if (this.attributes.year < 2010 || this.attributes.year > 3000) {
-        throw new Error('year-out-of-range');
-      }
-    },
-
     toJSON() {
       return {
         id: this.get('id'),

--- a/api/db/activity/statePersonnel.test.js
+++ b/api/db/activity/statePersonnel.test.js
@@ -125,34 +125,6 @@ tap.test(
       }
     );
 
-    statePersonnelCostModelTests.test('validation', async validationTests => {
-      const self = { attributes: { fte: 0, year: 0 } };
-      validationTests.test(
-        'fails if the year is too early or too late',
-        async test => {
-          self.attributes.year = 2009;
-          test.rejects(
-            cost.validate.bind(self),
-            'rejects if year is too early'
-          );
-          self.attributes.year = 3001;
-          test.rejects(cost.validate.bind(self), 'rejects if year is too late');
-        }
-      );
-
-      validationTests.test('fails if FTE is too small', async test => {
-        self.attributes.year = 2019;
-        self.attributes.fte = -0.3;
-        test.rejects(cost.validate.bind(self), 'rejects if fte is negative');
-      });
-
-      validationTests.test('succeeds if data is valid', async test => {
-        self.attributes.year = 2019;
-        self.attributes.fte = 0.5;
-        test.resolves(cost.validate.bind(self), 'resolves if year is valid');
-      });
-    });
-
     statePersonnelCostModelTests.test(
       'overrides toJSON method',
       async jsonTests => {


### PR DESCRIPTION
Until the frontend can properly report on save failures, the backend should be very liberal about what it accepts. This PR removes some validations to make the API more accepting.

### This pull request changes...
- removes validation that enforces that activity names are at least one character and are unique within the APD
- removes validation that enforces that activity contractor resource years are after 2010 and before 3000
- removes validation that enforces that activity state personnel FTE is not negative
- removes validation that enforces that activity state personnel years are after 2010 and before 3000
- removes validation that enforces that activity quarterly FFP is reported for at least one year
- closes #1659

### Does not remove...
This PR leaves date validation in place. The date validation just ensures that dates are valid before trying to insert them into the database. The database itself requires valid dates, so removing this validation wouldn't prevent save failures on invalid dates anyway, but keeping the validation at least means we'll get decent logging about why it failed. (And this is why #1661 is necessary.)
- activity start/end date validation
- activity contractor resource start/end date validation
- activity milestone end date validation

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author

### This feature is done when...
- [x] Product has approved the proposed behavior (no need to actually try to check that it works, though feel free if you're bored 😄)
