### PR TITLE
Show costs by year for APD key personnel in review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Anticipated release: TBD
 - Adds an ARIA region component to prevent screen readers from prematurely announcing quarterly budget numbers ([#1731])
 - Fixed alignment of the message if there are no APDs on the state dashboard ([#1602])
 - Adds spacing between the login form and the "forgotten password" help link ([#1600])
+- Adds per-year APD key personnel costs to the review view ([#1747])
 
 #### ⚙️ Behind the scenes
 
@@ -66,3 +67,4 @@ Pilot release to select state partners
 [#1713]: https://github.com/18F/cms-hitech-apd/pull/1713
 [#1715]: https://github.com/18F/cms-hitech-apd/pull/1715
 [#1730]: https://github.com/18F/cms-hitech-apd/pull/1730
+[#1747]: https://github.com/18F/cms-hitech-apd/issues/1747

--- a/web/src/containers/ApdKeyPerson/ApdKeyPersonReview.js
+++ b/web/src/containers/ApdKeyPerson/ApdKeyPersonReview.js
@@ -16,6 +16,18 @@ const ApdStateKeyPerson = ({
     [costs]
   );
 
+  const costByYear = useMemo(
+    () =>
+      hasCosts
+        ? Object.keys(costs).map(year => (
+            <li key={year}>
+              <strong>FFY {year} cost:</strong> <Dollars>{costs[year]}</Dollars>
+            </li>
+          ))
+        : null,
+    [costs]
+  );
+
   return (
     <Fragment>
       <div className="visibility--screen">
@@ -29,8 +41,10 @@ const ApdStateKeyPerson = ({
             {primary ? <li>Primary APD Point of Contact</li> : null}
             <li>{position}</li>
             <li>
-              <strong>Total cost:</strong> <Dollars>{hasCosts ? totalCost : 0}</Dollars>
+              <strong>Total cost:</strong>{' '}
+              <Dollars>{hasCosts ? totalCost : 0}</Dollars>
             </li>
+            {costByYear}
           </ul>
         </Review>
       </div>
@@ -40,10 +54,14 @@ const ApdStateKeyPerson = ({
             {primary ? <li>Primary APD Point of Contact</li> : null}
             <li>{position}</li>
             <li>{email}</li>
-            <li><strong>Time commitment to project:</strong> {percentTime}%</li>
             <li>
-              <strong>Total cost:</strong> <Dollars>{hasCosts ? totalCost : 0}</Dollars>
+              <strong>Time commitment to project:</strong> {percentTime}%
             </li>
+            <li>
+              <strong>Total cost:</strong>{' '}
+              <Dollars>{hasCosts ? totalCost : 0}</Dollars>
+            </li>
+            {costByYear}
           </ul>
         </Review>
       </div>
@@ -59,7 +77,8 @@ ApdStateKeyPerson.propTypes = {
     email: PropTypes.string.isRequired,
     hasCosts: PropTypes.bool.isRequired,
     name: PropTypes.string.isRequired,
-    percentTime: PropTypes.number.isRequired,
+    percentTime: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+      .isRequired,
     position: PropTypes.string.isRequired
   }).isRequired,
   onDeleteClick: PropTypes.func

--- a/web/src/containers/ApdKeyPerson/__snapshots__/ApdKeyPersonReview.test.js.snap
+++ b/web/src/containers/ApdKeyPerson/__snapshots__/ApdKeyPersonReview.test.js.snap
@@ -29,6 +29,36 @@ exports[`the ApdKeyPersonReview component renders correctly 1`] = `
             400
           </Dollars>
         </li>
+        <li
+          key="1992"
+        >
+          <strong>
+            FFY 
+            1992
+             cost:
+          </strong>
+           
+          <Dollars
+            long={false}
+          >
+            100
+          </Dollars>
+        </li>
+        <li
+          key="1993"
+        >
+          <strong>
+            FFY 
+            1993
+             cost:
+          </strong>
+           
+          <Dollars
+            long={false}
+          >
+            300
+          </Dollars>
+        </li>
       </ul>
     </StandardReview>
   </div>
@@ -67,6 +97,36 @@ exports[`the ApdKeyPersonReview component renders correctly 1`] = `
             long={false}
           >
             400
+          </Dollars>
+        </li>
+        <li
+          key="1992"
+        >
+          <strong>
+            FFY 
+            1992
+             cost:
+          </strong>
+           
+          <Dollars
+            long={false}
+          >
+            100
+          </Dollars>
+        </li>
+        <li
+          key="1993"
+        >
+          <strong>
+            FFY 
+            1993
+             cost:
+          </strong>
+           
+          <Dollars
+            long={false}
+          >
+            300
           </Dollars>
         </li>
       </ul>


### PR DESCRIPTION
### This pull request changes...

- instead of only showing the total, also show the cost per year (following the same format as the activity contractor costs)
   ![image](https://user-images.githubusercontent.com/1775733/62494225-91c48c00-b798-11e9-81d7-9525426691bb.png)
- closes #1747

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [x] Changelog is updated as appropriate

### This feature is done when...

- [ ] Design has approved the experience
