### PR TITLE
Add spacing to Medicaid director and office headers/legends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Anticipated release: TBD
 - Fixed semantic heading levels ([#1695])
 - Fixed a keyboard focus order problem when adding new items to a list ([#1712])
 - Fixed a keyboard focus order problem with the system use banner ([#1715])
+- Adds spacing around the Medicaid director and Medicaid office address form headers ([#1646])
 
 #### ⚙️ Behind the scenes
 
@@ -33,6 +34,7 @@ Released: July 9, 2019
 
 Pilot release to select state partners
 
+[#1646]: https://github.com/18F/cms-hitech-apd/pull/1646
 [#1647]: https://github.com/18F/cms-hitech-apd/pull/1647
 [#1651]: https://github.com/18F/cms-hitech-apd/pull/1651
 [#1688]: https://github.com/18F/cms-hitech-apd/pull/1688

--- a/web/src/containers/ApdStateProfileMedicaidOffice.js
+++ b/web/src/containers/ApdStateProfileMedicaidOffice.js
@@ -24,7 +24,9 @@ class ApdStateProfile extends Component {
     return (
       <Fragment>
         <fieldset>
-          <legend>{t(`${dirTRoot}.title`)}</legend>
+          <legend className="ds-u-padding-bottom--1">
+            {t(`${dirTRoot}.title`)}
+          </legend>
           <TextField
             name="apd-state-profile-mdname"
             label={t(`${dirTRoot}.labels.name`)}
@@ -46,7 +48,9 @@ class ApdStateProfile extends Component {
         </fieldset>
 
         <fieldset>
-          <legend>{t(`${offTRoot}.title`)}</legend>
+          <legend className="ds-u-padding-bottom--1">
+            {t(`${offTRoot}.title`)}
+          </legend>
           <TextField
             name="apd-state-profile-addr1"
             label={t(`${offTRoot}.labels.address1`)}

--- a/web/src/containers/__snapshots__/ApdStateProfileMedicaidOffice.test.js.snap
+++ b/web/src/containers/__snapshots__/ApdStateProfileMedicaidOffice.test.js.snap
@@ -3,7 +3,9 @@
 exports[`apd state profile, Medicaid office component renders correctly 1`] = `
 <Fragment>
   <fieldset>
-    <legend>
+    <legend
+      className="ds-u-padding-bottom--1"
+    >
       Medicaid director
     </legend>
     <TextField
@@ -29,7 +31,9 @@ exports[`apd state profile, Medicaid office component renders correctly 1`] = `
     />
   </fieldset>
   <fieldset>
-    <legend>
+    <legend
+      className="ds-u-padding-bottom--1"
+    >
       Medicaid office
     </legend>
     <TextField
@@ -426,7 +430,9 @@ exports[`apd state profile, Medicaid office component renders correctly 1`] = `
 exports[`apd state profile, Medicaid office component renders correctly 2`] = `
 <Fragment>
   <fieldset>
-    <legend>
+    <legend
+      className="ds-u-padding-bottom--1"
+    >
       Medicaid director
     </legend>
     <TextField
@@ -452,7 +458,9 @@ exports[`apd state profile, Medicaid office component renders correctly 2`] = `
     />
   </fieldset>
   <fieldset>
-    <legend>
+    <legend
+      className="ds-u-padding-bottom--1"
+    >
       Medicaid office
     </legend>
     <TextField


### PR DESCRIPTION
### This pull request changes...

- adds spacing to the headers/legends before the Medicaid director and office address forms:
  - Before:
    ![Screen Shot 2019-07-24 at 8 33 20 AM](https://user-images.githubusercontent.com/1775733/61798913-c70fc800-adef-11e9-88c3-686715781754.png)
  - After:
    ![Screen Shot 2019-07-24 at 8 33 43 AM](https://user-images.githubusercontent.com/1775733/61798933-cd05a900-adef-11e9-8b2a-cf28db0d2897.png)
- closes #1646

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [x] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [x] Changelog is updated as appropriate

### This feature is done when...

- [ ] Design has approved the experience
