### PR TITLE
Compute JSON patchset of APD edits in the state Medicaid director and office section

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 
   web:
     build: ./web
-    image: cms-eapd/web:3471340f410490c0807d0d382f3b5649
+    image: cms-eapd/web:d53dea8dbe180ca9c2e8e2cff49a9084
     environment:
       - API_URL=http://localhost:8081
     volumes:
@@ -31,7 +31,7 @@ services:
       - 8080:8001
   
   storybook:
-    image: cms-eapd/web:3471340f410490c0807d0d382f3b5649
+    image: cms-eapd/web:d53dea8dbe180ca9c2e8e2cff49a9084
     volumes:
       - ./web:/app
       - /app/node_modules

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12257,6 +12257,11 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
     },
+    "jsonpatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpatch/-/jsonpatch-3.0.1.tgz",
+      "integrity": "sha1-lyJTZ8HDxb8WQb5Zsvc74ZdZ8G8="
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -69,6 +69,7 @@
     "html-to-draftjs": "1.4.0",
     "i18n-js": "^3.3.0",
     "is_js": "^0.9.0",
+    "jsonpatch": "^3.0.1",
     "lodash.difference": "^4.5.0",
     "markdown-it": "^8.4.2",
     "moment": "^2.22.2",

--- a/web/src/actions/editApd.js
+++ b/web/src/actions/editApd.js
@@ -1,25 +1,25 @@
 export const EDIT_APD = Symbol('edit apd');
 
-export const setMedicaidDirectorName = name => {
-  return {
-    type: EDIT_APD,
-    path: 'stateProfile/medicaidDirector/name',
-    value: name
-  };
-};
-
 export const setMedicaidDirectorEmail = email => {
   return {
     type: EDIT_APD,
-    path: 'stateProfile/medicaidDirector/email',
+    path: '/stateProfile/medicaidDirector/email',
     value: email
+  };
+};
+
+export const setMedicaidDirectorName = name => {
+  return {
+    type: EDIT_APD,
+    path: '/stateProfile/medicaidDirector/name',
+    value: name
   };
 };
 
 export const setMedicaidDirectorPhoneNumber = phone => {
   return {
     type: EDIT_APD,
-    path: 'stateProfile/medicaidDirector/phone',
+    path: '/stateProfile/medicaidDirector/phone',
     value: phone
   };
 };
@@ -27,7 +27,7 @@ export const setMedicaidDirectorPhoneNumber = phone => {
 export const setMedicaidOfficeAddress1 = address => {
   return {
     type: EDIT_APD,
-    path: 'stateProfile/medicaidOffice/address1',
+    path: '/stateProfile/medicaidOffice/address1',
     value: address
   };
 };
@@ -35,7 +35,7 @@ export const setMedicaidOfficeAddress1 = address => {
 export const setMedicaidOfficeAddress2 = address => {
   return {
     type: EDIT_APD,
-    path: 'stateProfile/medicaidOffice/address2',
+    path: '/stateProfile/medicaidOffice/address2',
     value: address
   };
 };
@@ -43,7 +43,7 @@ export const setMedicaidOfficeAddress2 = address => {
 export const setMedicaidOfficeCity = city => {
   return {
     type: EDIT_APD,
-    path: 'stateProfile/medicaidOffice/city',
+    path: '/stateProfile/medicaidOffice/city',
     value: city
   };
 };
@@ -51,7 +51,7 @@ export const setMedicaidOfficeCity = city => {
 export const setMedicaidOfficeState = state => {
   return {
     type: EDIT_APD,
-    path: 'stateProfile/medicaidOffice/state',
+    path: '/stateProfile/medicaidOffice/state',
     value: state
   };
 };
@@ -59,7 +59,7 @@ export const setMedicaidOfficeState = state => {
 export const setMedicaidOfficeZip = zip => {
   return {
     type: EDIT_APD,
-    path: 'stateProfile/medicaidOffice/zip',
+    path: '/stateProfile/medicaidOffice/zip',
     value: zip
   };
 };

--- a/web/src/actions/editApd.js
+++ b/web/src/actions/editApd.js
@@ -1,0 +1,65 @@
+export const EDIT_APD = Symbol('edit apd');
+
+export const setMedicaidDirectorName = name => {
+  return {
+    type: EDIT_APD,
+    path: 'stateProfile/medicaidDirector/name',
+    value: name
+  };
+};
+
+export const setMedicaidDirectorEmail = email => {
+  return {
+    type: EDIT_APD,
+    path: 'stateProfile/medicaidDirector/email',
+    value: email
+  };
+};
+
+export const setMedicaidDirectorPhoneNumber = phone => {
+  return {
+    type: EDIT_APD,
+    path: 'stateProfile/medicaidDirector/phone',
+    value: phone
+  };
+};
+
+export const setMedicaidOfficeAddress1 = address => {
+  return {
+    type: EDIT_APD,
+    path: 'stateProfile/medicaidOffice/address1',
+    value: address
+  };
+};
+
+export const setMedicaidOfficeAddress2 = address => {
+  return {
+    type: EDIT_APD,
+    path: 'stateProfile/medicaidOffice/address2',
+    value: address
+  };
+};
+
+export const setMedicaidOfficeCity = city => {
+  return {
+    type: EDIT_APD,
+    path: 'stateProfile/medicaidOffice/city',
+    value: city
+  };
+};
+
+export const setMedicaidOfficeState = state => {
+  return {
+    type: EDIT_APD,
+    path: 'stateProfile/medicaidOffice/state',
+    value: state
+  };
+};
+
+export const setMedicaidOfficeZip = zip => {
+  return {
+    type: EDIT_APD,
+    path: 'stateProfile/medicaidOffice/zip',
+    value: zip
+  };
+};

--- a/web/src/actions/editApd.test.js
+++ b/web/src/actions/editApd.test.js
@@ -1,0 +1,77 @@
+import {
+  EDIT_APD,
+  setMedicaidDirectorEmail,
+  setMedicaidDirectorName,
+  setMedicaidDirectorPhoneNumber,
+  setMedicaidOfficeAddress1,
+  setMedicaidOfficeAddress2,
+  setMedicaidOfficeCity,
+  setMedicaidOfficeState,
+  setMedicaidOfficeZip
+} from './editApd';
+
+describe('APD edit actions', () => {
+  it('dispatches an action for setting the Medicaid director email', () => {
+    expect(setMedicaidDirectorEmail('email address')).toEqual({
+      type: EDIT_APD,
+      path: '/stateProfile/medicaidDirector/email',
+      value: 'email address'
+    });
+  });
+
+  it('dispatches an action for setting the Medicaid director name', () => {
+    expect(setMedicaidDirectorName('name')).toEqual({
+      type: EDIT_APD,
+      path: '/stateProfile/medicaidDirector/name',
+      value: 'name'
+    });
+  });
+
+  it('dispatches an action for setting the Medicaid director phone number', () => {
+    expect(setMedicaidDirectorPhoneNumber('phone number')).toEqual({
+      type: EDIT_APD,
+      path: '/stateProfile/medicaidDirector/phone',
+      value: 'phone number'
+    });
+  });
+
+  it('dispatches an action for setting the Medicaid office address line 1', () => {
+    expect(setMedicaidOfficeAddress1('address 1')).toEqual({
+      type: EDIT_APD,
+      path: '/stateProfile/medicaidOffice/address1',
+      value: 'address 1'
+    });
+  });
+
+  it('dispatches an action for setting the Medicaid office address line 2', () => {
+    expect(setMedicaidOfficeAddress2('address 2')).toEqual({
+      type: EDIT_APD,
+      path: '/stateProfile/medicaidOffice/address2',
+      value: 'address 2'
+    });
+  });
+
+  it('dispatches an action for setting the Medicaid office city', () => {
+    expect(setMedicaidOfficeCity('city')).toEqual({
+      type: EDIT_APD,
+      path: '/stateProfile/medicaidOffice/city',
+      value: 'city'
+    });
+  });
+
+  it('dispatches an action for setting the Medicaid office state', () => {
+    expect(setMedicaidOfficeState('state')).toEqual({
+      type: EDIT_APD,
+      path: '/stateProfile/medicaidOffice/state',
+      value: 'state'
+    });
+  });
+
+  it('dispatches an action for setting the Medicaid office zip code', () => {
+    expect(setMedicaidOfficeZip('zip code')).toEqual({
+      type: EDIT_APD,
+      path: '/stateProfile/medicaidOffice/zip',
+      value: 'zip code'
+    });
+  });
+});

--- a/web/src/containers/ApdStateProfileMedicaidOffice.js
+++ b/web/src/containers/ApdStateProfileMedicaidOffice.js
@@ -1,132 +1,158 @@
 import { FormLabel, Select, TextField } from '@cmsgov/design-system-core';
-import PropTypes from 'prop-types';
-import React, { Component, Fragment } from 'react';
-import { connect } from 'react-redux';
+import React, { Fragment } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 
-import { updateApd as updateApdAction } from '../actions/apd';
+import { updateApd } from '../actions/apd';
+import {
+  setMedicaidDirectorEmail,
+  setMedicaidDirectorName,
+  setMedicaidDirectorPhoneNumber,
+  setMedicaidOfficeAddress1,
+  setMedicaidOfficeAddress2,
+  setMedicaidOfficeCity,
+  setMedicaidOfficeState,
+  setMedicaidOfficeZip
+} from '../actions/editApd';
 import { t } from '../i18n';
 import { STATES } from '../util';
 
-class ApdStateProfile extends Component {
-  handleChange = (area, field) => e => {
-    const { updateApd } = this.props;
-    updateApd({ stateProfile: { [area]: { [field]: e.target.value } } });
+const dirTRoot = 'apd.stateProfile.directorAndAddress.director';
+const offTRoot = 'apd.stateProfile.directorAndAddress.address';
+
+const ApdStateProfile = () => {
+  const dispatch = useDispatch();
+
+  const handleChange = (action, area, field) => ({ target: { value } }) => {
+    dispatch(updateApd({ stateProfile: { [area]: { [field]: value } } }));
+    dispatch(action(value));
   };
 
-  render() {
-    const {
-      defaultStateID,
-      stateProfile: { medicaidDirector, medicaidOffice }
-    } = this.props;
-    const dirTRoot = 'apd.stateProfile.directorAndAddress.director';
-    const offTRoot = 'apd.stateProfile.directorAndAddress.address';
+  const {
+    defaultStateID,
+    stateProfile: { medicaidDirector, medicaidOffice }
+  } = useSelector(
+    ({
+      apd: {
+        data: { stateProfile }
+      },
+      user: {
+        data: {
+          state: { id }
+        }
+      }
+    }) => ({
+      defaultStateID: id.toUpperCase(),
+      stateProfile
+    })
+  );
 
-    return (
-      <Fragment>
-        <fieldset>
-          <legend className="ds-u-padding-bottom--1">
-            {t(`${dirTRoot}.title`)}
-          </legend>
-          <TextField
-            name="apd-state-profile-mdname"
-            label={t(`${dirTRoot}.labels.name`)}
-            value={medicaidDirector.name}
-            onChange={this.handleChange('medicaidDirector', 'name')}
-          />
-          <TextField
-            name="apd-state-profile-mdemail"
-            label={t(`${dirTRoot}.labels.email`)}
-            value={medicaidDirector.email}
-            onChange={this.handleChange('medicaidDirector', 'email')}
-          />
-          <TextField
-            name="apd-state-profile-mdphone"
-            label={t(`${dirTRoot}.labels.phone`)}
-            value={medicaidDirector.phone}
-            onChange={this.handleChange('medicaidDirector', 'phone')}
-          />
-        </fieldset>
+  return (
+    <Fragment>
+      <fieldset>
+        <legend className="ds-u-padding-bottom--1">
+          {t(`${dirTRoot}.title`)}
+        </legend>
+        <TextField
+          name="apd-state-profile-mdname"
+          label={t(`${dirTRoot}.labels.name`)}
+          value={medicaidDirector.name}
+          onChange={handleChange(
+            setMedicaidDirectorName,
+            'medicaidDirector',
+            'name'
+          )}
+        />
+        <TextField
+          name="apd-state-profile-mdemail"
+          label={t(`${dirTRoot}.labels.email`)}
+          value={medicaidDirector.email}
+          onChange={handleChange(
+            setMedicaidDirectorEmail,
+            'medicaidDirector',
+            'email'
+          )}
+        />
+        <TextField
+          name="apd-state-profile-mdphone"
+          label={t(`${dirTRoot}.labels.phone`)}
+          value={medicaidDirector.phone}
+          onChange={handleChange(
+            setMedicaidDirectorPhoneNumber,
+            'medicaidDirector',
+            'phone'
+          )}
+        />
+      </fieldset>
 
-        <fieldset>
-          <legend className="ds-u-padding-bottom--1">
-            {t(`${offTRoot}.title`)}
-          </legend>
+      <fieldset>
+        <legend className="ds-u-padding-bottom--1">
+          {t(`${offTRoot}.title`)}
+        </legend>
+        <TextField
+          name="apd-state-profile-addr1"
+          label={t(`${offTRoot}.labels.address1`)}
+          value={medicaidOffice.address1}
+          onChange={handleChange(
+            setMedicaidOfficeAddress1,
+            'medicaidOffice',
+            'address1'
+          )}
+        />
+        <TextField
+          name="apd-state-profile-addr2"
+          label={t(`${offTRoot}.labels.address2`)}
+          hint="Optional"
+          value={medicaidOffice.address2}
+          onChange={handleChange(
+            setMedicaidOfficeAddress2,
+            'medicaidOffice',
+            'address2'
+          )}
+        />
+        <div className="ds-l-row">
           <TextField
-            name="apd-state-profile-addr1"
-            label={t(`${offTRoot}.labels.address1`)}
-            value={medicaidOffice.address1}
-            onChange={this.handleChange('medicaidOffice', 'address1')}
+            name="apd-state-profile-city"
+            label={t(`${offTRoot}.labels.city`)}
+            value={medicaidOffice.city}
+            className="ds-l-col--6"
+            onChange={handleChange(
+              setMedicaidOfficeCity,
+              'medicaidOffice',
+              'city'
+            )}
           />
-          <TextField
-            name="apd-state-profile-addr2"
-            label={t(`${offTRoot}.labels.address2`)}
-            hint="Optional"
-            value={medicaidOffice.address2}
-            onChange={this.handleChange('medicaidOffice', 'address2')}
-          />
-          <div className="ds-l-row">
-            <TextField
-              name="apd-state-profile-city"
-              label={t(`${offTRoot}.labels.city`)}
-              value={medicaidOffice.city}
-              className="ds-l-col--6"
-              onChange={this.handleChange('medicaidOffice', 'city')}
-            />
-            <div className="ds-u-clearfix ds-l-col--6">
-              <FormLabel component="label">
-                {t(`${offTRoot}.labels.state`)}
-              </FormLabel>
-              <Select
-                name="apd-state-profile-state"
-                label={t(`${offTRoot}.labels.state`)}
-                value={medicaidOffice.state || defaultStateID}
-                onChange={this.handleChange('medicaidOffice', 'state')}
-              >
-                {STATES.map(({ id, name }) => (
-                  <option key={name} value={id.toUpperCase()}>
-                    {name}
-                  </option>
-                ))}
-              </Select>
-            </div>
+          <div className="ds-u-clearfix ds-l-col--6">
+            <FormLabel component="label">
+              {t(`${offTRoot}.labels.state`)}
+            </FormLabel>
+            <Select
+              name="apd-state-profile-state"
+              label={t(`${offTRoot}.labels.state`)}
+              value={medicaidOffice.state || defaultStateID}
+              onChange={handleChange(
+                setMedicaidOfficeState,
+                'medicaidOffice',
+                'state'
+              )}
+            >
+              {STATES.map(({ id, name }) => (
+                <option key={name} value={id.toUpperCase()}>
+                  {name}
+                </option>
+              ))}
+            </Select>
           </div>
-          <TextField
-            name="apd-state-profile-zip"
-            label={t(`${offTRoot}.labels.zip`)}
-            value={medicaidOffice.zip}
-            mask="zip"
-            onChange={this.handleChange('medicaidOffice', 'zip')}
-          />
-        </fieldset>
-      </Fragment>
-    );
-  }
-}
-
-ApdStateProfile.propTypes = {
-  defaultStateID: PropTypes.string.isRequired,
-  stateProfile: PropTypes.object.isRequired,
-  updateApd: PropTypes.func.isRequired
+        </div>
+        <TextField
+          name="apd-state-profile-zip"
+          label={t(`${offTRoot}.labels.zip`)}
+          value={medicaidOffice.zip}
+          mask="zip"
+          onChange={handleChange(setMedicaidOfficeZip, 'medicaidOffice', 'zip')}
+        />
+      </fieldset>
+    </Fragment>
+  );
 };
 
-const mapStateToProps = ({
-  apd: {
-    data: { stateProfile }
-  },
-  user: {
-    data: {
-      state: { id }
-    }
-  }
-}) => ({
-  defaultStateID: id.toUpperCase(),
-  stateProfile
-});
-const mapDispatchToProps = { updateApd: updateApdAction };
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(ApdStateProfile);
-
-export { ApdStateProfile as plain, mapStateToProps, mapDispatchToProps };
+export default ApdStateProfile;

--- a/web/src/containers/ApdStateProfileMedicaidOffice.js
+++ b/web/src/containers/ApdStateProfileMedicaidOffice.js
@@ -2,7 +2,6 @@ import { FormLabel, Select, TextField } from '@cmsgov/design-system-core';
 import React, { Fragment } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { updateApd } from '../actions/apd';
 import {
   setMedicaidDirectorEmail,
   setMedicaidDirectorName,
@@ -22,8 +21,7 @@ const offTRoot = 'apd.stateProfile.directorAndAddress.address';
 const ApdStateProfile = () => {
   const dispatch = useDispatch();
 
-  const handleChange = (action, area, field) => ({ target: { value } }) => {
-    dispatch(updateApd({ stateProfile: { [area]: { [field]: value } } }));
+  const handleChange = action => ({ target: { value } }) => {
     dispatch(action(value));
   };
 
@@ -56,31 +54,19 @@ const ApdStateProfile = () => {
           name="apd-state-profile-mdname"
           label={t(`${dirTRoot}.labels.name`)}
           value={medicaidDirector.name}
-          onChange={handleChange(
-            setMedicaidDirectorName,
-            'medicaidDirector',
-            'name'
-          )}
+          onChange={handleChange(setMedicaidDirectorName)}
         />
         <TextField
           name="apd-state-profile-mdemail"
           label={t(`${dirTRoot}.labels.email`)}
           value={medicaidDirector.email}
-          onChange={handleChange(
-            setMedicaidDirectorEmail,
-            'medicaidDirector',
-            'email'
-          )}
+          onChange={handleChange(setMedicaidDirectorEmail)}
         />
         <TextField
           name="apd-state-profile-mdphone"
           label={t(`${dirTRoot}.labels.phone`)}
           value={medicaidDirector.phone}
-          onChange={handleChange(
-            setMedicaidDirectorPhoneNumber,
-            'medicaidDirector',
-            'phone'
-          )}
+          onChange={handleChange(setMedicaidDirectorPhoneNumber)}
         />
       </fieldset>
 
@@ -92,22 +78,14 @@ const ApdStateProfile = () => {
           name="apd-state-profile-addr1"
           label={t(`${offTRoot}.labels.address1`)}
           value={medicaidOffice.address1}
-          onChange={handleChange(
-            setMedicaidOfficeAddress1,
-            'medicaidOffice',
-            'address1'
-          )}
+          onChange={handleChange(setMedicaidOfficeAddress1)}
         />
         <TextField
           name="apd-state-profile-addr2"
           label={t(`${offTRoot}.labels.address2`)}
           hint="Optional"
           value={medicaidOffice.address2}
-          onChange={handleChange(
-            setMedicaidOfficeAddress2,
-            'medicaidOffice',
-            'address2'
-          )}
+          onChange={handleChange(setMedicaidOfficeAddress2)}
         />
         <div className="ds-l-row">
           <TextField
@@ -115,11 +93,7 @@ const ApdStateProfile = () => {
             label={t(`${offTRoot}.labels.city`)}
             value={medicaidOffice.city}
             className="ds-l-col--6"
-            onChange={handleChange(
-              setMedicaidOfficeCity,
-              'medicaidOffice',
-              'city'
-            )}
+            onChange={handleChange(setMedicaidOfficeCity)}
           />
           <div className="ds-u-clearfix ds-l-col--6">
             <FormLabel component="label">
@@ -129,11 +103,7 @@ const ApdStateProfile = () => {
               name="apd-state-profile-state"
               label={t(`${offTRoot}.labels.state`)}
               value={medicaidOffice.state || defaultStateID}
-              onChange={handleChange(
-                setMedicaidOfficeState,
-                'medicaidOffice',
-                'state'
-              )}
+              onChange={handleChange(setMedicaidOfficeState)}
             >
               {STATES.map(({ id, name }) => (
                 <option key={name} value={id.toUpperCase()}>
@@ -148,7 +118,7 @@ const ApdStateProfile = () => {
           label={t(`${offTRoot}.labels.zip`)}
           value={medicaidOffice.zip}
           mask="zip"
-          onChange={handleChange(setMedicaidOfficeZip, 'medicaidOffice', 'zip')}
+          onChange={handleChange(setMedicaidOfficeZip)}
         />
       </fieldset>
     </Fragment>

--- a/web/src/containers/ApdStateProfileMedicaidOffice.test.js
+++ b/web/src/containers/ApdStateProfileMedicaidOffice.test.js
@@ -4,7 +4,6 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
-import { UPDATE_APD } from '../actions/apd';
 import { EDIT_APD } from '../actions/editApd';
 
 import StateProfile from './ApdStateProfileMedicaidOffice';
@@ -56,68 +55,44 @@ describe('apd state profile, Medicaid office component', () => {
     {
       testName: 'director name change',
       fieldName: 'apd-state-profile-mdname',
-      path: '/stateProfile/medicaidDirector/name',
-      getLegacyUpdates: value => ({
-        stateProfile: { medicaidDirector: { name: value } }
-      })
+      path: '/stateProfile/medicaidDirector/name'
     },
     {
       testName: 'director email change',
       fieldName: 'apd-state-profile-mdemail',
-      path: '/stateProfile/medicaidDirector/email',
-      getLegacyUpdates: value => ({
-        stateProfile: { medicaidDirector: { email: value } }
-      })
+      path: '/stateProfile/medicaidDirector/email'
     },
     {
       testName: 'director phone number change',
       fieldName: 'apd-state-profile-mdphone',
-      path: '/stateProfile/medicaidDirector/phone',
-      getLegacyUpdates: value => ({
-        stateProfile: { medicaidDirector: { phone: value } }
-      })
+      path: '/stateProfile/medicaidDirector/phone'
     },
     {
       testName: 'office address line 1 change',
       fieldName: 'apd-state-profile-addr1',
-      path: '/stateProfile/medicaidOffice/address1',
-      getLegacyUpdates: value => ({
-        stateProfile: { medicaidOffice: { address1: value } }
-      })
+      path: '/stateProfile/medicaidOffice/address1'
     },
     {
       testName: 'office address line 2 change',
       fieldName: 'apd-state-profile-addr2',
-      path: '/stateProfile/medicaidOffice/address2',
-      getLegacyUpdates: value => ({
-        stateProfile: { medicaidOffice: { address2: value } }
-      })
+      path: '/stateProfile/medicaidOffice/address2'
     },
     {
       testName: 'office city change',
       fieldName: 'apd-state-profile-city',
-      path: '/stateProfile/medicaidOffice/city',
-      getLegacyUpdates: value => ({
-        stateProfile: { medicaidOffice: { city: value } }
-      })
+      path: '/stateProfile/medicaidOffice/city'
     },
     {
       testName: 'office state change',
       fieldName: 'apd-state-profile-state',
-      path: '/stateProfile/medicaidOffice/state',
-      getLegacyUpdates: value => ({
-        stateProfile: { medicaidOffice: { state: value } }
-      })
+      path: '/stateProfile/medicaidOffice/state'
     },
     {
       testName: 'office zip change',
       fieldName: 'apd-state-profile-zip',
-      path: '/stateProfile/medicaidOffice/zip',
-      getLegacyUpdates: value => ({
-        stateProfile: { medicaidOffice: { zip: value } }
-      })
+      path: '/stateProfile/medicaidOffice/zip'
     }
-  ].forEach(({ testName, fieldName, path, getLegacyUpdates }) => {
+  ].forEach(({ testName, fieldName, path }) => {
     test(`dispatches on ${testName}`, () => {
       const component = mount(
         <Provider store={store}>
@@ -131,10 +106,6 @@ describe('apd state profile, Medicaid office component', () => {
         .prop('onChange')({ target: { value: 'new text' } });
 
       const expectedActions = [
-        {
-          type: UPDATE_APD,
-          updates: getLegacyUpdates('new text')
-        },
         {
           type: EDIT_APD,
           path,

--- a/web/src/containers/ApdStateProfileMedicaidOffice.test.js
+++ b/web/src/containers/ApdStateProfileMedicaidOffice.test.js
@@ -56,7 +56,7 @@ describe('apd state profile, Medicaid office component', () => {
     {
       testName: 'director name change',
       fieldName: 'apd-state-profile-mdname',
-      path: 'stateProfile/medicaidDirector/name',
+      path: '/stateProfile/medicaidDirector/name',
       getLegacyUpdates: value => ({
         stateProfile: { medicaidDirector: { name: value } }
       })
@@ -64,7 +64,7 @@ describe('apd state profile, Medicaid office component', () => {
     {
       testName: 'director email change',
       fieldName: 'apd-state-profile-mdemail',
-      path: 'stateProfile/medicaidDirector/email',
+      path: '/stateProfile/medicaidDirector/email',
       getLegacyUpdates: value => ({
         stateProfile: { medicaidDirector: { email: value } }
       })
@@ -72,7 +72,7 @@ describe('apd state profile, Medicaid office component', () => {
     {
       testName: 'director phone number change',
       fieldName: 'apd-state-profile-mdphone',
-      path: 'stateProfile/medicaidDirector/phone',
+      path: '/stateProfile/medicaidDirector/phone',
       getLegacyUpdates: value => ({
         stateProfile: { medicaidDirector: { phone: value } }
       })
@@ -80,7 +80,7 @@ describe('apd state profile, Medicaid office component', () => {
     {
       testName: 'office address line 1 change',
       fieldName: 'apd-state-profile-addr1',
-      path: 'stateProfile/medicaidOffice/address1',
+      path: '/stateProfile/medicaidOffice/address1',
       getLegacyUpdates: value => ({
         stateProfile: { medicaidOffice: { address1: value } }
       })
@@ -88,7 +88,7 @@ describe('apd state profile, Medicaid office component', () => {
     {
       testName: 'office address line 2 change',
       fieldName: 'apd-state-profile-addr2',
-      path: 'stateProfile/medicaidOffice/address2',
+      path: '/stateProfile/medicaidOffice/address2',
       getLegacyUpdates: value => ({
         stateProfile: { medicaidOffice: { address2: value } }
       })
@@ -96,7 +96,7 @@ describe('apd state profile, Medicaid office component', () => {
     {
       testName: 'office city change',
       fieldName: 'apd-state-profile-city',
-      path: 'stateProfile/medicaidOffice/city',
+      path: '/stateProfile/medicaidOffice/city',
       getLegacyUpdates: value => ({
         stateProfile: { medicaidOffice: { city: value } }
       })
@@ -104,7 +104,7 @@ describe('apd state profile, Medicaid office component', () => {
     {
       testName: 'office state change',
       fieldName: 'apd-state-profile-state',
-      path: 'stateProfile/medicaidOffice/state',
+      path: '/stateProfile/medicaidOffice/state',
       getLegacyUpdates: value => ({
         stateProfile: { medicaidOffice: { state: value } }
       })
@@ -112,7 +112,7 @@ describe('apd state profile, Medicaid office component', () => {
     {
       testName: 'office zip change',
       fieldName: 'apd-state-profile-zip',
-      path: 'stateProfile/medicaidOffice/zip',
+      path: '/stateProfile/medicaidOffice/zip',
       getLegacyUpdates: value => ({
         stateProfile: { medicaidOffice: { zip: value } }
       })

--- a/web/src/containers/ApdStateProfileMedicaidOffice.test.js
+++ b/web/src/containers/ApdStateProfileMedicaidOffice.test.js
@@ -1,83 +1,148 @@
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import React from 'react';
-import sinon from 'sinon';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
 
-import {
-  plain as StateProfile,
-  mapStateToProps,
-  mapDispatchToProps
-} from './ApdStateProfileMedicaidOffice';
-import { updateApd } from '../actions/apd';
+import { UPDATE_APD } from '../actions/apd';
+import { EDIT_APD } from '../actions/editApd';
+
+import StateProfile from './ApdStateProfileMedicaidOffice';
+
+const mockStore = configureStore([thunk]);
 
 describe('apd state profile, Medicaid office component', () => {
-  const props = {
-    stateProfile: {
-      medicaidDirector: {
-        name: 'name',
-        email: 'email',
-        phone: 'phone'
-      },
-      medicaidOffice: {
-        address1: 'address 1',
-        address2: 'address 2',
-        city: 'city',
-        state: 'state',
-        zip: 'zip'
+  const store = mockStore({
+    apd: {
+      data: {
+        stateProfile: {
+          medicaidDirector: {
+            name: 'name',
+            email: 'email',
+            phone: 'phone'
+          },
+          medicaidOffice: {
+            address1: 'address 1',
+            address2: 'address 2',
+            city: 'city',
+            state: 'state',
+            zip: 'zip'
+          }
+        }
       }
     },
-    updateApd: sinon.spy()
-  };
+    user: {
+      data: {
+        state: { id: 'mn' }
+      }
+    }
+  });
 
   beforeEach(() => {
-    props.updateApd.resetHistory();
+    store.clearActions();
   });
 
   test('renders correctly', () => {
-    const localProps = JSON.parse(JSON.stringify(props));
-
-    // all good
     expect(
-      shallow(<StateProfile {...localProps} updateApd={props.updateApd} />)
-    ).toMatchSnapshot();
-
-    // name length validation
-    localProps.stateProfile.medicaidDirector.name = 'a';
-    expect(
-      shallow(<StateProfile {...localProps} updateApd={props.updateApd} />)
+      mount(
+        <Provider store={store}>
+          <StateProfile />
+        </Provider>
+      )
     ).toMatchSnapshot();
   });
 
-  test('dispatches on text change', () => {
-    shallow(<StateProfile {...props} />)
-      .find('TextField')
-      .at(0)
-      .simulate('change', { target: { value: 'new text' } });
-
-    // based on knowledge that director name is first
-    expect(
-      props.updateApd.calledWith({
-        stateProfile: { medicaidDirector: { name: 'new text' } }
+  [
+    {
+      testName: 'director name change',
+      fieldName: 'apd-state-profile-mdname',
+      path: 'stateProfile/medicaidDirector/name',
+      getLegacyUpdates: value => ({
+        stateProfile: { medicaidDirector: { name: value } }
       })
-    );
-  });
+    },
+    {
+      testName: 'director email change',
+      fieldName: 'apd-state-profile-mdemail',
+      path: 'stateProfile/medicaidDirector/email',
+      getLegacyUpdates: value => ({
+        stateProfile: { medicaidDirector: { email: value } }
+      })
+    },
+    {
+      testName: 'director phone number change',
+      fieldName: 'apd-state-profile-mdphone',
+      path: 'stateProfile/medicaidDirector/phone',
+      getLegacyUpdates: value => ({
+        stateProfile: { medicaidDirector: { phone: value } }
+      })
+    },
+    {
+      testName: 'office address line 1 change',
+      fieldName: 'apd-state-profile-addr1',
+      path: 'stateProfile/medicaidOffice/address1',
+      getLegacyUpdates: value => ({
+        stateProfile: { medicaidOffice: { address1: value } }
+      })
+    },
+    {
+      testName: 'office address line 2 change',
+      fieldName: 'apd-state-profile-addr2',
+      path: 'stateProfile/medicaidOffice/address2',
+      getLegacyUpdates: value => ({
+        stateProfile: { medicaidOffice: { address2: value } }
+      })
+    },
+    {
+      testName: 'office city change',
+      fieldName: 'apd-state-profile-city',
+      path: 'stateProfile/medicaidOffice/city',
+      getLegacyUpdates: value => ({
+        stateProfile: { medicaidOffice: { city: value } }
+      })
+    },
+    {
+      testName: 'office state change',
+      fieldName: 'apd-state-profile-state',
+      path: 'stateProfile/medicaidOffice/state',
+      getLegacyUpdates: value => ({
+        stateProfile: { medicaidOffice: { state: value } }
+      })
+    },
+    {
+      testName: 'office zip change',
+      fieldName: 'apd-state-profile-zip',
+      path: 'stateProfile/medicaidOffice/zip',
+      getLegacyUpdates: value => ({
+        stateProfile: { medicaidOffice: { zip: value } }
+      })
+    }
+  ].forEach(({ testName, fieldName, path, getLegacyUpdates }) => {
+    test(`dispatches on ${testName}`, () => {
+      const component = mount(
+        <Provider store={store}>
+          <StateProfile />
+        </Provider>
+      );
 
-  test('maps state to props', () => {
-    const state = {
-      apd: {
-        data: {
-          stateProfile: 'state profile'
+      component
+        .findWhere(c => c.prop('name') === fieldName)
+        .first()
+        .prop('onChange')({ target: { value: 'new text' } });
+
+      const expectedActions = [
+        {
+          type: UPDATE_APD,
+          updates: getLegacyUpdates('new text')
+        },
+        {
+          type: EDIT_APD,
+          path,
+          value: 'new text'
         }
-      },
-      user: { data: { state: { id: 'logged-in state id' } } }
-    };
+      ];
 
-    expect(mapStateToProps(state)).toEqual({
-      defaultStateID: 'LOGGED-IN STATE ID',
-      stateProfile: 'state profile'
+      expect(store.getActions()).toEqual(expectedActions);
     });
-  });
-
-  test('maps dispatch to props', () => {
-    expect(mapDispatchToProps).toEqual({ updateApd });
   });
 });

--- a/web/src/containers/__snapshots__/ApdStateProfileMedicaidOffice.test.js.snap
+++ b/web/src/containers/__snapshots__/ApdStateProfileMedicaidOffice.test.js.snap
@@ -1,855 +1,672 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`apd state profile, Medicaid office component renders correctly 1`] = `
-<Fragment>
-  <fieldset>
-    <legend
-      className="ds-u-padding-bottom--1"
-    >
-      Medicaid director
-    </legend>
-    <TextField
-      label="Name"
-      name="apd-state-profile-mdname"
-      onChange={[Function]}
-      type="text"
-      value="name"
-    />
-    <TextField
-      label="Email address"
-      name="apd-state-profile-mdemail"
-      onChange={[Function]}
-      type="text"
-      value="email"
-    />
-    <TextField
-      label="Phone number"
-      name="apd-state-profile-mdphone"
-      onChange={[Function]}
-      type="text"
-      value="phone"
-    />
-  </fieldset>
-  <fieldset>
-    <legend
-      className="ds-u-padding-bottom--1"
-    >
-      Medicaid office
-    </legend>
-    <TextField
-      label="Address"
-      name="apd-state-profile-addr1"
-      onChange={[Function]}
-      type="text"
-      value="address 1"
-    />
-    <TextField
-      hint="Optional"
-      label="Address continued"
-      name="apd-state-profile-addr2"
-      onChange={[Function]}
-      type="text"
-      value="address 2"
-    />
-    <div
-      className="ds-l-row"
-    >
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <ApdStateProfile>
+    <fieldset>
+      <legend
+        className="ds-u-padding-bottom--1"
+      >
+        Medicaid director
+      </legend>
       <TextField
-        className="ds-l-col--6"
-        label="City"
-        name="apd-state-profile-city"
+        label="Name"
+        name="apd-state-profile-mdname"
         onChange={[Function]}
         type="text"
-        value="city"
-      />
-      <div
-        className="ds-u-clearfix ds-l-col--6"
+        value="name"
       >
-        <FormLabel
-          component="label"
+        <div
+          className="ds-u-clearfix"
         >
-          State
-        </FormLabel>
-        <Select
-          label="State"
-          name="apd-state-profile-state"
-          onChange={[Function]}
-          value="state"
-        >
-          <option
-            key="Alabama"
-            value="AL"
+          <FormLabel
+            component="label"
+            fieldId="textfield_1"
           >
-            Alabama
-          </option>
-          <option
-            key="Alaska"
-            value="AK"
-          >
-            Alaska
-          </option>
-          <option
-            key="Arizona"
-            value="AZ"
-          >
-            Arizona
-          </option>
-          <option
-            key="Arkansas"
-            value="AR"
-          >
-            Arkansas
-          </option>
-          <option
-            key="California"
-            value="CA"
-          >
-            California
-          </option>
-          <option
-            key="Colorado"
-            value="CO"
-          >
-            Colorado
-          </option>
-          <option
-            key="Connecticut"
-            value="CT"
-          >
-            Connecticut
-          </option>
-          <option
-            key="Delaware"
-            value="DE"
-          >
-            Delaware
-          </option>
-          <option
-            key="Florida"
-            value="FL"
-          >
-            Florida
-          </option>
-          <option
-            key="Georgia"
-            value="GA"
-          >
-            Georgia
-          </option>
-          <option
-            key="Hawaii"
-            value="HI"
-          >
-            Hawaii
-          </option>
-          <option
-            key="Idaho"
-            value="ID"
-          >
-            Idaho
-          </option>
-          <option
-            key="Iowa"
-            value="IA"
-          >
-            Iowa
-          </option>
-          <option
-            key="Illinois"
-            value="IL"
-          >
-            Illinois
-          </option>
-          <option
-            key="Indiana"
-            value="IN"
-          >
-            Indiana
-          </option>
-          <option
-            key="Kansas"
-            value="KS"
-          >
-            Kansas
-          </option>
-          <option
-            key="Kentucky"
-            value="KY"
-          >
-            Kentucky
-          </option>
-          <option
-            key="Louisiana"
-            value="LA"
-          >
-            Louisiana
-          </option>
-          <option
-            key="Maine"
-            value="ME"
-          >
-            Maine
-          </option>
-          <option
-            key="Maryland"
-            value="MD"
-          >
-            Maryland
-          </option>
-          <option
-            key="Massachusetts"
-            value="MA"
-          >
-            Massachusetts
-          </option>
-          <option
-            key="Michigan"
-            value="MI"
-          >
-            Michigan
-          </option>
-          <option
-            key="Minnesota"
-            value="MN"
-          >
-            Minnesota
-          </option>
-          <option
-            key="Mississippi"
-            value="MS"
-          >
-            Mississippi
-          </option>
-          <option
-            key="Missouri"
-            value="MO"
-          >
-            Missouri
-          </option>
-          <option
-            key="Montana"
-            value="MT"
-          >
-            Montana
-          </option>
-          <option
-            key="Nebraska"
-            value="NE"
-          >
-            Nebraska
-          </option>
-          <option
-            key="North Carolina"
-            value="NC"
-          >
-            North Carolina
-          </option>
-          <option
-            key="North Dakota"
-            value="ND"
-          >
-            North Dakota
-          </option>
-          <option
-            key="New Hampshire"
-            value="NH"
-          >
-            New Hampshire
-          </option>
-          <option
-            key="New Jersey"
-            value="NJ"
-          >
-            New Jersey
-          </option>
-          <option
-            key="New Mexico"
-            value="NM"
-          >
-            New Mexico
-          </option>
-          <option
-            key="Nevada"
-            value="NV"
-          >
-            Nevada
-          </option>
-          <option
-            key="New York"
-            value="NY"
-          >
-            New York
-          </option>
-          <option
-            key="Ohio"
-            value="OH"
-          >
-            Ohio
-          </option>
-          <option
-            key="Oklahoma"
-            value="OK"
-          >
-            Oklahoma
-          </option>
-          <option
-            key="Oregon"
-            value="OR"
-          >
-            Oregon
-          </option>
-          <option
-            key="Pennsylvania"
-            value="PA"
-          >
-            Pennsylvania
-          </option>
-          <option
-            key="Rhode Island"
-            value="RI"
-          >
-            Rhode Island
-          </option>
-          <option
-            key="South Carolina"
-            value="SC"
-          >
-            South Carolina
-          </option>
-          <option
-            key="South Dakota"
-            value="SD"
-          >
-            South Dakota
-          </option>
-          <option
-            key="Tennessee"
-            value="TN"
-          >
-            Tennessee
-          </option>
-          <option
-            key="Texas"
-            value="TX"
-          >
-            Texas
-          </option>
-          <option
-            key="Utah"
-            value="UT"
-          >
-            Utah
-          </option>
-          <option
-            key="Vermont"
-            value="VT"
-          >
-            Vermont
-          </option>
-          <option
-            key="Virginia"
-            value="VA"
-          >
-            Virginia
-          </option>
-          <option
-            key="Washington"
-            value="WA"
-          >
-            Washington
-          </option>
-          <option
-            key="West Virginia"
-            value="WV"
-          >
-            West Virginia
-          </option>
-          <option
-            key="Wisconsin"
-            value="WI"
-          >
-            Wisconsin
-          </option>
-          <option
-            key="Wyoming"
-            value="WY"
-          >
-            Wyoming
-          </option>
-          <option
-            key="District of Columbia"
-            value="DC"
-          >
-            District of Columbia
-          </option>
-          <option
-            key="American Samoa"
-            value="AS"
-          >
-            American Samoa
-          </option>
-          <option
-            key="Guam"
-            value="GU"
-          >
-            Guam
-          </option>
-          <option
-            key="Northern Mariana Islands"
-            value="MP"
-          >
-            Northern Mariana Islands
-          </option>
-          <option
-            key="Puerto Rico"
-            value="PR"
-          >
-            Puerto Rico
-          </option>
-          <option
-            key="U.S. Virgin Islands"
-            value="VI"
-          >
-            U.S. Virgin Islands
-          </option>
-        </Select>
-      </div>
-    </div>
-    <TextField
-      label="ZIP Code"
-      mask="zip"
-      name="apd-state-profile-zip"
-      onChange={[Function]}
-      type="text"
-      value="zip"
-    />
-  </fieldset>
-</Fragment>
-`;
-
-exports[`apd state profile, Medicaid office component renders correctly 2`] = `
-<Fragment>
-  <fieldset>
-    <legend
-      className="ds-u-padding-bottom--1"
-    >
-      Medicaid director
-    </legend>
-    <TextField
-      label="Name"
-      name="apd-state-profile-mdname"
-      onChange={[Function]}
-      type="text"
-      value="a"
-    />
-    <TextField
-      label="Email address"
-      name="apd-state-profile-mdemail"
-      onChange={[Function]}
-      type="text"
-      value="email"
-    />
-    <TextField
-      label="Phone number"
-      name="apd-state-profile-mdphone"
-      onChange={[Function]}
-      type="text"
-      value="phone"
-    />
-  </fieldset>
-  <fieldset>
-    <legend
-      className="ds-u-padding-bottom--1"
-    >
-      Medicaid office
-    </legend>
-    <TextField
-      label="Address"
-      name="apd-state-profile-addr1"
-      onChange={[Function]}
-      type="text"
-      value="address 1"
-    />
-    <TextField
-      hint="Optional"
-      label="Address continued"
-      name="apd-state-profile-addr2"
-      onChange={[Function]}
-      type="text"
-      value="address 2"
-    />
-    <div
-      className="ds-l-row"
-    >
+            <label
+              className="ds-c-label"
+              htmlFor="textfield_1"
+            >
+              <span
+                className=""
+              >
+                Name
+              </span>
+            </label>
+          </FormLabel>
+          <input
+            className="ds-c-field"
+            id="textfield_1"
+            name="apd-state-profile-mdname"
+            onChange={[Function]}
+            type="text"
+            value="name"
+          />
+        </div>
+      </TextField>
       <TextField
-        className="ds-l-col--6"
-        label="City"
-        name="apd-state-profile-city"
+        label="Email address"
+        name="apd-state-profile-mdemail"
         onChange={[Function]}
         type="text"
-        value="city"
-      />
-      <div
-        className="ds-u-clearfix ds-l-col--6"
+        value="email"
       >
-        <FormLabel
-          component="label"
+        <div
+          className="ds-u-clearfix"
         >
-          State
-        </FormLabel>
-        <Select
-          label="State"
-          name="apd-state-profile-state"
+          <FormLabel
+            component="label"
+            fieldId="textfield_2"
+          >
+            <label
+              className="ds-c-label"
+              htmlFor="textfield_2"
+            >
+              <span
+                className=""
+              >
+                Email address
+              </span>
+            </label>
+          </FormLabel>
+          <input
+            className="ds-c-field"
+            id="textfield_2"
+            name="apd-state-profile-mdemail"
+            onChange={[Function]}
+            type="text"
+            value="email"
+          />
+        </div>
+      </TextField>
+      <TextField
+        label="Phone number"
+        name="apd-state-profile-mdphone"
+        onChange={[Function]}
+        type="text"
+        value="phone"
+      >
+        <div
+          className="ds-u-clearfix"
+        >
+          <FormLabel
+            component="label"
+            fieldId="textfield_3"
+          >
+            <label
+              className="ds-c-label"
+              htmlFor="textfield_3"
+            >
+              <span
+                className=""
+              >
+                Phone number
+              </span>
+            </label>
+          </FormLabel>
+          <input
+            className="ds-c-field"
+            id="textfield_3"
+            name="apd-state-profile-mdphone"
+            onChange={[Function]}
+            type="text"
+            value="phone"
+          />
+        </div>
+      </TextField>
+    </fieldset>
+    <fieldset>
+      <legend
+        className="ds-u-padding-bottom--1"
+      >
+        Medicaid office
+      </legend>
+      <TextField
+        label="Address"
+        name="apd-state-profile-addr1"
+        onChange={[Function]}
+        type="text"
+        value="address 1"
+      >
+        <div
+          className="ds-u-clearfix"
+        >
+          <FormLabel
+            component="label"
+            fieldId="textfield_4"
+          >
+            <label
+              className="ds-c-label"
+              htmlFor="textfield_4"
+            >
+              <span
+                className=""
+              >
+                Address
+              </span>
+            </label>
+          </FormLabel>
+          <input
+            className="ds-c-field"
+            id="textfield_4"
+            name="apd-state-profile-addr1"
+            onChange={[Function]}
+            type="text"
+            value="address 1"
+          />
+        </div>
+      </TextField>
+      <TextField
+        hint="Optional"
+        label="Address continued"
+        name="apd-state-profile-addr2"
+        onChange={[Function]}
+        type="text"
+        value="address 2"
+      >
+        <div
+          className="ds-u-clearfix"
+        >
+          <FormLabel
+            component="label"
+            fieldId="textfield_5"
+            hint="Optional"
+          >
+            <label
+              className="ds-c-label"
+              htmlFor="textfield_5"
+            >
+              <span
+                className=""
+              >
+                Address continued
+              </span>
+              <span
+                className="ds-c-field__hint"
+              >
+                Optional
+              </span>
+            </label>
+          </FormLabel>
+          <input
+            className="ds-c-field"
+            id="textfield_5"
+            name="apd-state-profile-addr2"
+            onChange={[Function]}
+            type="text"
+            value="address 2"
+          />
+        </div>
+      </TextField>
+      <div
+        className="ds-l-row"
+      >
+        <TextField
+          className="ds-l-col--6"
+          label="City"
+          name="apd-state-profile-city"
           onChange={[Function]}
-          value="state"
+          type="text"
+          value="city"
         >
-          <option
-            key="Alabama"
-            value="AL"
+          <div
+            className="ds-u-clearfix ds-l-col--6"
           >
-            Alabama
-          </option>
-          <option
-            key="Alaska"
-            value="AK"
+            <FormLabel
+              component="label"
+              fieldId="textfield_6"
+            >
+              <label
+                className="ds-c-label"
+                htmlFor="textfield_6"
+              >
+                <span
+                  className=""
+                >
+                  City
+                </span>
+              </label>
+            </FormLabel>
+            <input
+              className="ds-c-field"
+              id="textfield_6"
+              name="apd-state-profile-city"
+              onChange={[Function]}
+              type="text"
+              value="city"
+            />
+          </div>
+        </TextField>
+        <div
+          className="ds-u-clearfix ds-l-col--6"
+        >
+          <FormLabel
+            component="label"
           >
-            Alaska
-          </option>
-          <option
-            key="Arizona"
-            value="AZ"
+            <label
+              className="ds-c-label"
+            >
+              <span
+                className=""
+              >
+                State
+              </span>
+            </label>
+          </FormLabel>
+          <Select
+            label="State"
+            name="apd-state-profile-state"
+            onChange={[Function]}
+            value="state"
           >
-            Arizona
-          </option>
-          <option
-            key="Arkansas"
-            value="AR"
-          >
-            Arkansas
-          </option>
-          <option
-            key="California"
-            value="CA"
-          >
-            California
-          </option>
-          <option
-            key="Colorado"
-            value="CO"
-          >
-            Colorado
-          </option>
-          <option
-            key="Connecticut"
-            value="CT"
-          >
-            Connecticut
-          </option>
-          <option
-            key="Delaware"
-            value="DE"
-          >
-            Delaware
-          </option>
-          <option
-            key="Florida"
-            value="FL"
-          >
-            Florida
-          </option>
-          <option
-            key="Georgia"
-            value="GA"
-          >
-            Georgia
-          </option>
-          <option
-            key="Hawaii"
-            value="HI"
-          >
-            Hawaii
-          </option>
-          <option
-            key="Idaho"
-            value="ID"
-          >
-            Idaho
-          </option>
-          <option
-            key="Iowa"
-            value="IA"
-          >
-            Iowa
-          </option>
-          <option
-            key="Illinois"
-            value="IL"
-          >
-            Illinois
-          </option>
-          <option
-            key="Indiana"
-            value="IN"
-          >
-            Indiana
-          </option>
-          <option
-            key="Kansas"
-            value="KS"
-          >
-            Kansas
-          </option>
-          <option
-            key="Kentucky"
-            value="KY"
-          >
-            Kentucky
-          </option>
-          <option
-            key="Louisiana"
-            value="LA"
-          >
-            Louisiana
-          </option>
-          <option
-            key="Maine"
-            value="ME"
-          >
-            Maine
-          </option>
-          <option
-            key="Maryland"
-            value="MD"
-          >
-            Maryland
-          </option>
-          <option
-            key="Massachusetts"
-            value="MA"
-          >
-            Massachusetts
-          </option>
-          <option
-            key="Michigan"
-            value="MI"
-          >
-            Michigan
-          </option>
-          <option
-            key="Minnesota"
-            value="MN"
-          >
-            Minnesota
-          </option>
-          <option
-            key="Mississippi"
-            value="MS"
-          >
-            Mississippi
-          </option>
-          <option
-            key="Missouri"
-            value="MO"
-          >
-            Missouri
-          </option>
-          <option
-            key="Montana"
-            value="MT"
-          >
-            Montana
-          </option>
-          <option
-            key="Nebraska"
-            value="NE"
-          >
-            Nebraska
-          </option>
-          <option
-            key="North Carolina"
-            value="NC"
-          >
-            North Carolina
-          </option>
-          <option
-            key="North Dakota"
-            value="ND"
-          >
-            North Dakota
-          </option>
-          <option
-            key="New Hampshire"
-            value="NH"
-          >
-            New Hampshire
-          </option>
-          <option
-            key="New Jersey"
-            value="NJ"
-          >
-            New Jersey
-          </option>
-          <option
-            key="New Mexico"
-            value="NM"
-          >
-            New Mexico
-          </option>
-          <option
-            key="Nevada"
-            value="NV"
-          >
-            Nevada
-          </option>
-          <option
-            key="New York"
-            value="NY"
-          >
-            New York
-          </option>
-          <option
-            key="Ohio"
-            value="OH"
-          >
-            Ohio
-          </option>
-          <option
-            key="Oklahoma"
-            value="OK"
-          >
-            Oklahoma
-          </option>
-          <option
-            key="Oregon"
-            value="OR"
-          >
-            Oregon
-          </option>
-          <option
-            key="Pennsylvania"
-            value="PA"
-          >
-            Pennsylvania
-          </option>
-          <option
-            key="Rhode Island"
-            value="RI"
-          >
-            Rhode Island
-          </option>
-          <option
-            key="South Carolina"
-            value="SC"
-          >
-            South Carolina
-          </option>
-          <option
-            key="South Dakota"
-            value="SD"
-          >
-            South Dakota
-          </option>
-          <option
-            key="Tennessee"
-            value="TN"
-          >
-            Tennessee
-          </option>
-          <option
-            key="Texas"
-            value="TX"
-          >
-            Texas
-          </option>
-          <option
-            key="Utah"
-            value="UT"
-          >
-            Utah
-          </option>
-          <option
-            key="Vermont"
-            value="VT"
-          >
-            Vermont
-          </option>
-          <option
-            key="Virginia"
-            value="VA"
-          >
-            Virginia
-          </option>
-          <option
-            key="Washington"
-            value="WA"
-          >
-            Washington
-          </option>
-          <option
-            key="West Virginia"
-            value="WV"
-          >
-            West Virginia
-          </option>
-          <option
-            key="Wisconsin"
-            value="WI"
-          >
-            Wisconsin
-          </option>
-          <option
-            key="Wyoming"
-            value="WY"
-          >
-            Wyoming
-          </option>
-          <option
-            key="District of Columbia"
-            value="DC"
-          >
-            District of Columbia
-          </option>
-          <option
-            key="American Samoa"
-            value="AS"
-          >
-            American Samoa
-          </option>
-          <option
-            key="Guam"
-            value="GU"
-          >
-            Guam
-          </option>
-          <option
-            key="Northern Mariana Islands"
-            value="MP"
-          >
-            Northern Mariana Islands
-          </option>
-          <option
-            key="Puerto Rico"
-            value="PR"
-          >
-            Puerto Rico
-          </option>
-          <option
-            key="U.S. Virgin Islands"
-            value="VI"
-          >
-            U.S. Virgin Islands
-          </option>
-        </Select>
+            <select
+              className="ds-c-field"
+              id="select_apd-state-profile-state_9"
+              label="State"
+              name="apd-state-profile-state"
+              onChange={[Function]}
+              value="state"
+            >
+              <option
+                key="Alabama"
+                value="AL"
+              >
+                Alabama
+              </option>
+              <option
+                key="Alaska"
+                value="AK"
+              >
+                Alaska
+              </option>
+              <option
+                key="Arizona"
+                value="AZ"
+              >
+                Arizona
+              </option>
+              <option
+                key="Arkansas"
+                value="AR"
+              >
+                Arkansas
+              </option>
+              <option
+                key="California"
+                value="CA"
+              >
+                California
+              </option>
+              <option
+                key="Colorado"
+                value="CO"
+              >
+                Colorado
+              </option>
+              <option
+                key="Connecticut"
+                value="CT"
+              >
+                Connecticut
+              </option>
+              <option
+                key="Delaware"
+                value="DE"
+              >
+                Delaware
+              </option>
+              <option
+                key="Florida"
+                value="FL"
+              >
+                Florida
+              </option>
+              <option
+                key="Georgia"
+                value="GA"
+              >
+                Georgia
+              </option>
+              <option
+                key="Hawaii"
+                value="HI"
+              >
+                Hawaii
+              </option>
+              <option
+                key="Idaho"
+                value="ID"
+              >
+                Idaho
+              </option>
+              <option
+                key="Iowa"
+                value="IA"
+              >
+                Iowa
+              </option>
+              <option
+                key="Illinois"
+                value="IL"
+              >
+                Illinois
+              </option>
+              <option
+                key="Indiana"
+                value="IN"
+              >
+                Indiana
+              </option>
+              <option
+                key="Kansas"
+                value="KS"
+              >
+                Kansas
+              </option>
+              <option
+                key="Kentucky"
+                value="KY"
+              >
+                Kentucky
+              </option>
+              <option
+                key="Louisiana"
+                value="LA"
+              >
+                Louisiana
+              </option>
+              <option
+                key="Maine"
+                value="ME"
+              >
+                Maine
+              </option>
+              <option
+                key="Maryland"
+                value="MD"
+              >
+                Maryland
+              </option>
+              <option
+                key="Massachusetts"
+                value="MA"
+              >
+                Massachusetts
+              </option>
+              <option
+                key="Michigan"
+                value="MI"
+              >
+                Michigan
+              </option>
+              <option
+                key="Minnesota"
+                value="MN"
+              >
+                Minnesota
+              </option>
+              <option
+                key="Mississippi"
+                value="MS"
+              >
+                Mississippi
+              </option>
+              <option
+                key="Missouri"
+                value="MO"
+              >
+                Missouri
+              </option>
+              <option
+                key="Montana"
+                value="MT"
+              >
+                Montana
+              </option>
+              <option
+                key="Nebraska"
+                value="NE"
+              >
+                Nebraska
+              </option>
+              <option
+                key="North Carolina"
+                value="NC"
+              >
+                North Carolina
+              </option>
+              <option
+                key="North Dakota"
+                value="ND"
+              >
+                North Dakota
+              </option>
+              <option
+                key="New Hampshire"
+                value="NH"
+              >
+                New Hampshire
+              </option>
+              <option
+                key="New Jersey"
+                value="NJ"
+              >
+                New Jersey
+              </option>
+              <option
+                key="New Mexico"
+                value="NM"
+              >
+                New Mexico
+              </option>
+              <option
+                key="Nevada"
+                value="NV"
+              >
+                Nevada
+              </option>
+              <option
+                key="New York"
+                value="NY"
+              >
+                New York
+              </option>
+              <option
+                key="Ohio"
+                value="OH"
+              >
+                Ohio
+              </option>
+              <option
+                key="Oklahoma"
+                value="OK"
+              >
+                Oklahoma
+              </option>
+              <option
+                key="Oregon"
+                value="OR"
+              >
+                Oregon
+              </option>
+              <option
+                key="Pennsylvania"
+                value="PA"
+              >
+                Pennsylvania
+              </option>
+              <option
+                key="Rhode Island"
+                value="RI"
+              >
+                Rhode Island
+              </option>
+              <option
+                key="South Carolina"
+                value="SC"
+              >
+                South Carolina
+              </option>
+              <option
+                key="South Dakota"
+                value="SD"
+              >
+                South Dakota
+              </option>
+              <option
+                key="Tennessee"
+                value="TN"
+              >
+                Tennessee
+              </option>
+              <option
+                key="Texas"
+                value="TX"
+              >
+                Texas
+              </option>
+              <option
+                key="Utah"
+                value="UT"
+              >
+                Utah
+              </option>
+              <option
+                key="Vermont"
+                value="VT"
+              >
+                Vermont
+              </option>
+              <option
+                key="Virginia"
+                value="VA"
+              >
+                Virginia
+              </option>
+              <option
+                key="Washington"
+                value="WA"
+              >
+                Washington
+              </option>
+              <option
+                key="West Virginia"
+                value="WV"
+              >
+                West Virginia
+              </option>
+              <option
+                key="Wisconsin"
+                value="WI"
+              >
+                Wisconsin
+              </option>
+              <option
+                key="Wyoming"
+                value="WY"
+              >
+                Wyoming
+              </option>
+              <option
+                key="District of Columbia"
+                value="DC"
+              >
+                District of Columbia
+              </option>
+              <option
+                key="American Samoa"
+                value="AS"
+              >
+                American Samoa
+              </option>
+              <option
+                key="Guam"
+                value="GU"
+              >
+                Guam
+              </option>
+              <option
+                key="Northern Mariana Islands"
+                value="MP"
+              >
+                Northern Mariana Islands
+              </option>
+              <option
+                key="Puerto Rico"
+                value="PR"
+              >
+                Puerto Rico
+              </option>
+              <option
+                key="U.S. Virgin Islands"
+                value="VI"
+              >
+                U.S. Virgin Islands
+              </option>
+            </select>
+          </Select>
+        </div>
       </div>
-    </div>
-    <TextField
-      label="ZIP Code"
-      mask="zip"
-      name="apd-state-profile-zip"
-      onChange={[Function]}
-      type="text"
-      value="zip"
-    />
-  </fieldset>
-</Fragment>
+      <TextField
+        label="ZIP Code"
+        mask="zip"
+        name="apd-state-profile-zip"
+        onChange={[Function]}
+        type="text"
+        value="zip"
+      >
+        <div
+          className="ds-u-clearfix"
+        >
+          <FormLabel
+            component="label"
+            fieldId="textfield_8"
+          >
+            <label
+              className="ds-c-label"
+              htmlFor="textfield_8"
+            >
+              <span
+                className=""
+              >
+                ZIP Code
+              </span>
+            </label>
+          </FormLabel>
+          <div
+            className="ds-c-field-mask ds-c-field-mask--zip"
+          >
+            <div
+              className="ds-c-field__before ds-c-field__before--zip"
+            />
+            <Mask
+              mask="zip"
+            >
+              <input
+                className="ds-c-field ds-c-field--zip"
+                id="textfield_8"
+                name="apd-state-profile-zip"
+                onBlur={[Function]}
+                onChange={[Function]}
+                type="text"
+                value="zip"
+              />
+            </Mask>
+          </div>
+        </div>
+      </TextField>
+    </fieldset>
+  </ApdStateProfile>
+</Provider>
 `;

--- a/web/src/reducers/apd.js
+++ b/web/src/reducers/apd.js
@@ -1,5 +1,6 @@
 import diff from 'lodash.difference';
 import u from 'updeep';
+import { apply_patch as applyPatch } from 'jsonpatch';
 
 import {
   ADD_APD_KEY_PERSON,
@@ -15,6 +16,7 @@ import {
   WITHDRAW_APD_SUCCESS,
   SAVE_APD_SUCCESS
 } from '../actions/apd';
+import { EDIT_APD } from '../actions/editApd';
 import { defaultAPDYearOptions, generateKey } from '../util';
 
 const getHumanTimestamp = iso8601 => {
@@ -153,6 +155,20 @@ const reducer = (state = initialState, action) => {
       return { ...state, selectAPDOnLoad: true };
     case SUBMIT_APD_SUCCESS:
       return u({ data: { status: 'submitted' } }, state);
+
+    case EDIT_APD: {
+      return {
+        ...state,
+        data: applyPatch(state.data, [
+          {
+            op: 'replace',
+            path: action.path,
+            value: action.value
+          }
+        ])
+      };
+    }
+
     case UPDATE_APD: {
       if (!action.updates.years) {
         return u({ data: { ...action.updates } }, state);

--- a/web/src/reducers/apd.test.js
+++ b/web/src/reducers/apd.test.js
@@ -11,6 +11,7 @@ const {
   WITHDRAW_APD_SUCCESS,
   SAVE_APD_SUCCESS
 } = require('../actions/apd');
+const { EDIT_APD } = require('../actions/editApd');
 
 describe('APD reducer', () => {
   afterAll(() => {
@@ -161,6 +162,21 @@ describe('APD reducer', () => {
     expect(apd(initialState, { type: 'SET_SELECT_APD_ON_LOAD' })).toEqual({
       ...initialState,
       selectAPDOnLoad: true
+    });
+  });
+
+  it('should handle an APD edit', () => {
+    const state = {
+      data: {
+        overview: 'bleep'
+      }
+    };
+    expect(
+      apd(state, { type: EDIT_APD, path: '/overview', value: 'bloop' })
+    ).toEqual({
+      data: {
+        overview: 'bloop'
+      }
     });
   });
 

--- a/web/src/reducers/index.js
+++ b/web/src/reducers/index.js
@@ -10,6 +10,7 @@ import budget from './budget';
 import dirty from './dirty';
 import errors from './errors';
 import navigation from './navigation';
+import patch from './patch';
 import user from './user';
 import working from './working';
 
@@ -24,6 +25,7 @@ const rootReducer = history =>
     dirty,
     errors,
     navigation,
+    patch,
     user,
     working,
     router: connectRouter(history)

--- a/web/src/reducers/index.test.js
+++ b/web/src/reducers/index.test.js
@@ -13,6 +13,7 @@ describe('root reducer', () => {
       'dirty',
       'errors',
       'navigation',
+      'patch',
       'user',
       'working',
       'router'

--- a/web/src/reducers/patch.js
+++ b/web/src/reducers/patch.js
@@ -1,0 +1,33 @@
+import u from 'updeep';
+
+import { SAVE_APD_SUCCESS } from '../actions/apd';
+import { EDIT_APD } from '../actions/editApd';
+
+const initialState = [];
+
+const reducer = (state = initialState, action) => {
+  switch (action.type) {
+    case SAVE_APD_SUCCESS:
+      return initialState;
+
+    case EDIT_APD: {
+      const existingIndex = state.findIndex(
+        ({ op, path }) => op === 'replace' && path === action.path
+      );
+      if (existingIndex < 0) {
+        return [
+          ...state,
+          { op: 'replace', path: action.path, value: action.value }
+        ];
+      }
+      return u({ [existingIndex]: { value: action.value } }, state);
+    }
+
+    default:
+      return state;
+  }
+};
+
+export default reducer;
+
+export const getHasChanges = ({ patch }) => patch.length > 0;

--- a/web/src/reducers/patch.js
+++ b/web/src/reducers/patch.js
@@ -5,22 +5,53 @@ import { EDIT_APD } from '../actions/editApd';
 
 const initialState = [];
 
+const indexOfLastReplacePatch = (patches, path) => {
+  for (let i = patches.length - 1; i >= 0; i -= 1) {
+    if (patches[i].path === path) {
+      if (patches[i].op === 'replace') {
+        return i;
+      }
+      return false;
+    }
+  }
+
+  return false;
+};
+
 const reducer = (state = initialState, action) => {
   switch (action.type) {
     case SAVE_APD_SUCCESS:
       return initialState;
 
     case EDIT_APD: {
-      const existingIndex = state.findIndex(
-        ({ op, path }) => op === 'replace' && path === action.path
-      );
-      if (existingIndex < 0) {
-        return [
-          ...state,
-          { op: 'replace', path: action.path, value: action.value }
-        ];
+      // If the last patch for the given path is already a replace, we can just
+      // update that patch instead of pushing a new one. If the last patch for
+      // this path is anything else, then we need to add this as a new patch
+      //
+      // For example, modifying an array with 10 elements:
+      //   1. update /some/array/3
+      //   2. update /some/array/7
+      //   3. update /some/array/3
+      //
+      // In this case, we can just replace the original patch with the new one
+      // because the sequence of events doesn't matter. However:
+      //
+      //  1. update /some/array/3
+      //  2. delete /some/array/3
+      //  3. update /some/array/3
+      //
+      // In this case, the second update to element 3 is actually updating a
+      // different element than the first update. The sequence matters, so
+      // we need to push the second update as a separate patch.
+      const indexToUpdate = indexOfLastReplacePatch(state, action.path);
+
+      if (indexToUpdate !== false) {
+        return u({ [indexToUpdate]: { value: action.value } }, state);
       }
-      return u({ [existingIndex]: { value: action.value } }, state);
+      return [
+        ...state,
+        { op: 'replace', path: action.path, value: action.value }
+      ];
     }
 
     default:

--- a/web/src/reducers/patch.test.js
+++ b/web/src/reducers/patch.test.js
@@ -1,0 +1,61 @@
+import { SAVE_APD_SUCCESS } from '../actions/apd';
+import { EDIT_APD } from '../actions/editApd';
+
+import reducer, { getHasChanges } from './patch';
+
+describe('JSON patch reducer', () => {
+  it('provides an initial state', () => {
+    expect(reducer(undefined, {})).toEqual([]);
+  });
+
+  it('resets to the initial state when an APD is saved', () => {
+    expect(reducer({}, { type: SAVE_APD_SUCCESS })).toEqual([]);
+  });
+
+  it('pushes a new edit to the list when an APD is edited', () => {
+    expect(
+      reducer([], { type: EDIT_APD, path: '/path/to/edit', value: 'new value' })
+    ).toEqual([{ op: 'replace', path: '/path/to/edit', value: 'new value' }]);
+  });
+
+  it('updates an existing patch if the path was replaced previously', () => {
+    expect(
+      reducer(
+        [
+          { op: 'replace', path: '/path/to/edit', value: 'old value' },
+          { op: 'replace', path: '/path/to/leave', value: 'leave' }
+        ],
+        { type: EDIT_APD, path: '/path/to/edit', value: 'new value' }
+      )
+    ).toEqual([
+      { op: 'replace', path: '/path/to/edit', value: 'new value' },
+      { op: 'replace', path: '/path/to/leave', value: 'leave' }
+    ]);
+  });
+
+  it('adds a new patch if the path was replaced previously but has had a different op applied since then', () => {
+    expect(
+      reducer(
+        [
+          { op: 'replace', path: '/path/to/edit', value: 'old value' },
+          { op: 'remove', path: '/path/to/edit' }
+        ],
+        { type: EDIT_APD, path: '/path/to/edit', value: 'new value' }
+      )
+    ).toEqual([
+      { op: 'replace', path: '/path/to/edit', value: 'old value' },
+      { op: 'remove', path: '/path/to/edit' },
+      { op: 'replace', path: '/path/to/edit', value: 'new value' }
+    ]);
+  });
+});
+
+describe('JSON patch selector', () => {
+  it('returns false if there are no pending patches', () => {
+    expect(getHasChanges({ patch: [] })).toEqual(false);
+  });
+
+  it('returns true if there are pending patches', () => {
+    expect(getHasChanges({ patch: [''] })).toEqual(true);
+  });
+});


### PR DESCRIPTION
To prepare for the glorious future in which saves are done via JSON patches, this PR does the work of capturing user edits as a JSON patchset.

My first thought was to just make a new `patch` reducer that captures all the existing edit actions. Good news! The edit actions are sending along nested objects which we'd need to extract the keys from in order to build a property path. E.g.:

```js
{
  stateProfile: {
    medicaidDirector: {
      name: "Bob"
    }
  }
}
```

...would get converted into this path:

```js
"stateProfile/medicaidDirector/name"
```

And it turns out, that's actually kinda tricky, mainly around knowing when to stop traversing the object for keys. For example, what if the value itself is an object? How do you know you've reached the actual value?

So... I decided our current actions are kind of messy anyway, so I would experiment with adding a whole new set of actions. Enter `editApd`, which has such actions as `setMedicaidDirectorName` and `setMedicaidOfficeCity`. These are really simple functions that return redux-dispatchable objects with the correct type, path, and value.  E.g.:

```js
setMedicaidDirectorName("Bob")
```

...returns:

```js
{ type: Symbol('edit apd'), path: 'stateProfile/medicaidDirector/name', value: 'Bob' }
```

One of the huge upsides I see here is that components no longer need to know about the shape of the state in order to dispatch changes. They can just say "I want to update the Medicaid director's name," and the action creator abstracts away the path for them. That feels like it falls in line with using selectors for pulling stuff from the state, so the components just don't have to know what's under the hood.

With those in place, I jumped into the state profile/director/office component (`containers/ApdStateProfileMedicaidOffice.js`) to update it to use these new actions in addition to the old ones. (We can't take out the old ones yet, since they're still used to do the actual saves.) While I was in there, I also switched it over to using hooks, including redux hooks.  Yay, we can get rid of the `connect()` method, and the component can directly dispatch actions instead of relying on that weird wrapper thing.

**If we decide to go this route**, I think the right path forward is to do multiple pull requests over time as we refactor each piece, rather than trying to do it all in one ginormous PR.

### This pull request changes...

- no visible changes
- closes #1831

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author