### PR TITLE
Add a link to skip navigation and go straight to the main content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Anticipated release: TBD
 
 #### 🐛 Bugs fixed
 
+- Add a "skip to main content" link ([#1304])
 - Prompt for confirmation before deleting APD key personnel ([#1651], [#1647])
 - Fixed accessibility issues on the login page and the dashboard ([#1688])
 - Fixed semantic heading levels ([#1695])
@@ -42,6 +43,7 @@ Released: July 9, 2019
 
 Pilot release to select state partners
 
+[#1304]: https://github.com/18F/cms-hitech-apd/issues/1304
 [#1423]: https://github.com/18F/cms-hitech-apd/issues/1423
 [#1475]: https://github.com/18F/cms-hitech-apd/issues/1475
 [#1601]: https://github.com/18F/cms-hitech-apd/pull/1601

--- a/web/src/components/CardForm.js
+++ b/web/src/components/CardForm.js
@@ -20,27 +20,21 @@ const CardForm = ({
   title,
   working
 }) => (
-  <div className="card--container">
+  <div id="start-main-content" className="card--container">
     <div className="ds-l-container">
       <div className="ds-l-row card">
         <div className="ds-l-col--1 ds-u-margin-left--auto" />
         <div className="ds-l-col--12 ds-l-sm-col--10 ds-l-lg-col--6">
-          {!!success && 
-            <Alert
-              variation="success"
-              role="alert"
-            >
+          {!!success && (
+            <Alert variation="success" role="alert">
               {success}
             </Alert>
-          }
-          {!!error && 
-            <Alert
-              variation="error"
-              role="alert"
-            >
+          )}
+          {!!error && (
+            <Alert variation="error" role="alert">
               {error}
             </Alert>
-          }
+          )}
 
           <h1 className="ds-h1">
             {sectionName.length > 0 && (

--- a/web/src/components/Wrapper.js
+++ b/web/src/components/Wrapper.js
@@ -22,7 +22,7 @@ class Wrapper extends Component {
     const showSiteTitle = document.location.pathname === '/';
     return (
       <div className="site">
-        <a href="#apd-title" className="skip-nav">
+        <a href="#start-main-content" className="skip-nav">
           Skip to main content
         </a>
         <Header showSiteTitle={showSiteTitle} />

--- a/web/src/components/Wrapper.js
+++ b/web/src/components/Wrapper.js
@@ -22,11 +22,14 @@ class Wrapper extends Component {
     const showSiteTitle = document.location.pathname === '/';
     return (
       <div className="site">
+        <a href="#apd-title" className="skip-nav">
+          Skip to main content
+        </a>
         <Header showSiteTitle={showSiteTitle} />
         {children}
         <Footer />
-      </div>)
-    ;
+      </div>
+    );
   }
 }
 

--- a/web/src/components/__snapshots__/CardForm.test.js.snap
+++ b/web/src/components/__snapshots__/CardForm.test.js.snap
@@ -3,6 +3,7 @@
 exports[`card form wrapper disables the save button if canSubmit is false 1`] = `
 <div
   className="card--container"
+  id="start-main-content"
 >
   <div
     className="ds-l-container"
@@ -60,6 +61,7 @@ exports[`card form wrapper disables the save button if canSubmit is false 1`] = 
 exports[`card form wrapper does not render a cancel button if form is not cancelable 1`] = `
 <div
   className="card--container"
+  id="start-main-content"
 >
   <div
     className="ds-l-container"
@@ -102,6 +104,7 @@ exports[`card form wrapper does not render a cancel button if form is not cancel
 exports[`card form wrapper renders a footer if provided 1`] = `
 <div
   className="card--container"
+  id="start-main-content"
 >
   <div
     className="ds-l-container"
@@ -159,6 +162,7 @@ exports[`card form wrapper renders a footer if provided 1`] = `
 exports[`card form wrapper renders a legend if provided 1`] = `
 <div
   className="card--container"
+  id="start-main-content"
 >
   <div
     className="ds-l-container"
@@ -214,6 +218,7 @@ exports[`card form wrapper renders a legend if provided 1`] = `
 exports[`card form wrapper renders a spinny-wheel on the save button and disables it if the form is busy 1`] = `
 <div
   className="card--container"
+  id="start-main-content"
 >
   <div
     className="ds-l-container"
@@ -276,6 +281,7 @@ exports[`card form wrapper renders a spinny-wheel on the save button and disable
 exports[`card form wrapper renders a success alert if message provided 1`] = `
 <div
   className="card--container"
+  id="start-main-content"
 >
   <div
     className="ds-l-container"
@@ -332,6 +338,7 @@ exports[`card form wrapper renders a success alert if message provided 1`] = `
 exports[`card form wrapper renders an error alert if message provided 1`] = `
 <div
   className="card--container"
+  id="start-main-content"
 >
   <div
     className="ds-l-container"
@@ -388,6 +395,7 @@ exports[`card form wrapper renders an error alert if message provided 1`] = `
 exports[`card form wrapper renders with a save button if onSave prop is provided 1`] = `
 <div
   className="card--container"
+  id="start-main-content"
 >
   <div
     className="ds-l-container"
@@ -445,6 +453,7 @@ exports[`card form wrapper renders with a save button if onSave prop is provided
 exports[`card form wrapper renders without a save button if onSave prop is missing 1`] = `
 <div
   className="card--container"
+  id="start-main-content"
 >
   <div
     className="ds-l-container"

--- a/web/src/components/__snapshots__/Wrapper.test.js.snap
+++ b/web/src/components/__snapshots__/Wrapper.test.js.snap
@@ -4,6 +4,12 @@ exports[`Wrapper component renders correctly in dev mode 1`] = `
 <div
   className="site"
 >
+  <a
+    className="skip-nav"
+    href="#apd-title"
+  >
+    Skip to main content
+  </a>
   <Connect(Header)
     showSiteTitle={true}
   />
@@ -16,6 +22,12 @@ exports[`Wrapper component renders correctly in non-dev mode 1`] = `
 <div
   className="site"
 >
+  <a
+    className="skip-nav"
+    href="#apd-title"
+  >
+    Skip to main content
+  </a>
   <Connect(Header)
     showSiteTitle={true}
   />

--- a/web/src/components/__snapshots__/Wrapper.test.js.snap
+++ b/web/src/components/__snapshots__/Wrapper.test.js.snap
@@ -6,7 +6,7 @@ exports[`Wrapper component renders correctly in dev mode 1`] = `
 >
   <a
     className="skip-nav"
-    href="#apd-title"
+    href="#start-main-content"
   >
     Skip to main content
   </a>
@@ -24,7 +24,7 @@ exports[`Wrapper component renders correctly in non-dev mode 1`] = `
 >
   <a
     className="skip-nav"
-    href="#apd-title"
+    href="#start-main-content"
   >
     Skip to main content
   </a>

--- a/web/src/containers/ApdApplication.js
+++ b/web/src/containers/ApdApplication.js
@@ -86,7 +86,7 @@ class ApdApplication extends Component {
         <div className="ds-l-row ds-u-margin--0">
           <Sidebar place={place} />
           <div className="site-main p2 sm-p4 md-px0 ds-l-col--9">
-            <h1 id="apd-title" className="ds-h1 apd--title">
+            <h1 id="start-main-content" className="ds-h1 apd--title">
               <span className="ds-h6 ds-u-display--block">{apdName}</span>
               {place.name} {year} APD
             </h1>

--- a/web/src/containers/ApdApplication.js
+++ b/web/src/containers/ApdApplication.js
@@ -86,7 +86,7 @@ class ApdApplication extends Component {
         <div className="ds-l-row ds-u-margin--0">
           <Sidebar place={place} />
           <div className="site-main p2 sm-p4 md-px0 ds-l-col--9">
-            <h1 className="ds-h1 apd--title">
+            <h1 id="apd-title" className="ds-h1 apd--title">
               <span className="ds-h6 ds-u-display--block">{apdName}</span>
               {place.name} {year} APD
             </h1>

--- a/web/src/containers/StateDashboard.js
+++ b/web/src/containers/StateDashboard.js
@@ -39,7 +39,10 @@ const StateDashboard = (
   };
 
   return (
-    <div className="ds-l-container ds-u-margin-top--7 ds-u-margin-bottom--5">
+    <div
+      id="start-main-content"
+      className="ds-l-container ds-u-margin-top--7 ds-u-margin-bottom--5"
+    >
       <div className="ds-l-row">
         <div className="ds-l-col--8 ds-u-margin-x--auto ">
           <h1 className="ds-h1">

--- a/web/src/containers/__snapshots__/ApdApplication.test.js.snap
+++ b/web/src/containers/__snapshots__/ApdApplication.test.js.snap
@@ -19,7 +19,7 @@ exports[`apd (application) component renders correctly 1`] = `
     >
       <h1
         className="ds-h1 apd--title"
-        id="apd-title"
+        id="start-main-content"
       >
         <span
           className="ds-h6 ds-u-display--block"

--- a/web/src/containers/__snapshots__/ApdApplication.test.js.snap
+++ b/web/src/containers/__snapshots__/ApdApplication.test.js.snap
@@ -19,6 +19,7 @@ exports[`apd (application) component renders correctly 1`] = `
     >
       <h1
         className="ds-h1 apd--title"
+        id="apd-title"
       >
         <span
           className="ds-h6 ds-u-display--block"

--- a/web/src/styles/scss/layout.scss
+++ b/web/src/styles/scss/layout.scss
@@ -17,3 +17,18 @@
 footer {
   margin-top: auto; // will push the footer as far down as it can
 }
+
+.skip-nav {
+  background: white;
+  height: 3rem;
+  line-height: 3rem;
+  padding: 0 0.5rem;
+  position: absolute;
+  top: -3rem;
+  transition: top 1s ease-out;
+
+  &:focus {
+    top: 0;
+    transition: top 200ms ease-out;
+  }
+}


### PR DESCRIPTION
### This pull request changes...

- adds a link at the top of the page, only visible when focused (e.g., if the user tabs to it), that lets the user skip the navigation and go directly to the main content
- closes #1304

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [x] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [x] Changelog is updated as appropriate
