### PR TITLE
Remove React context

### DIFF
--- a/web/src/containers/activity/ActivityContext.js
+++ b/web/src/containers/activity/ActivityContext.js
@@ -1,5 +1,0 @@
-import { createContext } from 'react';
-
-export const ActivityContext = createContext({ index: -1 });
-
-export const { Consumer, Provider } = ActivityContext;

--- a/web/src/containers/activity/ContractorResource/ContractorResourceForm.js
+++ b/web/src/containers/activity/ContractorResource/ContractorResourceForm.js
@@ -1,9 +1,7 @@
 import { FormLabel, TextField } from '@cmsgov/design-system-core';
 import PropTypes from 'prop-types';
-import React, { Fragment, useContext, useMemo } from 'react';
+import React, { Fragment, useMemo } from 'react';
 import { connect } from 'react-redux';
-
-import { ActivityContext } from '../ActivityContext';
 
 import Choice from '../../../components/Choice';
 import DateField from '../../../components/DateField';
@@ -25,6 +23,7 @@ import {
 } from '../../../actions/editActivity';
 
 const ContractorResourceForm = ({
+  activityIndex,
   index,
   item: { description, end, hourly, key, name, start, totalCost, years },
   setDescription,
@@ -37,8 +36,6 @@ const ContractorResourceForm = ({
   setNumberOfHoursForYear,
   setHourlyRateForYear
 }) => {
-  const { index: activityIndex } = useContext(ActivityContext);
-
   const apdFFYs = useMemo(() => Object.keys(years), [years]);
 
   const getHandler = action => ({ target: { value } }) => {
@@ -185,6 +182,7 @@ const ContractorResourceForm = ({
 };
 
 ContractorResourceForm.propTypes = {
+  activityIndex: PropTypes.number.isRequired,
   index: PropTypes.number.isRequired,
   item: PropTypes.shape({
     description: PropTypes.string,

--- a/web/src/containers/activity/ContractorResource/ContractorResourceForm.test.js
+++ b/web/src/containers/activity/ContractorResource/ContractorResourceForm.test.js
@@ -1,18 +1,11 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 
-jest.spyOn(React, 'useContext');
-React.useContext.mockImplementation(() => ({
-  index: 'activity index'
-}));
-
-// Have to require() this because import statements get executed before
-// anything else, but we need that spyOn call to happen first. So...
-// this is how we can enforce the order we need.
-const { plain: ContractorForm } = require('./ContractorResourceForm');
+import { plain as ContractorForm } from './ContractorResourceForm';
 
 describe('the ContractorResourceForm component', () => {
   const props = {
+    activityIndex: 43,
     index: 1,
     item: {
       description: 'They cleaned up the latrines after the Battle of Hastings',
@@ -80,11 +73,7 @@ describe('the ContractorResourceForm component', () => {
       .findWhere(c => c.prop('name') === 'contractor-name')
       .simulate('change', { target: { value: 'new value' } });
 
-    expect(props.setName).toHaveBeenCalledWith(
-      'activity index',
-      1,
-      'new value'
-    );
+    expect(props.setName).toHaveBeenCalledWith(43, 1, 'new value');
   });
 
   test('handles changing the contractor description', () => {
@@ -93,11 +82,7 @@ describe('the ContractorResourceForm component', () => {
       .findWhere(c => c.prop('name') === 'contractor-description')
       .simulate('change', { target: { value: 'new value' } });
 
-    expect(props.setDescription).toHaveBeenCalledWith(
-      'activity index',
-      1,
-      'new value'
-    );
+    expect(props.setDescription).toHaveBeenCalledWith(43, 1, 'new value');
   });
 
   test('handles changing the contractor total cost', () => {
@@ -106,11 +91,7 @@ describe('the ContractorResourceForm component', () => {
       .findWhere(c => c.prop('name') === 'contractor-total-cost')
       .simulate('change', { target: { value: 'new value' } });
 
-    expect(props.setTotalCost).toHaveBeenCalledWith(
-      'activity index',
-      1,
-      'new value'
-    );
+    expect(props.setTotalCost).toHaveBeenCalledWith(43, 1, 'new value');
   });
 
   test('handles changing the contractor start date', () => {
@@ -119,11 +100,7 @@ describe('the ContractorResourceForm component', () => {
       .findWhere(c => c.name() === 'DateField' && c.prop('label') === 'Start')
       .simulate('change', 'ignored stuff', 'new start date');
 
-    expect(props.setStartDate).toHaveBeenCalledWith(
-      'activity index',
-      1,
-      'new start date'
-    );
+    expect(props.setStartDate).toHaveBeenCalledWith(43, 1, 'new start date');
   });
 
   test('handles changing the contractor end date', () => {
@@ -132,11 +109,7 @@ describe('the ContractorResourceForm component', () => {
       .findWhere(c => c.name() === 'DateField' && c.prop('label') === 'End')
       .simulate('change', 'ignored stuff', 'new end date');
 
-    expect(props.setEndDate).toHaveBeenCalledWith(
-      'activity index',
-      1,
-      'new end date'
-    );
+    expect(props.setEndDate).toHaveBeenCalledWith(43, 1, 'new end date');
   });
 
   test('handles toggling hourly resource off', () => {
@@ -147,7 +120,7 @@ describe('the ContractorResourceForm component', () => {
       )
       .simulate('change');
 
-    expect(props.setIsHourly).toHaveBeenCalledWith('activity index', 1, false);
+    expect(props.setIsHourly).toHaveBeenCalledWith(43, 1, false);
   });
 
   test('handles toggling hourly resource on', () => {
@@ -158,7 +131,7 @@ describe('the ContractorResourceForm component', () => {
       )
       .simulate('change');
 
-    expect(props.setIsHourly).toHaveBeenCalledWith('activity index', 1, true);
+    expect(props.setIsHourly).toHaveBeenCalledWith(43, 1, true);
   });
 
   test('handles changing the contractor yearly cost', () => {
@@ -169,12 +142,7 @@ describe('the ContractorResourceForm component', () => {
       .findWhere(c => c.prop('name') === 'contractor-cost-ffy-1066')
       .simulate('change', { target: { value: 773 } });
 
-    expect(props.setCostForYear).toHaveBeenCalledWith(
-      'activity index',
-      1,
-      '1066',
-      773
-    );
+    expect(props.setCostForYear).toHaveBeenCalledWith(43, 1, '1066', 773);
   });
 
   test('handles changing the contractor yearly cost', () => {
@@ -193,7 +161,7 @@ describe('the ContractorResourceForm component', () => {
       .simulate('change', { target: { value: 3752 } });
 
     expect(props.setNumberOfHoursForYear).toHaveBeenCalledWith(
-      'activity index',
+      43,
       1,
       '1066',
       3752
@@ -216,7 +184,7 @@ describe('the ContractorResourceForm component', () => {
       .simulate('change', { target: { value: 9364 } });
 
     expect(props.setHourlyRateForYear).toHaveBeenCalledWith(
-      'activity index',
+      43,
       1,
       '1067',
       9364

--- a/web/src/containers/activity/ContractorResources.js
+++ b/web/src/containers/activity/ContractorResources.js
@@ -39,6 +39,7 @@ const ContractorResources = ({
   return (
     <Subsection resource="activities.contractorResources" nested>
       <FormAndReviewList
+        activityIndex={activityIndex}
         addButtonText="Add another contractor"
         list={contractors}
         collapsed={ContractorResourceReview}

--- a/web/src/containers/activity/EntryDetails.js
+++ b/web/src/containers/activity/EntryDetails.js
@@ -5,7 +5,6 @@ import { connect } from 'react-redux';
 
 import { selectActivityByIndex } from '../../reducers/activities.selectors';
 
-import { Provider } from './ActivityContext';
 import ContractorResources from './ContractorResources';
 import CostAllocate from './CostAllocate';
 import Costs from './Costs';
@@ -69,29 +68,27 @@ const EntryDetails = ({ activityIndex, fundingSource, activityKey, name }) => {
   );
 
   return (
-    <Provider value={{ index: activityIndex }}>
-      <div
-        id={`activity-${activityKey}`}
-        className={`activity--body activity--body__${
-          collapsed ? 'collapsed' : 'expanded'
-        } activity--body__${activityIndex === 0 ? 'first' : 'notfirst'}`}
-        ref={container}
-      >
-        <Review heading={title} headingLevel={4} editContent={editContent} />
-        <div className={collapsed ? 'visibility--print' : ''}>
-          <Overview activityIndex={activityIndex} />
-          <Goals activityIndex={activityIndex} aKey={activityKey} />
-          <Schedule activityIndex={activityIndex} />
-          <Costs aKey={activityKey} />
-          <ContractorResources activityIndex={activityIndex} />
-          <CostAllocate activityIndex={activityIndex} aKey={activityKey} />
-          <StandardsAndConditions aKey={activityKey} />
-          <Button variation="primary" onClick={() => setCollapsed(true)}>
-            Done
-          </Button>
-        </div>
+    <div
+      id={`activity-${activityKey}`}
+      className={`activity--body activity--body__${
+        collapsed ? 'collapsed' : 'expanded'
+      } activity--body__${activityIndex === 0 ? 'first' : 'notfirst'}`}
+      ref={container}
+    >
+      <Review heading={title} headingLevel={4} editContent={editContent} />
+      <div className={collapsed ? 'visibility--print' : ''}>
+        <Overview activityIndex={activityIndex} />
+        <Goals activityIndex={activityIndex} aKey={activityKey} />
+        <Schedule activityIndex={activityIndex} />
+        <Costs aKey={activityKey} />
+        <ContractorResources activityIndex={activityIndex} />
+        <CostAllocate activityIndex={activityIndex} aKey={activityKey} />
+        <StandardsAndConditions aKey={activityKey} />
+        <Button variation="primary" onClick={() => setCollapsed(true)}>
+          Done
+        </Button>
       </div>
-    </Provider>
+    </div>
   );
 };
 

--- a/web/src/containers/activity/Goal/GoalForm.js
+++ b/web/src/containers/activity/Goal/GoalForm.js
@@ -1,9 +1,8 @@
 import { TextField } from '@cmsgov/design-system-core';
 
 import PropTypes from 'prop-types';
-import React, { Fragment, useContext, useMemo } from 'react';
+import React, { Fragment, useMemo } from 'react';
 import { connect } from 'react-redux';
-import { ActivityContext } from '../ActivityContext';
 import { t } from '../../../i18n';
 import TextArea from '../../../components/TextArea';
 import {
@@ -12,13 +11,12 @@ import {
 } from '../../../actions/editActivity';
 
 const GoalForm = ({
+  activityIndex,
   item: { description, objective },
   index,
   setDescription,
   setObjective
 }) => {
-  const { index: activityIndex } = useContext(ActivityContext);
-
   const changeDescription = useMemo(
     () => ({ target: { value } }) => {
       setDescription(activityIndex, index, value);
@@ -67,6 +65,7 @@ const GoalForm = ({
 };
 
 GoalForm.propTypes = {
+  activityIndex: PropTypes.number.isRequired,
   index: PropTypes.number.isRequired,
   item: PropTypes.shape({
     description: PropTypes.string,

--- a/web/src/containers/activity/Goal/GoalForm.test.js
+++ b/web/src/containers/activity/Goal/GoalForm.test.js
@@ -1,20 +1,16 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 
+import { plain as GoalForm, mapDispatchToProps } from './GoalForm';
+
 import {
   setGoalDescription,
   setGoalObjective
 } from '../../../actions/editActivity';
 
-jest.spyOn(React, 'useContext');
-React.useContext.mockImplementation(() => ({
-  index: 'activity index'
-}));
-
-const { plain: GoalForm, mapDispatchToProps } = require('./GoalForm');
-
 describe('the GoalForm component', () => {
   const props = {
+    activityIndex: 93,
     index: 1,
     item: {
       description: 'goal description',
@@ -41,11 +37,7 @@ describe('the GoalForm component', () => {
       .findWhere(c => c.prop('name') === 'name')
       .simulate('change', { target: { value: 'new name' } });
 
-    expect(props.setDescription).toHaveBeenCalledWith(
-      'activity index',
-      1,
-      'new name'
-    );
+    expect(props.setDescription).toHaveBeenCalledWith(93, 1, 'new name');
   });
 
   it('it handles changing the goal objective', () => {
@@ -54,11 +46,7 @@ describe('the GoalForm component', () => {
       .findWhere(c => c.prop('name') === 'milestones')
       .simulate('change', { target: { value: 'new objective' } });
 
-    expect(props.setObjective).toHaveBeenCalledWith(
-      'activity index',
-      1,
-      'new objective'
-    );
+    expect(props.setObjective).toHaveBeenCalledWith(93, 1, 'new objective');
   });
 
   it('maps dispatch actions to props', () => {

--- a/web/src/containers/activity/Goals.js
+++ b/web/src/containers/activity/Goals.js
@@ -25,6 +25,7 @@ const Goals = ({ activityIndex, add, goals, remove }) => {
   return (
     <Subsection resource="activities.goals" nested>
       <FormAndReviewList
+        activityIndex={activityIndex}
         addButtonText="Add a goal"
         list={goals}
         collapsed={GoalReview}

--- a/web/src/containers/activity/Milestone/MilestoneForm.js
+++ b/web/src/containers/activity/Milestone/MilestoneForm.js
@@ -1,9 +1,8 @@
 import { TextField } from '@cmsgov/design-system-core';
 import PropTypes from 'prop-types';
-import React, { Fragment, useCallback, useContext } from 'react';
+import React, { Fragment, useCallback } from 'react';
 import { connect } from 'react-redux';
 
-import { ActivityContext } from '../ActivityContext';
 import {
   setMilestoneEndDate,
   setMilestoneName
@@ -11,13 +10,12 @@ import {
 import DateField from '../../../components/DateField';
 
 const MilestoneForm = ({
+  activityIndex,
   index,
   item: { endDate, milestone },
   setEndDate,
   setName
 }) => {
-  const { index: activityIndex } = useContext(ActivityContext);
-
   const changeDate = useCallback(
     (_, dateStr) => setEndDate(activityIndex, index, dateStr),
     []
@@ -48,6 +46,7 @@ const MilestoneForm = ({
 };
 
 MilestoneForm.propTypes = {
+  activityIndex: PropTypes.number.isRequired,
   index: PropTypes.number.isRequired,
   item: PropTypes.shape({
     endDate: PropTypes.string.isRequired,

--- a/web/src/containers/activity/Milestone/MilestoneForm.test.js
+++ b/web/src/containers/activity/Milestone/MilestoneForm.test.js
@@ -1,17 +1,12 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 
+import { plain as MilestoneForm, mapDispatchToProps } from './MilestoneForm';
+
 import {
   setMilestoneEndDate,
   setMilestoneName
 } from '../../../actions/editActivity';
-
-jest.spyOn(React, 'useContext');
-React.useContext.mockImplementation(() => ({
-  index: 'activity index'
-}));
-
-const { plain: MilestoneForm, mapDispatchToProps } = require('./MilestoneForm');
 
 describe('the MilestoneForm component', () => {
   const setEndDate = jest.fn();
@@ -19,13 +14,14 @@ describe('the MilestoneForm component', () => {
 
   const component = shallow(
     <MilestoneForm
+      activityIndex={225}
       index={3252}
       item={{
         // Operation Torch, the Allied invasion of North Africa, is launched
         // to relieve pressure on Egypt and provide an invasion route into
         // southern Europe,
         endDate: '1942-8-16',
-        name: 'Milestone name'
+        milestone: 'Milestone name'
       }}
       setEndDate={setEndDate}
       setName={setName}
@@ -46,18 +42,14 @@ describe('the MilestoneForm component', () => {
       component
         .find('TextField')
         .simulate('change', { target: { value: 'new name' } });
-      expect(setName).toHaveBeenCalledWith('activity index', 3252, 'new name');
+      expect(setName).toHaveBeenCalledWith(225, 3252, 'new name');
     });
 
     test('handles changing the milestone date', () => {
       component
         .find('DateField')
         .simulate('change', 'ignored text', 'new date');
-      expect(setEndDate).toHaveBeenCalledWith(
-        'activity index',
-        3252,
-        'new date'
-      );
+      expect(setEndDate).toHaveBeenCalledWith(225, 3252, 'new date');
     });
   });
 

--- a/web/src/containers/activity/Milestone/__snapshots__/MilestoneForm.test.js.snap
+++ b/web/src/containers/activity/Milestone/__snapshots__/MilestoneForm.test.js.snap
@@ -15,6 +15,7 @@ exports[`the MilestoneForm component renders correctly 1`] = `
     name="name"
     onChange={[Function]}
     type="text"
+    value="Milestone name"
   />
   <DateField
     hint=""

--- a/web/src/containers/activity/Schedule.js
+++ b/web/src/containers/activity/Schedule.js
@@ -81,6 +81,7 @@ const Schedule = ({
           <hr />
 
           <FormAndReviewList
+            activityIndex={activityIndex}
             addButtonText={t('activities.schedule.addMilestoneButtonText')}
             list={activity.schedule}
             collapsed={MilestoneReview}

--- a/web/src/containers/activity/__snapshots__/ContractorResources.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/ContractorResources.test.js.snap
@@ -8,6 +8,7 @@ exports[`the ContractorResources component renders correctly 1`] = `
   resource="activities.contractorResources"
 >
   <FormAndReviewList
+    activityIndex="activity index"
     addButtonText="Add another contractor"
     allowDeleteAll={false}
     className={null}

--- a/web/src/containers/activity/__snapshots__/EntryDetails.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/EntryDetails.test.js.snap
@@ -1,70 +1,62 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`the (Activity) EntryDetails component renders correctly 1`] = `
-<ContextProvider
-  value={
-    Object {
-      "index": 2,
-    }
-  }
+<div
+  className="activity--body activity--body__collapsed activity--body__notfirst"
+  id="activity-activity key"
 >
-  <div
-    className="activity--body activity--body__collapsed activity--body__notfirst"
-    id="activity-activity key"
-  >
-    <Review
-      editContent={
-        <div
-          className="nowrap visibility--screen"
-        >
-          <Button
-            onClick={[Function]}
-            size="small"
-            type="button"
-            variation="transparent"
-          >
-            Edit
-          </Button>
-        </div>
-      }
-      editText="Edit"
-      heading="Activity 3: activity name (money pit)"
-      headingLevel={4}
-    />
-    <div
-      className="visibility--print"
-    >
-      <Connect(ActivityOverview)
-        activityIndex={2}
-      />
-      <Connect(Goals)
-        aKey="activity key"
-        activityIndex={2}
-      />
-      <Connect(Schedule)
-        activityIndex={2}
-      />
-      <Costs
-        aKey="activity key"
-      />
-      <Connect(ContractorResources)
-        activityIndex={2}
-      />
-      <Connect(CostAllocate)
-        aKey="activity key"
-        activityIndex={2}
-      />
-      <Connect(StandardsAndConditions)
-        aKey="activity key"
-      />
-      <Button
-        onClick={[Function]}
-        type="button"
-        variation="primary"
+  <Review
+    editContent={
+      <div
+        className="nowrap visibility--screen"
       >
-        Done
-      </Button>
-    </div>
+        <Button
+          onClick={[Function]}
+          size="small"
+          type="button"
+          variation="transparent"
+        >
+          Edit
+        </Button>
+      </div>
+    }
+    editText="Edit"
+    heading="Activity 3: activity name (money pit)"
+    headingLevel={4}
+  />
+  <div
+    className="visibility--print"
+  >
+    <Connect(ActivityOverview)
+      activityIndex={2}
+    />
+    <Connect(Goals)
+      aKey="activity key"
+      activityIndex={2}
+    />
+    <Connect(Schedule)
+      activityIndex={2}
+    />
+    <Costs
+      aKey="activity key"
+    />
+    <Connect(ContractorResources)
+      activityIndex={2}
+    />
+    <Connect(CostAllocate)
+      aKey="activity key"
+      activityIndex={2}
+    />
+    <Connect(StandardsAndConditions)
+      aKey="activity key"
+    />
+    <Button
+      onClick={[Function]}
+      type="button"
+      variation="primary"
+    >
+      Done
+    </Button>
   </div>
-</ContextProvider>
+</div>
 `;

--- a/web/src/containers/activity/__snapshots__/Goals.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/Goals.test.js.snap
@@ -8,6 +8,7 @@ exports[`activity Goals component renders properly 1`] = `
   resource="activities.goals"
 >
   <FormAndReviewList
+    activityIndex="activity index"
     addButtonText="Add a goal"
     allowDeleteAll={false}
     className={null}

--- a/web/src/containers/activity/__snapshots__/Schedule.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/Schedule.test.js.snap
@@ -56,6 +56,7 @@ exports[`the Schedule (milestones) component renders correctly 1`] = `
     />
     <hr />
     <FormAndReviewList
+      activityIndex={7}
       addButtonText="Add another milestone"
       allowDeleteAll={false}
       className={null}


### PR DESCRIPTION
I added a React context provider to the `EntryDetails` component to give descendant components access to the activity index, but it's a little confusing to use and we don't really need it. Every component along the way needs the activity index anyway, so we're never passing it just to pass it.

### This pull request changes...

- remove `useContext` from everywhere
- removes activity index context
- removes context provider wrapper

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)