### PR TITLE
Prepare changelog for next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Anticipated release: TBD
 
 #### 🚀 New features
 
+#### 🐛 Bugs fixed
+
+#### 🐛 Bugs fixed
+
+# v1.1.0
+
+Released: September 27, 2019
+
+#### 🚀 New features
+
 - Attempt to alert users before automatically logging them out due to inactivity. The app will try to use built-in browser notifications as well as flashing the tab title. In browsers that support it, the app treats activity in any eAPD tab as valid, so all eAPD tabs will remain valid as long as at least one of them is getting activity. ([#1697])
 - Scroll the collapsed activity review panel into view after collapsing an activity form. This way, when you collapse an activity, you end up essentially looking at the list of activities again instead of being pushed way down the page. ([#1732])
 - Automatically select numeric form field contents when the field is focused if the current value is 0 ([#1736])


### PR DESCRIPTION
Adds the latest release info to the changelog and prepares it for the next release.

A question: should we keep the complete change history in the changelog, or would we rather only track changes for *upcoming* releases in the changelog? Once we do a release, we'll have the change history on the [releases page](https://github.com/18F/cms-hitech-apd/releases), so having the complete history in the changelog seems redundant. 🤷‍♂