### PR TITLE
Fix Sass warnings

### DIFF
--- a/web/src/styles/scss/editor.scss
+++ b/web/src/styles/scss/editor.scss
@@ -5,7 +5,6 @@
 .rdw-editor-toolbar {
   background-color: #f5f5f5;
   border: 0;
-  border-radius: var(--border-radius);
 
   & * {
     box-sizing: content-box;
@@ -15,7 +14,6 @@
 .rdw-dropdown-wrapper,
 .rdw-option-wrapper {
   border: 1px solid #eee;
-  border-radius: var(--border-radius);
 }
 
 .rdw-emoji-modal {
@@ -34,7 +32,6 @@
 
 .public-DraftEditor-content {
   border: 1px solid #ddd;
-  border-radius: var(--border-radius);
   overflow: auto;
   padding: 0.5rem;
 }


### PR DESCRIPTION
We had rounded borders applied to some parts of the rich text editor, but those borders were based on a radius variable that was set in the legacy CSS index file. When that file went away, the variables were no longer defined, so Sass would give us a warning. Since nobody seemed to notice or mind that the borders were no longer rounded, I opted to just remove them rather than put the variable back.

### This pull request changes...

- removes references to `--border-radius` variable in scss
- closes #1774

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- ~Changelog is updated as appropriate~ Not necessary. This is part of removing the old styles, which is already in the changelog