### PR TITLE
Make a copy of the Choice component to remove the aria-live attribute

### DIFF
--- a/web/src/components/Choice.js
+++ b/web/src/components/Choice.js
@@ -1,0 +1,25 @@
+import { Choice } from '@cmsgov/design-system-core';
+import PropTypes from 'prop-types';
+import React, { useEffect, useRef } from 'react';
+
+const ChoiceComponent = props => {
+  const ref = useRef(null);
+
+  useEffect(() => {
+    const ariaRegion = ref.current.querySelector('[aria-live]');
+
+    if (ariaRegion) {
+      ariaRegion.removeAttribute('aria-live');
+      ariaRegion.removeAttribute('aria-relevant');
+      ariaRegion.removeAttribute('aria-atomic');
+    }
+  }, [])
+
+  return (
+    <div ref={ref}>
+      <Choice {...props} />
+    </div>
+    )
+ };
+
+ export default ChoiceComponent;

--- a/web/src/components/Choice.js
+++ b/web/src/components/Choice.js
@@ -1,5 +1,4 @@
 import { Choice } from '@cmsgov/design-system-core';
-import PropTypes from 'prop-types';
 import React, { useEffect, useRef } from 'react';
 
 const ChoiceComponent = props => {

--- a/web/src/components/Choice.test.js
+++ b/web/src/components/Choice.test.js
@@ -1,0 +1,84 @@
+import { mount, shallow } from 'enzyme';
+import React from 'react';
+
+import Choice from '../components/Choice';
+
+
+
+describe('Choice wrapper component', () => {
+  it('renders correctly without checkedChildren', () =>{
+    const component = shallow(
+      <Choice
+        type="radio"
+        value="radio-no-children"
+        name="radio-no-children"
+        size="small"
+      >
+        I have no checkedChildren
+      </Choice>
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
+  it('renders correctly with checkedChildren when unchecked', () => {
+    const component = shallow(
+      <Choice
+        type="radio"
+        value="radio-with-children"
+        name="radio-with-children"
+        size="small"
+        checkedChildren={
+          <div className="ds-c-choice__checkedChild">
+            <p>I am the child element</p>
+          </div>
+        }
+      >
+        I have checkedChildren
+      </Choice>
+    );
+    expect(component).toMatchSnapshot();
+  });
+
+  it('renders correctly with checkedChildren when checked', () => {
+    const component = shallow(
+      <Choice
+        type="radio"
+        value="radio-with-children"
+        name="radio-with-children"
+        size="small"
+        checked
+        checkedChildren={
+          <div className="ds-c-choice__checkedChild">
+            <p>I am the child element</p>
+          </div>
+        }
+      >
+        I have checkedChildren
+      </Choice>
+    );
+    expect(component).toMatchSnapshot();
+  });
+
+  it('removes ARIA components from checkedChildren', () => {
+    const component = mount(
+      <Choice
+        type="radio"
+        value="radio-with-children"
+        name="radio-with-children"
+        size="small"
+        checked
+        checkedChildren={
+          <div className="ds-c-choice__checkedChild">
+            <p>I am the child element</p>
+          </div>
+        }
+      >
+        I have checkedChildren
+      </Choice>
+    );
+   
+    const child = component.find('.ds-c-choice__checkedChild').render();
+    expect(child[0].attribs['aria-live']).toBeFalsy();
+  });
+});

--- a/web/src/components/Choice.test.js
+++ b/web/src/components/Choice.test.js
@@ -1,9 +1,7 @@
 import { mount, shallow } from 'enzyme';
 import React from 'react';
 
-import Choice from '../components/Choice';
-
-
+import Choice from './Choice';
 
 describe('Choice wrapper component', () => {
   it('renders correctly without checkedChildren', () =>{

--- a/web/src/components/PasswordWithMeter.js
+++ b/web/src/components/PasswordWithMeter.js
@@ -1,7 +1,8 @@
-import { Choice, TextField } from '@cmsgov/design-system-core';
+import { TextField } from '@cmsgov/design-system-core';
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import zxcvbn from '../lazy/zxcvbn';
+import Choice from './Choice';
 
 class Password extends Component {
   state = { showPassword: false, strength: 0 };

--- a/web/src/components/PasswordWithMeter.test.js
+++ b/web/src/components/PasswordWithMeter.test.js
@@ -36,7 +36,7 @@ describe('PasswordWithmeter component', () => {
 
   it('shows the password', () => {
     const component = shallow(<Password value="abcd1234" />);
-    component.find('Choice').simulate('change');
+    component.find('ChoiceComponent').simulate('change');
 
     expect(component).toMatchSnapshot();
   });

--- a/web/src/components/__snapshots__/Choice.test.js.snap
+++ b/web/src/components/__snapshots__/Choice.test.js.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Choice wrapper component renders correctly with checkedChildren when checked 1`] = `
+<div>
+  <Choice
+    checked={true}
+    checkedChildren={
+      <div
+        className="ds-c-choice__checkedChild"
+      >
+        <p>
+          I am the child element
+        </p>
+      </div>
+    }
+    inputPlacement="left"
+    name="radio-with-children"
+    size="small"
+    type="radio"
+    value="radio-with-children"
+  >
+    I have checkedChildren
+  </Choice>
+</div>
+`;
+
+exports[`Choice wrapper component renders correctly with checkedChildren when unchecked 1`] = `
+<div>
+  <Choice
+    checkedChildren={
+      <div
+        className="ds-c-choice__checkedChild"
+      >
+        <p>
+          I am the child element
+        </p>
+      </div>
+    }
+    inputPlacement="left"
+    name="radio-with-children"
+    size="small"
+    type="radio"
+    value="radio-with-children"
+  >
+    I have checkedChildren
+  </Choice>
+</div>
+`;
+
+exports[`Choice wrapper component renders correctly without checkedChildren 1`] = `
+<div>
+  <Choice
+    inputPlacement="left"
+    name="radio-no-children"
+    size="small"
+    type="radio"
+    value="radio-no-children"
+  >
+    I have no checkedChildren
+  </Choice>
+</div>
+`;

--- a/web/src/components/__snapshots__/PasswordWithMeter.test.js.snap
+++ b/web/src/components/__snapshots__/PasswordWithMeter.test.js.snap
@@ -7,18 +7,16 @@ exports[`PasswordWithmeter component renders with no props 1`] = `
   <div
     className="password-input"
   >
-    <Choice
+    <ChoiceComponent
       checked={false}
       className="password-input--show-password ds-u-float--right"
-      inputPlacement="left"
       name="show password"
       onChange={[Function]}
       size="small"
-      type="checkbox"
       value="Show password"
     >
       Show password
-    </Choice>
+    </ChoiceComponent>
     <TextField
       className="no-clearfix"
       hint={false}
@@ -39,18 +37,16 @@ exports[`PasswordWithmeter component renders with various passwords 1`] = `
   <div
     className="password-input"
   >
-    <Choice
+    <ChoiceComponent
       checked={false}
       className="password-input--show-password ds-u-float--right"
-      inputPlacement="left"
       name="show password"
       onChange={[Function]}
       size="small"
-      type="checkbox"
       value="Show password"
     >
       Show password
-    </Choice>
+    </ChoiceComponent>
     <TextField
       className="no-clearfix"
       hint="A strong password is at least 9 characters, not a commonly-used word or phrase, and not too similar to the person’s name or email address."
@@ -86,18 +82,16 @@ exports[`PasswordWithmeter component renders with various passwords 2`] = `
   <div
     className="password-input"
   >
-    <Choice
+    <ChoiceComponent
       checked={false}
       className="password-input--show-password ds-u-float--right"
-      inputPlacement="left"
       name="show password"
       onChange={[Function]}
       size="small"
-      type="checkbox"
       value="Show password"
     >
       Show password
-    </Choice>
+    </ChoiceComponent>
     <TextField
       className="no-clearfix"
       hint="A strong password is at least 9 characters, not a commonly-used word or phrase, and not too similar to the person’s name or email address."
@@ -133,18 +127,16 @@ exports[`PasswordWithmeter component renders with various passwords 3`] = `
   <div
     className="password-input"
   >
-    <Choice
+    <ChoiceComponent
       checked={false}
       className="password-input--show-password ds-u-float--right"
-      inputPlacement="left"
       name="show password"
       onChange={[Function]}
       size="small"
-      type="checkbox"
       value="Show password"
     >
       Show password
-    </Choice>
+    </ChoiceComponent>
     <TextField
       className="no-clearfix"
       hint="A strong password is at least 9 characters, not a commonly-used word or phrase, and not too similar to the person’s name or email address."
@@ -180,18 +172,16 @@ exports[`PasswordWithmeter component renders with various passwords 4`] = `
   <div
     className="password-input"
   >
-    <Choice
+    <ChoiceComponent
       checked={false}
       className="password-input--show-password ds-u-float--right"
-      inputPlacement="left"
       name="show password"
       onChange={[Function]}
       size="small"
-      type="checkbox"
       value="Show password"
     >
       Show password
-    </Choice>
+    </ChoiceComponent>
     <TextField
       className="no-clearfix"
       hint="A strong password is at least 9 characters, not a commonly-used word or phrase, and not too similar to the person’s name or email address."
@@ -227,18 +217,16 @@ exports[`PasswordWithmeter component renders with various passwords 5`] = `
   <div
     className="password-input"
   >
-    <Choice
+    <ChoiceComponent
       checked={false}
       className="password-input--show-password ds-u-float--right"
-      inputPlacement="left"
       name="show password"
       onChange={[Function]}
       size="small"
-      type="checkbox"
       value="Show password"
     >
       Show password
-    </Choice>
+    </ChoiceComponent>
     <TextField
       className="no-clearfix"
       hint="A strong password is at least 9 characters, not a commonly-used word or phrase, and not too similar to the person’s name or email address."
@@ -274,18 +262,16 @@ exports[`PasswordWithmeter component shows the password 1`] = `
   <div
     className="password-input"
   >
-    <Choice
+    <ChoiceComponent
       checked={true}
       className="password-input--show-password ds-u-float--right"
-      inputPlacement="left"
       name="show password"
       onChange={[Function]}
       size="small"
-      type="checkbox"
       value="Show password"
     >
       Show password
-    </Choice>
+    </ChoiceComponent>
     <TextField
       className="no-clearfix"
       hint={false}

--- a/web/src/containers/ApdKeyPerson/ApdKeyPersonForm.js
+++ b/web/src/containers/ApdKeyPerson/ApdKeyPersonForm.js
@@ -1,7 +1,8 @@
-import { Choice, FormLabel, TextField } from '@cmsgov/design-system-core';
+import { FormLabel, TextField } from '@cmsgov/design-system-core';
 import PropTypes from 'prop-types';
 import React, { Fragment, useCallback } from 'react';
 import { t } from '../../i18n';
+import Choice from '../../components/Choice';
 import DollarField from '../../components/DollarField';
 import Dollars from '../../components/Dollars';
 

--- a/web/src/containers/ApdKeyPerson/ApdKeyPersonForm.test.js
+++ b/web/src/containers/ApdKeyPerson/ApdKeyPersonForm.test.js
@@ -68,7 +68,7 @@ describe('the ApdKeyPersonForm component', () => {
 
     it('handles toggling hasCosts off', () => {
       component
-        .findWhere(c => c.name() === 'Choice' && c.prop('value') === 'no')
+        .findWhere(c => c.name() === 'ChoiceComponent' && c.prop('value') === 'no')
         .simulate('change');
       expect(props.handleChange).toHaveBeenCalledWith(
         1,
@@ -80,7 +80,7 @@ describe('the ApdKeyPersonForm component', () => {
 
     it('handles toggling hasCosts on', () => {
       component
-        .findWhere(c => c.name() === 'Choice' && c.prop('value') === 'yes')
+        .findWhere(c => c.name() === 'ChoiceComponent' && c.prop('value') === 'yes')
         .simulate('change');
       expect(props.handleChange).toHaveBeenCalledWith(
         1,
@@ -93,7 +93,7 @@ describe('the ApdKeyPersonForm component', () => {
     it('handles changing cost for FFY', () => {
       const hasCostsForm = shallow(
         component
-          .findWhere(c => c.name() === 'Choice' && c.prop('value') === 'yes')
+          .findWhere(c => c.name() === 'ChoiceComponent' && c.prop('value') === 'yes')
           .prop('checkedChildren')
       );
 

--- a/web/src/containers/ApdKeyPerson/__snapshots__/ApdKeyPersonForm.test.js.snap
+++ b/web/src/containers/ApdKeyPerson/__snapshots__/ApdKeyPersonForm.test.js.snap
@@ -46,17 +46,16 @@ exports[`the ApdKeyPersonForm component renders correctly 1`] = `
     >
       Does this person have costs directly attributable to this program?
     </legend>
-    <Choice
+    <ChoiceComponent
       checked={false}
-      inputPlacement="left"
       name="apd-state-profile-hascosts-no1"
       onChange={[Function]}
       type="radio"
       value="no"
     >
       No
-    </Choice>
-    <Choice
+    </ChoiceComponent>
+    <ChoiceComponent
       checked={true}
       checkedChildren={
         <div
@@ -104,14 +103,13 @@ exports[`the ApdKeyPersonForm component renders correctly 1`] = `
           </div>
         </div>
       }
-      inputPlacement="left"
       name="apd-state-profile-hascosts-yes1"
       onChange={[Function]}
       type="radio"
       value="yes"
     >
       Yes
-    </Choice>
+    </ChoiceComponent>
   </fieldset>
 </Fragment>
 `;
@@ -162,17 +160,16 @@ exports[`the ApdKeyPersonForm component renders correctly if the person does not
     >
       Does this person have costs directly attributable to this program?
     </legend>
-    <Choice
+    <ChoiceComponent
       checked={true}
-      inputPlacement="left"
       name="apd-state-profile-hascosts-no1"
       onChange={[Function]}
       type="radio"
       value="no"
     >
       No
-    </Choice>
-    <Choice
+    </ChoiceComponent>
+    <ChoiceComponent
       checked={false}
       checkedChildren={
         <div
@@ -220,14 +217,13 @@ exports[`the ApdKeyPersonForm component renders correctly if the person does not
           </div>
         </div>
       }
-      inputPlacement="left"
       name="apd-state-profile-hascosts-yes1"
       onChange={[Function]}
       type="radio"
       value="yes"
     >
       Yes
-    </Choice>
+    </ChoiceComponent>
   </fieldset>
 </Fragment>
 `;

--- a/web/src/containers/ApdSummary.js
+++ b/web/src/containers/ApdSummary.js
@@ -1,10 +1,10 @@
-import { Choice } from '@cmsgov/design-system-core';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import Waypoint from './ConnectedWaypoint';
 import { updateApd as updateApdAction } from '../actions/apd';
+import Choice from '../components/Choice';
 import RichText from '../components/RichText';
 import Instruction from '../components/Instruction';
 import { Section } from '../components/Section';

--- a/web/src/containers/ApdSummary.test.js
+++ b/web/src/containers/ApdSummary.test.js
@@ -45,13 +45,13 @@ describe('apd summary component', () => {
   test('dispatches on a year change', () => {
     // add a year
     shallow(<ApdSummary {...props} />)
-      .find('Choice[value="3"]')
+      .find('ChoiceComponent[value="3"]')
       .simulate('change', { target: { value: '3' } });
     expect(props.updateApd.calledWith({ years: ['1', '2', '3'] }));
 
     // remove a year
     shallow(<ApdSummary {...props} />)
-      .find('Choice[value="2"]')
+      .find('ChoiceComponent[value="2"]')
       .simulate('change', { target: { value: '2' } });
     expect(props.updateApd.calledWith({ years: ['1'] }));
   });

--- a/web/src/containers/AssurancesAndCompliance.js
+++ b/web/src/containers/AssurancesAndCompliance.js
@@ -1,10 +1,11 @@
-import { Choice, TextField } from '@cmsgov/design-system-core';
+import { TextField } from '@cmsgov/design-system-core';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import Waypoint from './ConnectedWaypoint';
 import { updateApd as updateApdAction } from '../actions/apd';
+import Choice from '../components/Choice';
 import { Section, Subsection } from '../components/Section';
 import regLinks from '../data/assurancesAndCompliance.yaml';
 import { t } from '../i18n';

--- a/web/src/containers/AssurancesAndCompliance.test.js
+++ b/web/src/containers/AssurancesAndCompliance.test.js
@@ -71,8 +71,10 @@ describe('assurances and compliance component', () => {
       const component = shallow(<AssurancesAndCompliance {...props} />);
 
       component
-        .find('Choice')
+        .find('ChoiceComponent')
         .at(1) // choice 0 is yes, choice 1 is no
+        .dive()
+        .find('Choice')
         .dive()
         .find('TextField')
         .simulate('change', { target: { value: 'new text' } });

--- a/web/src/containers/__snapshots__/ApdSummary.test.js.snap
+++ b/web/src/containers/__snapshots__/ApdSummary.test.js.snap
@@ -25,9 +25,8 @@ exports[`apd summary component renders correctly 1`] = `
       reverse={false}
       source="apd.overview.instruction"
     />
-    <Choice
+    <ChoiceComponent
       checked={true}
-      inputPlacement="left"
       key="1"
       name="apd year 1"
       onChange={[Function]}
@@ -35,10 +34,9 @@ exports[`apd summary component renders correctly 1`] = `
       value="1"
     >
       1
-    </Choice>
-    <Choice
+    </ChoiceComponent>
+    <ChoiceComponent
       checked={true}
-      inputPlacement="left"
       key="2"
       name="apd year 2"
       onChange={[Function]}
@@ -46,10 +44,9 @@ exports[`apd summary component renders correctly 1`] = `
       value="2"
     >
       2
-    </Choice>
-    <Choice
+    </ChoiceComponent>
+    <ChoiceComponent
       checked={false}
-      inputPlacement="left"
       key="3"
       name="apd year 3"
       onChange={[Function]}
@@ -57,7 +54,7 @@ exports[`apd summary component renders correctly 1`] = `
       value="3"
     >
       3
-    </Choice>
+    </ChoiceComponent>
     <div
       className="ds-u-margin-y--3"
     >

--- a/web/src/containers/__snapshots__/AssurancesAndCompliance.test.js.snap
+++ b/web/src/containers/__snapshots__/AssurancesAndCompliance.test.js.snap
@@ -52,9 +52,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             </strong>
             ?
           </legend>
-          <Choice
+          <ChoiceComponent
             checked={false}
-            inputPlacement="left"
             name="apd-assurances-yes-explanation-procurement-42_CFR_Part_495.348"
             onChange={[Function]}
             size="small"
@@ -62,8 +61,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="yes"
           >
             Yes
-          </Choice>
-          <Choice
+          </ChoiceComponent>
+          <ChoiceComponent
             checked={true}
             checkedChildren={
               <div
@@ -80,7 +79,6 @@ exports[`assurances and compliance component main component renders correctly 1`
                 />
               </div>
             }
-            inputPlacement="left"
             name="apd-assurances-no-explanation-procurement-42_CFR_Part_495.348"
             onChange={[Function]}
             size="small"
@@ -88,7 +86,7 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="no"
           >
             No
-          </Choice>
+          </ChoiceComponent>
         </fieldset>
         <fieldset
           className="ds-u-margin-top--2"
@@ -107,9 +105,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             </strong>
             ?
           </legend>
-          <Choice
+          <ChoiceComponent
             checked={true}
-            inputPlacement="left"
             name="apd-assurances-yes-explanation-procurement-SMM_Section_11267"
             onChange={[Function]}
             size="small"
@@ -117,8 +114,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="yes"
           >
             Yes
-          </Choice>
-          <Choice
+          </ChoiceComponent>
+          <ChoiceComponent
             checked={false}
             checkedChildren={
               <div
@@ -135,7 +132,6 @@ exports[`assurances and compliance component main component renders correctly 1`
                 />
               </div>
             }
-            inputPlacement="left"
             name="apd-assurances-no-explanation-procurement-SMM_Section_11267"
             onChange={[Function]}
             size="small"
@@ -143,7 +139,7 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="no"
           >
             No
-          </Choice>
+          </ChoiceComponent>
         </fieldset>
         <fieldset
           className="ds-u-margin-top--2"
@@ -162,9 +158,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             </strong>
             ?
           </legend>
-          <Choice
+          <ChoiceComponent
             checked={false}
-            inputPlacement="left"
             name="apd-assurances-yes-explanation-procurement-45_CFR_Part_95.615"
             onChange={[Function]}
             size="small"
@@ -172,8 +167,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="yes"
           >
             Yes
-          </Choice>
-          <Choice
+          </ChoiceComponent>
+          <ChoiceComponent
             checked={false}
             checkedChildren={
               <div
@@ -190,7 +185,6 @@ exports[`assurances and compliance component main component renders correctly 1`
                 />
               </div>
             }
-            inputPlacement="left"
             name="apd-assurances-no-explanation-procurement-45_CFR_Part_95.615"
             onChange={[Function]}
             size="small"
@@ -198,7 +192,7 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="no"
           >
             No
-          </Choice>
+          </ChoiceComponent>
         </fieldset>
         <fieldset
           className="ds-u-margin-top--2"
@@ -217,9 +211,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             </strong>
             ?
           </legend>
-          <Choice
+          <ChoiceComponent
             checked={true}
-            inputPlacement="left"
             name="apd-assurances-yes-explanation-procurement-45_CFR_Part_75.326"
             onChange={[Function]}
             size="small"
@@ -227,8 +220,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="yes"
           >
             Yes
-          </Choice>
-          <Choice
+          </ChoiceComponent>
+          <ChoiceComponent
             checked={false}
             checkedChildren={
               <div
@@ -245,7 +238,6 @@ exports[`assurances and compliance component main component renders correctly 1`
                 />
               </div>
             }
-            inputPlacement="left"
             name="apd-assurances-no-explanation-procurement-45_CFR_Part_75.326"
             onChange={[Function]}
             size="small"
@@ -253,7 +245,7 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="no"
           >
             No
-          </Choice>
+          </ChoiceComponent>
         </fieldset>
       </div>
       <div
@@ -282,9 +274,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             </strong>
             ?
           </legend>
-          <Choice
+          <ChoiceComponent
             checked={false}
-            inputPlacement="left"
             name="apd-assurances-yes-explanation-recordsAccess-42_CFR_Part_495.350"
             onChange={[Function]}
             size="small"
@@ -292,8 +283,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="yes"
           >
             Yes
-          </Choice>
-          <Choice
+          </ChoiceComponent>
+          <ChoiceComponent
             checked={true}
             checkedChildren={
               <div
@@ -310,7 +301,6 @@ exports[`assurances and compliance component main component renders correctly 1`
                 />
               </div>
             }
-            inputPlacement="left"
             name="apd-assurances-no-explanation-recordsAccess-42_CFR_Part_495.350"
             onChange={[Function]}
             size="small"
@@ -318,7 +308,7 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="no"
           >
             No
-          </Choice>
+          </ChoiceComponent>
         </fieldset>
         <fieldset
           className="ds-u-margin-top--2"
@@ -337,9 +327,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             </strong>
             ?
           </legend>
-          <Choice
+          <ChoiceComponent
             checked={true}
-            inputPlacement="left"
             name="apd-assurances-yes-explanation-recordsAccess-42_CFR_Part_495.352"
             onChange={[Function]}
             size="small"
@@ -347,8 +336,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="yes"
           >
             Yes
-          </Choice>
-          <Choice
+          </ChoiceComponent>
+          <ChoiceComponent
             checked={false}
             checkedChildren={
               <div
@@ -365,7 +354,6 @@ exports[`assurances and compliance component main component renders correctly 1`
                 />
               </div>
             }
-            inputPlacement="left"
             name="apd-assurances-no-explanation-recordsAccess-42_CFR_Part_495.352"
             onChange={[Function]}
             size="small"
@@ -373,7 +361,7 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="no"
           >
             No
-          </Choice>
+          </ChoiceComponent>
         </fieldset>
         <fieldset
           className="ds-u-margin-top--2"
@@ -392,9 +380,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             </strong>
             ?
           </legend>
-          <Choice
+          <ChoiceComponent
             checked={true}
-            inputPlacement="left"
             name="apd-assurances-yes-explanation-recordsAccess-42_CFR_Part_495.346"
             onChange={[Function]}
             size="small"
@@ -402,8 +389,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="yes"
           >
             Yes
-          </Choice>
-          <Choice
+          </ChoiceComponent>
+          <ChoiceComponent
             checked={false}
             checkedChildren={
               <div
@@ -420,7 +407,6 @@ exports[`assurances and compliance component main component renders correctly 1`
                 />
               </div>
             }
-            inputPlacement="left"
             name="apd-assurances-no-explanation-recordsAccess-42_CFR_Part_495.346"
             onChange={[Function]}
             size="small"
@@ -428,7 +414,7 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="no"
           >
             No
-          </Choice>
+          </ChoiceComponent>
         </fieldset>
         <fieldset
           className="ds-u-margin-top--2"
@@ -447,9 +433,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             </strong>
             ?
           </legend>
-          <Choice
+          <ChoiceComponent
             checked={true}
-            inputPlacement="left"
             name="apd-assurances-yes-explanation-recordsAccess-42_CFR_Part_433.112(b)(5)_-_(9)"
             onChange={[Function]}
             size="small"
@@ -457,8 +442,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="yes"
           >
             Yes
-          </Choice>
-          <Choice
+          </ChoiceComponent>
+          <ChoiceComponent
             checked={false}
             checkedChildren={
               <div
@@ -475,7 +460,6 @@ exports[`assurances and compliance component main component renders correctly 1`
                 />
               </div>
             }
-            inputPlacement="left"
             name="apd-assurances-no-explanation-recordsAccess-42_CFR_Part_433.112(b)(5)_-_(9)"
             onChange={[Function]}
             size="small"
@@ -483,7 +467,7 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="no"
           >
             No
-          </Choice>
+          </ChoiceComponent>
         </fieldset>
         <fieldset
           className="ds-u-margin-top--2"
@@ -502,9 +486,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             </strong>
             ?
           </legend>
-          <Choice
+          <ChoiceComponent
             checked={false}
-            inputPlacement="left"
             name="apd-assurances-yes-explanation-recordsAccess-45_CFR_Part_95.615"
             onChange={[Function]}
             size="small"
@@ -512,8 +495,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="yes"
           >
             Yes
-          </Choice>
-          <Choice
+          </ChoiceComponent>
+          <ChoiceComponent
             checked={true}
             checkedChildren={
               <div
@@ -530,7 +513,6 @@ exports[`assurances and compliance component main component renders correctly 1`
                 />
               </div>
             }
-            inputPlacement="left"
             name="apd-assurances-no-explanation-recordsAccess-45_CFR_Part_95.615"
             onChange={[Function]}
             size="small"
@@ -538,7 +520,7 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="no"
           >
             No
-          </Choice>
+          </ChoiceComponent>
         </fieldset>
         <fieldset
           className="ds-u-margin-top--2"
@@ -557,9 +539,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             </strong>
             ?
           </legend>
-          <Choice
+          <ChoiceComponent
             checked={true}
-            inputPlacement="left"
             name="apd-assurances-yes-explanation-recordsAccess-SMM_Section_11267"
             onChange={[Function]}
             size="small"
@@ -567,8 +548,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="yes"
           >
             Yes
-          </Choice>
-          <Choice
+          </ChoiceComponent>
+          <ChoiceComponent
             checked={false}
             checkedChildren={
               <div
@@ -585,7 +566,6 @@ exports[`assurances and compliance component main component renders correctly 1`
                 />
               </div>
             }
-            inputPlacement="left"
             name="apd-assurances-no-explanation-recordsAccess-SMM_Section_11267"
             onChange={[Function]}
             size="small"
@@ -593,7 +573,7 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="no"
           >
             No
-          </Choice>
+          </ChoiceComponent>
         </fieldset>
       </div>
       <div
@@ -622,9 +602,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             </strong>
             ?
           </legend>
-          <Choice
+          <ChoiceComponent
             checked={true}
-            inputPlacement="left"
             name="apd-assurances-yes-explanation-softwareRights-42_CFR_Part_495.360"
             onChange={[Function]}
             size="small"
@@ -632,8 +611,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="yes"
           >
             Yes
-          </Choice>
-          <Choice
+          </ChoiceComponent>
+          <ChoiceComponent
             checked={false}
             checkedChildren={
               <div
@@ -650,7 +629,6 @@ exports[`assurances and compliance component main component renders correctly 1`
                 />
               </div>
             }
-            inputPlacement="left"
             name="apd-assurances-no-explanation-softwareRights-42_CFR_Part_495.360"
             onChange={[Function]}
             size="small"
@@ -658,7 +636,7 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="no"
           >
             No
-          </Choice>
+          </ChoiceComponent>
         </fieldset>
         <fieldset
           className="ds-u-margin-top--2"
@@ -677,9 +655,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             </strong>
             ?
           </legend>
-          <Choice
+          <ChoiceComponent
             checked={true}
-            inputPlacement="left"
             name="apd-assurances-yes-explanation-softwareRights-45_CFR_Part_95.617"
             onChange={[Function]}
             size="small"
@@ -687,8 +664,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="yes"
           >
             Yes
-          </Choice>
-          <Choice
+          </ChoiceComponent>
+          <ChoiceComponent
             checked={false}
             checkedChildren={
               <div
@@ -705,7 +682,6 @@ exports[`assurances and compliance component main component renders correctly 1`
                 />
               </div>
             }
-            inputPlacement="left"
             name="apd-assurances-no-explanation-softwareRights-45_CFR_Part_95.617"
             onChange={[Function]}
             size="small"
@@ -713,7 +689,7 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="no"
           >
             No
-          </Choice>
+          </ChoiceComponent>
         </fieldset>
         <fieldset
           className="ds-u-margin-top--2"
@@ -732,9 +708,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             </strong>
             ?
           </legend>
-          <Choice
+          <ChoiceComponent
             checked={true}
-            inputPlacement="left"
             name="apd-assurances-yes-explanation-softwareRights-42_CFR_Part_431.300"
             onChange={[Function]}
             size="small"
@@ -742,8 +717,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="yes"
           >
             Yes
-          </Choice>
-          <Choice
+          </ChoiceComponent>
+          <ChoiceComponent
             checked={false}
             checkedChildren={
               <div
@@ -760,7 +735,6 @@ exports[`assurances and compliance component main component renders correctly 1`
                 />
               </div>
             }
-            inputPlacement="left"
             name="apd-assurances-no-explanation-softwareRights-42_CFR_Part_431.300"
             onChange={[Function]}
             size="small"
@@ -768,7 +742,7 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="no"
           >
             No
-          </Choice>
+          </ChoiceComponent>
         </fieldset>
         <fieldset
           className="ds-u-margin-top--2"
@@ -787,9 +761,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             </strong>
             ?
           </legend>
-          <Choice
+          <ChoiceComponent
             checked={true}
-            inputPlacement="left"
             name="apd-assurances-yes-explanation-softwareRights-42_CFR_Part_433.112"
             onChange={[Function]}
             size="small"
@@ -797,8 +770,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="yes"
           >
             Yes
-          </Choice>
-          <Choice
+          </ChoiceComponent>
+          <ChoiceComponent
             checked={false}
             checkedChildren={
               <div
@@ -815,7 +788,6 @@ exports[`assurances and compliance component main component renders correctly 1`
                 />
               </div>
             }
-            inputPlacement="left"
             name="apd-assurances-no-explanation-softwareRights-42_CFR_Part_433.112"
             onChange={[Function]}
             size="small"
@@ -823,7 +795,7 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="no"
           >
             No
-          </Choice>
+          </ChoiceComponent>
         </fieldset>
       </div>
       <div
@@ -852,9 +824,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             </strong>
             ?
           </legend>
-          <Choice
+          <ChoiceComponent
             checked={true}
-            inputPlacement="left"
             name="apd-assurances-yes-explanation-security-45_CFR_164_Securities_and_Privacy"
             onChange={[Function]}
             size="small"
@@ -862,8 +833,8 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="yes"
           >
             Yes
-          </Choice>
-          <Choice
+          </ChoiceComponent>
+          <ChoiceComponent
             checked={false}
             checkedChildren={
               <div
@@ -880,7 +851,6 @@ exports[`assurances and compliance component main component renders correctly 1`
                 />
               </div>
             }
-            inputPlacement="left"
             name="apd-assurances-no-explanation-security-45_CFR_164_Securities_and_Privacy"
             onChange={[Function]}
             size="small"
@@ -888,7 +858,7 @@ exports[`assurances and compliance component main component renders correctly 1`
             value="no"
           >
             No
-          </Choice>
+          </ChoiceComponent>
         </fieldset>
       </div>
     </Subsection>

--- a/web/src/containers/activity/ContractorResource/ContractorResourceForm.js
+++ b/web/src/containers/activity/ContractorResource/ContractorResourceForm.js
@@ -1,7 +1,8 @@
-import { Choice, FormLabel, TextField } from '@cmsgov/design-system-core';
+import { FormLabel, TextField } from '@cmsgov/design-system-core';
 import PropTypes from 'prop-types';
 import React, { Fragment, useCallback, useMemo } from 'react';
 
+import Choice from '../../../components/Choice';
 import DateField from '../../../components/DateField';
 import DollarField from '../../../components/DollarField';
 import Dollars from '../../../components/Dollars';

--- a/web/src/containers/activity/ContractorResource/__snapshots__/ContractorResourceForm.test.js.snap
+++ b/web/src/containers/activity/ContractorResource/__snapshots__/ContractorResourceForm.test.js.snap
@@ -52,16 +52,15 @@ exports[`the ContractorResourceForm component renders correctly 1`] = `
     >
       This is an hourly resource
     </legend>
-    <Choice
+    <ChoiceComponent
       checked={true}
-      inputPlacement="left"
       name="apd-activity-contractor-hourly-key 1-no"
       type="radio"
       value="no"
     >
       No
-    </Choice>
-    <Choice
+    </ChoiceComponent>
+    <ChoiceComponent
       checked={false}
       checkedChildren={
         <div
@@ -127,13 +126,12 @@ exports[`the ContractorResourceForm component renders correctly 1`] = `
           </React.Fragment>
         </div>
       }
-      inputPlacement="left"
       name="apd-activity-contractor-hourly-key 1-yes"
       type="radio"
       value="yes"
     >
       Yes
-    </Choice>
+    </ChoiceComponent>
   </fieldset>
   <DollarField
     disabled={false}
@@ -208,16 +206,15 @@ exports[`the ContractorResourceForm component renders if use hourly data is sele
     >
       This is an hourly resource
     </legend>
-    <Choice
+    <ChoiceComponent
       checked={false}
-      inputPlacement="left"
       name="apd-activity-contractor-hourly-key 1-no"
       type="radio"
       value="no"
     >
       No
-    </Choice>
-    <Choice
+    </ChoiceComponent>
+    <ChoiceComponent
       checked={true}
       checkedChildren={
         <div
@@ -283,13 +280,12 @@ exports[`the ContractorResourceForm component renders if use hourly data is sele
           </React.Fragment>
         </div>
       }
-      inputPlacement="left"
       name="apd-activity-contractor-hourly-key 1-yes"
       type="radio"
       value="yes"
     >
       Yes
-    </Choice>
+    </ChoiceComponent>
   </fieldset>
   <p
     className="ds-u-margin-bottom--0"


### PR DESCRIPTION
In the final ARIA announcement saga episode, we create a wrapper around the design system's Choice component that brute-force removes the `aria-live`, `aria-atomic`, and `aria-relevant` attributes.

**TODO** Open a ticket with the design system folks asking them to make the aria region optional via a component flag.

### This pull request changes...

- ☝️ 

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [x] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented