### PR TITLE
Patch for inconsistent sidebar

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 
   web:
     build: ./web
-    image: cms-eapd/web:e10990ea3421fdd4fa3ceb93942deccc
+    image: cms-eapd/web:a3676e8ff156398faa91bb35fcdc1cd3
     environment:
       - API_URL=http://localhost:8081
     volumes:
@@ -31,7 +31,7 @@ services:
       - 8080:8001
   
   storybook:
-    image: cms-eapd/web:e10990ea3421fdd4fa3ceb93942deccc
+    image: cms-eapd/web:a3676e8ff156398faa91bb35fcdc1cd3
     volumes:
       - ./web:/app
       - /app/node_modules

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -20230,11 +20230,6 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
-    "stickybits": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/stickybits/-/stickybits-3.6.6.tgz",
-      "integrity": "sha512-+++I84+V+IqRXCDIgSn7tGHXF1BtsPn/Nb3Ve3ZEH2NnTauorHyUFbKTW+nycobxtsGQMnl5V0WdHxGTDdmp+A=="
-    },
     "stream-browserify": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -84,7 +84,6 @@
     "redux": "^4.0.4",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
-    "stickybits": "^3.6.6",
     "updeep": "^1.0.0",
     "zxcvbn": "^4.4.2"
   },

--- a/web/src/containers/ApdApplication.js
+++ b/web/src/containers/ApdApplication.js
@@ -83,9 +83,9 @@ class ApdApplication extends Component {
             return unsavedPrompt;
           }}
         />
-        <div className="ds-l-row ds-u-margin--0">
+        <div className="ds-u-margin--0">
           <Sidebar place={place} />
-          <div className="site-main ds-u-padding-top--2 ds-l-col--9">
+          <div className="site-main ds-u-padding-top--2">
             <h1 id="start-main-content" className="ds-h1 apd--title">
               <span className="ds-h6 ds-u-display--block">{apdName}</span>
               {place.name} {year} APD

--- a/web/src/containers/Sidebar.js
+++ b/web/src/containers/Sidebar.js
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import VerticalNav from '@cmsgov/design-system-core/dist/components/VerticalNav/VerticalNav';
-import stickybits from 'stickybits';
 
 import { t } from '../i18n';
 import { jumpTo } from '../actions/navigation';
@@ -12,10 +11,6 @@ import { selectActivitiesSidebar } from '../reducers/activities.selectors';
 import { selectActiveSection } from '../reducers/navigation';
 
 class Sidebar extends Component {
-  componentDidMount() {
-    stickybits('.site-sidebar');
-  }
-
   handleSelectClick = id => {
     const { jumpTo: action } = this.props;
     action(id);

--- a/web/src/containers/Sidebar.js
+++ b/web/src/containers/Sidebar.js
@@ -201,28 +201,24 @@ class Sidebar extends Component {
     const hasImage = ['as', 'gu', 'mp', 'vi'].indexOf(place.id) < 0;
 
     return (
-      <div className="ds-l-col--3">
-        <aside className={`site-sidebar${isIE() ? ' site-sidebar__ie' : ''}`}>
-          <div className="site-sidebar__sticky">
-            <div className="ds-u-display--flex ds-u-align-items--center ds-u-border-bottom--1 ds-u-padding-y--2 ds-u-margin-bottom--4">
-              {hasImage && (
-                <img
-                  src={`/static/img/states/${place.id}.svg`}
-                  alt={place.name}
-                  className="ds-u-margin-right--2"
-                  width="40"
-                  height="40"
-                />
-              )}
-              <h1>{place.name}</h1>
-            </div>
-            <VerticalNav
-              selectedId={activeSection || 'apd-state-profile-overview'}
-              items={links}
-            />
+      <aside className={`site-sidebar${isIE() ? ' site-sidebar__ie' : ''}`}>
+          <div className="ds-u-display--flex ds-u-align-items--center ds-u-border-bottom--1 ds-u-padding-y--2 ds-u-margin-bottom--4">
+            {hasImage && (
+              <img
+                src={`/static/img/states/${place.id}.svg`}
+                alt={place.name}
+                className="ds-u-margin-right--2"
+                width="40"
+                height="40"
+              />
+            )}
+            <h1>{place.name}</h1>
           </div>
-        </aside>
-      </div>
+          <VerticalNav
+            selectedId={activeSection || 'apd-state-profile-overview'}
+            items={links}
+          />
+      </aside>
     );
   }
 }

--- a/web/src/containers/__snapshots__/ApdApplication.test.js.snap
+++ b/web/src/containers/__snapshots__/ApdApplication.test.js.snap
@@ -9,13 +9,13 @@ exports[`apd (application) component renders correctly 1`] = `
     when={true}
   />
   <div
-    className="ds-l-row ds-u-margin--0"
+    className="ds-u-margin--0"
   >
     <Connect(Sidebar)
       place={Object {}}
     />
     <div
-      className="site-main ds-u-padding-top--2 ds-l-col--9"
+      className="site-main ds-u-padding-top--2"
     >
       <h1
         className="ds-h1 apd--title"

--- a/web/src/containers/__snapshots__/Sidebar.test.js.snap
+++ b/web/src/containers/__snapshots__/Sidebar.test.js.snap
@@ -1,390 +1,374 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Sidebar component leaves off the state image for states we don't have images for 1`] = `
-<div
-  className="ds-l-col--3"
+<aside
+  className="site-sidebar"
 >
-  <aside
-    className="site-sidebar"
+  <div
+    className="ds-u-display--flex ds-u-align-items--center ds-u-border-bottom--1 ds-u-padding-y--2 ds-u-margin-bottom--4"
   >
-    <div
-      className="site-sidebar__sticky"
-    >
-      <div
-        className="ds-u-display--flex ds-u-align-items--center ds-u-border-bottom--1 ds-u-padding-y--2 ds-u-margin-bottom--4"
-      >
-        <h1>
-          U.S. Virgin Islands
-        </h1>
-      </div>
-      <VerticalNav
-        collapsed={false}
-        items={
-          Array [
+    <h1>
+      U.S. Virgin Islands
+    </h1>
+  </div>
+  <VerticalNav
+    collapsed={false}
+    items={
+      Array [
+        Object {
+          "defaultCollapsed": true,
+          "id": "apd-state-profile",
+          "items": Array [
             Object {
-              "defaultCollapsed": true,
-              "id": "apd-state-profile",
-              "items": Array [
-                Object {
-                  "id": "apd-state-profile-overview",
-                  "label": "Overview",
-                  "onClick": [Function],
-                  "url": "#apd-state-profile",
-                },
-                Object {
-                  "id": "apd-state-profile-office",
-                  "label": "State Director and Office Address",
-                  "onClick": [Function],
-                  "url": "#apd-state-profile-office",
-                },
-                Object {
-                  "id": "apd-state-profile-key-personnel",
-                  "label": "Key Personnel and Program Management",
-                  "onClick": [Function],
-                  "url": "#apd-state-profile-key-personnel",
-                },
-              ],
-              "label": "Key State Personnel",
-            },
-            Object {
-              "id": "apd-summary",
-              "label": "Program Summary",
+              "id": "apd-state-profile-overview",
+              "label": "Overview",
               "onClick": [Function],
-              "url": "#apd-summary",
+              "url": "#apd-state-profile",
             },
             Object {
-              "defaultCollapsed": true,
-              "id": "prev-activities",
-              "items": Array [
-                Object {
-                  "id": "prev-activities-overview",
-                  "label": "Overview",
-                  "onClick": [Function],
-                  "url": "#prev-activities",
-                },
-                Object {
-                  "id": "prev-activities-outline",
-                  "label": "Prior Activities Overview",
-                  "onClick": [Function],
-                  "url": "#prev-activities-outline",
-                },
-                Object {
-                  "id": "prev-activities-table",
-                  "label": "Actual Costs",
-                  "onClick": [Function],
-                  "url": "#prev-activities-table",
-                },
-              ],
-              "label": "Results of Previous Activities",
-            },
-            Object {
-              "defaultCollapsed": true,
-              "id": "activities",
-              "items": Array [
-                Object {
-                  "id": "activities-overview",
-                  "label": "Overview",
-                  "onClick": [Function],
-                  "url": "#activities",
-                },
-                Object {
-                  "id": "activities-list",
-                  "label": "Activity List",
-                  "onClick": [Function],
-                  "url": "#activities-list",
-                },
-                Object {
-                  "id": "key 1",
-                  "label": "Activity 1",
-                  "onClick": [Function],
-                  "url": "##key1",
-                },
-                Object {
-                  "id": "key 2",
-                  "label": "Activity 2",
-                  "onClick": [Function],
-                  "url": "##key2",
-                },
-              ],
-              "label": "Program Activities",
-            },
-            Object {
-              "id": "schedule-summary",
-              "label": "Activity Schedule Summary",
+              "id": "apd-state-profile-office",
+              "label": "State Director and Office Address",
               "onClick": [Function],
-              "url": "#schedule-summary",
+              "url": "#apd-state-profile-office",
             },
             Object {
-              "defaultCollapsed": true,
-              "id": "budget",
-              "items": Array [
-                Object {
-                  "id": "budget-overview",
-                  "label": "Overview",
-                  "onClick": [Function],
-                  "url": "#budget",
-                },
-                Object {
-                  "id": "budget-summary-table",
-                  "label": "Summary Budget Table",
-                  "onClick": [Function],
-                  "url": "#budget-summary-table",
-                },
-                Object {
-                  "id": "budget-federal-by-quarter",
-                  "label": "Quarterly Federal Share",
-                  "onClick": [Function],
-                  "url": "#budget-federal-by-quarter",
-                },
-                Object {
-                  "id": "budget-incentive-by-quarter",
-                  "label": "Estimated Quarterly Incentive Payments",
-                  "onClick": [Function],
-                  "url": "#budget-incentive-by-quarter",
-                },
-              ],
-              "label": "Proposed Budget",
-            },
-            Object {
-              "id": "assurances-compliance",
-              "label": "Assurances and Compliance",
+              "id": "apd-state-profile-key-personnel",
+              "label": "Key Personnel and Program Management",
               "onClick": [Function],
-              "url": "#assurances-compliance",
+              "url": "#apd-state-profile-key-personnel",
             },
+          ],
+          "label": "Key State Personnel",
+        },
+        Object {
+          "id": "apd-summary",
+          "label": "Program Summary",
+          "onClick": [Function],
+          "url": "#apd-summary",
+        },
+        Object {
+          "defaultCollapsed": true,
+          "id": "prev-activities",
+          "items": Array [
             Object {
-              "defaultCollapsed": true,
-              "id": "executive-summary",
-              "items": Array [
-                Object {
-                  "id": "executive-summary-overview",
-                  "label": "Overview",
-                  "onClick": [Function],
-                  "url": "#executive-summary",
-                },
-                Object {
-                  "id": "executive-summary-summary",
-                  "label": "Activities Summary",
-                  "onClick": [Function],
-                  "url": "#executive-summary-summary",
-                },
-                Object {
-                  "id": "executive-summary-budget-table",
-                  "label": "Program Budget Tables",
-                  "onClick": [Function],
-                  "url": "#executive-summary-budget-table",
-                },
-              ],
-              "label": "Executive Summary",
-            },
-            Object {
-              "id": "export-and-submit",
-              "label": "Export and Submit",
+              "id": "prev-activities-overview",
+              "label": "Overview",
               "onClick": [Function],
-              "url": "#export-and-submit",
+              "url": "#prev-activities",
             },
-          ]
-        }
-        selectedId="some section"
-      />
-    </div>
-  </aside>
-</div>
+            Object {
+              "id": "prev-activities-outline",
+              "label": "Prior Activities Overview",
+              "onClick": [Function],
+              "url": "#prev-activities-outline",
+            },
+            Object {
+              "id": "prev-activities-table",
+              "label": "Actual Costs",
+              "onClick": [Function],
+              "url": "#prev-activities-table",
+            },
+          ],
+          "label": "Results of Previous Activities",
+        },
+        Object {
+          "defaultCollapsed": true,
+          "id": "activities",
+          "items": Array [
+            Object {
+              "id": "activities-overview",
+              "label": "Overview",
+              "onClick": [Function],
+              "url": "#activities",
+            },
+            Object {
+              "id": "activities-list",
+              "label": "Activity List",
+              "onClick": [Function],
+              "url": "#activities-list",
+            },
+            Object {
+              "id": "key 1",
+              "label": "Activity 1",
+              "onClick": [Function],
+              "url": "##key1",
+            },
+            Object {
+              "id": "key 2",
+              "label": "Activity 2",
+              "onClick": [Function],
+              "url": "##key2",
+            },
+          ],
+          "label": "Program Activities",
+        },
+        Object {
+          "id": "schedule-summary",
+          "label": "Activity Schedule Summary",
+          "onClick": [Function],
+          "url": "#schedule-summary",
+        },
+        Object {
+          "defaultCollapsed": true,
+          "id": "budget",
+          "items": Array [
+            Object {
+              "id": "budget-overview",
+              "label": "Overview",
+              "onClick": [Function],
+              "url": "#budget",
+            },
+            Object {
+              "id": "budget-summary-table",
+              "label": "Summary Budget Table",
+              "onClick": [Function],
+              "url": "#budget-summary-table",
+            },
+            Object {
+              "id": "budget-federal-by-quarter",
+              "label": "Quarterly Federal Share",
+              "onClick": [Function],
+              "url": "#budget-federal-by-quarter",
+            },
+            Object {
+              "id": "budget-incentive-by-quarter",
+              "label": "Estimated Quarterly Incentive Payments",
+              "onClick": [Function],
+              "url": "#budget-incentive-by-quarter",
+            },
+          ],
+          "label": "Proposed Budget",
+        },
+        Object {
+          "id": "assurances-compliance",
+          "label": "Assurances and Compliance",
+          "onClick": [Function],
+          "url": "#assurances-compliance",
+        },
+        Object {
+          "defaultCollapsed": true,
+          "id": "executive-summary",
+          "items": Array [
+            Object {
+              "id": "executive-summary-overview",
+              "label": "Overview",
+              "onClick": [Function],
+              "url": "#executive-summary",
+            },
+            Object {
+              "id": "executive-summary-summary",
+              "label": "Activities Summary",
+              "onClick": [Function],
+              "url": "#executive-summary-summary",
+            },
+            Object {
+              "id": "executive-summary-budget-table",
+              "label": "Program Budget Tables",
+              "onClick": [Function],
+              "url": "#executive-summary-budget-table",
+            },
+          ],
+          "label": "Executive Summary",
+        },
+        Object {
+          "id": "export-and-submit",
+          "label": "Export and Submit",
+          "onClick": [Function],
+          "url": "#export-and-submit",
+        },
+      ]
+    }
+    selectedId="some section"
+  />
+</aside>
 `;
 
 exports[`Sidebar component renders correctly 1`] = `
-<div
-  className="ds-l-col--3"
+<aside
+  className="site-sidebar"
 >
-  <aside
-    className="site-sidebar"
+  <div
+    className="ds-u-display--flex ds-u-align-items--center ds-u-border-bottom--1 ds-u-padding-y--2 ds-u-margin-bottom--4"
   >
-    <div
-      className="site-sidebar__sticky"
-    >
-      <div
-        className="ds-u-display--flex ds-u-align-items--center ds-u-border-bottom--1 ds-u-padding-y--2 ds-u-margin-bottom--4"
-      >
-        <img
-          alt="place name"
-          className="ds-u-margin-right--2"
-          height="40"
-          src="/static/img/states/place id.svg"
-          width="40"
-        />
-        <h1>
-          place name
-        </h1>
-      </div>
-      <VerticalNav
-        collapsed={false}
-        items={
-          Array [
+    <img
+      alt="place name"
+      className="ds-u-margin-right--2"
+      height="40"
+      src="/static/img/states/place id.svg"
+      width="40"
+    />
+    <h1>
+      place name
+    </h1>
+  </div>
+  <VerticalNav
+    collapsed={false}
+    items={
+      Array [
+        Object {
+          "defaultCollapsed": true,
+          "id": "apd-state-profile",
+          "items": Array [
             Object {
-              "defaultCollapsed": true,
-              "id": "apd-state-profile",
-              "items": Array [
-                Object {
-                  "id": "apd-state-profile-overview",
-                  "label": "Overview",
-                  "onClick": [Function],
-                  "url": "#apd-state-profile",
-                },
-                Object {
-                  "id": "apd-state-profile-office",
-                  "label": "State Director and Office Address",
-                  "onClick": [Function],
-                  "url": "#apd-state-profile-office",
-                },
-                Object {
-                  "id": "apd-state-profile-key-personnel",
-                  "label": "Key Personnel and Program Management",
-                  "onClick": [Function],
-                  "url": "#apd-state-profile-key-personnel",
-                },
-              ],
-              "label": "Key State Personnel",
-            },
-            Object {
-              "id": "apd-summary",
-              "label": "Program Summary",
+              "id": "apd-state-profile-overview",
+              "label": "Overview",
               "onClick": [Function],
-              "url": "#apd-summary",
+              "url": "#apd-state-profile",
             },
             Object {
-              "defaultCollapsed": true,
-              "id": "prev-activities",
-              "items": Array [
-                Object {
-                  "id": "prev-activities-overview",
-                  "label": "Overview",
-                  "onClick": [Function],
-                  "url": "#prev-activities",
-                },
-                Object {
-                  "id": "prev-activities-outline",
-                  "label": "Prior Activities Overview",
-                  "onClick": [Function],
-                  "url": "#prev-activities-outline",
-                },
-                Object {
-                  "id": "prev-activities-table",
-                  "label": "Actual Costs",
-                  "onClick": [Function],
-                  "url": "#prev-activities-table",
-                },
-              ],
-              "label": "Results of Previous Activities",
-            },
-            Object {
-              "defaultCollapsed": true,
-              "id": "activities",
-              "items": Array [
-                Object {
-                  "id": "activities-overview",
-                  "label": "Overview",
-                  "onClick": [Function],
-                  "url": "#activities",
-                },
-                Object {
-                  "id": "activities-list",
-                  "label": "Activity List",
-                  "onClick": [Function],
-                  "url": "#activities-list",
-                },
-                Object {
-                  "id": "key 1",
-                  "label": "Activity 1",
-                  "onClick": [Function],
-                  "url": "##key1",
-                },
-                Object {
-                  "id": "key 2",
-                  "label": "Activity 2",
-                  "onClick": [Function],
-                  "url": "##key2",
-                },
-              ],
-              "label": "Program Activities",
-            },
-            Object {
-              "id": "schedule-summary",
-              "label": "Activity Schedule Summary",
+              "id": "apd-state-profile-office",
+              "label": "State Director and Office Address",
               "onClick": [Function],
-              "url": "#schedule-summary",
+              "url": "#apd-state-profile-office",
             },
             Object {
-              "defaultCollapsed": true,
-              "id": "budget",
-              "items": Array [
-                Object {
-                  "id": "budget-overview",
-                  "label": "Overview",
-                  "onClick": [Function],
-                  "url": "#budget",
-                },
-                Object {
-                  "id": "budget-summary-table",
-                  "label": "Summary Budget Table",
-                  "onClick": [Function],
-                  "url": "#budget-summary-table",
-                },
-                Object {
-                  "id": "budget-federal-by-quarter",
-                  "label": "Quarterly Federal Share",
-                  "onClick": [Function],
-                  "url": "#budget-federal-by-quarter",
-                },
-                Object {
-                  "id": "budget-incentive-by-quarter",
-                  "label": "Estimated Quarterly Incentive Payments",
-                  "onClick": [Function],
-                  "url": "#budget-incentive-by-quarter",
-                },
-              ],
-              "label": "Proposed Budget",
-            },
-            Object {
-              "id": "assurances-compliance",
-              "label": "Assurances and Compliance",
+              "id": "apd-state-profile-key-personnel",
+              "label": "Key Personnel and Program Management",
               "onClick": [Function],
-              "url": "#assurances-compliance",
+              "url": "#apd-state-profile-key-personnel",
             },
+          ],
+          "label": "Key State Personnel",
+        },
+        Object {
+          "id": "apd-summary",
+          "label": "Program Summary",
+          "onClick": [Function],
+          "url": "#apd-summary",
+        },
+        Object {
+          "defaultCollapsed": true,
+          "id": "prev-activities",
+          "items": Array [
             Object {
-              "defaultCollapsed": true,
-              "id": "executive-summary",
-              "items": Array [
-                Object {
-                  "id": "executive-summary-overview",
-                  "label": "Overview",
-                  "onClick": [Function],
-                  "url": "#executive-summary",
-                },
-                Object {
-                  "id": "executive-summary-summary",
-                  "label": "Activities Summary",
-                  "onClick": [Function],
-                  "url": "#executive-summary-summary",
-                },
-                Object {
-                  "id": "executive-summary-budget-table",
-                  "label": "Program Budget Tables",
-                  "onClick": [Function],
-                  "url": "#executive-summary-budget-table",
-                },
-              ],
-              "label": "Executive Summary",
-            },
-            Object {
-              "id": "export-and-submit",
-              "label": "Export and Submit",
+              "id": "prev-activities-overview",
+              "label": "Overview",
               "onClick": [Function],
-              "url": "#export-and-submit",
+              "url": "#prev-activities",
             },
-          ]
-        }
-        selectedId="some section"
-      />
-    </div>
-  </aside>
-</div>
+            Object {
+              "id": "prev-activities-outline",
+              "label": "Prior Activities Overview",
+              "onClick": [Function],
+              "url": "#prev-activities-outline",
+            },
+            Object {
+              "id": "prev-activities-table",
+              "label": "Actual Costs",
+              "onClick": [Function],
+              "url": "#prev-activities-table",
+            },
+          ],
+          "label": "Results of Previous Activities",
+        },
+        Object {
+          "defaultCollapsed": true,
+          "id": "activities",
+          "items": Array [
+            Object {
+              "id": "activities-overview",
+              "label": "Overview",
+              "onClick": [Function],
+              "url": "#activities",
+            },
+            Object {
+              "id": "activities-list",
+              "label": "Activity List",
+              "onClick": [Function],
+              "url": "#activities-list",
+            },
+            Object {
+              "id": "key 1",
+              "label": "Activity 1",
+              "onClick": [Function],
+              "url": "##key1",
+            },
+            Object {
+              "id": "key 2",
+              "label": "Activity 2",
+              "onClick": [Function],
+              "url": "##key2",
+            },
+          ],
+          "label": "Program Activities",
+        },
+        Object {
+          "id": "schedule-summary",
+          "label": "Activity Schedule Summary",
+          "onClick": [Function],
+          "url": "#schedule-summary",
+        },
+        Object {
+          "defaultCollapsed": true,
+          "id": "budget",
+          "items": Array [
+            Object {
+              "id": "budget-overview",
+              "label": "Overview",
+              "onClick": [Function],
+              "url": "#budget",
+            },
+            Object {
+              "id": "budget-summary-table",
+              "label": "Summary Budget Table",
+              "onClick": [Function],
+              "url": "#budget-summary-table",
+            },
+            Object {
+              "id": "budget-federal-by-quarter",
+              "label": "Quarterly Federal Share",
+              "onClick": [Function],
+              "url": "#budget-federal-by-quarter",
+            },
+            Object {
+              "id": "budget-incentive-by-quarter",
+              "label": "Estimated Quarterly Incentive Payments",
+              "onClick": [Function],
+              "url": "#budget-incentive-by-quarter",
+            },
+          ],
+          "label": "Proposed Budget",
+        },
+        Object {
+          "id": "assurances-compliance",
+          "label": "Assurances and Compliance",
+          "onClick": [Function],
+          "url": "#assurances-compliance",
+        },
+        Object {
+          "defaultCollapsed": true,
+          "id": "executive-summary",
+          "items": Array [
+            Object {
+              "id": "executive-summary-overview",
+              "label": "Overview",
+              "onClick": [Function],
+              "url": "#executive-summary",
+            },
+            Object {
+              "id": "executive-summary-summary",
+              "label": "Activities Summary",
+              "onClick": [Function],
+              "url": "#executive-summary-summary",
+            },
+            Object {
+              "id": "executive-summary-budget-table",
+              "label": "Program Budget Tables",
+              "onClick": [Function],
+              "url": "#executive-summary-budget-table",
+            },
+          ],
+          "label": "Executive Summary",
+        },
+        Object {
+          "id": "export-and-submit",
+          "label": "Export and Submit",
+          "onClick": [Function],
+          "url": "#export-and-submit",
+        },
+      ]
+    }
+    selectedId="some section"
+  />
+</aside>
 `;

--- a/web/src/styles/scss/layout.scss
+++ b/web/src/styles/scss/layout.scss
@@ -10,17 +10,11 @@
   top: 50px;
   width: 212px;
   position: fixed;
+  max-height: 100vh;
+  overflow-y: auto;
   + .site-main {
     margin-left: 244px; // sidebar width plus $spacer-4
   }
-}
-
-.site-sidebar__sticky {
-  max-height: 100vh;
-  overflow-y: auto;
-  position: -webkit-sticky;
-  position: sticky;
-  top: 0;
 }
 
 footer {

--- a/web/src/styles/scss/layout.scss
+++ b/web/src/styles/scss/layout.scss
@@ -6,8 +6,13 @@
   min-height: 100vh;
 }
 
-.site-sidebar.site-sidebar__ie {
-  max-width: 212px;
+.site-sidebar {
+  top: 50px;
+  width: 212px;
+  position: fixed;
+  + .site-main {
+    margin-left: 244px; // sidebar width plus $spacer-4
+  }
 }
 
 .site-sidebar__sticky {


### PR DESCRIPTION
A whole bunch of our sidebar woes are due to us trying to use the built-in design system columns, which are flexbox-based, for that page. Flexbox and `position: sticky` work okay together, but flexbox and `position: fixed` do not. Since we don't really need or want the sidebar to flex in size and we need to support older browsers, let's just use the oldschool way of doing this: set a fixed width on the sidebar, set it to `position: fixed` in all browsers, and set a margin of the sidebar width + padding on the main content.

The one downside of this is that the sidebar is fixed slightly low on the screen, to account for the navbar in the initial position. This seems like a better tradeoff than the current sizing issue, though, and is something we can Javascript our way out of.

### This pull request changes...

- Removes `ds-l-col--` classes from `ApdApplication` and `Sidebar`
- Use fixed-width and -position sidebar instead of flexbox
- Removes stickybits

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] Changelog is updated as appropriate

### This feature is done when...

- [x] Product has approved the experience
