### PR TITLE
Update API POST endpoint to only create document model APD

### DIFF
--- a/api/migrations/20191004161449_harmonize-models.js
+++ b/api/migrations/20191004161449_harmonize-models.js
@@ -23,6 +23,9 @@ exports.up = async knex => {
         activity.contractorResources.forEach(c => {
           delete c.files;
 
+          c.description = c.desc;
+          delete c.desc;
+
           c.hourly = {
             useHourly: c.useHourly || false,
             data: (c.hourlyData || []).reduce(
@@ -91,22 +94,18 @@ exports.up = async knex => {
             ...acc,
             [ffy.year]: {
               1: {
-                combined: ffy.q1.combined * 100,
                 contractors: ffy.q1.contractors * 100,
                 state: ffy.q1.state * 100
               },
               2: {
-                combined: ffy.q2.combined * 100,
                 contractors: ffy.q2.contractors * 100,
                 state: ffy.q2.state * 100
               },
               3: {
-                combined: ffy.q3.combined * 100,
                 contractors: ffy.q3.contractors * 100,
                 state: ffy.q3.state * 100
               },
               4: {
-                combined: ffy.q4.combined * 100,
                 contractors: ffy.q4.contractors * 100,
                 state: ffy.q4.state * 100
               }

--- a/api/routes/apds/__snapshots__/post.endpoint.js.snap
+++ b/api/routes/apds/__snapshots__/post.endpoint.js.snap
@@ -8,146 +8,112 @@ Object {
       "contractorResources": Array [
         Object {
           "description": "",
-          "end": null,
-          "files": Array [],
-          "hourlyData": Array [
-            Object {
-              "hours": 0,
-              "id": 1,
-              "rate": 0,
-              "year": 2020,
+          "end": "",
+          "hourly": Object {
+            "data": Object {
+              "2020": Object {
+                "hours": 0,
+                "rate": 0,
+              },
+              "2021": Object {
+                "hours": 0,
+                "rate": 0,
+              },
             },
-            Object {
-              "hours": 0,
-              "id": 2,
-              "rate": 0,
-              "year": 2021,
-            },
-          ],
-          "id": 1,
+            "useHourly": false,
+          },
           "name": "",
-          "start": null,
+          "start": "",
           "totalCost": 0,
-          "useHourly": false,
-          "years": Array [
-            Object {
-              "cost": 0,
-              "id": 1,
-              "year": 2020,
-            },
-            Object {
-              "cost": 0,
-              "id": 2,
-              "year": 2021,
-            },
-          ],
+          "years": Object {
+            "2020": 0,
+            "2021": 0,
+          },
         },
       ],
-      "costAllocation": Array [
-        Object {
-          "federalPercent": "0.90",
-          "otherAmount": 0,
-          "statePercent": "0.10",
-          "year": 2020,
+      "costAllocation": Object {
+        "2020": Object {
+          "ffp": Object {
+            "federal": 90,
+            "state": 10,
+          },
+          "other": 0,
         },
-        Object {
-          "federalPercent": "0.90",
-          "otherAmount": 0,
-          "statePercent": "0.10",
-          "year": 2021,
+        "2021": Object {
+          "ffp": Object {
+            "federal": 90,
+            "state": 10,
+          },
+          "other": 0,
         },
-      ],
+      },
       "costAllocationNarrative": Object {
-        "methodology": null,
-        "otherSources": null,
+        "methodology": "",
+        "otherSources": "",
       },
       "description": "",
       "expenses": Array [
         Object {
           "category": "",
           "description": "",
-          "entries": Array [
-            Object {
-              "amount": 0,
-              "id": 1,
-              "year": "2020",
-            },
-            Object {
-              "amount": 0,
-              "id": 2,
-              "year": "2021",
-            },
-          ],
-          "id": 1,
+          "years": Object {
+            "2020": 0,
+            "2021": 0,
+          },
         },
       ],
-      "files": Array [],
       "fundingSource": "HIT",
       "goals": Array [
         Object {
           "description": "",
-          "id": 1,
           "objective": "",
         },
       ],
-      "id": 1,
       "name": "Program Administration",
-      "plannedEndDate": null,
-      "plannedStartDate": null,
-      "quarterlyFFP": Array [
-        Object {
-          "q1": Object {
-            "combined": 0,
+      "plannedEndDate": "",
+      "plannedStartDate": "",
+      "quarterlyFFP": Object {
+        "2020": Object {
+          "1": Object {
             "contractors": 0,
             "state": 0,
           },
-          "q2": Object {
-            "combined": 0,
+          "2": Object {
             "contractors": 0,
             "state": 0,
           },
-          "q3": Object {
-            "combined": 0,
+          "3": Object {
             "contractors": 0,
             "state": 0,
           },
-          "q4": Object {
-            "combined": 0,
+          "4": Object {
             "contractors": 0,
             "state": 0,
           },
-          "year": 2020,
         },
-        Object {
-          "q1": Object {
-            "combined": 0,
+        "2021": Object {
+          "1": Object {
             "contractors": 0,
             "state": 0,
           },
-          "q2": Object {
-            "combined": 0,
+          "2": Object {
             "contractors": 0,
             "state": 0,
           },
-          "q3": Object {
-            "combined": 0,
+          "3": Object {
             "contractors": 0,
             "state": 0,
           },
-          "q4": Object {
-            "combined": 0,
+          "4": Object {
             "contractors": 0,
             "state": 0,
           },
-          "year": 2021,
         },
-      ],
+      },
       "schedule": Array [
         Object {
-          "endDate": null,
-          "id": 1,
+          "endDate": "",
           "milestone": "",
-          "status": null,
         },
       ],
       "standardsAndConditions": Object {
@@ -166,102 +132,101 @@ Object {
       "statePersonnel": Array [
         Object {
           "description": "",
-          "id": 1,
           "title": "",
-          "years": Array [
-            Object {
-              "cost": 0,
-              "fte": 0,
-              "id": 1,
-              "year": 2020,
+          "years": Object {
+            "2020": Object {
+              "amt": 0,
+              "perc": 0,
             },
-            Object {
-              "cost": 0,
-              "fte": 0,
-              "id": 2,
-              "year": 2021,
+            "2021": Object {
+              "amt": 0,
+              "perc": 0,
             },
-          ],
+          },
         },
       ],
       "summary": "",
     },
   ],
-  "federalCitations": null,
+  "federalCitations": Object {},
   "id": 1,
-  "incentivePayments": Array [
-    Object {
-      "q1": Object {
-        "ehCount": null,
-        "ehPayment": 0,
-        "epCount": null,
-        "epPayment": 0,
+  "incentivePayments": Object {
+    "ehAmt": Object {
+      "2020": Object {
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 0,
       },
-      "q2": Object {
-        "ehCount": null,
-        "ehPayment": 0,
-        "epCount": null,
-        "epPayment": 0,
+      "2021": Object {
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 0,
       },
-      "q3": Object {
-        "ehCount": null,
-        "ehPayment": 0,
-        "epCount": null,
-        "epPayment": 0,
-      },
-      "q4": Object {
-        "ehCount": null,
-        "ehPayment": 0,
-        "epCount": null,
-        "epPayment": 0,
-      },
-      "year": "2020",
     },
-    Object {
-      "q1": Object {
-        "ehCount": null,
-        "ehPayment": 0,
-        "epCount": null,
-        "epPayment": 0,
+    "ehCt": Object {
+      "2020": Object {
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 0,
       },
-      "q2": Object {
-        "ehCount": null,
-        "ehPayment": 0,
-        "epCount": null,
-        "epPayment": 0,
+      "2021": Object {
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 0,
       },
-      "q3": Object {
-        "ehCount": null,
-        "ehPayment": 0,
-        "epCount": null,
-        "epPayment": 0,
-      },
-      "q4": Object {
-        "ehCount": null,
-        "ehPayment": 0,
-        "epCount": null,
-        "epPayment": 0,
-      },
-      "year": "2021",
     },
-  ],
+    "epAmt": Object {
+      "2020": Object {
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 0,
+      },
+      "2021": Object {
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 0,
+      },
+    },
+    "epCt": Object {
+      "2020": Object {
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 0,
+      },
+      "2021": Object {
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 0,
+      },
+    },
+  },
   "keyPersonnel": Array [
     Object {
-      "costs": Array [],
-      "email": null,
+      "costs": Object {
+        "2020": 0,
+        "2021": 0,
+      },
+      "email": "",
       "hasCosts": false,
-      "id": 1,
       "isPrimary": true,
-      "name": null,
-      "percentTime": "0.00",
-      "position": null,
+      "name": "",
+      "percentTime": "",
+      "position": "",
     },
   ],
   "narrativeHIE": "",
   "narrativeHIT": "",
   "narrativeMMIS": "",
-  "previousActivityExpenses": Array [
-    Object {
+  "previousActivityExpenses": Object {
+    "2018": Object {
       "hithie": Object {
         "federalActual": 0,
         "totalApproved": 0,
@@ -280,9 +245,8 @@ Object {
           "totalApproved": 0,
         },
       },
-      "year": "2020",
     },
-    Object {
+    "2019": Object {
       "hithie": Object {
         "federalActual": 0,
         "totalApproved": 0,
@@ -301,9 +265,8 @@ Object {
           "totalApproved": 0,
         },
       },
-      "year": "2019",
     },
-    Object {
+    "2020": Object {
       "hithie": Object {
         "federalActual": 0,
         "totalApproved": 0,
@@ -322,27 +285,24 @@ Object {
           "totalApproved": 0,
         },
       },
-      "year": "2018",
-    },
-  ],
-  "previousActivitySummary": "",
-  "programOverview": "",
-  "state": "mn",
-  "stateProfile": Object {
-    "medicaidDirector": Object {
-      "email": null,
-      "name": null,
-      "phone": null,
-    },
-    "medicaidOffice": Object {
-      "address1": null,
-      "address2": null,
-      "city": null,
-      "state": null,
-      "zip": null,
     },
   },
-  "status": "draft",
+  "previousActivitySummary": "",
+  "programOverview": "",
+  "stateProfile": Object {
+    "medicaidDirector": Object {
+      "email": "",
+      "name": "",
+      "phone": "",
+    },
+    "medicaidOffice": Object {
+      "address1": "",
+      "address2": "",
+      "city": "",
+      "state": "",
+      "zip": "",
+    },
+  },
   "years": Array [
     "2020",
     "2021",

--- a/api/routes/apds/post.data.js
+++ b/api/routes/apds/post.data.js
@@ -18,7 +18,7 @@ const getNewApd = () => {
     yearsToCover.reduce(
       (acc, year) => ({
         ...acc,
-        [year]: typeof obj === 'function' ? obj() : obj
+        [year]: obj
       }),
       {}
     );

--- a/api/routes/apds/post.data.js
+++ b/api/routes/apds/post.data.js
@@ -1,107 +1,4 @@
-const { state: defaultStateModel } = require('../../db').models;
-
-const yearsToArray = (years, obj) =>
-  years.map(year => ({
-    ...obj,
-    year: `${year}`
-  }));
-
-const getActivityCostAllocations = years =>
-  yearsToArray(years, {
-    federalPercent: 0.9,
-    statePercent: 0.1,
-    otherAmount: 0
-  });
-
-const getContractor = years => ({
-  description: '',
-  hourlyData: yearsToArray(years, { hours: 0, rate: 0 }),
-  name: '',
-  totalCost: 0,
-  useHourly: false,
-  years: yearsToArray(years, { cost: 0 })
-});
-
-const getGoal = () => ({
-  description: '',
-  objective: ''
-});
-
-const getExpense = years => ({
-  category: '',
-  description: '',
-  entries: yearsToArray(years, { amount: 0 })
-});
-
-const getIncentivePayments = years =>
-  yearsToArray(years, {
-    q1: { ehPayment: 0, epPayment: 0 },
-    q2: { ehPayment: 0, epPayment: 0 },
-    q3: { ehPayment: 0, epPayment: 0 },
-    q4: { ehPayment: 0, epPayment: 0 }
-  });
-
-const getPreviousActivityExpenses = years =>
-  yearsToArray(years, {
-    hie: {
-      federalActual: 0,
-      federalApproved: 0,
-      stateActual: 0,
-      stateApproved: 0
-    },
-    hit: {
-      federalActual: 0,
-      federalApproved: 0,
-      stateActual: 0,
-      stateApproved: 0
-    },
-    mmis: {
-      federal90Actual: 0,
-      federal90Approved: 0,
-      federal75Actual: 0,
-      federal75Approved: 0,
-      federal50Actual: 0,
-      federal50Approved: 0,
-      state10Actual: 0,
-      state10Approved: 0,
-      state25Actual: 0,
-      state25Approved: 0,
-      state50Actual: 0,
-      state50Approved: 0
-    }
-  });
-
-const getScheduleMilestone = () => ({
-  milestone: ''
-});
-
-const getStatePersonnel = years => ({
-  description: '',
-  title: '',
-  years: yearsToArray(years, {
-    cost: 0,
-    fte: 0
-  })
-});
-
-const getStateProfile = () => ({
-  medicaidDirector: {
-    email: '',
-    name: '',
-    phone: ''
-  },
-  medicaidOffice: {
-    address1: '',
-    address2: '',
-    city: '',
-    state: '',
-    zip: ''
-  }
-});
-
-const repeat = (number, obj) => [...Array(number)].map(() => obj);
-
-const getNewApd = async (stateID, { StateModel = defaultStateModel } = {}) => {
+const getNewApd = () => {
   const thisFFY = (() => {
     const year = new Date().getFullYear();
 
@@ -117,35 +14,65 @@ const getNewApd = async (stateID, { StateModel = defaultStateModel } = {}) => {
   const yearOptions = [thisFFY, thisFFY + 1, thisFFY + 2].map(y => `${y}`);
   const years = yearOptions.slice(0, 2);
 
-  const stateProfile = getStateProfile();
-  const state = await StateModel.where({ id: stateID }).fetch();
-  if (state.get('medicaid_office')) {
-    const stored = state.get('medicaid_office');
-    stateProfile.medicaidDirector = stored.medicaidDirector;
-    stateProfile.medicaidOffice = stored.medicaidOffice;
-  }
-
-  const pointsOfContact = [];
-  if (state.get('state_pocs')) {
-    pointsOfContact.push(...state.get('state_pocs'));
-  }
+  const forAllYears = (obj, yearsToCover = years) =>
+    yearsToCover.reduce(
+      (acc, year) => ({
+        ...acc,
+        [year]: typeof obj === 'function' ? obj() : obj
+      }),
+      {}
+    );
 
   return {
     activities: [
       {
         alternatives: '',
-        contractorResources: repeat(1, getContractor(years)),
-        costAllocation: getActivityCostAllocations(years),
+        contractorResources: [
+          {
+            description: '',
+            end: '',
+            hourly: {
+              data: forAllYears({ hours: 0, rate: 0 }),
+              useHourly: false
+            },
+            name: '',
+            start: '',
+            totalCost: 0,
+            years: forAllYears(0)
+          }
+        ],
+        costAllocation: forAllYears({
+          ffp: { federal: 90, state: 10 },
+          other: 0
+        }),
         costAllocationNarrative: {
           methodology: '',
           otherSources: ''
         },
         description: '',
-        expenses: repeat(1, getExpense(years)),
+        expenses: [
+          {
+            category: '',
+            description: '',
+            years: forAllYears(0)
+          }
+        ],
         fundingSource: 'HIT',
-        goals: [getGoal()],
+        goals: [
+          {
+            description: '',
+            objective: ''
+          }
+        ],
         name: 'Program Administration',
-        schedule: repeat(1, getScheduleMilestone()),
+        plannedEndDate: '',
+        plannedStartDate: '',
+        schedule: [
+          {
+            endDate: '',
+            milestone: ''
+          }
+        ],
         standardsAndConditions: {
           businessResults: '',
           documentation: '',
@@ -159,23 +86,77 @@ const getNewApd = async (stateID, { StateModel = defaultStateModel } = {}) => {
           mita: '',
           reporting: ''
         },
-        statePersonnel: repeat(1, getStatePersonnel(years)),
+        statePersonnel: [
+          {
+            description: '',
+            title: '',
+            years: forAllYears({
+              amt: 0,
+              perc: 0
+            })
+          }
+        ],
         summary: '',
-        quarterlyFFP: yearsToArray(years, { q1: 0, q2: 0, q3: 0, q4: 0 })
+        quarterlyFFP: forAllYears({
+          1: { contractors: 0, state: 0 },
+          2: { contractors: 0, state: 0 },
+          3: { contractors: 0, state: 0 },
+          4: { contractors: 0, state: 0 }
+        })
       }
     ],
-    incentivePayments: getIncentivePayments(years),
-    keyPersonnel: [{ isPrimary: true }],
+    federalCitations: {},
+    incentivePayments: {
+      ehAmt: forAllYears({ 1: 0, 2: 0, 3: 0, 4: 0 }),
+      ehCt: forAllYears({ 1: 0, 2: 0, 3: 0, 4: 0 }),
+      epAmt: forAllYears({ 1: 0, 2: 0, 3: 0, 4: 0 }),
+      epCt: forAllYears({ 1: 0, 2: 0, 3: 0, 4: 0 })
+    },
+    keyPersonnel: [
+      {
+        email: '',
+        hasCosts: false,
+        costs: forAllYears(0),
+        isPrimary: true,
+        name: '',
+        percentTime: '',
+        position: ''
+      }
+    ],
+    name: '',
     narrativeHIE: '',
     narrativeHIT: '',
     narrativeMMIS: '',
-    pointsOfContact,
-    previousActivityExpenses: getPreviousActivityExpenses(
+    previousActivityExpenses: forAllYears(
+      {
+        hithie: {
+          federalActual: 0,
+          totalApproved: 0
+        },
+        mmis: {
+          90: { federalActual: 0, totalApproved: 0 },
+          75: { federalActual: 0, totalApproved: 0 },
+          50: { federalActual: 0, totalApproved: 0 }
+        }
+      },
       [0, 1, 2].map(past => yearOptions[0] - past)
     ),
     previousActivitySummary: '',
     programOverview: '',
-    stateProfile,
+    stateProfile: {
+      medicaidDirector: {
+        email: '',
+        name: '',
+        phone: ''
+      },
+      medicaidOffice: {
+        address1: '',
+        address2: '',
+        city: '',
+        state: '',
+        zip: ''
+      }
+    },
     years
   };
 };

--- a/api/routes/apds/post.data.test.js
+++ b/api/routes/apds/post.data.test.js
@@ -16,27 +16,7 @@ tap.test('APD data initializer', async test => {
     mockClock.restore();
   });
 
-  const state = {
-    get: sinon.stub()
-  };
-  state.get.withArgs('medicaid_office').returns({
-    medicaidDirector: 'Director of Medicaid Operations',
-    medicaidOffice: 'Office Where the Director Sites'
-  });
-  state.get
-    .withArgs('state_pocs')
-    .returns(['State Person 1', 'State Person 2']);
-
-  const StateModel = {
-    where: sinon
-      .stub()
-      .withArgs('state id')
-      .returns({
-        fetch: sinon.stub().resolves(state)
-      })
-  };
-
-  const output = await getNewApd('state id', { StateModel });
+  const output = await getNewApd();
   // Do a "same" test.  This tests deep equality, which will catch
   // new properties being added to the getNewApd return.  If we use
   // a "match" test, new properties will fall through the cracks.
@@ -47,47 +27,24 @@ tap.test('APD data initializer', async test => {
         contractorResources: [
           {
             description: '',
+            end: '',
+            hourly: {
+              data: {
+                '1997': { hours: '', rate: '' },
+                '1998': { hours: '', rate: '' }
+              },
+              useHourly: false
+            },
             name: '',
+            start: '',
             totalCost: 0,
-            hourlyData: [
-              {
-                hours: '',
-                rate: '',
-                year: '1997'
-              },
-              {
-                hours: '',
-                rate: '',
-                year: '1998'
-              }
-            ],
-            useHourly: false,
-            years: [
-              {
-                cost: 0,
-                year: '1997'
-              },
-              {
-                cost: 0,
-                year: '1998'
-              }
-            ]
+            years: { '1997': 0, '1998': 0 }
           }
         ],
-        costAllocation: [
-          {
-            federalPercent: 0.9,
-            statePercent: 0.1,
-            otherAmount: 0,
-            year: '1997'
-          },
-          {
-            federalPercent: 0.9,
-            statePercent: 0.1,
-            otherAmount: 0,
-            year: '1998'
-          }
-        ],
+        costAllocation: {
+          '1997': { ffp: { federal: 90, state: 10 }, other: 0 },
+          '1998': { ffp: { federal: 90, state: 10 }, other: 0 }
+        },
         costAllocationNarrative: {
           methodology: '',
           otherSources: ''
@@ -97,22 +54,15 @@ tap.test('APD data initializer', async test => {
           {
             category: '',
             description: '',
-            entries: [
-              {
-                amount: 0,
-                year: '1997'
-              },
-              {
-                amount: 0,
-                year: '1998'
-              }
-            ]
+            years: { '1997': 0, '1998': 0 }
           }
         ],
         fundingSource: 'HIT',
         goals: [{ description: '', objective: '' }],
         name: 'Program Administration',
-        schedule: [{ milestone: '' }],
+        plannedEndDate: '',
+        plannedStartDate: '',
+        schedule: [{ endDate: '', milestone: '' }],
         standardsAndConditions: {
           businessResults: '',
           documentation: '',
@@ -130,142 +80,113 @@ tap.test('APD data initializer', async test => {
           {
             description: '',
             title: '',
-            years: [
-              {
-                cost: 0,
-                fte: 0,
-                year: '1997'
-              },
-              {
-                cost: 0,
-                fte: 0,
-                year: '1998'
-              }
-            ]
+            years: {
+              '1997': { amt: 0, perc: 0 },
+              '1998': { amt: 0, perc: 0 }
+            }
           }
         ],
         summary: '',
-        quarterlyFFP: [
-          { q1: 0, q2: 0, q3: 0, q4: 0, year: '1997' },
-          { q1: 0, q2: 0, q3: 0, q4: 0, year: '1998' }
-        ]
+        quarterlyFFP: {
+          '1997': {
+            1: { contractors: 0, state: 0 },
+            2: { contractors: 0, state: 0 },
+            3: { contractors: 0, state: 0 },
+            4: { contractors: 0, state: 0 }
+          },
+          '1998': {
+            1: { contractors: 0, state: 0 },
+            2: { contractors: 0, state: 0 },
+            3: { contractors: 0, state: 0 },
+            4: { contractors: 0, state: 0 }
+          }
+        }
       }
     ],
-    incentivePayments: [
-      {
-        q1: { ehPayment: 0, epPayment: 0 },
-        q2: { ehPayment: 0, epPayment: 0 },
-        q3: { ehPayment: 0, epPayment: 0 },
-        q4: { ehPayment: 0, epPayment: 0 },
-        year: '1997'
+    federalCitations: {},
+    incentivePayments: {
+      ehAmt: {
+        '1997': { 1: 0, 2: 0, 3: 0, 4: 0 },
+        '1998': { 1: 0, 2: 0, 3: 0, 4: 0 }
       },
+      ehCt: {
+        '1997': { 1: 0, 2: 0, 3: 0, 4: 0 },
+        '1998': { 1: 0, 2: 0, 3: 0, 4: 0 }
+      },
+      epAmt: {
+        '1997': { 1: 0, 2: 0, 3: 0, 4: 0 },
+        '1998': { 1: 0, 2: 0, 3: 0, 4: 0 }
+      },
+      epCt: {
+        '1997': { 1: 0, 2: 0, 3: 0, 4: 0 },
+        '1998': { 1: 0, 2: 0, 3: 0, 4: 0 }
+      }
+    },
+    keyPersonnel: [
       {
-        q1: { ehPayment: 0, epPayment: 0 },
-        q2: { ehPayment: 0, epPayment: 0 },
-        q3: { ehPayment: 0, epPayment: 0 },
-        q4: { ehPayment: 0, epPayment: 0 },
-        year: '1998'
+        costs: { '1997': 0, '1998': 0 },
+        email: '',
+        hasCosts: false,
+        isPrimary: true,
+        name: '',
+        percentTime: '',
+        position: ''
       }
     ],
-    keyPersonnel: [{ isPrimary: true }],
+    name: '',
     narrativeHIE: '',
     narrativeHIT: '',
     narrativeMMIS: '',
-    pointsOfContact: ['State Person 1', 'State Person 2'],
-    previousActivityExpenses: [
-      {
-        hie: {
+    previousActivityExpenses: {
+      '1997': {
+        hithie: {
           federalActual: 0,
-          federalApproved: 0,
-          stateActual: 0,
-          stateApproved: 0
-        },
-        hit: {
-          federalActual: 0,
-          federalApproved: 0,
-          stateActual: 0,
-          stateApproved: 0
+          totalApproved: 0
         },
         mmis: {
-          federal90Actual: 0,
-          federal90Approved: 0,
-          federal75Actual: 0,
-          federal75Approved: 0,
-          federal50Actual: 0,
-          federal50Approved: 0,
-          state10Actual: 0,
-          state10Approved: 0,
-          state25Actual: 0,
-          state25Approved: 0,
-          state50Actual: 0,
-          state50Approved: 0
-        },
-        year: '1997'
+          90: { federalActual: 0, totalApproved: 0 },
+          75: { federalActual: 0, totalApproved: 0 },
+          50: { federalActual: 0, totalApproved: 0 }
+        }
       },
-      {
-        hie: {
+      '1996': {
+        hithie: {
           federalActual: 0,
-          federalApproved: 0,
-          stateActual: 0,
-          stateApproved: 0
-        },
-        hit: {
-          federalActual: 0,
-          federalApproved: 0,
-          stateActual: 0,
-          stateApproved: 0
+          totalApproved: 0
         },
         mmis: {
-          federal90Actual: 0,
-          federal90Approved: 0,
-          federal75Actual: 0,
-          federal75Approved: 0,
-          federal50Actual: 0,
-          federal50Approved: 0,
-          state10Actual: 0,
-          state10Approved: 0,
-          state25Actual: 0,
-          state25Approved: 0,
-          state50Actual: 0,
-          state50Approved: 0
-        },
-        year: '1996'
+          90: { federalActual: 0, totalApproved: 0 },
+          75: { federalActual: 0, totalApproved: 0 },
+          50: { federalActual: 0, totalApproved: 0 }
+        }
       },
-      {
-        hie: {
+      '1995': {
+        hithie: {
           federalActual: 0,
-          federalApproved: 0,
-          stateActual: 0,
-          stateApproved: 0
-        },
-        hit: {
-          federalActual: 0,
-          federalApproved: 0,
-          stateActual: 0,
-          stateApproved: 0
+          totalApproved: 0
         },
         mmis: {
-          federal90Actual: 0,
-          federal90Approved: 0,
-          federal75Actual: 0,
-          federal75Approved: 0,
-          federal50Actual: 0,
-          federal50Approved: 0,
-          state10Actual: 0,
-          state10Approved: 0,
-          state25Actual: 0,
-          state25Approved: 0,
-          state50Actual: 0,
-          state50Approved: 0
-        },
-        year: '1995'
+          90: { federalActual: 0, totalApproved: 0 },
+          75: { federalActual: 0, totalApproved: 0 },
+          50: { federalActual: 0, totalApproved: 0 }
+        }
       }
-    ],
+    },
     previousActivitySummary: '',
     programOverview: '',
     stateProfile: {
-      medicaidDirector: 'Director of Medicaid Operations',
-      medicaidOffice: 'Office Where the Director Sites'
+      medicaidDirector: {
+        email: '',
+        name: '',
+        phone: ''
+      },
+      medicaidOffice: {
+        address1: '',
+        address2: '',
+        city: '',
+        state: '',
+        zip: ''
+      }
     },
     years: ['1997', '1998']
   });

--- a/api/routes/apds/post.js
+++ b/api/routes/apds/post.js
@@ -38,6 +38,10 @@ module.exports = (app, { db = raw } = {}) => {
         .first();
 
       if (stateProfile) {
+        // Merge the state profile from the states table into the default
+        // values so that if the states table info is missing any fields,
+        // we preserve the defaults
+
         apd.stateProfile.medicaidDirector = {
           ...apd.stateProfile.medicaidDirector,
           ...stateProfile.medicaid_office.medicaidDirector

--- a/api/routes/apds/post.test.js
+++ b/api/routes/apds/post.test.js
@@ -10,7 +10,7 @@ const postEndpoint = require('./post');
 // atmosphere to burn up so it couldn't possibly contaminate any of Saturn's
 // moons that might be favorable to life. It spent nearly 20 years in space,
 // far beyond its original mission plan of 11 years. Good job, Cassini!
-const mockClock = sinon.useFakeTimers(new Date(2004, 6, 1).getTime());
+const mockClock = sinon.useFakeTimers(Date.UTC(2004, 6, 1, 12));
 tap.tearDown(() => {
   mockClock.restore();
 });
@@ -308,7 +308,7 @@ tap.test('apds POST endpoint', async endpointTest => {
       test.same(res.send.args[0][0], {
         ...expectedApd,
         id: 'apd id',
-        updated: '2004-07-01T05:00:00.000Z'
+        updated: '2004-07-01T12:00:00.000Z'
       });
     });
   });

--- a/api/routes/apds/post.test.js
+++ b/api/routes/apds/post.test.js
@@ -10,6 +10,8 @@ const postEndpoint = require('./post');
 // atmosphere to burn up so it couldn't possibly contaminate any of Saturn's
 // moons that might be favorable to life. It spent nearly 20 years in space,
 // far beyond its original mission plan of 11 years. Good job, Cassini!
+//
+// Mock with UTC date so the time is consistent regardless of local timezone
 const mockClock = sinon.useFakeTimers(Date.UTC(2004, 6, 1, 12));
 tap.tearDown(() => {
   mockClock.restore();

--- a/api/routes/openAPI/__snapshots__/get.endpoint.js.snap
+++ b/api/routes/openAPI/__snapshots__/get.endpoint.js.snap
@@ -4,319 +4,102 @@ exports[`open-api endpoint | GET /open-api 1`] = `
 Object {
   "components": Object {
     "schemas": Object {
-      "activity": Object {
+      "apd": Object {
         "properties": Object {
-          "alernatives": Object {
-            "description": "Alternative considerations for the activity",
-            "type": "string",
-          },
-          "contractorResources": Object {
+          "activities": Object {
             "items": Object {
-              "description": "Activity contractor resource",
               "properties": Object {
-                "description": Object {
-                  "description": "Description",
+                "alernatives": Object {
+                  "description": "Alternative considerations for the activity",
                   "type": "string",
                 },
-                "end": Object {
-                  "description": "When the contractor resource will end work; date only",
-                  "format": "date-time",
-                  "type": "string",
+                "contractorResources": Object {
+                  "items": Object {
+                    "description": "Activity contractor resource",
+                    "properties": Object {
+                      "description": Object {
+                        "description": "Description",
+                        "type": "string",
+                      },
+                      "end": Object {
+                        "description": "When the contractor resource will end work; date only",
+                        "format": "date-time",
+                        "type": "string",
+                      },
+                      "hourly": Object {
+                        "properties": Object {
+                          "data": Object {
+                            "x-patternProperties": Object {
+                              "^[0-9]{4}$": Object {
+                                "properties": Object {
+                                  "hours": Object {
+                                    "description": "Number of hours the contractor is expected to work for the given federal fiscal year",
+                                    "type": "number",
+                                  },
+                                  "rate": Object {
+                                    "description": "Contractor hourly rate for the given federal fiscal year",
+                                    "type": "number",
+                                  },
+                                },
+                                "type": "object",
+                              },
+                            },
+                          },
+                          "useHourly": Object {
+                            "description": "Whether to use hourly rates for this contractor",
+                            "type": "boolean",
+                          },
+                        },
+                        "type": "object",
+                      },
+                      "name": Object {
+                        "description": "Name of the contractor resource",
+                        "type": "string",
+                      },
+                      "start": Object {
+                        "description": "When the contractor resource will begin work; date only",
+                        "format": "date-time",
+                        "type": "string",
+                      },
+                      "totalCost": Object {
+                        "description": "Contractor resource total cost",
+                        "type": "number",
+                      },
+                      "years": Object {
+                        "description": "Details of each year the contractor resource will be working",
+                        "type": "object",
+                        "x-patternProperties": Object {
+                          "^[0-9]{4}$": Object {
+                            "description": "Contractor resource cost of the year",
+                            "type": "number",
+                          },
+                        },
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
                 },
-                "hourly": Object {
-                  "properties": Object {
-                    "data": Object {
-                      "x-patternProperties": Object {
-                        "^[0-9]{4}$": Object {
+                "costAllocation": Object {
+                  "type": "object",
+                  "x-patternProperties": Object {
+                    "^[0-9]{4}$": Object {
+                      "properties": Object {
+                        "ffp": Object {
                           "properties": Object {
-                            "hours": Object {
-                              "description": "Number of hours the contractor is expected to work for the given federal fiscal year",
+                            "federal": Object {
+                              "description": "Federal share for this activity for this year, from 0 to 100",
                               "type": "number",
                             },
-                            "rate": Object {
-                              "description": "Contractor hourly rate for the given federal fiscal year",
+                            "state": Object {
+                              "description": "State share for this activity for this year, from 0 to 100",
                               "type": "number",
                             },
                           },
                           "type": "object",
                         },
-                      },
-                    },
-                    "useHourly": Object {
-                      "description": "Whether to use hourly rates for this contractor",
-                      "type": "boolean",
-                    },
-                  },
-                  "type": "object",
-                },
-                "name": Object {
-                  "description": "Name of the contractor resource",
-                  "type": "string",
-                },
-                "start": Object {
-                  "description": "When the contractor resource will begin work; date only",
-                  "format": "date-time",
-                  "type": "string",
-                },
-                "totalCost": Object {
-                  "description": "Contractor resource total cost",
-                  "type": "number",
-                },
-                "years": Object {
-                  "description": "Details of each year the contractor resource will be working",
-                  "type": "object",
-                  "x-patternProperties": Object {
-                    "^[0-9]{4}$": Object {
-                      "description": "Contractor resource cost of the year",
-                      "type": "number",
-                    },
-                  },
-                },
-              },
-              "type": "object",
-            },
-            "type": "array",
-          },
-          "costAllocation": Object {
-            "type": "object",
-            "x-patternProperties": Object {
-              "^[0-9]{4}$": Object {
-                "properties": Object {
-                  "ffp": Object {
-                    "properties": Object {
-                      "federal": Object {
-                        "description": "Federal share for this activity for this year, from 0 to 100",
-                        "type": "number",
-                      },
-                      "state": Object {
-                        "description": "State share for this activity for this year, from 0 to 100",
-                        "type": "number",
-                      },
-                    },
-                    "type": "object",
-                  },
-                  "other": Object {
-                    "description": "Other amount (dollars) for this activity for this year",
-                    "type": "number",
-                  },
-                },
-                "type": "object",
-              },
-            },
-          },
-          "costAllocationNarrative": Object {
-            "properties": Object {
-              "methodology": Object {
-                "description": "Description of the cost allocation methodology",
-                "type": "string",
-              },
-              "otherSources": Object {
-                "description": "Description of other funding sources",
-                "type": "string",
-              },
-            },
-            "type": "object",
-          },
-          "description": Object {
-            "description": "Activity description",
-            "type": "string",
-          },
-          "expenses": Object {
-            "items": Object {
-              "description": "Activity expense",
-              "properties": Object {
-                "category": Object {
-                  "description": "Expense category, such as \\"Hardware, software, and licensing\\"",
-                  "type": "string",
-                },
-                "description": Object {
-                  "description": "Short description of the expense",
-                  "type": "string",
-                },
-                "years": Object {
-                  "description": "Expense entry",
-                  "type": "object",
-                  "x-patternProperties": Object {
-                    "^[0-9]{4}$": Object {
-                      "description": "Expense amount for the given federal fiscal year",
-                      "type": "number",
-                    },
-                  },
-                },
-              },
-              "type": "object",
-            },
-            "type": "array",
-          },
-          "fundingSource": Object {
-            "description": "Federal funding source that applies to this activity",
-            "type": "string",
-          },
-          "goals": Object {
-            "items": Object {
-              "description": "Activity goal",
-              "properties": Object {
-                "description": Object {
-                  "description": "Goal description",
-                  "type": "string",
-                },
-                "objective": Object {
-                  "description": "Goal objective",
-                  "type": "string",
-                },
-              },
-              "type": "object",
-            },
-            "type": "array",
-          },
-          "id": Object {
-            "description": "Activity globally-unique ID",
-            "type": "number",
-          },
-          "name": Object {
-            "description": "Activity name, unique within an APD",
-            "type": "string",
-          },
-          "plannedEndDate": Object {
-            "description": "The date this activity is planned to begin",
-            "format": "date-time",
-            "type": "string",
-          },
-          "plannedStartDate": Object {
-            "description": "The date this activity is planned to be completed",
-            "format": "date-time",
-            "type": "string",
-          },
-          "quarterlyFFP": Object {
-            "description": "Federal share of this activity cost, by expense type, per fiscal quarter",
-            "type": "object",
-            "x-patternProperties": Object {
-              "^[0-9]{4}$": Object {
-                "properties": Object {
-                  "1": Object {
-                    "properties": Object {
-                      "combined": Object {
-                        "description": "Combined cost for the first quarter of the given federal fiscal year",
-                        "type": "number",
-                      },
-                      "contractors": Object {
-                        "description": "Contractor costs for the first quarter of the given federal fiscal year",
-                        "type": "number",
-                      },
-                      "state": Object {
-                        "description": "In-house (state personnel + non-personnel) costs for the first quarter of the given federal fiscal year",
-                        "type": "number",
-                      },
-                    },
-                    "type": "object",
-                  },
-                  "2": Object {
-                    "properties": Object {
-                      "combined": Object {
-                        "description": "Combined cost for the second quarter of the given federal fiscal year",
-                        "type": "number",
-                      },
-                      "contractors": Object {
-                        "description": "Contractor costs for the second quarter of the given federal fiscal year",
-                        "type": "number",
-                      },
-                      "state": Object {
-                        "description": "In-house (state personnel + non-personnel) costs for the second quarter of the given federal fiscal year",
-                        "type": "number",
-                      },
-                    },
-                    "type": "object",
-                  },
-                  "3": Object {
-                    "properties": Object {
-                      "combined": Object {
-                        "description": "Combined cost for the third quarter of the given federal fiscal year",
-                        "type": "number",
-                      },
-                      "contractors": Object {
-                        "description": "Contractor costs for the third quarter of the given federal fiscal year",
-                        "type": "number",
-                      },
-                      "state": Object {
-                        "description": "In-house (state personnel + non-personnel) costs for the third quarter of the given federal fiscal year",
-                        "type": "number",
-                      },
-                    },
-                    "type": "object",
-                  },
-                  "4": Object {
-                    "properties": Object {
-                      "combined": Object {
-                        "description": "Combined cost for the fourth quarter of the given federal fiscal year",
-                        "type": "number",
-                      },
-                      "contractors": Object {
-                        "description": "Contractor costs for the fourth quarter of the given federal fiscal year",
-                        "type": "number",
-                      },
-                      "state": Object {
-                        "description": "In-house (state personnel + non-personnel) costs for the fourth quarter of the given federal fiscal year",
-                        "type": "number",
-                      },
-                    },
-                    "type": "object",
-                  },
-                },
-                "type": "object",
-              },
-            },
-          },
-          "schedule": Object {
-            "items": Object {
-              "description": "Activity schedule item",
-              "properties": Object {
-                "endDate": Object {
-                  "description": "The date this milestone is planned to be met",
-                  "format": "date-time",
-                  "type": "string",
-                },
-                "milestone": Object {
-                  "description": "The name of the milestone this schedule entry refers to",
-                  "type": "string",
-                },
-                "status": Object {
-                  "description": "The status of the milestone",
-                  "type": "string",
-                },
-              },
-              "type": "object",
-            },
-            "type": "array",
-          },
-          "standardsAndConditions": Object {
-            "type": "object",
-          },
-          "statePersonnel": Object {
-            "items": Object {
-              "properties": Object {
-                "description": Object {
-                  "description": "Description of the role",
-                  "type": "string",
-                },
-                "keyPersonnel": Object {
-                  "description": "\\"Key Personnel\\" designation",
-                  "type": "boolean",
-                },
-                "title": Object {
-                  "description": "Title for the state personnel",
-                  "type": "string",
-                },
-                "years": Object {
-                  "type": "object",
-                  "x-patternProperties": Object {
-                    "^[0-9]{4}$": Object {
-                      "properties": Object {
-                        "amt": Object {
-                          "description": "State personnel's total cost for the federal fiscal year",
-                          "type": "number",
-                        },
-                        "perc": Object {
-                          "description": "Number of FTEs this state personnel will spend on the project for the federal fiscal year",
+                        "other": Object {
+                          "description": "Other amount (dollars) for this activity for this year",
                           "type": "number",
                         },
                       },
@@ -324,23 +107,206 @@ Object {
                     },
                   },
                 },
+                "costAllocationNarrative": Object {
+                  "properties": Object {
+                    "methodology": Object {
+                      "description": "Description of the cost allocation methodology",
+                      "type": "string",
+                    },
+                    "otherSources": Object {
+                      "description": "Description of other funding sources",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+                "description": Object {
+                  "description": "Activity description",
+                  "type": "string",
+                },
+                "expenses": Object {
+                  "items": Object {
+                    "description": "Activity expense",
+                    "properties": Object {
+                      "category": Object {
+                        "description": "Expense category, such as \\"Hardware, software, and licensing\\"",
+                        "type": "string",
+                      },
+                      "description": Object {
+                        "description": "Short description of the expense",
+                        "type": "string",
+                      },
+                      "years": Object {
+                        "description": "Expense entry",
+                        "type": "object",
+                        "x-patternProperties": Object {
+                          "^[0-9]{4}$": Object {
+                            "description": "Expense amount for the given federal fiscal year",
+                            "type": "number",
+                          },
+                        },
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+                "fundingSource": Object {
+                  "description": "Federal funding source that applies to this activity",
+                  "type": "string",
+                },
+                "goals": Object {
+                  "items": Object {
+                    "description": "Activity goal",
+                    "properties": Object {
+                      "description": Object {
+                        "description": "Goal description",
+                        "type": "string",
+                      },
+                      "objective": Object {
+                        "description": "Goal objective",
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+                "name": Object {
+                  "description": "Activity name, unique within an APD",
+                  "type": "string",
+                },
+                "plannedEndDate": Object {
+                  "description": "The date this activity is planned to begin",
+                  "format": "date-time",
+                  "type": "string",
+                },
+                "plannedStartDate": Object {
+                  "description": "The date this activity is planned to be completed",
+                  "format": "date-time",
+                  "type": "string",
+                },
+                "quarterlyFFP": Object {
+                  "description": "Federal share of this activity cost, by expense type, per fiscal quarter",
+                  "type": "object",
+                  "x-patternProperties": Object {
+                    "^[0-9]{4}$": Object {
+                      "type": "object",
+                      "x-patternProperties": Object {
+                        "^[1-4]$": Object {
+                          "properties": Object {
+                            "contractors": Object {
+                              "description": "Contractor costs for the given quarter of the given federal fiscal year",
+                              "type": "number",
+                            },
+                            "state": Object {
+                              "description": "In-house (state personnel + non-personnel) costs for the given quarter of the given federal fiscal year",
+                              "type": "number",
+                            },
+                          },
+                          "type": "object",
+                        },
+                      },
+                    },
+                  },
+                },
+                "schedule": Object {
+                  "items": Object {
+                    "description": "Activity schedule item",
+                    "properties": Object {
+                      "endDate": Object {
+                        "description": "The date this milestone is planned to be met",
+                        "format": "date-time",
+                        "type": "string",
+                      },
+                      "milestone": Object {
+                        "description": "The name of the milestone this schedule entry refers to",
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+                "standardsAndConditions": Object {
+                  "description": "Description of the 11 standards and conditions",
+                  "properties": Object {
+                    "businessResults": Object {
+                      "type": "string",
+                    },
+                    "documentation": Object {
+                      "type": "string",
+                    },
+                    "industryStandards": Object {
+                      "type": "string",
+                    },
+                    "interoperability": Object {
+                      "type": "string",
+                    },
+                    "keyPersonnel": Object {
+                      "type": "string",
+                    },
+                    "leverage": Object {
+                      "type": "string",
+                    },
+                    "minimizeCost": Object {
+                      "type": "string",
+                    },
+                    "mita": Object {
+                      "type": "string",
+                    },
+                    "mitigationStrategy": Object {
+                      "type": "string",
+                    },
+                    "modularity": Object {
+                      "type": "string",
+                    },
+                    "reporting": Object {
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+                "statePersonnel": Object {
+                  "items": Object {
+                    "properties": Object {
+                      "description": Object {
+                        "description": "Description of the role",
+                        "type": "string",
+                      },
+                      "title": Object {
+                        "description": "Title for the state personnel",
+                        "type": "string",
+                      },
+                      "years": Object {
+                        "type": "object",
+                        "x-patternProperties": Object {
+                          "^[0-9]{4}$": Object {
+                            "properties": Object {
+                              "amt": Object {
+                                "description": "State personnel's total cost for the federal fiscal year",
+                                "type": "number",
+                              },
+                              "perc": Object {
+                                "description": "Number of FTEs this state personnel will spend on the project for the federal fiscal year",
+                                "type": "number",
+                              },
+                            },
+                            "type": "object",
+                          },
+                        },
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+                "summary": Object {
+                  "description": "Short summary of the activity",
+                  "type": "string",
+                },
               },
               "type": "object",
-            },
-            "type": "array",
-          },
-          "summary": Object {
-            "description": "Short summary of the activity",
-            "type": "string",
-          },
-        },
-        "type": "object",
-      },
-      "apd": Object {
-        "properties": Object {
-          "activities": Object {
-            "items": Object {
-              "$ref": "#/components/schemas/activity",
             },
             "type": "array",
           },
@@ -353,24 +319,24 @@ Object {
             "type": "number",
           },
           "incentivePayments": Object {
-            "items": Object {
-              "properties": Object {
-                "ehAmt": Object {
-                  "$ref": "#/components/schemas/incentivePaymentType",
-                },
-                "ehCt": Object {
-                  "$ref": "#/components/schemas/incentivePaymentType",
-                },
-                "epAmt": Object {
-                  "$ref": "#/components/schemas/incentivePaymentType",
-                },
-                "epCt": Object {
-                  "$ref": "#/components/schemas/incentivePaymentType",
+            "description": "APD incentive payments",
+            "type": "object",
+            "x-patternProperties": Object {
+              "^e[hc](Amt|Ct)$": Object {
+                "type": "object",
+                "x-patternProperties": Object {
+                  "^[0-9]{4}$": Object {
+                    "type": "object",
+                    "x-patternProperties": Object {
+                      "^[1-4]$": Object {
+                        "description": "EH or EC payment or count for the given federal fiscal year and quarter",
+                        "type": "number",
+                      },
+                    },
+                  },
                 },
               },
-              "type": "object",
             },
-            "type": "array",
           },
           "keyPersonnel": Object {
             "items": Object {
@@ -391,9 +357,6 @@ Object {
                 "hasCosts": Object {
                   "description": "Whether the person has costs attributable to the project",
                   "type": "boolean",
-                },
-                "id": Object {
-                  "type": "number",
                 },
                 "isPrimary": Object {
                   "description": "Whether the person is the primary point of contact for the APD",
@@ -502,6 +465,10 @@ Object {
             "description": "An overview of the overall program",
             "type": "string",
           },
+          "state": Object {
+            "description": "Two-letter ID of the state, territory, or district this APD belongs to, lowercase",
+            "type": "string",
+          },
           "stateProfile": Object {
             "description": "The state profile for this specific APD",
             "properties": Object {
@@ -562,92 +529,6 @@ Object {
           "years": Object {
             "items": Object {
               "type": "string",
-            },
-            "type": "array",
-          },
-        },
-        "type": "object",
-      },
-      "incentivePaymentType": Object {
-        "type": "object",
-        "x-patternProperties": Object {
-          "^[0-9]{4}$": Object {
-            "properties": Object {
-              "1": Object {
-                "description": "EH payment amount for the first quarter of the given fiscal year",
-                "type": "number",
-              },
-              "2": Object {
-                "description": "EH payment amount for the second quarter of the given fiscal year",
-                "type": "number",
-              },
-              "3": Object {
-                "description": "EH payment amount for the third quarter of the given fiscal year",
-                "type": "number",
-              },
-              "4": Object {
-                "description": "EH payment amount for the fourth quarter of the given fiscal year",
-                "type": "number",
-              },
-            },
-            "type": "object",
-          },
-        },
-      },
-      "state": Object {
-        "properties": Object {
-          "id": Object {
-            "description": "State, territory, or district ID (2-letter abbreviation, lowercase)",
-            "type": "string",
-          },
-          "medicaid_office": Object {
-            "description": "Address of the state, territory, or district Medicaid office",
-            "properties": Object {
-              "address": Object {
-                "description": "Street address",
-                "type": "string",
-              },
-              "city": Object {
-                "description": "City",
-                "type": "string",
-              },
-              "zip": Object {
-                "description": "ZIP code",
-                "type": "string",
-              },
-            },
-            "type": "object",
-          },
-          "name": Object {
-            "description": "State, territory, or district name",
-            "type": "string",
-          },
-          "program_benefits": Object {
-            "description": "Planned benefits of the program",
-            "type": "string",
-          },
-          "program_vision": Object {
-            "description": "Program vision statement",
-            "type": "string",
-          },
-          "state_pocs": Object {
-            "items": Object {
-              "description": "A list of points of contact for the state, territory, or district",
-              "properties": Object {
-                "email": Object {
-                  "description": "Point of contact's email address",
-                  "type": "string",
-                },
-                "name": Object {
-                  "description": "Point of contact's name",
-                  "type": "string",
-                },
-                "position": Object {
-                  "description": "Point of contact's position in the state, territory, or district",
-                  "type": "string",
-                },
-              },
-              "type": "object",
             },
             "type": "array",
           },

--- a/api/routes/openAPI/index.js
+++ b/api/routes/openAPI/index.js
@@ -37,349 +37,6 @@ module.exports = {
   },
   components: {
     schemas: {
-      activity: {
-        type: 'object',
-        properties: {
-          id: {
-            type: 'number',
-            description: 'Activity globally-unique ID'
-          },
-          name: {
-            type: 'string',
-            description: 'Activity name, unique within an APD'
-          },
-          fundingSource: {
-            type: 'string',
-            description: 'Federal funding source that applies to this activity'
-          },
-          summary: {
-            type: 'string',
-            description: 'Short summary of the activity'
-          },
-          description: {
-            type: 'string',
-            description: 'Activity description'
-          },
-          alernatives: {
-            type: 'string',
-            description: 'Alternative considerations for the activity'
-          },
-          plannedEndDate: {
-            type: 'string',
-            format: 'date-time',
-            description: 'The date this activity is planned to begin'
-          },
-          plannedStartDate: {
-            type: 'string',
-            format: 'date-time',
-            description: 'The date this activity is planned to be completed'
-          },
-          contractorResources: arrayOf({
-            type: 'object',
-            description: 'Activity contractor resource',
-            properties: {
-              name: {
-                type: 'string',
-                description: 'Name of the contractor resource'
-              },
-              description: {
-                type: 'string',
-                description: 'Description'
-              },
-              hourly: {
-                type: 'object',
-                properties: {
-                  data: {
-                    'x-patternProperties': {
-                      '^[0-9]{4}$': {
-                        type: 'object',
-                        properties: {
-                          hours: {
-                            type: 'number',
-                            description:
-                              'Number of hours the contractor is expected to work for the given federal fiscal year'
-                          },
-                          rate: {
-                            type: 'number',
-                            description:
-                              'Contractor hourly rate for the given federal fiscal year'
-                          }
-                        }
-                      }
-                    }
-                  },
-                  useHourly: {
-                    type: 'boolean',
-                    description:
-                      'Whether to use hourly rates for this contractor'
-                  }
-                }
-              },
-              start: {
-                type: 'string',
-                format: 'date-time',
-                description:
-                  'When the contractor resource will begin work; date only'
-              },
-              end: {
-                type: 'string',
-                format: 'date-time',
-                description:
-                  'When the contractor resource will end work; date only'
-              },
-              totalCost: {
-                type: 'number',
-                description: 'Contractor resource total cost'
-              },
-              years: {
-                type: 'object',
-                description:
-                  'Details of each year the contractor resource will be working',
-                'x-patternProperties': {
-                  '^[0-9]{4}$': {
-                    type: 'number',
-                    description: 'Contractor resource cost of the year'
-                  }
-                }
-              }
-            }
-          }),
-          costAllocationNarrative: {
-            type: 'object',
-            properties: {
-              methodology: {
-                type: 'string',
-                description: 'Description of the cost allocation methodology'
-              },
-              otherSources: {
-                type: 'string',
-                description: 'Description of other funding sources'
-              }
-            }
-          },
-          costAllocation: {
-            type: 'object',
-            'x-patternProperties': {
-              '^[0-9]{4}$': {
-                type: 'object',
-                properties: {
-                  ffp: {
-                    type: 'object',
-                    properties: {
-                      federal: {
-                        type: 'number',
-                        description:
-                          'Federal share for this activity for this year, from 0 to 100'
-                      },
-                      state: {
-                        type: 'number',
-                        description:
-                          'State share for this activity for this year, from 0 to 100'
-                      }
-                    }
-                  },
-                  other: {
-                    type: 'number',
-                    description:
-                      'Other amount (dollars) for this activity for this year'
-                  }
-                }
-              }
-            }
-          },
-          goals: arrayOf({
-            type: 'object',
-            description: 'Activity goal',
-            properties: {
-              description: {
-                type: 'string',
-                description: 'Goal description'
-              },
-              objective: {
-                type: 'string',
-                description: 'Goal objective'
-              }
-            }
-          }),
-          expenses: arrayOf({
-            type: 'object',
-            description: 'Activity expense',
-            properties: {
-              category: {
-                type: 'string',
-                description:
-                  'Expense category, such as "Hardware, software, and licensing"'
-              },
-              description: {
-                type: 'string',
-                description: 'Short description of the expense'
-              },
-              years: {
-                type: 'object',
-                description: 'Expense entry',
-                'x-patternProperties': {
-                  '^[0-9]{4}$': {
-                    type: 'number',
-                    description:
-                      'Expense amount for the given federal fiscal year'
-                  }
-                }
-              }
-            }
-          }),
-          schedule: arrayOf({
-            type: 'object',
-            description: 'Activity schedule item',
-            properties: {
-              endDate: {
-                type: 'string',
-                format: 'date-time',
-                description: 'The date this milestone is planned to be met'
-              },
-              milestone: {
-                type: 'string',
-                description:
-                  'The name of the milestone this schedule entry refers to'
-              },
-              status: {
-                type: 'string',
-                description: 'The status of the milestone'
-              }
-            }
-          }),
-          standardsAndConditions: {
-            type: 'object'
-          },
-          statePersonnel: arrayOf({
-            type: 'object',
-            properties: {
-              title: {
-                type: 'string',
-                description: 'Title for the state personnel'
-              },
-              description: {
-                type: 'string',
-                description: 'Description of the role'
-              },
-              keyPersonnel: {
-                type: 'boolean',
-                description: '"Key Personnel" designation'
-              },
-              years: {
-                type: 'object',
-                'x-patternProperties': {
-                  '^[0-9]{4}$': {
-                    type: 'object',
-                    properties: {
-                      amt: {
-                        type: 'number',
-                        description: `State personnel's total cost for the federal fiscal year`
-                      },
-                      perc: {
-                        type: 'number',
-                        description:
-                          'Number of FTEs this state personnel will spend on the project for the federal fiscal year'
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }),
-          quarterlyFFP: {
-            type: 'object',
-            description:
-              'Federal share of this activity cost, by expense type, per fiscal quarter',
-            'x-patternProperties': {
-              '^[0-9]{4}$': {
-                type: 'object',
-                properties: {
-                  '1': {
-                    type: 'object',
-                    properties: {
-                      combined: {
-                        type: 'number',
-                        description:
-                          'Combined cost for the first quarter of the given federal fiscal year'
-                      },
-                      contractors: {
-                        type: 'number',
-                        description:
-                          'Contractor costs for the first quarter of the given federal fiscal year'
-                      },
-                      state: {
-                        type: 'number',
-                        description:
-                          'In-house (state personnel + non-personnel) costs for the first quarter of the given federal fiscal year'
-                      }
-                    }
-                  },
-                  '2': {
-                    type: 'object',
-                    properties: {
-                      combined: {
-                        type: 'number',
-                        description:
-                          'Combined cost for the second quarter of the given federal fiscal year'
-                      },
-                      contractors: {
-                        type: 'number',
-                        description:
-                          'Contractor costs for the second quarter of the given federal fiscal year'
-                      },
-                      state: {
-                        type: 'number',
-                        description:
-                          'In-house (state personnel + non-personnel) costs for the second quarter of the given federal fiscal year'
-                      }
-                    }
-                  },
-                  '3': {
-                    type: 'object',
-                    properties: {
-                      combined: {
-                        type: 'number',
-                        description:
-                          'Combined cost for the third quarter of the given federal fiscal year'
-                      },
-                      contractors: {
-                        type: 'number',
-                        description:
-                          'Contractor costs for the third quarter of the given federal fiscal year'
-                      },
-                      state: {
-                        type: 'number',
-                        description:
-                          'In-house (state personnel + non-personnel) costs for the third quarter of the given federal fiscal year'
-                      }
-                    }
-                  },
-                  '4': {
-                    type: 'object',
-                    properties: {
-                      combined: {
-                        type: 'number',
-                        description:
-                          'Combined cost for the fourth quarter of the given federal fiscal year'
-                      },
-                      contractors: {
-                        type: 'number',
-                        description:
-                          'Contractor costs for the fourth quarter of the given federal fiscal year'
-                      },
-                      state: {
-                        type: 'number',
-                        description:
-                          'In-house (state personnel + non-personnel) costs for the fourth quarter of the given federal fiscal year'
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
       apd: {
         type: 'object',
         properties: {
@@ -393,26 +50,338 @@ module.exports = {
               'The APD document name, following SEA naming conventions'
           },
           activities: arrayOf({
-            $ref: '#/components/schemas/activity'
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string',
+                description: 'Activity name, unique within an APD'
+              },
+              fundingSource: {
+                type: 'string',
+                description:
+                  'Federal funding source that applies to this activity'
+              },
+              summary: {
+                type: 'string',
+                description: 'Short summary of the activity'
+              },
+              description: {
+                type: 'string',
+                description: 'Activity description'
+              },
+              alernatives: {
+                type: 'string',
+                description: 'Alternative considerations for the activity'
+              },
+              plannedEndDate: {
+                type: 'string',
+                format: 'date-time',
+                description: 'The date this activity is planned to begin'
+              },
+              plannedStartDate: {
+                type: 'string',
+                format: 'date-time',
+                description: 'The date this activity is planned to be completed'
+              },
+              contractorResources: arrayOf({
+                type: 'object',
+                description: 'Activity contractor resource',
+                properties: {
+                  name: {
+                    type: 'string',
+                    description: 'Name of the contractor resource'
+                  },
+                  description: {
+                    type: 'string',
+                    description: 'Description'
+                  },
+                  hourly: {
+                    type: 'object',
+                    properties: {
+                      data: {
+                        'x-patternProperties': {
+                          '^[0-9]{4}$': {
+                            type: 'object',
+                            properties: {
+                              hours: {
+                                type: 'number',
+                                description:
+                                  'Number of hours the contractor is expected to work for the given federal fiscal year'
+                              },
+                              rate: {
+                                type: 'number',
+                                description:
+                                  'Contractor hourly rate for the given federal fiscal year'
+                              }
+                            }
+                          }
+                        }
+                      },
+                      useHourly: {
+                        type: 'boolean',
+                        description:
+                          'Whether to use hourly rates for this contractor'
+                      }
+                    }
+                  },
+                  start: {
+                    type: 'string',
+                    format: 'date-time',
+                    description:
+                      'When the contractor resource will begin work; date only'
+                  },
+                  end: {
+                    type: 'string',
+                    format: 'date-time',
+                    description:
+                      'When the contractor resource will end work; date only'
+                  },
+                  totalCost: {
+                    type: 'number',
+                    description: 'Contractor resource total cost'
+                  },
+                  years: {
+                    type: 'object',
+                    description:
+                      'Details of each year the contractor resource will be working',
+                    'x-patternProperties': {
+                      '^[0-9]{4}$': {
+                        type: 'number',
+                        description: 'Contractor resource cost of the year'
+                      }
+                    }
+                  }
+                }
+              }),
+              costAllocationNarrative: {
+                type: 'object',
+                properties: {
+                  methodology: {
+                    type: 'string',
+                    description:
+                      'Description of the cost allocation methodology'
+                  },
+                  otherSources: {
+                    type: 'string',
+                    description: 'Description of other funding sources'
+                  }
+                }
+              },
+              costAllocation: {
+                type: 'object',
+                'x-patternProperties': {
+                  '^[0-9]{4}$': {
+                    type: 'object',
+                    properties: {
+                      ffp: {
+                        type: 'object',
+                        properties: {
+                          federal: {
+                            type: 'number',
+                            description:
+                              'Federal share for this activity for this year, from 0 to 100'
+                          },
+                          state: {
+                            type: 'number',
+                            description:
+                              'State share for this activity for this year, from 0 to 100'
+                          }
+                        }
+                      },
+                      other: {
+                        type: 'number',
+                        description:
+                          'Other amount (dollars) for this activity for this year'
+                      }
+                    }
+                  }
+                }
+              },
+              goals: arrayOf({
+                type: 'object',
+                description: 'Activity goal',
+                properties: {
+                  description: {
+                    type: 'string',
+                    description: 'Goal description'
+                  },
+                  objective: {
+                    type: 'string',
+                    description: 'Goal objective'
+                  }
+                }
+              }),
+              expenses: arrayOf({
+                type: 'object',
+                description: 'Activity expense',
+                properties: {
+                  category: {
+                    type: 'string',
+                    description:
+                      'Expense category, such as "Hardware, software, and licensing"'
+                  },
+                  description: {
+                    type: 'string',
+                    description: 'Short description of the expense'
+                  },
+                  years: {
+                    type: 'object',
+                    description: 'Expense entry',
+                    'x-patternProperties': {
+                      '^[0-9]{4}$': {
+                        type: 'number',
+                        description:
+                          'Expense amount for the given federal fiscal year'
+                      }
+                    }
+                  }
+                }
+              }),
+              schedule: arrayOf({
+                type: 'object',
+                description: 'Activity schedule item',
+                properties: {
+                  endDate: {
+                    type: 'string',
+                    format: 'date-time',
+                    description: 'The date this milestone is planned to be met'
+                  },
+                  milestone: {
+                    type: 'string',
+                    description:
+                      'The name of the milestone this schedule entry refers to'
+                  }
+                }
+              }),
+              standardsAndConditions: {
+                type: 'object',
+                description: 'Description of the 11 standards and conditions',
+                properties: {
+                  businessResults: {
+                    type: 'string'
+                  },
+                  documentation: {
+                    type: 'string'
+                  },
+                  industryStandards: {
+                    type: 'string'
+                  },
+                  interoperability: {
+                    type: 'string'
+                  },
+                  keyPersonnel: {
+                    type: 'string'
+                  },
+                  leverage: {
+                    type: 'string'
+                  },
+                  minimizeCost: {
+                    type: 'string'
+                  },
+                  mitigationStrategy: {
+                    type: 'string'
+                  },
+                  modularity: {
+                    type: 'string'
+                  },
+                  mita: {
+                    type: 'string'
+                  },
+                  reporting: {
+                    type: 'string'
+                  }
+                }
+              },
+              statePersonnel: arrayOf({
+                type: 'object',
+                properties: {
+                  title: {
+                    type: 'string',
+                    description: 'Title for the state personnel'
+                  },
+                  description: {
+                    type: 'string',
+                    description: 'Description of the role'
+                  },
+                  years: {
+                    type: 'object',
+                    'x-patternProperties': {
+                      '^[0-9]{4}$': {
+                        type: 'object',
+                        properties: {
+                          amt: {
+                            type: 'number',
+                            description: `State personnel's total cost for the federal fiscal year`
+                          },
+                          perc: {
+                            type: 'number',
+                            description:
+                              'Number of FTEs this state personnel will spend on the project for the federal fiscal year'
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }),
+              quarterlyFFP: {
+                type: 'object',
+                description:
+                  'Federal share of this activity cost, by expense type, per fiscal quarter',
+                'x-patternProperties': {
+                  '^[0-9]{4}$': {
+                    type: 'object',
+                    'x-patternProperties': {
+                      '^[1-4]$': {
+                        type: 'object',
+                        properties: {
+                          contractors: {
+                            type: 'number',
+                            description:
+                              'Contractor costs for the given quarter of the given federal fiscal year'
+                          },
+                          state: {
+                            type: 'number',
+                            description:
+                              'In-house (state personnel + non-personnel) costs for the given quarter of the given federal fiscal year'
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }),
           federalCitations: {
             type: 'object',
             description:
               'Federal citations that states must assert compliance with. This is a free-form object.'
           },
-          incentivePayments: arrayOf({
+          incentivePayments: {
             type: 'object',
-            properties: {
-              ehAmt: { $ref: '#/components/schemas/incentivePaymentType' },
-              ehCt: { $ref: '#/components/schemas/incentivePaymentType' },
-              epAmt: { $ref: '#/components/schemas/incentivePaymentType' },
-              epCt: { $ref: '#/components/schemas/incentivePaymentType' }
+            description: 'APD incentive payments',
+            'x-patternProperties': {
+              '^e[hc](Amt|Ct)$': {
+                type: 'object',
+                'x-patternProperties': {
+                  '^[0-9]{4}$': {
+                    type: 'object',
+                    'x-patternProperties': {
+                      '^[1-4]$': {
+                        type: 'number',
+                        description:
+                          'EH or EC payment or count for the given federal fiscal year and quarter'
+                      }
+                    }
+                  }
+                }
+              }
             }
-          }),
+          },
           keyPersonnel: arrayOf({
             type: 'object',
             properties: {
-              id: { type: 'number' },
               costs: {
                 type: 'object',
                 'x-patternProperties': {
@@ -527,6 +496,11 @@ module.exports = {
             type: 'string',
             description: 'An overview of the overall program'
           },
+          state: {
+            type: 'string',
+            description:
+              'Two-letter ID of the state, territory, or district this APD belongs to, lowercase'
+          },
           stateProfile: {
             type: 'object',
             description: 'The state profile for this specific APD',
@@ -586,93 +560,6 @@ module.exports = {
           },
           years: arrayOf({
             type: 'string'
-          })
-        }
-      },
-      incentivePaymentType: {
-        type: 'object',
-        'x-patternProperties': {
-          '^[0-9]{4}$': {
-            type: 'object',
-            properties: {
-              '1': {
-                type: 'number',
-                description:
-                  'EH payment amount for the first quarter of the given fiscal year'
-              },
-              '2': {
-                type: 'number',
-                description:
-                  'EH payment amount for the second quarter of the given fiscal year'
-              },
-              '3': {
-                type: 'number',
-                description:
-                  'EH payment amount for the third quarter of the given fiscal year'
-              },
-              '4': {
-                type: 'number',
-                description:
-                  'EH payment amount for the fourth quarter of the given fiscal year'
-              }
-            }
-          }
-        }
-      },
-      state: {
-        type: 'object',
-        properties: {
-          id: {
-            type: 'string',
-            description:
-              'State, territory, or district ID (2-letter abbreviation, lowercase)'
-          },
-          medicaid_office: {
-            type: 'object',
-            description:
-              'Address of the state, territory, or district Medicaid office',
-            properties: {
-              address: {
-                type: 'string',
-                description: 'Street address'
-              },
-              city: {
-                type: 'string',
-                description: 'City'
-              },
-              zip: {
-                type: 'string',
-                description: 'ZIP code'
-              }
-            }
-          },
-          name: {
-            type: 'string',
-            description: 'State, territory, or district name'
-          },
-          program_vision: {
-            type: 'string',
-            description: 'Program vision statement'
-          },
-          program_benefits: {
-            type: 'string',
-            description: 'Planned benefits of the program'
-          },
-          state_pocs: arrayOf({
-            type: 'object',
-            description:
-              'A list of points of contact for the state, territory, or district',
-            properties: {
-              name: { type: 'string', description: `Point of contact's name` },
-              position: {
-                type: 'string',
-                description: `Point of contact's position in the state, territory, or district`
-              },
-              email: {
-                type: 'string',
-                description: `Point of contact's email address`
-              }
-            }
           })
         }
       }

--- a/api/schemas/apd.json
+++ b/api/schemas/apd.json
@@ -385,7 +385,7 @@
                   "^(1|2|3|4)$": {
                     "$id": "#/properties/activities/items/properties/quarterlyFFP/year/quarter",
                     "type": "object",
-                    "required": ["combined", "contractors", "state"],
+                    "required": ["contractors", "state"],
                     "properties": {
                       "contractors": {
                         "$id": "#/properties/activities/items/properties/quarterlyFFP/year/quarter/contractors",

--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -1,4 +1,3 @@
-import { apply_patch as applyPatch } from 'jsonpatch';
 import u from 'updeep';
 
 import {

--- a/web/src/reducers/activities.test.js
+++ b/web/src/reducers/activities.test.js
@@ -13,7 +13,6 @@ const mockClock = sinon.useFakeTimers(new Date(1972, 11, 13).getTime());
 // library computes years as soon as it's loaded, so...  require() is left
 // alone, so it will come after the clock fakery.  :pixar-joy:
 const imported = require('./activities');
-const { ADD_APD_YEAR, REMOVE_APD_YEAR } = require('../actions/editApd');
 
 const activities = imported.default;
 const { setKeyGenerator } = imported;


### PR DESCRIPTION
### This pull request changes...

- fixes an interim migration to change `apd.activities[].contractorResources[].desc` to `apd.activities[].contractorResources[].description` (this was changed elsewhere already, but it got missed in the data migrations)
- updates the `POST /apds` endpoint to no longer use the relational model to build APDs and instead now goes directly to the document model
- closes #1800 

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated