### PR TITLE
Fix document model migration

### DIFF
--- a/api/migrations/20190729185138_document-model.js
+++ b/api/migrations/20190729185138_document-model.js
@@ -1,5 +1,30 @@
-require('../db').setup();
-const apdModel = require('../db').models.apd;
+const { fork } = require('child_process');
+
+if (process.argv[2] === 'fork') {
+  // Bookshelf creates another instance of knex. That instance of knex creates
+  // an open connection that lasts until the process closes. As a result, if
+  // this Bookshelf query is run in the same process as the mgiration, the
+  // migration will never finish and subsequent migrations will block. To
+  // handle that, we'll have this migration fork itself; in the fork process,
+  // that's where we'll use the Bookshelf query. Then we'll send the data
+  // back to the parent process and have the fork kill itself.
+
+  /* eslint-disable global-require */
+  require('../db').setup();
+  const apdModel = require('../db').models.apd;
+
+  const fetch = async () => {
+    const apds = await apdModel.fetchAll({
+      withRelated: apdModel.withRelated
+    });
+    return apds;
+  };
+
+  fetch().then(apds => {
+    process.send(apds.toJSON());
+    process.exit(0);
+  });
+}
 
 exports.up = async knex => {
   // Check if there are any APDs in the database first. If we're migrating
@@ -10,12 +35,15 @@ exports.up = async knex => {
 
   let apds;
 
-  if (count > 0) {
+  if (count[0].count > 0) {
     // If there are APDs, fetch before updating the table because knex will
     // lock the table and we won't be able to fetch with bookshelf afterwards.
-    apds = (await apdModel.fetchAll({
-      withRelated: apdModel.withRelated
-    })).toJSON();
+    apds = await new Promise(resolve => {
+      const child = fork(__filename, ['fork']);
+      child.on('message', msg => {
+        resolve(msg);
+      });
+    });
   }
 
   await knex.schema.alterTable('apds', table => {

--- a/api/migrations/20190729185138_document-model.js
+++ b/api/migrations/20190729185138_document-model.js
@@ -1,5 +1,7 @@
 const { fork } = require('child_process');
 
+// If this is a fork, it'll have its second argument set to the value "fork".
+// See below (around like 45) for where the process is forked.
 if (process.argv[2] === 'fork') {
   // Bookshelf creates another instance of knex. That instance of knex creates
   // an open connection that lasts until the process closes. As a result, if
@@ -39,6 +41,7 @@ exports.up = async knex => {
     // If there are APDs, fetch before updating the table because knex will
     // lock the table and we won't be able to fetch with bookshelf afterwards.
     apds = await new Promise(resolve => {
+      // Pass it an argument so we can identify that it's a fork.
       const child = fork(__filename, ['fork']);
       child.on('message', msg => {
         resolve(msg);


### PR DESCRIPTION
The document model migration makes use of Bookshelf to pull relational APDs as single objects (rather than writing complex queries in SQL to do it manually) and then writes those objects into the new `document` column for APDs. This is basically the conversion step from relational model to document model.

However, Bookshelf creates an instance of knex _in addition to_ the instance of knex being used to run the migrations. knex instances don't close until the process exits, and the open connection actually causes a process to stay alive - so a process must be manually killed in order to disconnect knex. This isn't necessarily a problem.  If you are running ***ONLY*** the document model migration (or if it is the last one in a list of migrations), it works fine - when the migration is finished, the process exits, and everything is happy.

However, if any other migrations run *after* the document model migration, they can fail because Bookshelf's knex instance is still open and is preventing the document model migration from being committed to the database. Thus, if any subsequent migrations rely on the `document` column in the `apds` table, those migrations will fail because the column doesn't exist.

There are two potential solutions. One is to manually pull out all the APDs using knex to manually grab all the related parts and build up the right objects. That is pretty high risk because we'd have to make sure columns across nearly 20 tables were converted into the right property names, data types were properly massaged, etc. Plus it's complicated.

The other option is to put the Bookshelf code into a separate process and have it send back its query results over an IPC (interprocess communications) channel. Node.js supports this pretty well out of the box, so that's what I did. If there are APDs that need to be converted, the migration will spawn a fork process of itself. That forked process will load Bookshelf, fetch the APDs, convert them to JSON, send them back to the parent process over an IPC, and then kill itself. The parent will wait until it gets a message from the fork. Once it does, it continues with the migration. The Bookshelf instance of knex disconnects when the fork dies, and subsequent migrations carry on fine.

### This pull request changes...

- implements ☝️ that

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)