### PR TITLE
Add whitespace to the bottom of the dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Anticipated release: TBD
 - Fixed semantic heading levels ([#1695])
 - Fixed a keyboard focus order problem when adding new items to a list ([#1712])
 - Fixed a keyboard focus order problem with the system use banner ([#1715])
+- Adds margin to the bottom of the state dashboard ([#1601])
 
 #### ⚙️ Behind the scenes
 
@@ -33,6 +34,7 @@ Released: July 9, 2019
 
 Pilot release to select state partners
 
+[#1601]: https://github.com/18F/cms-hitech-apd/pull/1601
 [#1647]: https://github.com/18F/cms-hitech-apd/pull/1647
 [#1651]: https://github.com/18F/cms-hitech-apd/pull/1651
 [#1688]: https://github.com/18F/cms-hitech-apd/pull/1688

--- a/web/src/containers/StateDashboard.js
+++ b/web/src/containers/StateDashboard.js
@@ -39,7 +39,7 @@ const StateDashboard = (
   };
 
   return (
-    <div className="ds-l-container ds-u-margin-top--7">
+    <div className="ds-l-container ds-u-margin-top--7 ds-u-margin-bottom--5">
       <div className="ds-l-row">
         <div className="ds-l-col--8 ds-u-margin-x--auto ">
           <h1 className="ds-h1">
@@ -73,7 +73,8 @@ const StateDashboard = (
               <div className="ds-u-display--inline-block">
                 <h3 className="ds-u-margin-top--0">
                   <a href="#!" onClick={open(apd.id)}>
-                    <span className="sr-only">Edit APD: </span>{apd.name}
+                    <span className="sr-only">Edit APD: </span>
+                    {apd.name}
                   </a>
                 </h3>
                 <ul className="ds-c-list--bare">


### PR DESCRIPTION
### This pull request changes...

- adds 40px to the bottom of the state dashboard
- closes #1601

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [x] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [x] Changelog is updated as appropriate

### This feature is done when...

- [ ] Design has approved the experience
