### PR TITLE
Don't collapse the consent banner

### DIFF
--- a/web/src/components/ConsentBanner.js
+++ b/web/src/components/ConsentBanner.js
@@ -44,6 +44,20 @@ class ConsentBanner extends PureComponent {
           <div className="ds-l-row card">
             <div className="ds-l-col--1 ds-u-margin-left--auto" />
             <div className="ds-l-col--12 ds-l-sm-col--10 ds-l-lg-col--6">
+              <p>
+                This is a U.S. government service. Your use indicates your
+                consent to monitoring, recording, and no expectation of privacy.
+                Misuse is subject to criminal and civil penalties.
+                {showDetails ? null : (
+                  <Button
+                    size="small"
+                    variation="transparent"
+                    onClick={this.toggleDetails}
+                  >
+                    Read more details
+                  </Button>
+                )}
+              </p>
               {showDetails ? (
                 <Fragment>
                   <p>
@@ -92,33 +106,13 @@ class ConsentBanner extends PureComponent {
                       be cancelled.
                     </li>
                   </ul>
-                  <div className="ds-u-text-align--right">
-                    <Button variation="primary" onClick={this.toggleDetails}>
-                      Hide details
-                    </Button>
-                  </div>
                 </Fragment>
-              ) : (
-                <Fragment>
-                  <p>
-                    This is a U.S. government service. Your use indicates your
-                    consent to monitoring, recording, and no expectation of
-                    privacy. Misuse is subject to criminal and civil penalties.{' '}
-                    <Button
-                      size="small"
-                      variation="transparent"
-                      onClick={this.toggleDetails}
-                    >
-                      Read more details
-                    </Button>
-                  </p>
-                  <div className="ds-u-text-align--center">
-                    <Button variation="primary" onClick={this.agreeAndContinue}>
-                      Agree and continue
-                    </Button>
-                  </div>
-                </Fragment>
-              )}
+              ) : null}
+              <div className="ds-u-text-align--center">
+                <Button variation="primary" onClick={this.agreeAndContinue}>
+                  Agree and continue
+                </Button>
+              </div>
             </div>
             <div className="ds-l-col--1 ds-u-margin-right--auto" />
           </div>

--- a/web/src/components/ConsentBanner.test.js
+++ b/web/src/components/ConsentBanner.test.js
@@ -18,7 +18,7 @@ describe('Consent banner component', () => {
       expect(component).toMatchSnapshot();
     });
 
-    test('toggles consent details on and off', () => {
+    test('toggles consent details on', () => {
       const component = shallow(<ConsentBanner onAgree={onAgree} />);
       expect(component).toMatchSnapshot();
 
@@ -27,10 +27,6 @@ describe('Consent banner component', () => {
         .find('Button')
         .find({ variation: 'transparent' })
         .simulate('click');
-      expect(component).toMatchSnapshot();
-
-      // toggle them off
-      component.find('Button').simulate('click');
       expect(component).toMatchSnapshot();
     });
 

--- a/web/src/components/__snapshots__/ConsentBanner.test.js.snap
+++ b/web/src/components/__snapshots__/ConsentBanner.test.js.snap
@@ -20,7 +20,6 @@ exports[`Consent banner component when there is no cookie renders the banner 1`]
       >
         <p>
           This is a U.S. government service. Your use indicates your consent to monitoring, recording, and no expectation of privacy. Misuse is subject to criminal and civil penalties.
-           
           <Button
             onClick={[Function]}
             size="small"
@@ -50,7 +49,7 @@ exports[`Consent banner component when there is no cookie renders the banner 1`]
 </div>
 `;
 
-exports[`Consent banner component when there is no cookie toggles consent details on and off 1`] = `
+exports[`Consent banner component when there is no cookie toggles consent details on 1`] = `
 <div
   className="card--container"
 >
@@ -68,7 +67,6 @@ exports[`Consent banner component when there is no cookie toggles consent detail
       >
         <p>
           This is a U.S. government service. Your use indicates your consent to monitoring, recording, and no expectation of privacy. Misuse is subject to criminal and civil penalties.
-           
           <Button
             onClick={[Function]}
             size="small"
@@ -98,7 +96,7 @@ exports[`Consent banner component when there is no cookie toggles consent detail
 </div>
 `;
 
-exports[`Consent banner component when there is no cookie toggles consent details on and off 2`] = `
+exports[`Consent banner component when there is no cookie toggles consent details on 2`] = `
 <div
   className="card--container"
 >
@@ -114,6 +112,9 @@ exports[`Consent banner component when there is no cookie toggles consent detail
       <div
         className="ds-l-col--12 ds-l-sm-col--10 ds-l-lg-col--6"
       >
+        <p>
+          This is a U.S. government service. Your use indicates your consent to monitoring, recording, and no expectation of privacy. Misuse is subject to criminal and civil penalties.
+        </p>
         <p>
           This warning banner provides privacy and security notices consistent with applicable federal laws, directives, and other federal guidance for accessing this Government system, which includes (1) this computer network, (2) all computers connected to this network, and (3) all devices and storage media attached to this network or to a computer on this network.
         </p>
@@ -137,54 +138,6 @@ exports[`Consent banner component when there is no cookie toggles consent detail
             Any communication or data transiting or stored on this system may be disclosed or used for any lawful Government purpose. To continue, you must accept the terms and conditions. If you decline, your login will automatically be cancelled.
           </li>
         </ul>
-        <div
-          className="ds-u-text-align--right"
-        >
-          <Button
-            onClick={[Function]}
-            type="button"
-            variation="primary"
-          >
-            Hide details
-          </Button>
-        </div>
-      </div>
-      <div
-        className="ds-l-col--1 ds-u-margin-right--auto"
-      />
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Consent banner component when there is no cookie toggles consent details on and off 3`] = `
-<div
-  className="card--container"
->
-  <div
-    className="ds-l-container"
-  >
-    <div
-      className="ds-l-row card"
-    >
-      <div
-        className="ds-l-col--1 ds-u-margin-left--auto"
-      />
-      <div
-        className="ds-l-col--12 ds-l-sm-col--10 ds-l-lg-col--6"
-      >
-        <p>
-          This is a U.S. government service. Your use indicates your consent to monitoring, recording, and no expectation of privacy. Misuse is subject to criminal and civil penalties.
-           
-          <Button
-            onClick={[Function]}
-            size="small"
-            type="button"
-            variation="transparent"
-          >
-            Read more details
-          </Button>
-        </p>
         <div
           className="ds-u-text-align--center"
         >


### PR DESCRIPTION
Change the consent banner so that it can only be expanded, not collapsed

### This pull request changes...
- when the consent banner is expanded, keeps the "Agree and Continue" button available
- removes the "Hide details" button when the banner is expanded
- removes the "Read more details" button when the banner is expanded
- tabbing to the "Read more details" button, pressing space, and tabbing again will take you to the "Agree and Continue" button as expected (I think that's expected?)
- closes #1677

### This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented

### This feature is done when...
- [ ] Product has approved the experience
