### PR TITLE
Refactor activity cost allocation quarterly tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Anticipated release: TBD
 - Removed old styles ([#1770])
 - Remove unused code
 - Updated 3rd-party dependencies
+- Refactored the activity quarterly cost allocation tables ([#1574])
 
 # v1.0.3
 
@@ -77,6 +78,7 @@ Pilot release to select state partners
 [#1304]: https://github.com/18F/cms-hitech-apd/issues/1304
 [#1423]: https://github.com/18F/cms-hitech-apd/issues/1423
 [#1475]: https://github.com/18F/cms-hitech-apd/issues/1475
+[#1574]: https://github.com/18F/cms-hitech-apd/issues/1574
 [#1600]: https://github.com/18F/cms-hitech-apd/issues/1600
 [#1601]: https://github.com/18F/cms-hitech-apd/pull/1601
 [#1602]: https://github.com/18F/cms-hitech-apd/pull/1602
@@ -108,4 +110,3 @@ Pilot release to select state partners
 [#1765]: https://github.com/18F/cms-hitech-apd/issues/1765
 [#1767]: https://github.com/18F/cms-hitech-apd/issues/1767
 [#1770]: https://github.com/18F/cms-hitech-apd/pull/1770
-

--- a/web/src/containers/activity/CostAllocateFFP.js
+++ b/web/src/containers/activity/CostAllocateFFP.js
@@ -4,6 +4,7 @@ import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 
 import CostAllocateFFPQuarterly from './CostAllocateFFPQuarterly';
+import CostAllocateFFPYearTotal from './CostAllocateFFPYearTotal';
 import { updateActivity as updateActivityAction } from '../../actions/activities';
 import DollarField from '../../components/DollarField';
 import Dollars from '../../components/Dollars';
@@ -86,6 +87,7 @@ class CostAllocateFFP extends Component {
                 </p>
               </div>
               <CostAllocateFFPQuarterly aKey={aKey} year={year} />
+              <CostAllocateFFPYearTotal aKey={aKey} />
               <hr />
             </div>
           )

--- a/web/src/containers/activity/CostAllocateFFPQuarterly.js
+++ b/web/src/containers/activity/CostAllocateFFPQuarterly.js
@@ -34,7 +34,7 @@ class CostAllocateFFPQuarterly extends Component {
   };
 
   render() {
-    const { aKey, quarterlyFFP, year, years } = this.props;
+    const { aKey, quarterlyFFP, year } = this.props;
 
     // Wait until the budget is ready
     if (!quarterlyFFP) return null;
@@ -145,7 +145,6 @@ class CostAllocateFFPQuarterly extends Component {
 CostAllocateFFPQuarterly.propTypes = {
   aKey: PropTypes.string.isRequired,
   quarterlyFFP: PropTypes.object.isRequired,
-  years: PropTypes.array.isRequired,
   year: PropTypes.string.isRequired,
   update: PropTypes.func.isRequired,
   announce: PropTypes.func.isRequired

--- a/web/src/containers/activity/CostAllocateFFPQuarterly.js
+++ b/web/src/containers/activity/CostAllocateFFPQuarterly.js
@@ -40,126 +40,104 @@ class CostAllocateFFPQuarterly extends Component {
     if (!quarterlyFFP) return null;
 
     return (
-      <Fragment>
-        <table className="budget-table" key={year}>
-          <caption className="ds-u-visibility--screen-reader">
-            Enter the federal fiscal year {year} quarterly breakdown by
-            percentage.
-          </caption>
-          <thead>
-            <tr>
-              <th>
-                <span aria-hidden="true">{t('ffy', { year })}</span>
-              </th>
-              <Fragment key={year}>
-                {QUARTERS.map(q => (
-                  <th key={q} scope="col" className="ds-u-text-align--right">
-                    <span className="ds-u-visibility--screen-reader">
-                      {t('ffy', { year })}
-                    </span>
-                    {t('table.quarter', { q })}
-                  </th>
-                ))}
-                <th
-                  scope="col"
-                  className="budget-table--subtotal ds-u-text-align--right"
-                >
+      <table className="budget-table" key={year}>
+        <caption className="ds-u-visibility--screen-reader">
+          Enter the federal fiscal year {year} quarterly breakdown by
+          percentage.
+        </caption>
+        <thead>
+          <tr>
+            <th>
+              <span aria-hidden="true">{t('ffy', { year })}</span>
+            </th>
+            <Fragment key={year}>
+              {QUARTERS.map(q => (
+                <th key={q} scope="col" className="ds-u-text-align--right">
                   <span className="ds-u-visibility--screen-reader">
                     {t('ffy', { year })}
                   </span>
-                  {t('table.subtotal')}
+                  {t('table.quarter', { q })}
                 </th>
-              </Fragment>
-            </tr>
-          </thead>
-          <tbody>
-            {['state', 'contractors'].map(name => (
-              <Fragment key={name}>
-                <tr key={name}>
-                  <th rowSpan="2" scope="row">
-                    {EXPENSE_NAME_DISPLAY[name]}
-                  </th>
-                  <Fragment key={year}>
-                    {QUARTERS.map(q => (
-                      <td key={q}>
-                        <div className="budget-table--input__percent">
-                          <NumberField
-                            className="budget-table--input-holder"
-                            fieldClassName="budget-table--input__number"
-                            label={`federal share for ffy ${year}, quarter ${q}, ${name}`}
-                            labelClassName="sr-only"
-                            name={`ffp-${aKey}-${year}-${q}-${name}`}
-                            onChange={this.handleChange(year, q, name)}
-                            value={quarterlyFFP[year][q][name].percent * 100}
-                            aria-controls={`ffp-${aKey}-${year}-${q}-${name}-dollar-equivalent`}
-                          />
-                        </div>
-                      </td>
-                    ))}
-                    <td className="budget-table--number budget-table--subtotal">
-                      {formatPerc(quarterlyFFP[year].subtotal[name].percent)}
-                    </td>
-                  </Fragment>
-                </tr>
-                <tr>
-                  <Fragment key={year}>
-                    {QUARTERS.map(q => (
-                      <td className="budget-table--number" key={q}>
-                        <Dollars>{quarterlyFFP[year][q][name].dollars}</Dollars>
-                      </td>
-                    ))}
-                    <td className="budget-table--number budget-table--subtotal">
-                      <Dollars>
-                        {quarterlyFFP[year].subtotal[name].dollars}
-                      </Dollars>
-                    </td>
-                  </Fragment>
-                </tr>
-              </Fragment>
-            ))}
-            <tr className="budget-table--row__highlight">
-              <th scope="row" className="budget-table--total">
-                {EXPENSE_NAME_DISPLAY.combined}
+              ))}
+              <th
+                scope="col"
+                className="budget-table--subtotal ds-u-text-align--right"
+              >
+                <span className="ds-u-visibility--screen-reader">
+                  {t('ffy', { year })}
+                </span>
+                {t('table.subtotal')}
               </th>
-              <Fragment key={year}>
-                {QUARTERS.map(q => (
-                  <td
-                    className="budget-table--number budget-table--total"
-                    key={q}
-                  >
-                    <Dollars>{quarterlyFFP[year][q].combined.dollars}</Dollars>
+            </Fragment>
+          </tr>
+        </thead>
+        <tbody>
+          {['state', 'contractors'].map(name => (
+            <Fragment key={name}>
+              <tr key={name}>
+                <th rowSpan="2" scope="row">
+                  {EXPENSE_NAME_DISPLAY[name]}
+                </th>
+                <Fragment key={year}>
+                  {QUARTERS.map(q => (
+                    <td key={q}>
+                      <div className="budget-table--input__percent">
+                        <NumberField
+                          className="budget-table--input-holder"
+                          fieldClassName="budget-table--input__number"
+                          label={`federal share for ffy ${year}, quarter ${q}, ${name}`}
+                          labelClassName="sr-only"
+                          name={`ffp-${aKey}-${year}-${q}-${name}`}
+                          onChange={this.handleChange(year, q, name)}
+                          value={quarterlyFFP[year][q][name].percent * 100}
+                          aria-controls={`ffp-${aKey}-${year}-${q}-${name}-dollar-equivalent`}
+                        />
+                      </div>
+                    </td>
+                  ))}
+                  <td className="budget-table--number budget-table--subtotal">
+                    {formatPerc(quarterlyFFP[year].subtotal[name].percent)}
                   </td>
-                ))}
-                <td className="budget-table--number budget-table--subtotal">
-                  <Dollars>
-                    {quarterlyFFP[year].subtotal.combined.dollars}
-                  </Dollars>
+                </Fragment>
+              </tr>
+              <tr>
+                <Fragment key={year}>
+                  {QUARTERS.map(q => (
+                    <td className="budget-table--number" key={q}>
+                      <Dollars>{quarterlyFFP[year][q][name].dollars}</Dollars>
+                    </td>
+                  ))}
+                  <td className="budget-table--number budget-table--subtotal">
+                    <Dollars>
+                      {quarterlyFFP[year].subtotal[name].dollars}
+                    </Dollars>
+                  </td>
+                </Fragment>
+              </tr>
+            </Fragment>
+          ))}
+          <tr className="budget-table--row__highlight">
+            <th scope="row" className="budget-table--total">
+              {EXPENSE_NAME_DISPLAY.combined}
+            </th>
+            <Fragment key={year}>
+              {QUARTERS.map(q => (
+                <td
+                  className="budget-table--number budget-table--total"
+                  key={q}
+                >
+                  <Dollars>{quarterlyFFP[year][q].combined.dollars}</Dollars>
                 </td>
-              </Fragment>
-            </tr>
-          </tbody>
-        </table>
-        {year === years[years.length - 1] && (
-          <Fragment>
-            <hr />
-            <h6 className="ds-h3">{`Total FFY ${years[0]} - ${
-              years[years.length - 1]
-            }`}</h6>
-            {['state', 'contractors'].map(name => (
-              <Fragment key={name}>
-                <p className="ds-h5">{EXPENSE_NAME_DISPLAY[name]}</p>
-                <p>
-                  <Dollars long>{quarterlyFFP.total[name]}</Dollars>
-                </p>
-              </Fragment>
-            ))}
-            <p className="ds-h5">{EXPENSE_NAME_DISPLAY.combined}</p>
-            <p>
-              <Dollars long>{quarterlyFFP.total.combined}</Dollars>
-            </p>
-          </Fragment>
-        )}
-      </Fragment>
+              ))}
+              <td className="budget-table--number budget-table--subtotal">
+                <Dollars>
+                  {quarterlyFFP[year].subtotal.combined.dollars}
+                </Dollars>
+              </td>
+            </Fragment>
+          </tr>
+        </tbody>
+      </table>
     );
   }
 }

--- a/web/src/containers/activity/CostAllocateFFPYearTotal.js
+++ b/web/src/containers/activity/CostAllocateFFPYearTotal.js
@@ -39,7 +39,6 @@ const CostAllocateFFPYearTotal = ({ quarterlyFFP, years }) => {
 };
 
 CostAllocateFFPYearTotal.propTypes = {
-  aKey: PropTypes.string.isRequired,
   quarterlyFFP: PropTypes.object.isRequired,
   years: PropTypes.array.isRequired
 };

--- a/web/src/containers/activity/CostAllocateFFPYearTotal.js
+++ b/web/src/containers/activity/CostAllocateFFPYearTotal.js
@@ -1,0 +1,59 @@
+import PropTypes from 'prop-types';
+import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
+
+import Dollars from '../../components/Dollars';
+import { t } from '../../i18n';
+import { makeSelectCostAllocateFFPBudget } from '../../reducers/activities.selectors';
+
+const EXPENSE_NAME_DISPLAY = {
+  state: t('activities.costAllocate.quarterly.expenseNames.state'),
+  contractors: t('activities.costAllocate.quarterly.expenseNames.contractor'),
+  combined: t('activities.costAllocate.quarterly.expenseNames.combined')
+};
+
+const CostAllocateFFPYearTotal = ({ quarterlyFFP, years }) => {
+  // Wait until the budget is ready
+  if (!quarterlyFFP) return null;
+
+  return (
+    <Fragment>
+      <hr />
+      <h6 className="ds-h3">{`Total FFY ${years[0]} - ${
+        years[years.length - 1]
+      }`}</h6>
+      {['state', 'contractors'].map(name => (
+        <Fragment key={name}>
+          <p className="ds-h5">{EXPENSE_NAME_DISPLAY[name]}</p>
+          <p>
+            <Dollars long>{quarterlyFFP.total[name]}</Dollars>
+          </p>
+        </Fragment>
+      ))}
+      <p className="ds-h5">{EXPENSE_NAME_DISPLAY.combined}</p>
+      <p>
+        <Dollars long>{quarterlyFFP.total.combined}</Dollars>
+      </p>
+    </Fragment>
+  );
+};
+
+CostAllocateFFPYearTotal.propTypes = {
+  aKey: PropTypes.string.isRequired,
+  quarterlyFFP: PropTypes.object.isRequired,
+  years: PropTypes.array.isRequired
+};
+
+const makeMapStateToProps = () => {
+  const selectCostAllocateFFPBudget = makeSelectCostAllocateFFPBudget();
+  const mapStateToProps = (state, props) =>
+    selectCostAllocateFFPBudget(state, props);
+  return mapStateToProps;
+};
+
+export default connect(
+  makeMapStateToProps,
+  null
+)(CostAllocateFFPYearTotal);
+
+export { CostAllocateFFPYearTotal as raw, makeMapStateToProps };

--- a/web/src/containers/activity/CostAllocateFFPYearTotal.test.js
+++ b/web/src/containers/activity/CostAllocateFFPYearTotal.test.js
@@ -1,0 +1,47 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import {
+  raw as CostAllocateFFPYearTotal,
+  makeMapStateToProps
+} from './CostAllocateFFPYearTotal';
+
+describe('the CostAllocateFFPYearTotal component', () => {
+  test('renders correctly', () => {
+    const component = shallow(
+      <CostAllocateFFPYearTotal
+        aKey="activity key"
+        quarterlyFFP={{
+          total: {
+            combined: 100,
+            contractors: 200,
+            state: 300
+          }
+        }}
+        years={['year 1', 'year 2']}
+      />
+    );
+    expect(component).toMatchSnapshot();
+  });
+
+  test('maps state to props', () => {
+    const mapStateToProps = makeMapStateToProps();
+    expect(
+      mapStateToProps(
+        {
+          apd: { data: { years: ['year 1', 'year 2'] } },
+          budget: {
+            activities: {
+              'activity key': { quarterlyFFP: 'one beeellion dollars' },
+              'bad key': {}
+            }
+          }
+        },
+        { aKey: 'activity key' }
+      )
+    ).toEqual({
+      quarterlyFFP: 'one beeellion dollars',
+      years: ['year 1', 'year 2']
+    });
+  });
+});

--- a/web/src/containers/activity/__snapshots__/CostAllocateFFP.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/CostAllocateFFP.test.js.snap
@@ -104,6 +104,9 @@ exports[`the CostAllocateFFP component renders correctly 1`] = `
       aKey="activity key"
       year="1066"
     />
+    <Connect(CostAllocateFFPYearTotal)
+      aKey="activity key"
+    />
     <hr />
   </div>
   <div
@@ -202,6 +205,9 @@ exports[`the CostAllocateFFP component renders correctly 1`] = `
     <Connect(CostAllocateFFPQuarterly)
       aKey="activity key"
       year="1067"
+    />
+    <Connect(CostAllocateFFPYearTotal)
+      aKey="activity key"
     />
     <hr />
   </div>

--- a/web/src/containers/activity/__snapshots__/CostAllocateFFPYearTotal.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/CostAllocateFFPYearTotal.test.js.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`the CostAllocateFFPYearTotal component renders correctly 1`] = `
+<Fragment>
+  <hr />
+  <h6
+    className="ds-h3"
+  >
+    Total FFY year 1 - year 2
+  </h6>
+  <p
+    className="ds-h5"
+  >
+    In-House Costs
+  </p>
+  <p>
+    <Dollars
+      long={true}
+    >
+      300
+    </Dollars>
+  </p>
+  <p
+    className="ds-h5"
+  >
+    Private Contractor Costs
+  </p>
+  <p>
+    <Dollars
+      long={true}
+    >
+      200
+    </Dollars>
+  </p>
+  <p
+    className="ds-h5"
+  >
+    Total Enhanced FFP
+  </p>
+  <p>
+    <Dollars
+      long={true}
+    >
+      100
+    </Dollars>
+  </p>
+</Fragment>
+`;


### PR DESCRIPTION
Moves the cost allocation yearly totals table into a separate component, and out of the quarterly tables component.

### This pull request changes...

- no visible changes
- closes #1574

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [x] Changelog is updated as appropriate