### PR TITLE
Handle empty/invalid dollar and date values

### DIFF
--- a/web/src/components/Dollars.js
+++ b/web/src/components/Dollars.js
@@ -49,7 +49,7 @@ const Dollars = ({ children, long }) => {
   const num = parseFloat(children);
 
   if (Number.isNaN(num) || !Number.isFinite(num)) {
-    return <Fragment>--</Fragment>;
+    return <Fragment>$0</Fragment>;
   }
 
   if (long) {

--- a/web/src/components/__snapshots__/Dollars.test.js.snap
+++ b/web/src/components/__snapshots__/Dollars.test.js.snap
@@ -53,30 +53,30 @@ exports[`Dollars formatting container shows B for billions instead of G for giga
 
 exports[`Dollars formatting container with not-numbers handles NaN 1`] = `
 <Fragment>
-  --
+  $0
 </Fragment>
 `;
 
 exports[`Dollars formatting container with not-numbers handles infinity 1`] = `
 <Fragment>
-  --
+  $0
 </Fragment>
 `;
 
 exports[`Dollars formatting container with not-numbers handles non-numeric children 1`] = `
 <Fragment>
-  --
+  $0
 </Fragment>
 `;
 
 exports[`Dollars formatting container with not-numbers handles non-numeric children 2`] = `
 <Fragment>
-  --
+  $0
 </Fragment>
 `;
 
 exports[`Dollars formatting container with not-numbers handles non-numeric children 3`] = `
 <Fragment>
-  --
+  $0
 </Fragment>
 `;

--- a/web/src/containers/ExecutiveSummary.test.js
+++ b/web/src/containers/ExecutiveSummary.test.js
@@ -95,7 +95,7 @@ describe('executive summary component', () => {
       data: [
         {
           key: 'a1',
-          dateRange: '1/3/1969 – 2/25/1870',
+          dateRange: '1/3/1969 - 2/25/1870',
           name: 'activity 1',
           summary: 'first activity',
           combined: 950,

--- a/web/src/containers/ExecutiveSummary.test.js
+++ b/web/src/containers/ExecutiveSummary.test.js
@@ -95,7 +95,7 @@ describe('executive summary component', () => {
       data: [
         {
           key: 'a1',
-          dateRange: '01/03/1969 – 02/25/1870',
+          dateRange: '1/3/1969 – 2/25/1870',
           name: 'activity 1',
           summary: 'first activity',
           combined: 950,

--- a/web/src/containers/ExecutiveSummary.test.js
+++ b/web/src/containers/ExecutiveSummary.test.js
@@ -95,7 +95,7 @@ describe('executive summary component', () => {
       data: [
         {
           key: 'a1',
-          dateRange: '1/3/1969 - 2/25/1870',
+          dateRange: '01/03/1969 – 02/25/1870',
           name: 'activity 1',
           summary: 'first activity',
           combined: 950,
@@ -104,7 +104,7 @@ describe('executive summary component', () => {
         },
         {
           key: 'a2',
-          dateRange: 'Dates not set',
+          dateRange: 'Dates not specified',
           name: 'activity 2',
           summary: 'second activity',
           combined: 310,

--- a/web/src/containers/ScheduleSummary.js
+++ b/web/src/containers/ScheduleSummary.js
@@ -16,42 +16,38 @@ const ScheduleSummary = ({ activities }) => (
             {t('scheduleSummary.noDataMessage')}
           </div>
         ) : (
-          activities.map(
-            ({ end, name: activityName, milestones, start }, i) => (
-              <table key={activityName} className="budget-table">
-                <caption className="ds-u-visibility--screen-reader">
-                  Activity {i + 1}: {activityName}
-                </caption>
-                <thead>
-                  <tr>
-                    <th
-                      className="ds-u-font-weight--bold ds-u-border-right--0"
-                      style={{ width: '70%' }}
-                    >
-                      Activity {i + 1}: {activityName}
-                    </th>
-                    <th className="ds-u-font-weight--bold ds-u-padding-right--3 ds-u-text-align--left ds-u-border-left--0 budget-table--cell__nowrap">
-                      {start} – {end}
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {milestones.map(
-                    ({ end: milestoneEnd, name: milestoneName }) => (
-                      <tr>
-                        <td className="ds-u-border-right--0">
-                          {milestoneName}
-                        </td>
-                        <td className="ds-u-border-left--0 ds-u-text-align--left">
-                          {milestoneEnd}
-                        </td>
-                      </tr>
-                    )
-                  )}
-                </tbody>
-              </table>
-            )
-          )
+          activities.map(({ name: activityName, dateRange, milestones }, i) => (
+            <table key={activityName} className="budget-table">
+              <caption className="ds-u-visibility--screen-reader">
+                Activity {i + 1}: {activityName}
+              </caption>
+              <thead>
+                <tr>
+                  <th
+                    className="ds-u-font-weight--bold ds-u-border-right--0"
+                    style={{ width: '70%' }}
+                  >
+                    Activity {i + 1}: {activityName}
+                  </th>
+                  <th className="ds-u-font-weight--bold ds-u-padding-right--3 ds-u-text-align--left ds-u-border-left--0 budget-table--cell__nowrap">
+                    {dateRange}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {milestones.map(
+                  ({ end: milestoneEnd, name: milestoneName }) => (
+                    <tr>
+                      <td className="ds-u-border-right--0">{milestoneName}</td>
+                      <td className="ds-u-border-left--0 ds-u-text-align--left">
+                        {milestoneEnd}
+                      </td>
+                    </tr>
+                  )
+                )}
+              </tbody>
+            </table>
+          ))
         )}
       </Subsection>
     </Section>

--- a/web/src/containers/ScheduleSummary.test.js
+++ b/web/src/containers/ScheduleSummary.test.js
@@ -118,7 +118,7 @@ describe('schedule summary component', () => {
     expect(props).toMatchObject({
       activities: [
         {
-          dateRange: '1/1/1901 – 10/14/1947',
+          dateRange: '1/1/1901 - 10/14/1947',
           end: '10/14/1947',
           name: 'activity 1',
           milestones: [
@@ -129,7 +129,7 @@ describe('schedule summary component', () => {
           start: '1/1/1901'
         },
         {
-          dateRange: '3/3/1855 – 3/4/1853',
+          dateRange: '3/3/1855 - 3/4/1853',
           end: '3/4/1853',
           name: 'activity 2',
           milestones: [

--- a/web/src/containers/ScheduleSummary.test.js
+++ b/web/src/containers/ScheduleSummary.test.js
@@ -16,6 +16,7 @@ describe('schedule summary component', () => {
         // Winding Road"
         { end: '05/23/1970', name: 'one-two' }
       ],
+      dateRange: 'date range 1',
       // The first modern Olympics come to a close in Athens, Greece.
       end: '4/15/1896',
       // For the first time, Captain Picard gives Commander Riker his most
@@ -35,6 +36,7 @@ describe('schedule summary component', () => {
         // total of 4 times.
         { end: '08/21/1965', name: 'two-three' }
       ],
+      dateRange: 'date range 2',
       // Al Roker trusted a fart in the White House press room. He soon
       // realized his mistake.
       end: '07/14/2002',
@@ -47,6 +49,7 @@ describe('schedule summary component', () => {
       // The horse Justify wins the Triple Crown, 99 years after it was first
       // won by the horse Sir Barton.
       milestones: [{ end: '06/09/2018', name: 'three-one' }],
+      dateRange: 'date range 3',
       // Researchers conclude that bronze medalists are happier than silver
       // medalists.
       end: '10/15/2009',
@@ -115,6 +118,7 @@ describe('schedule summary component', () => {
     expect(props).toMatchObject({
       activities: [
         {
+          dateRange: '01/01/1901 – 10/14/1947',
           end: '10/14/1947',
           name: 'activity 1',
           milestones: [
@@ -125,6 +129,7 @@ describe('schedule summary component', () => {
           start: '01/01/1901'
         },
         {
+          dateRange: '03/03/1855 – 03/04/1853',
           end: '03/04/1853',
           name: 'activity 2',
           milestones: [

--- a/web/src/containers/ScheduleSummary.test.js
+++ b/web/src/containers/ScheduleSummary.test.js
@@ -118,25 +118,25 @@ describe('schedule summary component', () => {
     expect(props).toMatchObject({
       activities: [
         {
-          dateRange: '01/01/1901 – 10/14/1947',
+          dateRange: '1/1/1901 – 10/14/1947',
           end: '10/14/1947',
           name: 'activity 1',
           milestones: [
-            { end: '01/31/2006', name: '1-one' },
-            { end: '10/01/1991', name: '1-two' },
+            { end: '1/31/2006', name: '1-one' },
+            { end: '10/1/1991', name: '1-two' },
             { end: '11/28/1872', name: '1-three' }
           ],
-          start: '01/01/1901'
+          start: '1/1/1901'
         },
         {
-          dateRange: '03/03/1855 – 03/04/1853',
-          end: '03/04/1853',
+          dateRange: '3/3/1855 – 3/4/1853',
+          end: '3/4/1853',
           name: 'activity 2',
           milestones: [
-            { end: '06/06/1864', name: '2-one' },
-            { end: '08/08/1873', name: '2-two' }
+            { end: '6/6/1864', name: '2-one' },
+            { end: '8/8/1873', name: '2-two' }
           ],
-          start: '03/03/1855'
+          start: '3/3/1855'
         }
       ]
     });

--- a/web/src/containers/__snapshots__/ScheduleSummary.test.js.snap
+++ b/web/src/containers/__snapshots__/ScheduleSummary.test.js.snap
@@ -44,9 +44,7 @@ exports[`schedule summary component renders correctly 1`] = `
             <th
               className="ds-u-font-weight--bold ds-u-padding-right--3 ds-u-text-align--left ds-u-border-left--0 budget-table--cell__nowrap"
             >
-              12/10/1988
-               – 
-              4/15/1896
+              date range 1
             </th>
           </tr>
         </thead>
@@ -107,9 +105,7 @@ exports[`schedule summary component renders correctly 1`] = `
             <th
               className="ds-u-font-weight--bold ds-u-padding-right--3 ds-u-text-align--left ds-u-border-left--0 budget-table--cell__nowrap"
             >
-              02/18/1853
-               – 
-              07/14/2002
+              date range 2
             </th>
           </tr>
         </thead>
@@ -182,9 +178,7 @@ exports[`schedule summary component renders correctly 1`] = `
             <th
               className="ds-u-font-weight--bold ds-u-padding-right--3 ds-u-text-align--left ds-u-border-left--0 budget-table--cell__nowrap"
             >
-              11/22/1987
-               – 
-              10/15/2009
+              date range 3
             </th>
           </tr>
         </thead>

--- a/web/src/containers/activity/ContractorResource/ContractorResourceReview.js
+++ b/web/src/containers/activity/ContractorResource/ContractorResourceReview.js
@@ -1,18 +1,8 @@
 import PropTypes from 'prop-types';
 import React, { useMemo } from 'react';
-import Review from '../../../components/Review';
-
 import Dollars from '../../../components/Dollars';
-
-const getHumanReadableDateRange = (startDate, endDate) => {
-  const [startYear, startMonth, startDay] = startDate.split('-');
-  const [endYear, endMonth, endDay] = endDate.split('-');
-
-  if (startDay && startMonth && startYear && endDay && endMonth && endYear) {
-    return `${startMonth}/${startDay}/${startYear} - ${endMonth}/${endDay}/${endYear}`;
-  }
-  return null;
-};
+import Review from '../../../components/Review';
+import { stateDateRangeToDisplay } from '../../../util';
 
 const ContractorResourceReview = ({
   index,
@@ -23,7 +13,7 @@ const ContractorResourceReview = ({
   const apdFFYs = useMemo(() => Object.keys(years), [years]);
 
   const dateRangeForHumans = useMemo(
-    () => getHumanReadableDateRange(start, end),
+    () => stateDateRangeToDisplay(start, end),
     [end, start]
   );
 
@@ -38,10 +28,7 @@ const ContractorResourceReview = ({
       </p>
       <ul className="ds-c-list--bare">
         <li>
-          <strong>Contract term:</strong>{' '}
-          {dateRangeForHumans || (
-            <span className="ds-u-color--gray">Dates not specified</span>
-          )}
+          <strong>Contract term:</strong> {dateRangeForHumans}
         </li>
         <li>
           <strong>Total cost:</strong> <Dollars long>{totalCost}</Dollars>

--- a/web/src/containers/activity/ContractorResource/ContractorResourceReview.test.js
+++ b/web/src/containers/activity/ContractorResource/ContractorResourceReview.test.js
@@ -47,11 +47,4 @@ describe('the ContractorResourceReview component', () => {
       props.onDeleteClick
     );
   });
-
-  it('renders placeholder date text if they are not fully-formed', () => {
-    const component = shallow(
-      <ContractorReview {...props} item={{ ...props.item, start: '1993' }} />
-    );
-    expect(component).toMatchSnapshot();
-  });
 });

--- a/web/src/containers/activity/ContractorResource/__snapshots__/ContractorResourceReview.test.js.snap
+++ b/web/src/containers/activity/ContractorResource/__snapshots__/ContractorResourceReview.test.js.snap
@@ -20,7 +20,7 @@ exports[`the ContractorResourceReview component renders correctly 1`] = `
         Contract term:
       </strong>
        
-      10/14/1066 – 10/15/1066
+      10/14/1066 - 10/15/1066
     </li>
     <li>
       <strong>

--- a/web/src/containers/activity/ContractorResource/__snapshots__/ContractorResourceReview.test.js.snap
+++ b/web/src/containers/activity/ContractorResource/__snapshots__/ContractorResourceReview.test.js.snap
@@ -20,78 +20,7 @@ exports[`the ContractorResourceReview component renders correctly 1`] = `
         Contract term:
       </strong>
        
-      10/14/1066 - 10/15/1066
-    </li>
-    <li>
-      <strong>
-        Total cost:
-      </strong>
-       
-      <Dollars
-        long={true}
-      >
-        12345
-      </Dollars>
-    </li>
-    <li
-      key="1066"
-    >
-      <strong>
-        FFY 
-        1066
-         cost:
-      </strong>
-       
-      <Dollars
-        long={true}
-      >
-        300
-      </Dollars>
-    </li>
-    <li
-      key="1067"
-    >
-      <strong>
-        FFY 
-        1067
-         cost:
-      </strong>
-       
-      <Dollars
-        long={true}
-      >
-        400
-      </Dollars>
-    </li>
-  </ul>
-</StandardReview>
-`;
-
-exports[`the ContractorResourceReview component renders placeholder date text if they are not fully-formed 1`] = `
-<StandardReview
-  editHref={null}
-  heading="2. Honey Dipper Dan"
-  onDeleteClick={[MockFunction]}
-  onEditClick={[MockFunction]}
->
-  <p
-    className="ds-u-margin-top--0"
-  >
-    They cleaned up the latrines after the Battle of Hastings
-  </p>
-  <ul
-    className="ds-c-list--bare"
-  >
-    <li>
-      <strong>
-        Contract term:
-      </strong>
-       
-      <span
-        className="ds-u-color--gray"
-      >
-        Dates not specified
-      </span>
+      10/14/1066 – 10/15/1066
     </li>
     <li>
       <strong>

--- a/web/src/containers/activity/Milestone/MilestoneReview.js
+++ b/web/src/containers/activity/Milestone/MilestoneReview.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { useMemo } from 'react';
 import Review from '../../../components/Review';
+import { stateDateToDisplay } from '../../../util';
 
 const MilestoneReview = ({
   index,
@@ -8,10 +9,7 @@ const MilestoneReview = ({
   expand,
   onDeleteClick
 }) => {
-  const formattedDate = useMemo(() => {
-    const [year, month, day] = endDate.split('-');
-    return `${month}-${day}-${year}`;
-  }, [endDate]);
+  const formattedDate = useMemo(() => stateDateToDisplay(endDate), [endDate]);
 
   return (
     <Review

--- a/web/src/containers/activity/Milestone/__snapshots__/MilestoneReview.test.js.snap
+++ b/web/src/containers/activity/Milestone/__snapshots__/MilestoneReview.test.js.snap
@@ -15,7 +15,7 @@ exports[`the MilestoneReview component renders correctly 1`] = `
       Planned end date:
     </strong>
      
-    10-31-1940
+    10/31/1940
   </p>
 </StandardReview>
 `;

--- a/web/src/containers/activity/Schedule.js
+++ b/web/src/containers/activity/Schedule.js
@@ -14,6 +14,7 @@ import Instruction from '../../components/Instruction';
 import { Subsection } from '../../components/Section';
 import DateField from '../../components/DateField';
 import { t } from '../../i18n';
+import { stateDateToDisplay } from '../../util';
 
 const Schedule = ({
   activity,
@@ -62,8 +63,14 @@ const Schedule = ({
           />
         </div>
         <div className="visibility--print">
-          <p><strong>Planned start date:</strong> {activity.plannedStartDate || "No date entered"}</p>
-          <p><strong>Planned end date:</strong> {activity.plannedEndDate || "No date entered"}</p>
+          <p>
+            <strong>Planned start date:</strong>{' '}
+            {stateDateToDisplay(activity.plannedStartDate)}
+          </p>
+          <p>
+            <strong>Planned end date:</strong>{' '}
+            {stateDateToDisplay(activity.plannedEndDate)}
+          </p>
           <hr />
         </div>
         <div className="mb3">

--- a/web/src/containers/activity/__snapshots__/Schedule.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/Schedule.test.js.snap
@@ -31,14 +31,14 @@ exports[`the Schedule (milestones) component renders correctly 1`] = `
         Planned start date:
       </strong>
        
-      1944-10-02
+      10/02/1944
     </p>
     <p>
       <strong>
         Planned end date:
       </strong>
        
-      1944-11-08
+      11/08/1944
     </p>
     <hr />
   </div>

--- a/web/src/containers/activity/__snapshots__/Schedule.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/Schedule.test.js.snap
@@ -31,14 +31,14 @@ exports[`the Schedule (milestones) component renders correctly 1`] = `
         Planned start date:
       </strong>
        
-      10/02/1944
+      10/2/1944
     </p>
     <p>
       <strong>
         Planned end date:
       </strong>
        
-      11/08/1944
+      11/8/1944
     </p>
     <hr />
   </div>

--- a/web/src/reducers/activities.selectors.js
+++ b/web/src/reducers/activities.selectors.js
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 import { selectApdData } from './apd.selectors';
-import { stateDateToDisplay } from '../util';
+import { stateDateRangeToDisplay, stateDateToDisplay } from '../util';
 
 export const selectActivityKeys = ({ activities: { allKeys } }) => allKeys;
 
@@ -59,6 +59,7 @@ export const selectActivitySchedule = createSelector(
       ({ name, plannedEndDate, plannedStartDate, schedule }) => {
         const milestones = [];
         activities.push({
+          dateRange: stateDateRangeToDisplay(plannedStartDate, plannedEndDate),
           end: stateDateToDisplay(plannedEndDate),
           name,
           milestones,

--- a/web/src/reducers/budget.selectors.js
+++ b/web/src/reducers/budget.selectors.js
@@ -1,7 +1,6 @@
-import moment from 'moment';
 import { createSelector } from 'reselect';
 import { selectActivitiesByKey } from './activities.selectors';
-import { ACTIVITY_FUNDING_SOURCES } from '../util';
+import { ACTIVITY_FUNDING_SOURCES, stateDateRangeToDisplay } from '../util';
 
 const selectBudget = ({ budget }) => budget;
 
@@ -29,16 +28,9 @@ export const selectBudgetExecutiveSummary = createSelector(
       ([key, { name, plannedEndDate, plannedStartDate, summary }]) => {
         const activityCosts = budget.activities[key].costsByFFY;
 
-        let dateRange = 'Dates not set';
-        if (plannedEndDate && plannedStartDate) {
-          dateRange = `${moment(plannedStartDate, 'YYYY-MM-DD').format(
-            'M/D/YYYY'
-          )} - ${moment(plannedEndDate, 'YYYY-MM-DD').format('M/D/YYYY')}`;
-        }
-
         return {
           key,
-          dateRange,
+          dateRange: stateDateRangeToDisplay(plannedStartDate, plannedEndDate),
           name,
           summary,
           combined: activityCosts.total.total,

--- a/web/src/util/index.js
+++ b/web/src/util/index.js
@@ -206,7 +206,7 @@ export const stateDateRangeToDisplay = (start, end) => {
   const starty = moment(start, 'YYYY-MM-DD');
   const endy = moment(end, 'YYYY-MM-DD');
   if (starty.isValid() && endy.isValid()) {
-    return `${starty.format('M/D/YYYY')} – ${endy.format('M/D/YYYY')}`;
+    return `${starty.format('M/D/YYYY')} - ${endy.format('M/D/YYYY')}`;
   }
   return 'Dates not specified';
 };

--- a/web/src/util/index.js
+++ b/web/src/util/index.js
@@ -1,4 +1,4 @@
-/* eslint-disable import/prefer-default-export */
+import moment from 'moment';
 
 export const ACTIVITY_FUNDING_SOURCES = ['HIT', 'HIE', 'MMIS'];
 
@@ -187,18 +187,26 @@ export const generateKey = (() => {
  * @returns {String} Display-formatted date string.
  */
 export const stateDateToDisplay = date => {
-  if (date) {
-    const [year, month, day] = date.split('-');
-    return `${month}/${day}/${year}`;
+  const m = moment(date, 'YYYY-MM-DD');
+  if (m.isValid()) {
+    return m.format('M/D/YYYY');
   }
   return 'Date not specified';
 };
 
+/**
+ * Convert a pair of YYYY-MM-DD date strings from state format into a
+ * consistent display format
+ *
+ * @param {String} start Start date string from state
+ * @param {String} end End date string from state
+ * @returns {String} Display-formatted date range string
+ */
 export const stateDateRangeToDisplay = (start, end) => {
-  if (start && end) {
-    const starty = stateDateToDisplay(start);
-    const endy = stateDateToDisplay(end);
-    return `${starty} – ${endy}`;
+  const starty = moment(start, 'YYYY-MM-DD');
+  const endy = moment(end, 'YYYY-MM-DD');
+  if (starty.isValid() && endy.isValid()) {
+    return `${starty.format('M/D/YYYY')} – ${endy.format('M/D/YYYY')}`;
   }
   return 'Dates not specified';
 };

--- a/web/src/util/index.js
+++ b/web/src/util/index.js
@@ -191,7 +191,16 @@ export const stateDateToDisplay = date => {
     const [year, month, day] = date.split('-');
     return `${month}/${day}/${year}`;
   }
-  return 'N/A';
+  return 'Date not specified';
+};
+
+export const stateDateRangeToDisplay = (start, end) => {
+  if (start && end) {
+    const starty = stateDateToDisplay(start);
+    const endy = stateDateToDisplay(end);
+    return `${starty} – ${endy}`;
+  }
+  return 'Dates not specified';
 };
 
 /**

--- a/web/src/util/index.test.js
+++ b/web/src/util/index.test.js
@@ -112,7 +112,7 @@ describe('utility functions', () => {
 
   test('converts two state-formatted date strings into a display date range', () => {
     expect(stateDateRangeToDisplay('2014-04-03', '2015-04-19')).toEqual(
-      '4/3/2014 – 4/19/2015'
+      '4/3/2014 - 4/19/2015'
     );
     expect(stateDateRangeToDisplay(null, null)).toEqual('Dates not specified');
     expect(stateDateRangeToDisplay('2014-04-03', null)).toEqual(

--- a/web/src/util/index.test.js
+++ b/web/src/util/index.test.js
@@ -49,6 +49,7 @@ describe('utility functions', () => {
     getParams,
     replaceNulls,
     stateDateToDisplay,
+    stateDateRangeToDisplay,
     stateLookup
   } = load();
 
@@ -105,8 +106,22 @@ describe('utility functions', () => {
 
   test('converts a state-formatted date string into a display string', () => {
     expect(stateDateToDisplay('2014-04-03')).toEqual('04/03/2014');
-    expect(stateDateToDisplay(null)).toEqual('N/A');
-    expect(stateDateToDisplay()).toEqual('N/A');
+    expect(stateDateToDisplay(null)).toEqual('Date not specified');
+    expect(stateDateToDisplay()).toEqual('Date not specified');
+  });
+
+  test('converts two state-formatted date strings into a display date range', () => {
+    expect(stateDateRangeToDisplay('2014-04-03', '2015-04-09')).toEqual(
+      '04/03/2014 – 04/09/2015'
+    );
+    expect(stateDateRangeToDisplay(null, null)).toEqual('Dates not specified');
+    expect(stateDateRangeToDisplay('2014-04-03', null)).toEqual(
+      'Dates not specified'
+    );
+    expect(stateDateRangeToDisplay(null, '2015-04-09')).toEqual(
+      'Dates not specified'
+    );
+    expect(stateDateRangeToDisplay()).toEqual('Dates not specified');
   });
 
   test('converts an array into an object with array values as object keys', () => {

--- a/web/src/util/index.test.js
+++ b/web/src/util/index.test.js
@@ -105,14 +105,14 @@ describe('utility functions', () => {
   });
 
   test('converts a state-formatted date string into a display string', () => {
-    expect(stateDateToDisplay('2014-04-03')).toEqual('04/03/2014');
+    expect(stateDateToDisplay('2014-04-03')).toEqual('4/3/2014');
     expect(stateDateToDisplay(null)).toEqual('Date not specified');
     expect(stateDateToDisplay()).toEqual('Date not specified');
   });
 
   test('converts two state-formatted date strings into a display date range', () => {
-    expect(stateDateRangeToDisplay('2014-04-03', '2015-04-09')).toEqual(
-      '04/03/2014 – 04/09/2015'
+    expect(stateDateRangeToDisplay('2014-04-03', '2015-04-19')).toEqual(
+      '4/3/2014 – 4/19/2015'
     );
     expect(stateDateRangeToDisplay(null, null)).toEqual('Dates not specified');
     expect(stateDateRangeToDisplay('2014-04-03', null)).toEqual(


### PR DESCRIPTION
Describe the pull request here, including any supplemental information needed to understand it.

### This pull request changes...
- empty/invalid dollar values are displayed as `$0` instead of `--`
- empty/invalid single dates are displayed as `Date not specified`
- empty/invalid date ranges are displayed as `Dates not specified`
- several components updated to use util date methods, so we can make sure everything is consistent
- closes #1658

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author

### This feature is done when...
- [ ] Design has approved the experience
- [x] Product has approved the experience
