### PR TITLE
Show year range at APD title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Anticipated release: TBD
 - Disabled cacheing of the index page, so that clients always get the latest. ([#1775])
 - Fixed a bug where the APD Key Personnel section asked for a person's percent time using a plain number input box instead of a percent box ([#1753])
 - Improved ARIA metadata on the account management dropdown button for screen readers ([#1681])
+- Changed the APD title to include the full year range instead of just the start year ([#1820])
 
 #### ⚙️ Behind the scenes
 
@@ -124,3 +125,4 @@ Pilot release to select state partners
 [#1769]: https://github.com/18F/cms-hitech-apd/issues/1769
 [#1770]: https://github.com/18F/cms-hitech-apd/pull/1770
 [#1775]: https://github.com/18F/cms-hitech-apd/issues/1775
+[#1820]: https://github.com/18F/cms-hitech-apd/issues/1820

--- a/web/src/containers/ApdApplication.js
+++ b/web/src/containers/ApdApplication.js
@@ -18,7 +18,7 @@ import StateProfile from '../components/ApdStateProfile';
 
 import {
   getAPDName,
-  getAPDFirstYear,
+  getAPDYearRange,
   getIsAnAPDSelected
 } from '../reducers/apd';
 import { getIsDirty } from '../reducers/dirty';
@@ -124,7 +124,7 @@ const mapStateToProps = state => ({
   dirty: getIsDirty(state),
   isAdmin: getIsAdmin(state),
   place: getUserStateOrTerritory(state),
-  year: getAPDFirstYear(state)
+  year: getAPDYearRange(state)
 });
 
 const mapDispatchToProps = { selectApdOnLoad };

--- a/web/src/containers/ApdApplication.test.js
+++ b/web/src/containers/ApdApplication.test.js
@@ -67,7 +67,7 @@ describe('apd (application) component', () => {
         data: {
           id: 'bloop',
           name: 'florp',
-          years: ['dinkus', 'dorkus']
+          years: ['dinkus', 'dorkus', 'durkus']
         }
       },
       dirty: {
@@ -86,7 +86,7 @@ describe('apd (application) component', () => {
       dirty: 'moop moop',
       isAdmin: false,
       place: 'place',
-      year: 'dinkus'
+      year: 'dinkus-durkus'
     });
 
     state.apd.data.id = false;

--- a/web/src/reducers/apd.js
+++ b/web/src/reducers/apd.js
@@ -51,11 +51,14 @@ export const getAPDName = ({
   }
 }) => name;
 
-export const getAPDFirstYear = ({
+export const getAPDYearRange = ({
   apd: {
     data: { years }
   }
-}) => (years && years.length ? years[0] : '');
+}) =>
+  years && years.length
+    ? `${years[0]}${years.length > 1 ? `-${years[years.length - 1]}` : ''}`
+    : '';
 
 export const getIsAnAPDSelected = ({
   apd: {


### PR DESCRIPTION
### This pull request changes...

- updates the APD title to show the year range instead of just the first year
  ![screenshot](https://user-images.githubusercontent.com/1775733/65464730-2bff9280-de20-11e9-8197-1dd2571e608e.png)
- closes #1820

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [x] Changelog is updated as appropriate

### This feature is done when...

- [ ] Design has approved the experience