### PR TITLE
Better print display for radios and checkboxes

### DIFF
--- a/web/src/styles/scss/print.scss
+++ b/web/src/styles/scss/print.scss
@@ -31,6 +31,7 @@
   .btn-collapse svg,
   .alert,
   .rdw-editor-toolbar,
+  .ds-c-choice:not(:checked) + label,
   .ds-c-review .nowrap {
     display: none;
   }
@@ -102,6 +103,13 @@
   .rte-textarea-l .public-DraftEditor-content,
   .textarea-l {
     min-height: 0;
+  }
+
+  .ds-c-choice:checked + label {
+    padding-left: 0 !important;
+    &::before {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
Remove the radio/check `:before` element, which relies on a white SVG on a colored background. Just show the label. Looks like:
<img width="692" alt="Screen Shot 2019-07-02 at 5 18 23 PM" src="https://user-images.githubusercontent.com/509309/60552825-93101e00-9ced-11e9-9566-c9fcf405540a.png">
<img width="691" alt="Screen Shot 2019-07-02 at 5 18 37 PM" src="https://user-images.githubusercontent.com/509309/60552826-93101e00-9ced-11e9-9414-c19e565160a6.png">
