### PR TITLE
Show dates as text instead of inputs

### DIFF
--- a/web/src/containers/activity/Schedule.js
+++ b/web/src/containers/activity/Schedule.js
@@ -51,7 +51,7 @@ const Schedule = ({
     <Subsection resource="activities.schedule" nested>
       <Fragment>
         <h5 className="ds-h5">Activity start and end dates</h5>
-        <div className="ds-c-choice__checkedChild ds-u-padding-y--0">
+        <div className="ds-c-choice__checkedChild ds-u-padding-y--0 visibility--screen">
           <DateField
             value={activity.plannedStartDate}
             onChange={handleActivityStartChange}
@@ -60,6 +60,11 @@ const Schedule = ({
             value={activity.plannedEndDate}
             onChange={handleActivityEndChange}
           />
+        </div>
+        <div className="visibility--print">
+          <p><strong>Planned start date:</strong> {activity.plannedStartDate || "No date entered"}</p>
+          <p><strong>Planned end date:</strong> {activity.plannedEndDate || "No date entered"}</p>
+          <hr />
         </div>
         <div className="mb3">
           <Instruction

--- a/web/src/containers/activity/__snapshots__/Schedule.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/Schedule.test.js.snap
@@ -12,7 +12,7 @@ exports[`the Schedule (milestones) component renders correctly 1`] = `
     Activity start and end dates
   </h5>
   <div
-    className="ds-c-choice__checkedChild ds-u-padding-y--0"
+    className="ds-c-choice__checkedChild ds-u-padding-y--0 visibility--screen"
   >
     <DateField
       onChange={[Function]}
@@ -22,6 +22,25 @@ exports[`the Schedule (milestones) component renders correctly 1`] = `
       onChange={[Function]}
       value="1944-11-08"
     />
+  </div>
+  <div
+    className="visibility--print"
+  >
+    <p>
+      <strong>
+        Planned start date:
+      </strong>
+       
+      1944-10-02
+    </p>
+    <p>
+      <strong>
+        Planned end date:
+      </strong>
+       
+      1944-11-08
+    </p>
+    <hr />
   </div>
   <div
     className="mb3"


### PR DESCRIPTION
Replaces date fields in activity list with this in print:
<img width="689" alt="Screen Shot 2019-07-03 at 1 02 33 PM" src="https://user-images.githubusercontent.com/509309/60618219-db354c00-9d92-11e9-91d1-82bce1603412.png">
