### PR TITLE
Prompt before deleing APD key personnel

### DIFF
--- a/web/src/actions/apd.js
+++ b/web/src/actions/apd.js
@@ -41,10 +41,14 @@ export const selectApdOnLoad = () => (dispatch, getState) => {
 };
 
 export const addKeyPerson = () => ({ type: ADD_APD_KEY_PERSON });
-export const removeKeyPerson = key => ({
-  type: REMOVE_APD_KEY_PERSON,
-  key
-});
+export const removeKeyPerson = (key, { global = window } = {}) => dispatch => {
+  if (global.confirm('Do you really want to delete this key person?')) {
+    dispatch({
+      type: REMOVE_APD_KEY_PERSON,
+      key
+    });
+  }
+};
 
 export const updateBudget = () => (dispatch, getState) =>
   dispatch({ type: UPDATE_BUDGET, state: getState() });

--- a/web/src/actions/apd.test.js
+++ b/web/src/actions/apd.test.js
@@ -41,10 +41,34 @@ describe('apd actions', () => {
     });
   });
 
-  it('removeApdKeyPerson should create REMOVE_APD_KEY_PERSON action', () => {
-    expect(actions.removeKeyPerson('key')).toEqual({
-      type: actions.REMOVE_APD_KEY_PERSON,
-      key: 'key'
+  describe('removeApdKeyPerson should create REMOVE_APD_KEY_PERSON action', () => {
+    const global = {
+      confirm: jest.fn()
+    };
+
+    it('dispatches nothing if the user does not confirm', () => {
+      global.confirm.mockReset();
+      global.confirm.mockReturnValue(false);
+      const store = mockStore();
+
+      store.dispatch(actions.removeKeyPerson('key', { global }));
+      expect(global.confirm).toHaveBeenCalled();
+      expect(store.getActions()).toEqual([]);
+    });
+
+    it('dispatches the expected action if the user confirms', () => {
+      global.confirm.mockReset();
+      global.confirm.mockReturnValue(true);
+      const store = mockStore();
+
+      store.dispatch(actions.removeKeyPerson('key', { global }));
+      expect(global.confirm).toHaveBeenCalled();
+      expect(store.getActions()).toEqual([
+        {
+          type: actions.REMOVE_APD_KEY_PERSON,
+          key: 'key'
+        }
+      ]);
     });
   });
 


### PR DESCRIPTION
### This pull request changes...
- prompt the user with a confirmation dialog before deleting APD key personnel
- closes #1647

### This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author

### This feature is done when...
- ~Design has approved the experience~
- ~Product has approved the experience~
- skipping design and product review because the behavior is the same as other delete confirmations
