### PR TITLE
Select numeric field content on focus if the current value is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Anticipated release: TBD
 - Adds an ARIA region component to prevent screen readers from prematurely announcing quarterly budget numbers ([#1731])
 - Fixed alignment of the message if there are no APDs on the state dashboard ([#1602])
 - Adds spacing between the login form and the "forgotten password" help link ([#1600])
+- Use a dollar field for the "other funding" field in the cost allocation form ([#1754])
 
 #### ⚙️ Behind the scenes
 
@@ -68,3 +69,4 @@ Pilot release to select state partners
 [#1715]: https://github.com/18F/cms-hitech-apd/pull/1715
 [#1730]: https://github.com/18F/cms-hitech-apd/pull/1730
 [#1736]: https://github.com/18F/cms-hitech-apd/issues/1736
+[#1754]: https://github.com/18F/cms-hitech-apd/issues/1754

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Anticipated release: TBD
 - Adds an ARIA region component to prevent screen readers from prematurely announcing quarterly budget numbers ([#1731])
 - Fixed alignment of the message if there are no APDs on the state dashboard ([#1602])
 - Adds spacing between the login form and the "forgotten password" help link ([#1600])
+- Automatically select form field contents when the field is focused if they are numeric and the current value is 0 ([#1736])
 
 #### ⚙️ Behind the scenes
 
@@ -66,3 +67,4 @@ Pilot release to select state partners
 [#1713]: https://github.com/18F/cms-hitech-apd/pull/1713
 [#1715]: https://github.com/18F/cms-hitech-apd/pull/1715
 [#1730]: https://github.com/18F/cms-hitech-apd/pull/1730
+[#1736]: https://github.com/18F/cms-hitech-apd/issues/1736

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Anticipated release: TBD
 #### 🚀 New features
 
 - Attempt to alert users before automatically logging them out due to inactivity. The app will try to use built-in browser notifications as well as flashing the tab title. In browsers that support it, the app treats activity in any eAPD tab as valid, so all eAPD tabs will remain valid as long as at least one of them is getting activity. ([#1697])
+- Automatically select numeric form field contents when the field is focused if the current value is 0 ([#1736])
 
 #### 🐛 Bugs fixed
 
@@ -25,7 +26,6 @@ Anticipated release: TBD
 - Adds an ARIA region component to prevent screen readers from prematurely announcing quarterly budget numbers ([#1731])
 - Fixed alignment of the message if there are no APDs on the state dashboard ([#1602])
 - Adds spacing between the login form and the "forgotten password" help link ([#1600])
-- Automatically select form field contents when the field is focused if they are numeric and the current value is 0 ([#1736])
 
 #### ⚙️ Behind the scenes
 

--- a/web/src/components/DollarField.js
+++ b/web/src/components/DollarField.js
@@ -1,6 +1,7 @@
-import { TextField, unmaskValue } from '@cmsgov/design-system-core';
+import { unmaskValue } from '@cmsgov/design-system-core';
 import PropTypes from 'prop-types';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import NumberField from './NumberField';
 
 const maskValue = value => {
   const num = +value;
@@ -26,7 +27,7 @@ const DollarField = ({ onChange, value, ...rest }) => {
   );
 
   return (
-    <TextField
+    <NumberField
       {...rest}
       mask="currency"
       value={local}

--- a/web/src/components/DollarField.js
+++ b/web/src/components/DollarField.js
@@ -1,6 +1,6 @@
 import { unmaskValue } from '@cmsgov/design-system-core';
 import PropTypes from 'prop-types';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import NumberField from './NumberField';
 
 const maskValue = value => {

--- a/web/src/components/NumberField.js
+++ b/web/src/components/NumberField.js
@@ -1,0 +1,24 @@
+import { TextField } from '@cmsgov/design-system-core';
+import React, { useEffect, useRef } from 'react';
+
+const selectTextIfZero = ({ target }) => {
+  const value = +target.value.replace(/[^0-9]/g);
+  if (value === 0) {
+    target.select();
+  }
+};
+
+const NumberField = ({ ...props }) => {
+  const textField = useRef(null);
+
+  useEffect(() => {
+    textField.current.addEventListener('focus', selectTextIfZero);
+    return () => {
+      textField.current.removeEventListener('focus', selectTextIfZero);
+    };
+  }, []);
+
+  return <TextField {...props} fieldRef={textField} />;
+};
+
+export default NumberField;

--- a/web/src/components/NumberField.test.js
+++ b/web/src/components/NumberField.test.js
@@ -1,0 +1,84 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+
+import NumberField from './NumberField';
+
+describe('NumberField component', () => {
+  it('renders correctly', () => {
+    expect(
+      mount(
+        <NumberField
+          label="test label"
+          name="test name"
+          size="medium"
+          className="stuff"
+          value="123"
+          onChange={jest.fn()}
+        />
+      )
+    ).toMatchSnapshot();
+  });
+
+  it('selects the text field content if the value is zero', () => {
+    const component = mount(
+      <NumberField
+        label="test label"
+        name="test name"
+        size="medium"
+        className="stuff"
+        value="123"
+        onChange={jest.fn()}
+      />
+    );
+
+    const field = component.find('TextField').prop('fieldRef').current;
+
+    field.select = jest.fn();
+    field.value = '0';
+    field.focus();
+
+    expect(field.select).toHaveBeenCalled();
+  });
+
+  it('does not select the text field content if the value is not zero', () => {
+    const component = mount(
+      <NumberField
+        label="test label"
+        name="test name"
+        size="medium"
+        className="stuff"
+        value="123"
+        onChange={jest.fn()}
+      />
+    );
+
+    const field = component.find('TextField').prop('fieldRef').current;
+
+    field.select = jest.fn();
+    field.value = '1';
+    field.focus();
+
+    expect(field.select).not.toHaveBeenCalled();
+  });
+
+  it('does not select the text field content if the value is not zero', () => {
+    const component = mount(
+      <NumberField
+        label="test label"
+        name="test name"
+        size="medium"
+        className="stuff"
+        value="123"
+        onChange={jest.fn()}
+      />
+    );
+
+    const field = component.find('TextField').prop('fieldRef').current;
+
+    field.removeEventListener = jest.fn();
+    component.unmount();
+
+    expect(field.removeEventListener).toHaveBeenCalled();
+  });
+});

--- a/web/src/components/NumberField.test.js
+++ b/web/src/components/NumberField.test.js
@@ -1,6 +1,5 @@
 import { mount } from 'enzyme';
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 
 import NumberField from './NumberField';
 

--- a/web/src/components/__snapshots__/DollarField.test.js.snap
+++ b/web/src/components/__snapshots__/DollarField.test.js.snap
@@ -27,59 +27,81 @@ exports[`DollarField component passes back numeric values on change, but still r
   size="medium"
   value="12332"
 >
-  <TextField
+  <NumberField
     className="stuff"
     label="test label"
     mask="currency"
     name="test name"
     onChange={[Function]}
     size="medium"
-    type="text"
     value="123,456"
   >
-    <div
-      className="ds-u-clearfix stuff"
-    >
-      <FormLabel
-        component="label"
-        fieldId="textfield_3"
-      >
-        <label
-          className="ds-c-label"
-          htmlFor="textfield_3"
-        >
-          <span
-            className=""
-          >
-            test label
-          </span>
-        </label>
-      </FormLabel>
-      <div
-        className="ds-c-field-mask ds-c-field-mask--currency"
-      >
-        <div
-          className="ds-c-field__before ds-c-field__before--currency"
-        >
-          $
-        </div>
-        <Mask
-          mask="currency"
-        >
-          <input
+    <TextField
+      className="stuff"
+      fieldRef={
+        Object {
+          "current": <input
             aria-label="test label. Enter amount in dollars."
-            className="ds-c-field ds-c-field--currency ds-c-field--medium"
+            class="ds-c-field ds-c-field--currency ds-c-field--medium"
             id="textfield_3"
             name="test name"
-            onBlur={[Function]}
-            onChange={[Function]}
             type="text"
             value="123,456"
-          />
-        </Mask>
+          />,
+        }
+      }
+      label="test label"
+      mask="currency"
+      name="test name"
+      onChange={[Function]}
+      size="medium"
+      type="text"
+      value="123,456"
+    >
+      <div
+        className="ds-u-clearfix stuff"
+      >
+        <FormLabel
+          component="label"
+          fieldId="textfield_3"
+        >
+          <label
+            className="ds-c-label"
+            htmlFor="textfield_3"
+          >
+            <span
+              className=""
+            >
+              test label
+            </span>
+          </label>
+        </FormLabel>
+        <div
+          className="ds-c-field-mask ds-c-field-mask--currency"
+        >
+          <div
+            className="ds-c-field__before ds-c-field__before--currency"
+          >
+            $
+          </div>
+          <Mask
+            mask="currency"
+          >
+            <input
+              aria-label="test label. Enter amount in dollars."
+              className="ds-c-field ds-c-field--currency ds-c-field--medium"
+              id="textfield_3"
+              name="test name"
+              onBlur={[Function]}
+              onChange={[Function]}
+              type="text"
+              value="123,456"
+            />
+          </Mask>
+        </div>
       </div>
-    </div>
-  </TextField>
+    </TextField>
+  </NumberField>
 </DollarField>
 `;
 
@@ -92,59 +114,81 @@ exports[`DollarField component renders correctly, adds commas to big numbers, pa
   size="medium"
   value="123321"
 >
-  <TextField
+  <NumberField
     className="stuff"
     label="test label"
     mask="currency"
     name="test name"
     onChange={[Function]}
     size="medium"
-    type="text"
     value="123,321"
   >
-    <div
-      className="ds-u-clearfix stuff"
-    >
-      <FormLabel
-        component="label"
-        fieldId="textfield_2"
-      >
-        <label
-          className="ds-c-label"
-          htmlFor="textfield_2"
-        >
-          <span
-            className=""
-          >
-            test label
-          </span>
-        </label>
-      </FormLabel>
-      <div
-        className="ds-c-field-mask ds-c-field-mask--currency"
-      >
-        <div
-          className="ds-c-field__before ds-c-field__before--currency"
-        >
-          $
-        </div>
-        <Mask
-          mask="currency"
-        >
-          <input
+    <TextField
+      className="stuff"
+      fieldRef={
+        Object {
+          "current": <input
             aria-label="test label. Enter amount in dollars."
-            className="ds-c-field ds-c-field--currency ds-c-field--medium"
+            class="ds-c-field ds-c-field--currency ds-c-field--medium"
             id="textfield_2"
             name="test name"
-            onBlur={[Function]}
-            onChange={[Function]}
             type="text"
             value="123,321"
-          />
-        </Mask>
+          />,
+        }
+      }
+      label="test label"
+      mask="currency"
+      name="test name"
+      onChange={[Function]}
+      size="medium"
+      type="text"
+      value="123,321"
+    >
+      <div
+        className="ds-u-clearfix stuff"
+      >
+        <FormLabel
+          component="label"
+          fieldId="textfield_2"
+        >
+          <label
+            className="ds-c-label"
+            htmlFor="textfield_2"
+          >
+            <span
+              className=""
+            >
+              test label
+            </span>
+          </label>
+        </FormLabel>
+        <div
+          className="ds-c-field-mask ds-c-field-mask--currency"
+        >
+          <div
+            className="ds-c-field__before ds-c-field__before--currency"
+          >
+            $
+          </div>
+          <Mask
+            mask="currency"
+          >
+            <input
+              aria-label="test label. Enter amount in dollars."
+              className="ds-c-field ds-c-field--currency ds-c-field--medium"
+              id="textfield_2"
+              name="test name"
+              onBlur={[Function]}
+              onChange={[Function]}
+              type="text"
+              value="123,321"
+            />
+          </Mask>
+        </div>
       </div>
-    </div>
-  </TextField>
+    </TextField>
+  </NumberField>
 </DollarField>
 `;
 
@@ -157,58 +201,80 @@ exports[`DollarField component renders correctly, does not add commas to small n
   size="medium"
   value="123"
 >
-  <TextField
+  <NumberField
     className="stuff"
     label="test label"
     mask="currency"
     name="test name"
     onChange={[Function]}
     size="medium"
-    type="text"
     value="123"
   >
-    <div
-      className="ds-u-clearfix stuff"
-    >
-      <FormLabel
-        component="label"
-        fieldId="textfield_1"
-      >
-        <label
-          className="ds-c-label"
-          htmlFor="textfield_1"
-        >
-          <span
-            className=""
-          >
-            test label
-          </span>
-        </label>
-      </FormLabel>
-      <div
-        className="ds-c-field-mask ds-c-field-mask--currency"
-      >
-        <div
-          className="ds-c-field__before ds-c-field__before--currency"
-        >
-          $
-        </div>
-        <Mask
-          mask="currency"
-        >
-          <input
+    <TextField
+      className="stuff"
+      fieldRef={
+        Object {
+          "current": <input
             aria-label="test label. Enter amount in dollars."
-            className="ds-c-field ds-c-field--currency ds-c-field--medium"
+            class="ds-c-field ds-c-field--currency ds-c-field--medium"
             id="textfield_1"
             name="test name"
-            onBlur={[Function]}
-            onChange={[Function]}
             type="text"
             value="123"
-          />
-        </Mask>
+          />,
+        }
+      }
+      label="test label"
+      mask="currency"
+      name="test name"
+      onChange={[Function]}
+      size="medium"
+      type="text"
+      value="123"
+    >
+      <div
+        className="ds-u-clearfix stuff"
+      >
+        <FormLabel
+          component="label"
+          fieldId="textfield_1"
+        >
+          <label
+            className="ds-c-label"
+            htmlFor="textfield_1"
+          >
+            <span
+              className=""
+            >
+              test label
+            </span>
+          </label>
+        </FormLabel>
+        <div
+          className="ds-c-field-mask ds-c-field-mask--currency"
+        >
+          <div
+            className="ds-c-field__before ds-c-field__before--currency"
+          >
+            $
+          </div>
+          <Mask
+            mask="currency"
+          >
+            <input
+              aria-label="test label. Enter amount in dollars."
+              className="ds-c-field ds-c-field--currency ds-c-field--medium"
+              id="textfield_1"
+              name="test name"
+              onBlur={[Function]}
+              onChange={[Function]}
+              type="text"
+              value="123"
+            />
+          </Mask>
+        </div>
       </div>
-    </div>
-  </TextField>
+    </TextField>
+  </NumberField>
 </DollarField>
 `;

--- a/web/src/components/__snapshots__/NumberField.test.js.snap
+++ b/web/src/components/__snapshots__/NumberField.test.js.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NumberField component renders correctly 1`] = `
+<NumberField
+  className="stuff"
+  label="test label"
+  name="test name"
+  onChange={[MockFunction]}
+  size="medium"
+  value="123"
+>
+  <TextField
+    className="stuff"
+    fieldRef={
+      Object {
+        "current": <input
+          class="ds-c-field ds-c-field--medium"
+          id="textfield_1"
+          name="test name"
+          type="text"
+          value="123"
+        />,
+      }
+    }
+    label="test label"
+    name="test name"
+    onChange={[MockFunction]}
+    size="medium"
+    type="text"
+    value="123"
+  >
+    <div
+      className="ds-u-clearfix stuff"
+    >
+      <FormLabel
+        component="label"
+        fieldId="textfield_1"
+      >
+        <label
+          className="ds-c-label"
+          htmlFor="textfield_1"
+        >
+          <span
+            className=""
+          >
+            test label
+          </span>
+        </label>
+      </FormLabel>
+      <input
+        className="ds-c-field ds-c-field--medium"
+        id="textfield_1"
+        name="test name"
+        onChange={[MockFunction]}
+        type="text"
+        value="123"
+      />
+    </div>
+  </TextField>
+</NumberField>
+`;

--- a/web/src/containers/ApdKeyPerson/ApdKeyPersonForm.js
+++ b/web/src/containers/ApdKeyPerson/ApdKeyPersonForm.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React, { Fragment, useCallback } from 'react';
 import { t } from '../../i18n';
 import DollarField from '../../components/DollarField';
+import NumberField from '../../components/NumberField';
 import Dollars from '../../components/Dollars';
 
 const tRoot = 'apd.stateProfile.keyPersonnel';
@@ -61,7 +62,7 @@ const PersonForm = ({
         value={position}
         onChange={getOnChangeHandler('position')}
       />
-      <TextField
+      <NumberField
         name={`apd-state-profile-pocpercentTime${index}`}
         label={t(`${tRoot}.labels.percentTime`)}
         value={percentTime || 0}

--- a/web/src/containers/ApdKeyPerson/__snapshots__/ApdKeyPersonForm.test.js.snap
+++ b/web/src/containers/ApdKeyPerson/__snapshots__/ApdKeyPersonForm.test.js.snap
@@ -30,12 +30,11 @@ exports[`the ApdKeyPersonForm component renders correctly 1`] = `
     type="text"
     value="The Builder"
   />
-  <TextField
+  <NumberField
     label="Percent commitment to program"
     name="apd-state-profile-pocpercentTime1"
     onChange={[Function]}
     size="small"
-    type="text"
     value="32"
   />
   <fieldset
@@ -146,12 +145,11 @@ exports[`the ApdKeyPersonForm component renders correctly if the person does not
     type="text"
     value="The Builder"
   />
-  <TextField
+  <NumberField
     label="Percent commitment to program"
     name="apd-state-profile-pocpercentTime1"
     onChange={[Function]}
     size="small"
-    type="text"
     value="32"
   />
   <fieldset

--- a/web/src/containers/IncentivePayments.js
+++ b/web/src/containers/IncentivePayments.js
@@ -1,4 +1,3 @@
-import { TextField } from '@cmsgov/design-system-core';
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -6,6 +5,7 @@ import { connect } from 'react-redux';
 import { updateApd as updateApdAction } from '../actions/apd';
 import DollarField from '../components/DollarField';
 import Dollars from '../components/Dollars';
+import NumberField from '../components/NumberField';
 import { t } from '../i18n';
 import {
   selectApdYears,
@@ -66,7 +66,7 @@ class IncentivePayments extends Component {
               <tbody>
                 {INCENTIVE_ENTRIES.map(({ id, name, type }) => {
                   const InputComponent =
-                    type === 'amount' ? DollarField : TextField;
+                    type === 'amount' ? DollarField : NumberField;
 
                   return (
                     <tr key={id}>

--- a/web/src/containers/__snapshots__/IncentivePayments.test.js.snap
+++ b/web/src/containers/__snapshots__/IncentivePayments.test.js.snap
@@ -138,56 +138,52 @@ exports[`incentive payments component renders correctly 1`] = `
         <td
           key="1"
         >
-          <TextField
+          <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
             label="ehCt payments for 1, quarter 1"
             labelClassName="sr-only"
             name="ehCt-payments-1-q1"
             onChange={[Function]}
-            type="text"
             value={10}
           />
         </td>
         <td
           key="2"
         >
-          <TextField
+          <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
             label="ehCt payments for 1, quarter 2"
             labelClassName="sr-only"
             name="ehCt-payments-1-q2"
             onChange={[Function]}
-            type="text"
             value={11}
           />
         </td>
         <td
           key="3"
         >
-          <TextField
+          <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
             label="ehCt payments for 1, quarter 3"
             labelClassName="sr-only"
             name="ehCt-payments-1-q3"
             onChange={[Function]}
-            type="text"
             value={12}
           />
         </td>
         <td
           key="4"
         >
-          <TextField
+          <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
             label="ehCt payments for 1, quarter 4"
             labelClassName="sr-only"
             name="ehCt-payments-1-q4"
             onChange={[Function]}
-            type="text"
             value=""
           />
         </td>
@@ -278,56 +274,52 @@ exports[`incentive payments component renders correctly 1`] = `
         <td
           key="1"
         >
-          <TextField
+          <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
             label="epCt payments for 1, quarter 1"
             labelClassName="sr-only"
             name="epCt-payments-1-q1"
             onChange={[Function]}
-            type="text"
             value={26}
           />
         </td>
         <td
           key="2"
         >
-          <TextField
+          <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
             label="epCt payments for 1, quarter 2"
             labelClassName="sr-only"
             name="epCt-payments-1-q2"
             onChange={[Function]}
-            type="text"
             value={27}
           />
         </td>
         <td
           key="3"
         >
-          <TextField
+          <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
             label="epCt payments for 1, quarter 3"
             labelClassName="sr-only"
             name="epCt-payments-1-q3"
             onChange={[Function]}
-            type="text"
             value={28}
           />
         </td>
         <td
           key="4"
         >
-          <TextField
+          <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
             label="epCt payments for 1, quarter 4"
             labelClassName="sr-only"
             name="epCt-payments-1-q4"
             onChange={[Function]}
-            type="text"
             value=""
           />
         </td>
@@ -475,56 +467,52 @@ exports[`incentive payments component renders correctly 1`] = `
         <td
           key="1"
         >
-          <TextField
+          <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
             label="ehCt payments for 2, quarter 1"
             labelClassName="sr-only"
             name="ehCt-payments-2-q1"
             onChange={[Function]}
-            type="text"
             value={14}
           />
         </td>
         <td
           key="2"
         >
-          <TextField
+          <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
             label="ehCt payments for 2, quarter 2"
             labelClassName="sr-only"
             name="ehCt-payments-2-q2"
             onChange={[Function]}
-            type="text"
             value={15}
           />
         </td>
         <td
           key="3"
         >
-          <TextField
+          <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
             label="ehCt payments for 2, quarter 3"
             labelClassName="sr-only"
             name="ehCt-payments-2-q3"
             onChange={[Function]}
-            type="text"
             value={16}
           />
         </td>
         <td
           key="4"
         >
-          <TextField
+          <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
             label="ehCt payments for 2, quarter 4"
             labelClassName="sr-only"
             name="ehCt-payments-2-q4"
             onChange={[Function]}
-            type="text"
             value=""
           />
         </td>
@@ -615,56 +603,52 @@ exports[`incentive payments component renders correctly 1`] = `
         <td
           key="1"
         >
-          <TextField
+          <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
             label="epCt payments for 2, quarter 1"
             labelClassName="sr-only"
             name="epCt-payments-2-q1"
             onChange={[Function]}
-            type="text"
             value={30}
           />
         </td>
         <td
           key="2"
         >
-          <TextField
+          <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
             label="epCt payments for 2, quarter 2"
             labelClassName="sr-only"
             name="epCt-payments-2-q2"
             onChange={[Function]}
-            type="text"
             value={31}
           />
         </td>
         <td
           key="3"
         >
-          <TextField
+          <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
             label="epCt payments for 2, quarter 3"
             labelClassName="sr-only"
             name="epCt-payments-2-q3"
             onChange={[Function]}
-            type="text"
             value={32}
           />
         </td>
         <td
           key="4"
         >
-          <TextField
+          <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
             label="epCt payments for 2, quarter 4"
             labelClassName="sr-only"
             name="epCt-payments-2-q4"
             onChange={[Function]}
-            type="text"
             value=""
           />
         </td>

--- a/web/src/containers/activity/ContractorResource/ContractorResourceForm.js
+++ b/web/src/containers/activity/ContractorResource/ContractorResourceForm.js
@@ -5,6 +5,7 @@ import React, { Fragment, useCallback, useMemo } from 'react';
 import DateField from '../../../components/DateField';
 import DollarField from '../../../components/DollarField';
 import Dollars from '../../../components/Dollars';
+import NumberField from '../../../components/NumberField';
 
 const ContractorResourceForm = ({
   index,
@@ -121,7 +122,7 @@ const ContractorResourceForm = ({
                 <Fragment key={ffy}>
                   <FormLabel>FFY {ffy}</FormLabel>
                   <div className="ds-l-row ds-u-padding-left--2">
-                    <TextField
+                    <NumberField
                       label="Number of hours"
                       name={`contractor-num-hours-ffy-${ffy}`}
                       labelClassName="ds-u-margin-top--1"

--- a/web/src/containers/activity/ContractorResource/__snapshots__/ContractorResourceForm.test.js.snap
+++ b/web/src/containers/activity/ContractorResource/__snapshots__/ContractorResourceForm.test.js.snap
@@ -77,7 +77,7 @@ exports[`the ContractorResourceForm component renders correctly 1`] = `
             <div
               className="ds-l-row ds-u-padding-left--2"
             >
-              <TextField
+              <NumberField
                 label="Number of hours"
                 labelClassName="ds-u-margin-top--1"
                 name="contractor-num-hours-ffy-1066"
@@ -106,7 +106,7 @@ exports[`the ContractorResourceForm component renders correctly 1`] = `
             <div
               className="ds-l-row ds-u-padding-left--2"
             >
-              <TextField
+              <NumberField
                 label="Number of hours"
                 labelClassName="ds-u-margin-top--1"
                 name="contractor-num-hours-ffy-1067"
@@ -233,7 +233,7 @@ exports[`the ContractorResourceForm component renders if use hourly data is sele
             <div
               className="ds-l-row ds-u-padding-left--2"
             >
-              <TextField
+              <NumberField
                 label="Number of hours"
                 labelClassName="ds-u-margin-top--1"
                 name="contractor-num-hours-ffy-1066"
@@ -262,7 +262,7 @@ exports[`the ContractorResourceForm component renders if use hourly data is sele
             <div
               className="ds-l-row ds-u-padding-left--2"
             >
-              <TextField
+              <NumberField
                 label="Number of hours"
                 labelClassName="ds-u-margin-top--1"
                 name="contractor-num-hours-ffy-1067"

--- a/web/src/containers/activity/CostAllocateFFP.js
+++ b/web/src/containers/activity/CostAllocateFFP.js
@@ -1,4 +1,3 @@
-
 import { TextField, ChoiceList } from '@cmsgov/design-system-core';
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
@@ -6,6 +5,7 @@ import { connect } from 'react-redux';
 
 import CostAllocateFFPQuarterly from './CostAllocateFFPQuarterly';
 import { updateActivity as updateActivityAction } from '../../actions/activities';
+import DollarField from '../../components/DollarField';
 import Dollars from '../../components/Dollars';
 import { t } from '../../i18n';
 import { makeSelectCostAllocateFFP } from '../../reducers/activities.selectors';
@@ -14,7 +14,9 @@ class CostAllocateFFP extends Component {
   handleOther = year => e => {
     const { aKey, updateActivity } = this.props;
     const { value } = e.target;
-    const updates = { costAllocation: { [year]: { other: +value.replace(/[^\d]/g, '') } } };
+    const updates = {
+      costAllocation: { [year]: { other: +value.replace(/[^\d]/g, '') } }
+    };
 
     updateActivity(aKey, updates, true);
   };
@@ -41,16 +43,17 @@ class CostAllocateFFP extends Component {
               <p>
                 <Dollars long>{total}</Dollars>
               </p>
-              <TextField
+              <DollarField
                 label={t('activities.costAllocate.ffp.labels.other')}
-                labelClassName='ds-h5'
-                mask='currency'
+                labelClassName="ds-h5"
                 name={`cost-allocate-other-${year}`}
                 value={costAllocation[year].other || '0'}
                 onChange={this.handleOther(year)}
               />
 
-              <p className="ds-h4 ds-u-display--block">{t('activities.costAllocate.ffp.medicaidShare')}</p>
+              <p className="ds-h4 ds-u-display--block">
+                {t('activities.costAllocate.ffp.medicaidShare')}
+              </p>
               <p>
                 <Dollars long>{medicaidShare}</Dollars>
               </p>
@@ -58,10 +61,8 @@ class CostAllocateFFP extends Component {
               <ChoiceList
                 name={`ffp-${year}`}
                 type="select"
-                label={t(
-                  'activities.costAllocate.ffp.labels.fedStateSplit'
-                )}
-                labelClassName='ds-h5'
+                label={t('activities.costAllocate.ffp.labels.fedStateSplit')}
+                labelClassName="ds-h5"
                 choices={[
                   { label: '90-10', value: '90-10' },
                   { label: '75-25', value: '75-25' },
@@ -71,16 +72,20 @@ class CostAllocateFFP extends Component {
                 onChange={this.handleFFP(year)}
               />
               <div className="ds-u-margin-top--2 ds-u-border-left--2 ds-u-padding-left--2">
-                <p className="ds-u-margin-bottom--0"><strong>Federal</strong></p>
+                <p className="ds-u-margin-bottom--0">
+                  <strong>Federal</strong>
+                </p>
                 <p>
                   <Dollars long>{allocations.federal}</Dollars>
                 </p>
-                <p className="ds-u-margin-bottom--0"><strong>State</strong></p>
+                <p className="ds-u-margin-bottom--0">
+                  <strong>State</strong>
+                </p>
                 <p>
                   <Dollars long>{allocations.state}</Dollars>
                 </p>
               </div>
-              <CostAllocateFFPQuarterly aKey={aKey} year={year}/>
+              <CostAllocateFFPQuarterly aKey={aKey} year={year} />
               <hr />
             </div>
           )

--- a/web/src/containers/activity/CostAllocateFFP.js
+++ b/web/src/containers/activity/CostAllocateFFP.js
@@ -1,4 +1,4 @@
-import { TextField, ChoiceList } from '@cmsgov/design-system-core';
+import { ChoiceList } from '@cmsgov/design-system-core';
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';

--- a/web/src/containers/activity/CostAllocateFFP.test.js
+++ b/web/src/containers/activity/CostAllocateFFP.test.js
@@ -98,7 +98,7 @@ describe('the CostAllocateFFP component', () => {
   test('handles changes to other funding', () => {
     const component = shallow(<CostAllocateFFP {...props} />);
     component
-      .find('TextField')
+      .find('DollarField')
       .filterWhere(n => n.props().value === 10)
       .simulate('change', { target: { value: '150' } });
 

--- a/web/src/containers/activity/CostAllocateFFPQuarterly.js
+++ b/web/src/containers/activity/CostAllocateFFPQuarterly.js
@@ -1,4 +1,3 @@
-import { TextField } from '@cmsgov/design-system-core';
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -6,6 +5,7 @@ import { connect } from 'react-redux';
 import { updateActivity } from '../../actions/activities';
 import { ariaAnnounceFFPQuarterly } from '../../actions/aria';
 import Dollars from '../../components/Dollars';
+import NumberField from '../../components/NumberField';
 import { t } from '../../i18n';
 import { makeSelectCostAllocateFFPBudget } from '../../reducers/activities.selectors';
 import { formatPerc } from '../../util/formats';
@@ -83,7 +83,7 @@ class CostAllocateFFPQuarterly extends Component {
                     {QUARTERS.map(q => (
                       <td key={q}>
                         <div className="budget-table--input__percent">
-                          <TextField
+                          <NumberField
                             className="budget-table--input-holder"
                             fieldClassName="budget-table--input__number"
                             label={`federal share for ffy ${year}, quarter ${q}, ${name}`}
@@ -104,10 +104,7 @@ class CostAllocateFFPQuarterly extends Component {
                 <tr>
                   <Fragment key={year}>
                     {QUARTERS.map(q => (
-                      <td
-                        className="budget-table--number"
-                        key={q}
-                      >
+                      <td className="budget-table--number" key={q}>
                         <Dollars>{quarterlyFFP[year][q][name].dollars}</Dollars>
                       </td>
                     ))}
@@ -173,12 +170,13 @@ CostAllocateFFPQuarterly.propTypes = {
   years: PropTypes.array.isRequired,
   year: PropTypes.string.isRequired,
   update: PropTypes.func.isRequired,
-  announce: PropTypes.func.isRequired,
+  announce: PropTypes.func.isRequired
 };
 
 const makeMapStateToProps = () => {
   const selectCostAllocateFFPBudget = makeSelectCostAllocateFFPBudget();
-  const mapStateToProps = (state, props) => selectCostAllocateFFPBudget(state, props);
+  const mapStateToProps = (state, props) =>
+    selectCostAllocateFFPBudget(state, props);
   return mapStateToProps;
 };
 

--- a/web/src/containers/activity/StatePerson/StatePersonForm.js
+++ b/web/src/containers/activity/StatePerson/StatePersonForm.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React, { Fragment, useCallback } from 'react';
 
 import DollarField from '../../../components/DollarField';
+import NumberField from '../../../components/NumberField';
 
 const StatePersonForm = ({
   item: { desc, title, years },
@@ -61,7 +62,7 @@ const StatePersonForm = ({
               value={amt}
               onChange={getEditCostForYear(year)}
             />
-            <TextField
+            <NumberField
               label="Number of FTEs"
               name="ftes"
               size="medium"

--- a/web/src/containers/activity/StatePerson/StatePersonForm.test.js
+++ b/web/src/containers/activity/StatePerson/StatePersonForm.test.js
@@ -65,7 +65,7 @@ describe('the StatePersonForm component', () => {
 
     test('handles changing the personnel FTE for a year', () => {
       component
-        .findWhere(c => c.name() === 'TextField' && c.prop('name') === 'ftes')
+        .findWhere(c => c.name() === 'NumberField' && c.prop('name') === 'ftes')
         .first()
         .simulate('change', { target: { value: 'new ftes' } });
       expect(handleEditFTE).toHaveBeenCalledWith(83, '7473', 'new ftes');

--- a/web/src/containers/activity/StatePerson/__snapshots__/StatePersonForm.test.js.snap
+++ b/web/src/containers/activity/StatePerson/__snapshots__/StatePersonForm.test.js.snap
@@ -42,7 +42,7 @@ exports[`the StatePersonForm component renders correctly 1`] = `
       size="medium"
       value=""
     />
-    <TextField
+    <NumberField
       label="Number of FTEs"
       name="ftes"
       onChange={[Function]}
@@ -66,7 +66,7 @@ exports[`the StatePersonForm component renders correctly 1`] = `
       size="medium"
       value=""
     />
-    <TextField
+    <NumberField
       label="Number of FTEs"
       name="ftes"
       onChange={[Function]}

--- a/web/src/containers/activity/__snapshots__/CostAllocateFFP.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/CostAllocateFFP.test.js.snap
@@ -24,13 +24,11 @@ exports[`the CostAllocateFFP component renders correctly 1`] = `
         300
       </Dollars>
     </p>
-    <TextField
+    <DollarField
       label="Other Funding Amount"
       labelClassName="ds-h5"
-      mask="currency"
       name="cost-allocate-other-1066"
       onChange={[Function]}
-      type="text"
       value={10}
     />
     <p
@@ -124,13 +122,11 @@ exports[`the CostAllocateFFP component renders correctly 1`] = `
         3000
       </Dollars>
     </p>
-    <TextField
+    <DollarField
       label="Other Funding Amount"
       labelClassName="ds-h5"
-      mask="currency"
       name="cost-allocate-other-1067"
       onChange={[Function]}
-      type="text"
       value="0"
     />
     <p


### PR DESCRIPTION
Number fields whose current value is zero will have their contents selected when the form field is focused. That way when a user clicks in that field, they can just begin typing and overwrite the zero that's already there.

### This pull request changes...

- added `NumberField` component
- updated `DollarField` to be a `NumberField`
- updated APD key personnel, incentive payments, state personnel, contractor resources, and cost allocation forms to use the `NumberField` component
- updated cost allocation form to use `DollarField` component for "other funding" (see #1754); incidental - in order to fix #1736 across the app, #1754 needed to be fixed too... so I went ahead and did it
- closes #1736
- closes #1754 

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [x] Changelog is updated as appropriate

### This feature is done when...

- [ ] Design has approved the experience
- [ ] Product has approved the experience
