### PR TITLE
Make logout link text the same size as the manage account link text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Anticipated release: TBD
 - Fixed semantic heading levels ([#1695])
 - Fixed a keyboard focus order problem when adding new items to a list ([#1712])
 - Fixed a keyboard focus order problem with the system use banner ([#1715])
+- Made the "manage account" and "login" text the same size in the header dropdown ([#1655], [#1680])
 
 #### ⚙️ Behind the scenes
 
@@ -35,6 +36,8 @@ Pilot release to select state partners
 
 [#1647]: https://github.com/18F/cms-hitech-apd/pull/1647
 [#1651]: https://github.com/18F/cms-hitech-apd/pull/1651
+[#1655]: https://github.com/18F/cms-hitech-apd/issues/1655
+[#1680]: https://github.com/18F/cms-hitech-apd/issues/1680
 [#1688]: https://github.com/18F/cms-hitech-apd/pull/1688
 [#1695]: https://github.com/18F/cms-hitech-apd/pull/1695
 [#1697]: https://github.com/18F/cms-hitech-apd/pull/1697

--- a/web/src/components/Header.js
+++ b/web/src/components/Header.js
@@ -1,5 +1,3 @@
-import Button from '@cmsgov/design-system-core/dist/components/Button/Button';
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -32,13 +30,6 @@ class Header extends Component {
     this.setState({ ariaExpanded: false });
     // remove the global click handler when the dropdown is collapsed
     document.removeEventListener('click', this.handleOutsideClick);
-  };
-
-  handleLogout = e => {
-    e.preventDefault();
-    const { pushRoute } = this.props;
-    this.toggleDropdown();
-    pushRoute('/logout');
   };
 
   toggleDropdown = () => {
@@ -99,15 +90,14 @@ class Header extends Component {
                         </Link>
                       </li>
                       <li>
-                        <Button
-                          size="small"
+                        <Link
+                          to="/logout"
+                          onClick={this.toggleDropdown}
                           className="nav--dropdown__action"
-                          variation="transparent"
-                          onClick={this.handleLogout}
                         >
                           <Icon icon={faSignOutAlt} style={{ width: '14px' }} />
                           {t('logout')}
-                        </Button>
+                        </Link>
                       </li>
                     </ul>
                   </li>
@@ -133,7 +123,6 @@ Header.propTypes = {
   authenticated: PropTypes.bool.isRequired,
   currentUser: PropTypes.object,
   isAdmin: PropTypes.bool.isRequired,
-  pushRoute: PropTypes.func.isRequired,
   ariaExpanded: PropTypes.bool.isRequired,
   showSiteTitle: PropTypes.bool.isRequired
 };

--- a/web/src/components/Header.test.js
+++ b/web/src/components/Header.test.js
@@ -6,11 +6,15 @@ import { push } from 'connected-react-router';
 import { plain as Header, mapStateToProps, mapDispatchToProps } from './Header';
 
 describe('Header component', () => {
-  it('renders correctly when the dropdown is closed and the page is top level', ()=> {
+  it('renders correctly when the dropdown is closed and the page is top level', () => {
     const component = shallow(
       <Header
         authenticated
-        currentUser={{ role: "admin", state: { id: "wa", name: "Washington" }, username: "frasiercrane@kacl.com"}}
+        currentUser={{
+          role: 'admin',
+          state: { id: 'wa', name: 'Washington' },
+          username: 'frasiercrane@kacl.com'
+        }}
         isAdmin
         pushRoute={() => {}}
         ariaExpanded={false}
@@ -24,7 +28,11 @@ describe('Header component', () => {
     const component = shallow(
       <Header
         authenticated
-        currentUser={{ role: "admin", state: { id: "wa", name: "Washington" }, username: "frasiercrane@kacl.com"}}
+        currentUser={{
+          role: 'admin',
+          state: { id: 'wa', name: 'Washington' },
+          username: 'frasiercrane@kacl.com'
+        }}
         isAdmin
         pushRoute={() => {}}
         ariaExpanded={false}
@@ -105,7 +113,11 @@ describe('Header component', () => {
     const component = shallow(
       <Header
         authenticated
-        currentUser={{ role: "admin", state: { id: "wa", name: "Washington" }, username: "frasiercrane@kacl.com"}}
+        currentUser={{
+          role: 'admin',
+          state: { id: 'wa', name: 'Washington' },
+          username: 'frasiercrane@kacl.com'
+        }}
         isAdmin
         pushRoute={() => {}}
         ariaExpanded={false}
@@ -119,7 +131,11 @@ describe('Header component', () => {
     const component = shallow(
       <Header
         authenticated
-        currentUser={{ role: "admin", state: { id: "wa", name: "Washington" }, username: "frasiercrane@kacl.com"}}
+        currentUser={{
+          role: 'admin',
+          state: { id: 'wa', name: 'Washington' },
+          username: 'frasiercrane@kacl.com'
+        }}
         isAdmin={false}
         pushRoute={() => {}}
         ariaExpanded={false}
@@ -127,27 +143,6 @@ describe('Header component', () => {
       />
     );
     expect(component).toMatchSnapshot();
-  });
-
-  it('goes to the logout route', () => {
-    const event = { preventDefault: sinon.spy() };
-    const pushRouteProp = sinon.spy();
-
-    const component = shallow(
-     <Header
-        authenticated
-        currentUser={{ role: "admin", state: { id: "wa", name: "Washington" }, username: "frasiercrane@kacl.com"}}
-        isAdmin={false}
-        pushRoute={pushRouteProp}
-        ariaExpanded={false}
-        showSiteTitle={false}
-      />
-    );
-
-    component.find('Button').simulate('click', event);
-
-    expect(pushRouteProp.calledWith('/logout')).toBeTruthy();
-    expect(event.preventDefault.called).toBeTruthy();
   });
 
   it('maps state to props', () => {
@@ -165,7 +160,11 @@ describe('Header component', () => {
       }
     };
 
-    expect(mapStateToProps(state)).toEqual({ authenticated: 'some value', currentUser: { role: 'admin' }, isAdmin: true});
+    expect(mapStateToProps(state)).toEqual({
+      authenticated: 'some value',
+      currentUser: { role: 'admin' },
+      isAdmin: true
+    });
   });
 
   it('maps dispatch to props', () => {

--- a/web/src/components/Header.test.js
+++ b/web/src/components/Header.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-import sinon from 'sinon';
 import { push } from 'connected-react-router';
 
 import { plain as Header, mapStateToProps, mapDispatchToProps } from './Header';

--- a/web/src/components/__snapshots__/Header.test.js.snap
+++ b/web/src/components/__snapshots__/Header.test.js.snap
@@ -116,12 +116,10 @@ exports[`Header component opens and closes the dropdown when clicked 1`] = `
                 </Link>
               </li>
               <li>
-                <Button
+                <Link
                   className="nav--dropdown__action"
                   onClick={[Function]}
-                  size="small"
-                  type="button"
-                  variation="transparent"
+                  to="/logout"
                 >
                   <FontAwesomeIcon
                     border={false}
@@ -159,7 +157,7 @@ exports[`Header component opens and closes the dropdown when clicked 1`] = `
                     transform={null}
                   />
                   Log out
-                </Button>
+                </Link>
               </li>
             </ul>
           </li>
@@ -286,12 +284,10 @@ exports[`Header component renders correctly when the dropdown is closed and the 
                 </Link>
               </li>
               <li>
-                <Button
+                <Link
                   className="nav--dropdown__action"
                   onClick={[Function]}
-                  size="small"
-                  type="button"
-                  variation="transparent"
+                  to="/logout"
                 >
                   <FontAwesomeIcon
                     border={false}
@@ -329,7 +325,7 @@ exports[`Header component renders correctly when the dropdown is closed and the 
                     transform={null}
                   />
                   Log out
-                </Button>
+                </Link>
               </li>
             </ul>
           </li>
@@ -486,12 +482,10 @@ exports[`Header component renders the admin home title when an admin user is at 
                 </Link>
               </li>
               <li>
-                <Button
+                <Link
                   className="nav--dropdown__action"
                   onClick={[Function]}
-                  size="small"
-                  type="button"
-                  variation="transparent"
+                  to="/logout"
                 >
                   <FontAwesomeIcon
                     border={false}
@@ -529,7 +523,7 @@ exports[`Header component renders the admin home title when an admin user is at 
                     transform={null}
                   />
                   Log out
-                </Button>
+                </Link>
               </li>
             </ul>
           </li>
@@ -686,12 +680,10 @@ exports[`Header component renders the state user home title when a state user is
                 </Link>
               </li>
               <li>
-                <Button
+                <Link
                   className="nav--dropdown__action"
                   onClick={[Function]}
-                  size="small"
-                  type="button"
-                  variation="transparent"
+                  to="/logout"
                 >
                   <FontAwesomeIcon
                     border={false}
@@ -729,7 +721,7 @@ exports[`Header component renders the state user home title when a state user is
                     transform={null}
                   />
                   Log out
-                </Button>
+                </Link>
               </li>
             </ul>
           </li>


### PR DESCRIPTION
### This pull request changes...

- instead of the "logout" link being a button, make it an actual link like the "manage account" link; now they are the same!
- closes #1655

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [x] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [x] Changelog is updated as appropriate

### This feature is done when...

- [ ] Design has approved the experience