### PR TITLE
JSON patch bug

### DIFF
--- a/web/src/actions/editApd.js
+++ b/web/src/actions/editApd.js
@@ -4,10 +4,13 @@ export const ADD_APD_ITEM = Symbol('add apd item');
 export const EDIT_APD = Symbol('edit apd');
 export const REMOVE_APD_ITEM = Symbol('remove apd item');
 
-export const addKeyPerson = () => ({
-  type: ADD_APD_ITEM,
-  path: '/keyPersonnel/-'
-});
+export const addKeyPerson = () => (dispatch, getState) => {
+  dispatch({
+    type: ADD_APD_ITEM,
+    path: '/keyPersonnel/-',
+    state: getState()
+  });
+};
 
 export const removeKeyPerson = (
   index,

--- a/web/src/actions/editApd.test.js
+++ b/web/src/actions/editApd.test.js
@@ -30,10 +30,16 @@ const mockStore = configureStore([thunk]);
 describe('APD edit actions', () => {
   describe('for APD key personnel', () => {
     it('dispatchs an action for adding a key person', () => {
-      expect(addKeyPerson()).toEqual({
-        type: ADD_APD_ITEM,
-        path: '/keyPersonnel/-'
-      });
+      const store = mockStore('add state');
+      store.dispatch(addKeyPerson());
+
+      expect(store.getActions()).toEqual([
+        {
+          type: ADD_APD_ITEM,
+          path: '/keyPersonnel/-',
+          state: 'add state'
+        }
+      ]);
     });
 
     it('dispatches an action to remove a key person if confirmed', () => {

--- a/web/src/containers/ApdStateKeyPersonnel.test.js
+++ b/web/src/containers/ApdStateKeyPersonnel.test.js
@@ -68,7 +68,8 @@ describe('apd state profile, Medicaid office component', () => {
       expect(store.getActions()).toEqual([
         {
           type: ADD_APD_ITEM,
-          path: '/keyPersonnel/-'
+          path: '/keyPersonnel/-',
+          state
         }
       ]);
     });

--- a/web/src/reducers/apd.js
+++ b/web/src/reducers/apd.js
@@ -68,6 +68,15 @@ export const getIsAnAPDSelected = ({
   }
 }) => !!id;
 
+export const getPatchesForAddingItem = (state, path) => {
+  switch (path) {
+    case '/keyPersonnel/-':
+      return [{ op: 'add', path, value: getKeyPersonnel(state.data.years) }];
+    default:
+      return [{ op: 'add', path, value: null }];
+  }
+};
+
 const initialState = {
   data: {},
   byId: {},
@@ -80,25 +89,10 @@ const initialState = {
 const reducer = (state = initialState, action) => {
   switch (action.type) {
     case ADD_APD_ITEM: {
-      let newValue = null;
-
-      switch (action.path) {
-        case '/keyPersonnel/-':
-          newValue = getKeyPersonnel(state.data.years);
-          break;
-        default:
-          break;
-      }
-
+      const patches = getPatchesForAddingItem(state, action.path);
       return {
         ...state,
-        data: applyPatch(state.data, [
-          {
-            op: 'add',
-            path: action.path,
-            value: newValue
-          }
-        ])
+        data: applyPatch(state.data, patches)
       };
     }
 

--- a/web/src/reducers/apd.test.js
+++ b/web/src/reducers/apd.test.js
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 // so that the stuff we import will use our faked-out clock.
 const mockClock = sinon.useFakeTimers(new Date(1990, 3, 24).getTime());
 
-const { default: apd } = require('./apd');
+const { default: apd, getPatchesForAddingItem } = require('./apd');
 const {
   SUBMIT_APD_SUCCESS,
   WITHDRAW_APD_SUCCESS,
@@ -460,5 +460,41 @@ describe('APD reducer', () => {
     expect(
       apd({ data: { status: 'not draft' } }, { type: WITHDRAW_APD_SUCCESS })
     ).toEqual({ data: { status: 'draft' } });
+  });
+});
+
+describe('APD reducer helper methods', () => {
+  describe('it can get patches for adding new APD items', () => {
+    it(`gets patches for paths that don't need anything special`, () => {
+      expect(getPatchesForAddingItem({}, '/fake/path')).toEqual([
+        { op: 'add', path: '/fake/path', value: null }
+      ]);
+    });
+
+    it('gets patches for adding a key personnel', () => {
+      expect(
+        getPatchesForAddingItem(
+          { data: { years: ['1', '2'] } },
+          '/keyPersonnel/-'
+        )
+      ).toEqual([
+        {
+          op: 'add',
+          path: '/keyPersonnel/-',
+          value: {
+            costs: { '1': 0, '2': 0 },
+            email: '',
+            expanded: true,
+            hasCosts: false,
+            isPrimary: false,
+            percentTime: 0,
+            name: '',
+            position: '',
+            key: expect.stringMatching(/^[a-f0-9]{8}$/),
+            initialCollapsed: false
+          }
+        }
+      ]);
+    });
   });
 });

--- a/web/src/reducers/patch.js
+++ b/web/src/reducers/patch.js
@@ -1,7 +1,8 @@
 import u from 'updeep';
 
+import { getPatchesForAddingItem } from './apd';
 import { SAVE_APD_SUCCESS } from '../actions/apd';
-import { EDIT_APD } from '../actions/editApd';
+import { ADD_APD_ITEM, EDIT_APD, REMOVE_APD_ITEM } from '../actions/editApd';
 
 const initialState = [];
 
@@ -22,6 +23,11 @@ const reducer = (state = initialState, action) => {
   switch (action.type) {
     case SAVE_APD_SUCCESS:
       return initialState;
+
+    case ADD_APD_ITEM: {
+      const patches = getPatchesForAddingItem(action.state.apd, action.path);
+      return [...state, ...patches];
+    }
 
     case EDIT_APD: {
       // If the last patch for the given path is already a replace, we can just
@@ -53,6 +59,9 @@ const reducer = (state = initialState, action) => {
         { op: 'replace', path: action.path, value: action.value }
       ];
     }
+
+    case REMOVE_APD_ITEM:
+      return [...state, { op: 'remove', path: action.path }];
 
     default:
       return state;

--- a/web/src/reducers/patch.test.js
+++ b/web/src/reducers/patch.test.js
@@ -1,5 +1,5 @@
 import { SAVE_APD_SUCCESS } from '../actions/apd';
-import { EDIT_APD } from '../actions/editApd';
+import { ADD_APD_ITEM, EDIT_APD, REMOVE_APD_ITEM } from '../actions/editApd';
 
 import reducer, { getHasChanges } from './patch';
 
@@ -47,6 +47,22 @@ describe('JSON patch reducer', () => {
       { op: 'remove', path: '/path/to/edit' },
       { op: 'replace', path: '/path/to/edit', value: 'new value' }
     ]);
+  });
+
+  it('creates a patch for adding an APD item', () => {
+    expect(
+      reducer([], {
+        type: ADD_APD_ITEM,
+        path: '/path/to/add',
+        state: {}
+      })
+    ).toEqual([{ op: 'add', path: '/path/to/add', value: null }]);
+  });
+
+  it('creates a patch for removing an APD item', () => {
+    expect(
+      reducer([], { type: REMOVE_APD_ITEM, path: '/path/to/remove' })
+    ).toEqual([{ op: 'remove', path: '/path/to/remove' }]);
   });
 });
 


### PR DESCRIPTION
#1860 switched over the APD key personnel section to patches, but completely forgot to actually compute the patches for the `patch` reducer, meaning that adding/removing key personnel would never have been saved. 😬

### This pull request changes...

- fixes ☝️ that

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)