### PR TITLE
Add ARIA attributes to the account management button to make it more accessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Anticipated release: TBD
 - Round off dollar input fields when they lose focus ([#1739])
 - Fixed a bug where multiline plain text fields (such as the activity overview) gets exported as a text field, and the content is truncated within it. ([#1767])
 - Fixed a bug where the session authentication cookie would expire at the end of the browser session instead of at the scheduled time. ([#1756])
+- Improved ARIA metadata on the account management dropdown button for screen readers ([#1681])
 
 #### ⚙️ Behind the scenes
 
@@ -90,6 +91,7 @@ Pilot release to select state partners
 [#1651]: https://github.com/18F/cms-hitech-apd/pull/1651
 [#1655]: https://github.com/18F/cms-hitech-apd/issues/1655
 [#1680]: https://github.com/18F/cms-hitech-apd/issues/1680
+[#1681]: https://github.com/18F/cms-hitech-apd/issues/1681
 [#1686]: https://github.com/18F/cms-hitech-apd/issues/1686
 [#1688]: https://github.com/18F/cms-hitech-apd/pull/1688
 [#1695]: https://github.com/18F/cms-hitech-apd/pull/1695

--- a/web/src/components/Header.js
+++ b/web/src/components/Header.js
@@ -68,12 +68,15 @@ class Header extends Component {
             </div>
             {authenticated && (
               <div className="ds-l-col--12 ds-l-md-col--8">
-                <ul className="nav--dropdown" aria-expanded={ariaExpanded}>
+                <ul className="nav--dropdown">
                   <li>
                     <button
                       type="button"
                       className="nav--dropdown__trigger ds-c-button ds-c-button--small ds-c-button--transparent"
                       onClick={this.toggleDropdown}
+                      aria-expanded={ariaExpanded ? 'true' : 'false'}
+                      aria-haspopup="true"
+                      aria-label={`Logged in as ${currentUser.username}. Click to manage your account.`}
                     >
                       {currentUser ? currentUser.username : 'Your account'}
                       <Icon icon={faChevronDown} style={{ width: '8px' }} />

--- a/web/src/components/__snapshots__/Header.test.js.snap
+++ b/web/src/components/__snapshots__/Header.test.js.snap
@@ -21,11 +21,13 @@ exports[`Header component opens and closes the dropdown when clicked 1`] = `
         className="ds-l-col--12 ds-l-md-col--8"
       >
         <ul
-          aria-expanded={true}
           className="nav--dropdown"
         >
           <li>
             <button
+              aria-expanded="true"
+              aria-haspopup="true"
+              aria-label="Logged in as frasiercrane@kacl.com. Click to manage your account."
               className="nav--dropdown__trigger ds-c-button ds-c-button--small ds-c-button--transparent"
               onClick={[Function]}
               type="button"
@@ -189,11 +191,13 @@ exports[`Header component renders correctly when the dropdown is closed and the 
         className="ds-l-col--12 ds-l-md-col--8"
       >
         <ul
-          aria-expanded={false}
           className="nav--dropdown"
         >
           <li>
             <button
+              aria-expanded="false"
+              aria-haspopup="true"
+              aria-label="Logged in as frasiercrane@kacl.com. Click to manage your account."
               className="nav--dropdown__trigger ds-c-button ds-c-button--small ds-c-button--transparent"
               onClick={[Function]}
               type="button"
@@ -387,11 +391,13 @@ exports[`Header component renders the admin home title when an admin user is at 
         className="ds-l-col--12 ds-l-md-col--8"
       >
         <ul
-          aria-expanded={false}
           className="nav--dropdown"
         >
           <li>
             <button
+              aria-expanded="false"
+              aria-haspopup="true"
+              aria-label="Logged in as frasiercrane@kacl.com. Click to manage your account."
               className="nav--dropdown__trigger ds-c-button ds-c-button--small ds-c-button--transparent"
               onClick={[Function]}
               type="button"
@@ -585,11 +591,13 @@ exports[`Header component renders the state user home title when a state user is
         className="ds-l-col--12 ds-l-md-col--8"
       >
         <ul
-          aria-expanded={false}
           className="nav--dropdown"
         >
           <li>
             <button
+              aria-expanded="false"
+              aria-haspopup="true"
+              aria-label="Logged in as frasiercrane@kacl.com. Click to manage your account."
               className="nav--dropdown__trigger ds-c-button ds-c-button--small ds-c-button--transparent"
               onClick={[Function]}
               type="button"


### PR DESCRIPTION
### This pull request changes...

- sets a more descriptive ARIA label for screen readers: "You are logged in as [account]. Click to manage account."
  - Do we need the "click" part? The `aria-haspopup` attribute will indicate that it has a popup, but it doesn't give any clue as to what's hidden in the popup.
- sets `aria-haspopup="true"` so screen readers know the button controls a popup
- moves `aria-expanded` to the button instead of the containing UL, so the reader will announce the expand/collapse state when the button gets focus
- closes #1681 

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [x] Changelog is updated as appropriate

### This feature is done when...

- [ ] Product has approved the experience
