### PR TITLE
Set the auth session cookie to expire at the same time the session will expire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Anticipated release: TBD
 - Fixes a screen reader bug by adding a wrapper around the CMS Design System's Choice component ([#1760])
 - Round off dollar input fields when they lose focus ([#1739])
 - Fixed a bug where multiline plain text fields (such as the activity overview) gets exported as a text field, and the content is truncated within it. ([#1767])
+- Fixed a bug where the session authentication cookie would expire at the end of the browser session instead of at the scheduled time. ([#1756])
 
 #### ⚙️ Behind the scenes
 
@@ -104,8 +105,8 @@ Pilot release to select state partners
 [#1745]: https://github.com/18F/cms-hitech-apd/pull/1745
 [#1747]: https://github.com/18F/cms-hitech-apd/issues/1747
 [#1754]: https://github.com/18F/cms-hitech-apd/issues/1754
+[#1756]: https://github.com/18F/cms-hitech-apd/issues/1756
 [#1762]: https://github.com/18F/cms-hitech-apd/issues/1762
 [#1765]: https://github.com/18F/cms-hitech-apd/issues/1765
 [#1767]: https://github.com/18F/cms-hitech-apd/issues/1767
 [#1770]: https://github.com/18F/cms-hitech-apd/pull/1770
-

--- a/api/auth/session.js
+++ b/api/auth/session.js
@@ -5,6 +5,9 @@ const logger = require('../logger')('auth session');
 const COOKIE_NAME = 'token';
 const TOKEN_ISSUER = 'CMS eAPD API';
 
+const sessionLifetimeMilliseconds =
+  +process.env.SESSION_LIFETIME_MINUTES * 60 * 1000;
+
 /**
  * Load a session from client cookie
  * @param {Object} req - Express request object
@@ -93,7 +96,11 @@ module.exports = ({ Cookies = defaultCookies } = {}) => {
               expiresIn: `${process.env.SESSION_LIFETIME_MINUTES}m`
             }
           ),
-          { httpOnly: true, overwrite: true }
+          {
+            httpOnly: true,
+            maxAge: sessionLifetimeMilliseconds,
+            overwrite: true
+          }
         );
       } else {
         // Else, write a cookie with an immediate expiration


### PR DESCRIPTION
### This pull request changes...

- Sets the cookie's `maxAge` equal to the session lifetime, which results in it getting an expiration. Verified by checking the cookie in the browser dev tools.
- closes #1756

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [x] Changelog is updated as appropriate