### PR TITLE
For the 4 territories we don't have images for, don't try to display images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Anticipated release: TBD
 - Fixed semantic heading levels ([#1695])
 - Fixed a keyboard focus order problem when adding new items to a list ([#1712])
 - Fixed a keyboard focus order problem with the system use banner ([#1715])
+- For users in American Samoa, Guam, Northern Mariana Islands, or U.S. Virgin Islands, do not attempt to display a territory outline at the top of the sidebar because we don't have those outlines ([#1423]; see [#1730] for more information)
 
 #### ⚙️ Behind the scenes
 
@@ -33,6 +34,7 @@ Released: July 9, 2019
 
 Pilot release to select state partners
 
+[#1423]: https://github.com/18F/cms-hitech-apd/issues/1423
 [#1647]: https://github.com/18F/cms-hitech-apd/pull/1647
 [#1651]: https://github.com/18F/cms-hitech-apd/pull/1651
 [#1688]: https://github.com/18F/cms-hitech-apd/pull/1688
@@ -41,3 +43,4 @@ Pilot release to select state partners
 [#1712]: https://github.com/18F/cms-hitech-apd/pull/1712
 [#1713]: https://github.com/18F/cms-hitech-apd/pull/1713
 [#1715]: https://github.com/18F/cms-hitech-apd/pull/1715
+[#1730]: https://github.com/18F/cms-hitech-apd/pull/1730

--- a/web/src/containers/Sidebar.js
+++ b/web/src/containers/Sidebar.js
@@ -208,7 +208,7 @@ class Sidebar extends Component {
                 <img
                   src={`/static/img/states/${place.id}.svg`}
                   alt={place.name}
-                  className="align-middle mr2"
+                  className="ds-u-margin-right--2"
                   width="40"
                   height="40"
                 />

--- a/web/src/containers/Sidebar.js
+++ b/web/src/containers/Sidebar.js
@@ -197,18 +197,22 @@ class Sidebar extends Component {
 
     const { activeSection } = this.props;
 
+    const hasImage = ['as', 'gu', 'mp', 'vi'].indexOf(place.id) < 0;
+
     return (
       <div className="ds-l-col--3">
         <aside className="site-sidebar">
           <div className="xs-hide sm-hide site-sidebar__sticky">
             <div className="flex items-center ds-u-border-bottom--1 ds-u-padding-y--2 ds-u-margin-bottom--4">
-              <img
-                src={`/static/img/states/${place.id}.svg`}
-                alt={place.name}
-                className="align-middle mr2"
-                width="40"
-                height="40"
-              />
+              {hasImage && (
+                <img
+                  src={`/static/img/states/${place.id}.svg`}
+                  alt={place.name}
+                  className="align-middle mr2"
+                  width="40"
+                  height="40"
+                />
+              )}
               <h1 className="text-xl">{place.name}</h1>
             </div>
             <VerticalNav

--- a/web/src/containers/Sidebar.test.js
+++ b/web/src/containers/Sidebar.test.js
@@ -26,6 +26,14 @@ describe('Sidebar component', () => {
     expect(shallow(<Sidebar {...props} />)).toMatchSnapshot();
   });
 
+  test(`leaves off the state image for states we don't have images for`, () => {
+    expect(
+      shallow(
+        <Sidebar {...props} place={{ id: 'vi', name: 'U.S. Virgin Islands' }} />
+      )
+    ).toMatchSnapshot();
+  });
+
   test('maps state to props', () => {
     const state = {
       activities: {

--- a/web/src/containers/__snapshots__/Sidebar.test.js.snap
+++ b/web/src/containers/__snapshots__/Sidebar.test.js.snap
@@ -1,5 +1,198 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Sidebar component leaves off the state image for states we don't have images for 1`] = `
+<div
+  className="ds-l-col--3"
+>
+  <aside
+    className="site-sidebar"
+  >
+    <div
+      className="xs-hide sm-hide site-sidebar__sticky"
+    >
+      <div
+        className="flex items-center ds-u-border-bottom--1 ds-u-padding-y--2 ds-u-margin-bottom--4"
+      >
+        <h1
+          className="text-xl"
+        >
+          U.S. Virgin Islands
+        </h1>
+      </div>
+      <VerticalNav
+        collapsed={false}
+        items={
+          Array [
+            Object {
+              "defaultCollapsed": true,
+              "id": "apd-state-profile",
+              "items": Array [
+                Object {
+                  "id": "apd-state-profile-overview",
+                  "label": "Overview",
+                  "onClick": [Function],
+                  "url": "#apd-state-profile",
+                },
+                Object {
+                  "id": "apd-state-profile-office",
+                  "label": "State Director and Office Address",
+                  "onClick": [Function],
+                  "url": "#apd-state-profile-office",
+                },
+                Object {
+                  "id": "apd-state-profile-key-personnel",
+                  "label": "Key Personnel and Program Management",
+                  "onClick": [Function],
+                  "url": "#apd-state-profile-key-personnel",
+                },
+              ],
+              "label": "Key State Personnel",
+            },
+            Object {
+              "id": "apd-summary",
+              "label": "Program Summary",
+              "onClick": [Function],
+              "url": "#apd-summary",
+            },
+            Object {
+              "defaultCollapsed": true,
+              "id": "prev-activities",
+              "items": Array [
+                Object {
+                  "id": "prev-activities-overview",
+                  "label": "Overview",
+                  "onClick": [Function],
+                  "url": "#prev-activities",
+                },
+                Object {
+                  "id": "prev-activities-outline",
+                  "label": "Prior Activities Overview",
+                  "onClick": [Function],
+                  "url": "#prev-activities-outline",
+                },
+                Object {
+                  "id": "prev-activities-table",
+                  "label": "Actual Costs",
+                  "onClick": [Function],
+                  "url": "#prev-activities-table",
+                },
+              ],
+              "label": "Results of Previous Activities",
+            },
+            Object {
+              "defaultCollapsed": true,
+              "id": "activities",
+              "items": Array [
+                Object {
+                  "id": "activities-overview",
+                  "label": "Overview",
+                  "onClick": [Function],
+                  "url": "#activities",
+                },
+                Object {
+                  "id": "activities-list",
+                  "label": "Activity List",
+                  "onClick": [Function],
+                  "url": "#activities-list",
+                },
+                Object {
+                  "id": "key 1",
+                  "label": "Activity 1",
+                  "onClick": [Function],
+                  "url": "##key1",
+                },
+                Object {
+                  "id": "key 2",
+                  "label": "Activity 2",
+                  "onClick": [Function],
+                  "url": "##key2",
+                },
+              ],
+              "label": "Program Activities",
+            },
+            Object {
+              "id": "schedule-summary",
+              "label": "Activity Schedule Summary",
+              "onClick": [Function],
+              "url": "#schedule-summary",
+            },
+            Object {
+              "defaultCollapsed": true,
+              "id": "budget",
+              "items": Array [
+                Object {
+                  "id": "budget-overview",
+                  "label": "Overview",
+                  "onClick": [Function],
+                  "url": "#budget",
+                },
+                Object {
+                  "id": "budget-summary-table",
+                  "label": "Summary Budget Table",
+                  "onClick": [Function],
+                  "url": "#budget-summary-table",
+                },
+                Object {
+                  "id": "budget-federal-by-quarter",
+                  "label": "Quarterly Federal Share",
+                  "onClick": [Function],
+                  "url": "#budget-federal-by-quarter",
+                },
+                Object {
+                  "id": "budget-incentive-by-quarter",
+                  "label": "Estimated Quarterly Incentive Payments",
+                  "onClick": [Function],
+                  "url": "#budget-incentive-by-quarter",
+                },
+              ],
+              "label": "Proposed Budget",
+            },
+            Object {
+              "id": "assurances-compliance",
+              "label": "Assurances and Compliance",
+              "onClick": [Function],
+              "url": "#assurances-compliance",
+            },
+            Object {
+              "defaultCollapsed": true,
+              "id": "executive-summary",
+              "items": Array [
+                Object {
+                  "id": "executive-summary-overview",
+                  "label": "Overview",
+                  "onClick": [Function],
+                  "url": "#executive-summary",
+                },
+                Object {
+                  "id": "executive-summary-summary",
+                  "label": "Activities Summary",
+                  "onClick": [Function],
+                  "url": "#executive-summary-summary",
+                },
+                Object {
+                  "id": "executive-summary-budget-table",
+                  "label": "Program Budget Tables",
+                  "onClick": [Function],
+                  "url": "#executive-summary-budget-table",
+                },
+              ],
+              "label": "Executive Summary",
+            },
+            Object {
+              "id": "export-and-submit",
+              "label": "Export and Submit",
+              "onClick": [Function],
+              "url": "#export-and-submit",
+            },
+          ]
+        }
+        selectedId="some section"
+      />
+    </div>
+  </aside>
+</div>
+`;
+
 exports[`Sidebar component renders correctly 1`] = `
 <div
   className="ds-l-col--3"

--- a/web/src/containers/__snapshots__/Sidebar.test.js.snap
+++ b/web/src/containers/__snapshots__/Sidebar.test.js.snap
@@ -208,7 +208,7 @@ exports[`Sidebar component renders correctly 1`] = `
       >
         <img
           alt="place name"
-          className="align-middle mr2"
+          className="ds-u-margin-right--2"
           height="40"
           src="/static/img/states/place id.svg"
           width="40"


### PR DESCRIPTION
### This pull request changes...

- for American Samoa, Guam, Northern Mariana Islands, and U.S. Virgin Islands, don't display the state/territory outline in the sidebar because we don't have those outlines (thanks for the idea @hbillings!)
- addresses #1423
  - up to product whether this closes the issue and open a new one later about adding those outline images, but...

The outlines we have now are SVGs generated from TopoJSON files. The original source of the TopoJSON files is murky but [Bren used a minor modification](https://github.com/18F/cms-hitech-apd/pull/353#discussion_r177516462) of [a script by Mike Bostock](https://gist.github.com/mbostock/9821217#file-makefile) to pull data from the USGS and do some magic massaging on it to turn it into nice little blobs that fit into a 64x64 square, which works great for the 50 states plus DC and Puerto Rico, which are included in the original data. The big win here is converting from the USGS geographic projection (whatever that is) into an appropriate state plane projection and computing the right set of scales and translations to make it fit in a box that originates at 0,0.

However, adding the four remaining "state equivalents" (this was a new term to me, but it's fascinating) is difficult because the original USGS dataset doesn't include them, so 1) we'd have to find them and 2) we'd have to figure out how to convert whatever we find into the same thing that the Bostock script does, which is no easy task. I'm not even sure if there are appropriate state plane projections for, e.g., Guam (but probably).

My recommendation is to punt for now until we can find an original dataset that includes the 56 states and equivalents, then we can figure out how to convert those into what we want. Alternatively, if we can find a set of images of all 56 - we don't actually need GeoJSON or TopoJSON or SVGs, just plains PNGs or JPEGs will do fine.

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [x] Changelog is updated as appropriate

### This feature is done when...

- [ ] Product has approved the experience
