### PR TITLE
Extend labels before activity overview rich textboxes to full width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Anticipated release: TBD
 - Fixed semantic heading levels ([#1695])
 - Fixed a keyboard focus order problem when adding new items to a list ([#1712])
 - Fixed a keyboard focus order problem with the system use banner ([#1715])
+- Fixed the width on activity overview detail and statement of alternatives textbox labels ([#1640])
 
 #### ⚙️ Behind the scenes
 
@@ -33,6 +34,7 @@ Released: July 9, 2019
 
 Pilot release to select state partners
 
+[#1640]: https://github.com/18F/cms-hitech-apd/issues/1640
 [#1647]: https://github.com/18F/cms-hitech-apd/pull/1647
 [#1651]: https://github.com/18F/cms-hitech-apd/pull/1651
 [#1688]: https://github.com/18F/cms-hitech-apd/pull/1688

--- a/web/src/containers/activity/Overview.js
+++ b/web/src/containers/activity/Overview.js
@@ -100,7 +100,9 @@ const Description = props => {
       />
 
       <div className="data-entry-box">
-        <FormLabel hint={descriptionHint}>{descriptionLabel}</FormLabel>
+        <FormLabel className="ds-c-label--full-width" hint={descriptionHint}>
+          {descriptionLabel}
+        </FormLabel>
         {activity.fundingSource === 'HIE' && (
           <Instruction source="activities.overview.activityDescriptionInput.hie" />
         )}
@@ -112,7 +114,9 @@ const Description = props => {
       </div>
 
       <div className="data-entry-box">
-        <FormLabel hint={alternativesHint}>{alternativesLabel}</FormLabel>
+        <FormLabel className="ds-c-label--full-width" hint={alternativesHint}>
+          {alternativesLabel}
+        </FormLabel>
         <Instruction source="activities.overview.activityAlternativesInput" />
         <RichText
           content={alternatives}

--- a/web/src/styles/scss/forms.scss
+++ b/web/src/styles/scss/forms.scss
@@ -29,6 +29,10 @@ section > fieldset {
   margin-top: 0;
 }
 
+.data-entry-box .ds-c-label--full-width {
+  max-width: initial;
+}
+
 div.form--with-reviews {
   border-bottom: 2px solid $border-color;
   margin-bottom: nth($spacers, 3);


### PR DESCRIPTION
### This pull request changes...

- adds a `ds-c-label--full-width` class to design system `FormLabel` components that appear immediately before rich textboxes in the activity overview section
- sets the `max-width` to `initial` for the `ds-c-label--full-width` class
- closes #1640

### This pull request is ready to merge when...

- [x] This code has been reviewed by someone other than the original author
- [x] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [x] Changelog is updated as appropriate

### This feature is done when...

- [ ] Design has approved the experience