### PR TITLE
Add Percent field, switch APD key personnel and quarterly FFP share inputs to Percent field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Anticipated release: TBD
 - Round off dollar input fields when they lose focus ([#1739])
 - Fixed a bug where multiline plain text fields (such as the activity overview) gets exported as a text field, and the content is truncated within it. ([#1767])
 - Fixed a bug where the session authentication cookie would expire at the end of the browser session instead of at the scheduled time. ([#1756])
+- Fixed a bug where the APD Key Personnel section asked for a person's percent time using a plain number input box instead of a percent box ([#1753])
 
 #### ⚙️ Behind the scenes
 
@@ -106,6 +107,7 @@ Pilot release to select state partners
 [#1739]: https://github.com/18F/cms-hitech-apd/issues/1739
 [#1745]: https://github.com/18F/cms-hitech-apd/pull/1745
 [#1747]: https://github.com/18F/cms-hitech-apd/issues/1747
+[#1753]: https://github.com/18F/cms-hitech-apd/issues/1753
 [#1754]: https://github.com/18F/cms-hitech-apd/issues/1754
 [#1756]: https://github.com/18F/cms-hitech-apd/issues/1756
 [#1762]: https://github.com/18F/cms-hitech-apd/issues/1762

--- a/web/src/components/NumberField.js
+++ b/web/src/components/NumberField.js
@@ -8,8 +8,8 @@ const selectTextIfZero = ({ target }) => {
   }
 };
 
-const NumberField = ({ ...props }) => {
-  const textField = useRef(null);
+const NumberField = ({ fieldRef, ...props }) => {
+  const textField = fieldRef || useRef(null);
 
   useEffect(() => {
     textField.current.addEventListener('focus', selectTextIfZero);

--- a/web/src/components/NumberField.js
+++ b/web/src/components/NumberField.js
@@ -1,4 +1,5 @@
 import { TextField } from '@cmsgov/design-system-core';
+import PropTypes from 'prop-types';
 import React, { useEffect, useRef } from 'react';
 
 const selectTextIfZero = ({ target }) => {
@@ -20,5 +21,13 @@ const NumberField = ({ fieldRef, ...props }) => {
 
   return <TextField {...props} fieldRef={textField} />;
 };
+
+NumberField.propTypes = {
+  fieldRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) })
+  ])
+};
+NumberField.defaultProps = { fieldRef: null };
 
 export default NumberField;

--- a/web/src/components/PercentField.js
+++ b/web/src/components/PercentField.js
@@ -10,7 +10,7 @@ const PercentField = ({ ...props }) => {
       ref.current.parentNode.appendChild(wrapper);
       wrapper.appendChild(ref.current);
     }
-  });
+  }, []);
 
   return <NumberField {...props} fieldRef={ref} />;
 };

--- a/web/src/components/PercentField.js
+++ b/web/src/components/PercentField.js
@@ -1,0 +1,18 @@
+import React, { useEffect, useRef } from 'react';
+import NumberField from './NumberField';
+
+const PercentField = ({ ...props }) => {
+  const ref = useRef(null);
+  useEffect(() => {
+    if (ref && ref.current) {
+      const wrapper = document.createElement('div');
+      wrapper.setAttribute('class', 'input-holder__percent');
+      ref.current.parentNode.appendChild(wrapper);
+      wrapper.appendChild(ref.current);
+    }
+  }, []);
+
+  return <NumberField {...props} fieldRef={ref} />;
+};
+
+export default PercentField;

--- a/web/src/components/PercentField.js
+++ b/web/src/components/PercentField.js
@@ -10,7 +10,7 @@ const PercentField = ({ ...props }) => {
       ref.current.parentNode.appendChild(wrapper);
       wrapper.appendChild(ref.current);
     }
-  }, []);
+  });
 
   return <NumberField {...props} fieldRef={ref} />;
 };

--- a/web/src/components/PercentField.test.js
+++ b/web/src/components/PercentField.test.js
@@ -5,8 +5,7 @@ import PercentField from './PercentField';
 
 describe('PercentField component', () => {
   it('renders correctly', () => {
-    let component;
-    component = mount(
+    const component = mount(
       <PercentField
         label="test label"
         name="test name"

--- a/web/src/components/PercentField.test.js
+++ b/web/src/components/PercentField.test.js
@@ -1,0 +1,22 @@
+import { mount } from 'enzyme';
+import React from 'react';
+
+import PercentField from './PercentField';
+
+describe('PercentField component', () => {
+  it('renders correctly', () => {
+    let component;
+    component = mount(
+      <PercentField
+        label="test label"
+        name="test name"
+        size="medium"
+        className="stuff"
+        value="123"
+        onChange={jest.fn()}
+      />
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+});

--- a/web/src/components/__snapshots__/DollarField.test.js.snap
+++ b/web/src/components/__snapshots__/DollarField.test.js.snap
@@ -30,6 +30,7 @@ exports[`DollarField component passes back numeric values on change, but still r
 >
   <NumberField
     className="stuff"
+    fieldRef={null}
     label="test label"
     mask="currency"
     name="test name"
@@ -120,6 +121,7 @@ exports[`DollarField component renders correctly for non-numeric initial values 
 >
   <NumberField
     className="stuff"
+    fieldRef={null}
     label="test label"
     mask="currency"
     name="test name"
@@ -210,6 +212,7 @@ exports[`DollarField component renders correctly, adds commas to big numbers, pa
 >
   <NumberField
     className="stuff"
+    fieldRef={null}
     label="test label"
     mask="currency"
     name="test name"
@@ -300,6 +303,7 @@ exports[`DollarField component renders correctly, does not add commas to small n
 >
   <NumberField
     className="stuff"
+    fieldRef={null}
     label="test label"
     mask="currency"
     name="test name"
@@ -426,6 +430,7 @@ exports[`DollarField component rounds numbers when the component loses focus, bu
 >
   <NumberField
     className="stuff"
+    fieldRef={null}
     label="test label"
     mask="currency"
     name="test name"

--- a/web/src/components/__snapshots__/NumberField.test.js.snap
+++ b/web/src/components/__snapshots__/NumberField.test.js.snap
@@ -3,6 +3,7 @@
 exports[`NumberField component renders correctly 1`] = `
 <NumberField
   className="stuff"
+  fieldRef={null}
   label="test label"
   name="test name"
   onChange={[MockFunction]}

--- a/web/src/components/__snapshots__/PercentField.test.js.snap
+++ b/web/src/components/__snapshots__/PercentField.test.js.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PercentField component renders correctly 1`] = `
+<PercentField
+  className="stuff"
+  label="test label"
+  name="test name"
+  onChange={[MockFunction]}
+  size="medium"
+  value="123"
+>
+  <NumberField
+    className="stuff"
+    fieldRef={
+      Object {
+        "current": <input
+          class="ds-c-field ds-c-field--medium"
+          id="textfield_1"
+          name="test name"
+          type="text"
+          value="123"
+        />,
+      }
+    }
+    label="test label"
+    name="test name"
+    onChange={[MockFunction]}
+    size="medium"
+    value="123"
+  >
+    <TextField
+      className="stuff"
+      fieldRef={
+        Object {
+          "current": <input
+            class="ds-c-field ds-c-field--medium"
+            id="textfield_1"
+            name="test name"
+            type="text"
+            value="123"
+          />,
+        }
+      }
+      label="test label"
+      name="test name"
+      onChange={[MockFunction]}
+      size="medium"
+      type="text"
+      value="123"
+    >
+      <div
+        className="ds-u-clearfix stuff"
+      >
+        <FormLabel
+          component="label"
+          fieldId="textfield_1"
+        >
+          <label
+            className="ds-c-label"
+            htmlFor="textfield_1"
+          >
+            <span
+              className=""
+            >
+              test label
+            </span>
+          </label>
+        </FormLabel>
+        <input
+          className="ds-c-field ds-c-field--medium"
+          id="textfield_1"
+          name="test name"
+          onChange={[MockFunction]}
+          type="text"
+          value="123"
+        />
+      </div>
+    </TextField>
+  </NumberField>
+</PercentField>
+`;

--- a/web/src/containers/ApdKeyPerson/ApdKeyPersonForm.js
+++ b/web/src/containers/ApdKeyPerson/ApdKeyPersonForm.js
@@ -4,7 +4,7 @@ import React, { Fragment, useCallback } from 'react';
 import { t } from '../../i18n';
 import Choice from '../../components/Choice';
 import DollarField from '../../components/DollarField';
-import NumberField from '../../components/NumberField';
+import PercentField from '../../components/PercentField';
 import Dollars from '../../components/Dollars';
 
 const tRoot = 'apd.stateProfile.keyPersonnel';
@@ -63,7 +63,7 @@ const PersonForm = ({
         value={position}
         onChange={getOnChangeHandler('position')}
       />
-      <NumberField
+      <PercentField
         name={`apd-state-profile-pocpercentTime${index}`}
         label={t(`${tRoot}.labels.percentTime`)}
         value={percentTime || 0}

--- a/web/src/containers/ApdKeyPerson/__snapshots__/ApdKeyPersonForm.test.js.snap
+++ b/web/src/containers/ApdKeyPerson/__snapshots__/ApdKeyPersonForm.test.js.snap
@@ -30,7 +30,7 @@ exports[`the ApdKeyPersonForm component renders correctly 1`] = `
     type="text"
     value="The Builder"
   />
-  <NumberField
+  <PercentField
     label="Percent commitment to program"
     name="apd-state-profile-pocpercentTime1"
     onChange={[Function]}
@@ -145,7 +145,7 @@ exports[`the ApdKeyPersonForm component renders correctly if the person does not
     type="text"
     value="The Builder"
   />
-  <NumberField
+  <PercentField
     label="Percent commitment to program"
     name="apd-state-profile-pocpercentTime1"
     onChange={[Function]}

--- a/web/src/containers/__snapshots__/IncentivePayments.test.js.snap
+++ b/web/src/containers/__snapshots__/IncentivePayments.test.js.snap
@@ -145,6 +145,7 @@ exports[`incentive payments component renders correctly 1`] = `
           <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
+            fieldRef={null}
             label="ehCt payments for 1, quarter 1"
             labelClassName="sr-only"
             name="ehCt-payments-1-q1"
@@ -158,6 +159,7 @@ exports[`incentive payments component renders correctly 1`] = `
           <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
+            fieldRef={null}
             label="ehCt payments for 1, quarter 2"
             labelClassName="sr-only"
             name="ehCt-payments-1-q2"
@@ -171,6 +173,7 @@ exports[`incentive payments component renders correctly 1`] = `
           <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
+            fieldRef={null}
             label="ehCt payments for 1, quarter 3"
             labelClassName="sr-only"
             name="ehCt-payments-1-q3"
@@ -184,6 +187,7 @@ exports[`incentive payments component renders correctly 1`] = `
           <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
+            fieldRef={null}
             label="ehCt payments for 1, quarter 4"
             labelClassName="sr-only"
             name="ehCt-payments-1-q4"
@@ -285,6 +289,7 @@ exports[`incentive payments component renders correctly 1`] = `
           <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
+            fieldRef={null}
             label="epCt payments for 1, quarter 1"
             labelClassName="sr-only"
             name="epCt-payments-1-q1"
@@ -298,6 +303,7 @@ exports[`incentive payments component renders correctly 1`] = `
           <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
+            fieldRef={null}
             label="epCt payments for 1, quarter 2"
             labelClassName="sr-only"
             name="epCt-payments-1-q2"
@@ -311,6 +317,7 @@ exports[`incentive payments component renders correctly 1`] = `
           <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
+            fieldRef={null}
             label="epCt payments for 1, quarter 3"
             labelClassName="sr-only"
             name="epCt-payments-1-q3"
@@ -324,6 +331,7 @@ exports[`incentive payments component renders correctly 1`] = `
           <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
+            fieldRef={null}
             label="epCt payments for 1, quarter 4"
             labelClassName="sr-only"
             name="epCt-payments-1-q4"
@@ -482,6 +490,7 @@ exports[`incentive payments component renders correctly 1`] = `
           <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
+            fieldRef={null}
             label="ehCt payments for 2, quarter 1"
             labelClassName="sr-only"
             name="ehCt-payments-2-q1"
@@ -495,6 +504,7 @@ exports[`incentive payments component renders correctly 1`] = `
           <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
+            fieldRef={null}
             label="ehCt payments for 2, quarter 2"
             labelClassName="sr-only"
             name="ehCt-payments-2-q2"
@@ -508,6 +518,7 @@ exports[`incentive payments component renders correctly 1`] = `
           <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
+            fieldRef={null}
             label="ehCt payments for 2, quarter 3"
             labelClassName="sr-only"
             name="ehCt-payments-2-q3"
@@ -521,6 +532,7 @@ exports[`incentive payments component renders correctly 1`] = `
           <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
+            fieldRef={null}
             label="ehCt payments for 2, quarter 4"
             labelClassName="sr-only"
             name="ehCt-payments-2-q4"
@@ -622,6 +634,7 @@ exports[`incentive payments component renders correctly 1`] = `
           <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
+            fieldRef={null}
             label="epCt payments for 2, quarter 1"
             labelClassName="sr-only"
             name="epCt-payments-2-q1"
@@ -635,6 +648,7 @@ exports[`incentive payments component renders correctly 1`] = `
           <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
+            fieldRef={null}
             label="epCt payments for 2, quarter 2"
             labelClassName="sr-only"
             name="epCt-payments-2-q2"
@@ -648,6 +662,7 @@ exports[`incentive payments component renders correctly 1`] = `
           <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
+            fieldRef={null}
             label="epCt payments for 2, quarter 3"
             labelClassName="sr-only"
             name="epCt-payments-2-q3"
@@ -661,6 +676,7 @@ exports[`incentive payments component renders correctly 1`] = `
           <NumberField
             className="budget-table--input-holder"
             fieldClassName="budget-table--input__number"
+            fieldRef={null}
             label="epCt payments for 2, quarter 4"
             labelClassName="sr-only"
             name="epCt-payments-2-q4"

--- a/web/src/containers/activity/ContractorResource/__snapshots__/ContractorResourceForm.test.js.snap
+++ b/web/src/containers/activity/ContractorResource/__snapshots__/ContractorResourceForm.test.js.snap
@@ -76,6 +76,7 @@ exports[`the ContractorResourceForm component renders correctly 1`] = `
               className="ds-l-row ds-u-padding-left--2"
             >
               <NumberField
+                fieldRef={null}
                 label="Number of hours"
                 labelClassName="ds-u-margin-top--1"
                 name="contractor-num-hours-ffy-1066"
@@ -106,6 +107,7 @@ exports[`the ContractorResourceForm component renders correctly 1`] = `
               className="ds-l-row ds-u-padding-left--2"
             >
               <NumberField
+                fieldRef={null}
                 label="Number of hours"
                 labelClassName="ds-u-margin-top--1"
                 name="contractor-num-hours-ffy-1067"
@@ -233,6 +235,7 @@ exports[`the ContractorResourceForm component renders if use hourly data is sele
               className="ds-l-row ds-u-padding-left--2"
             >
               <NumberField
+                fieldRef={null}
                 label="Number of hours"
                 labelClassName="ds-u-margin-top--1"
                 name="contractor-num-hours-ffy-1066"
@@ -263,6 +266,7 @@ exports[`the ContractorResourceForm component renders if use hourly data is sele
               className="ds-l-row ds-u-padding-left--2"
             >
               <NumberField
+                fieldRef={null}
                 label="Number of hours"
                 labelClassName="ds-u-margin-top--1"
                 name="contractor-num-hours-ffy-1067"

--- a/web/src/containers/activity/CostAllocateFFPQuarterly.js
+++ b/web/src/containers/activity/CostAllocateFFPQuarterly.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { updateActivity } from '../../actions/activities';
 import { ariaAnnounceFFPQuarterly } from '../../actions/aria';
 import Dollars from '../../components/Dollars';
-import NumberField from '../../components/NumberField';
+import PercentField from '../../components/PercentField';
 import { t } from '../../i18n';
 import { makeSelectCostAllocateFFPBudget } from '../../reducers/activities.selectors';
 import { formatPerc } from '../../util/formats';
@@ -81,18 +81,16 @@ class CostAllocateFFPQuarterly extends Component {
                 <Fragment key={year}>
                   {QUARTERS.map(q => (
                     <td key={q}>
-                      <div className="budget-table--input__percent">
-                        <NumberField
-                          className="budget-table--input-holder"
-                          fieldClassName="budget-table--input__number"
-                          label={`federal share for ffy ${year}, quarter ${q}, ${name}`}
-                          labelClassName="sr-only"
-                          name={`ffp-${aKey}-${year}-${q}-${name}`}
-                          onChange={this.handleChange(year, q, name)}
-                          value={quarterlyFFP[year][q][name].percent * 100}
-                          aria-controls={`ffp-${aKey}-${year}-${q}-${name}-dollar-equivalent`}
-                        />
-                      </div>
+                      <PercentField
+                        className="budget-table--input-holder"
+                        fieldClassName="budget-table--input__number"
+                        label={`federal share for ffy ${year}, quarter ${q}, ${name}`}
+                        labelClassName="sr-only"
+                        name={`ffp-${aKey}-${year}-${q}-${name}`}
+                        onChange={this.handleChange(year, q, name)}
+                        value={quarterlyFFP[year][q][name].percent * 100}
+                        aria-controls={`ffp-${aKey}-${year}-${q}-${name}-dollar-equivalent`}
+                      />
                     </td>
                   ))}
                   <td className="budget-table--number budget-table--subtotal">

--- a/web/src/containers/activity/StatePerson/__snapshots__/StatePersonForm.test.js.snap
+++ b/web/src/containers/activity/StatePerson/__snapshots__/StatePersonForm.test.js.snap
@@ -42,6 +42,7 @@ exports[`the StatePersonForm component renders correctly 1`] = `
       value=""
     />
     <NumberField
+      fieldRef={null}
       label="Number of FTEs"
       name="ftes"
       onChange={[Function]}
@@ -67,6 +68,7 @@ exports[`the StatePersonForm component renders correctly 1`] = `
       value=""
     />
     <NumberField
+      fieldRef={null}
       label="Number of FTEs"
       name="ftes"
       onChange={[Function]}

--- a/web/src/styles/scss/forms.scss
+++ b/web/src/styles/scss/forms.scss
@@ -77,7 +77,7 @@ div.form--with-reviews {
     font-weight: $font-normal;
     font-size: $lead-font-size;
     position: absolute;
-    right: 8px;
+    right: $spacer-1;
     top: 12px;
   }
 

--- a/web/src/styles/scss/forms.scss
+++ b/web/src/styles/scss/forms.scss
@@ -74,7 +74,7 @@ div.form--with-reviews {
   position: relative;
   &:after {
     content: '%';
-    font-weight: 700;
+    font-weight: 300;
     font-size: 18px;
     position: absolute;
     right: 8px;

--- a/web/src/styles/scss/forms.scss
+++ b/web/src/styles/scss/forms.scss
@@ -74,7 +74,7 @@ div.form--with-reviews {
   position: relative;
   &:after {
     content: '%';
-    font-weight: 300;
+    font-weight: $font-normal;
     font-size: 18px;
     position: absolute;
     right: 8px;

--- a/web/src/styles/scss/forms.scss
+++ b/web/src/styles/scss/forms.scss
@@ -75,7 +75,7 @@ div.form--with-reviews {
   &:after {
     content: '%';
     font-weight: $font-normal;
-    font-size: 18px;
+    font-size: $lead-font-size;
     position: absolute;
     right: 8px;
     top: 12px;

--- a/web/src/styles/scss/forms.scss
+++ b/web/src/styles/scss/forms.scss
@@ -69,6 +69,23 @@ div.form--with-reviews {
   }
 }
 
+.input-holder__percent {
+  display: inline-block;
+  position: relative;
+  &:after {
+    content: '%';
+    font-weight: 700;
+    font-size: 18px;
+    position: absolute;
+    right: 8px;
+    top: 12px;
+  }
+
+  input {
+    padding-right: 28px;
+  }
+}
+
 /* for forms that display computed values, but those computed values should
 be aligned vertically with their input field comrades */
 div.form--computed-value__input-aligned {
@@ -88,6 +105,10 @@ div.form--computed-value__input-aligned {
 /* dolla dolla inputs */
 .budget-table--input-holder {
   padding-bottom: 0;
+  .input-holder__percent:after {
+    font-size: 12px;
+    top: 12px;
+  }
 }
 
 .budget-table--input__number {
@@ -98,24 +119,6 @@ div.form--computed-value__input-aligned {
   border-radius: $border-radius;
   padding: $spacer-1;
   width: 100%;
-}
-
-.budget-table--input__percent {
-  position: relative;
-}
-
-.budget-table--input__percent::before {
-  content: '%';
-  font-weight: bold;
-  line-height: 1.3;
-  padding: 8px 0;
-  position: absolute;
-  right: 8px;
-  top: 4px;
-}
-
-.budget-table--input__percent .budget-table--input__number {
-  padding-right: $spacer-1 + $spacer-1 + $spacer-half;
 }
 
 .budget-table--number {


### PR DESCRIPTION
Adds a `<PercentField>` component that does DOM jujitsu to insert a percent sign into number input fields. I had to use gymnastics here because we're using design system components, and they render the `<input>` deep inside some other stuff. That doesn't seem like a problem though, right? We can target that input with CSS!

Well, yes we can, but did you know that input elements don't have `:before` or `:after` pseudoelements? So you can't put a percent sign next to them that way, which is the most obvious way.

Okay, but we could target the container and put the percent sign on that! Sure, that's possible. But the container is the full content width and the input element is not. If we want the percent sign to be nestled against the right side of the input element...  well, tough luck, there's no way in CSS to position the wrapper's `:before` pseudoelement relative to one of the wrapper's children.

So the somersaulting solution: grab the input element after it has been rendered, programmatically create our own wrapper div, put our custom wrapper in place of the input element, and add the input element into our wrapper.  Then we relatively position the wrapper and, the key step, we set its display to `inline-block`. Now the wrapper has the same size as the input element, and we can position the `:before` pseudoelement relative to the wrapper itself.

### This pull request changes...

- adds `<PercentField>` to APD key personnel and updates quarterly FFP share table
  ![image](https://user-images.githubusercontent.com/1775733/64815181-971caf80-d56a-11e9-92a2-81dc51804c11.png)
- closes #1753

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [x] Changelog is updated as appropriate

### This feature is done when...

- [ ] Design has approved the experience
- [ ] Product has approved the experience
