### PR TITLE
Update domain, samesite, and secure properties on auth cookies

### DIFF
--- a/api/auth/session.js
+++ b/api/auth/session.js
@@ -97,15 +97,26 @@ module.exports = ({ Cookies = defaultCookies } = {}) => {
             }
           ),
           {
+            domain:
+              process.env.NODE_ENV === 'production' ? '.cms.gov' : undefined,
             httpOnly: true,
             maxAge: sessionLifetimeMilliseconds,
-            overwrite: true
+            overwrite: true,
+            sameSite: 'strict',
+            secure: process.env.NODE_ENV === 'production'
           }
         );
       } else {
         // Else, write a cookie with an immediate expiration
         logger.silly('expiring/setting empty session cookie');
-        cookies.set(COOKIE_NAME, '', { maxAge: 0, httpOnly: true });
+        cookies.set(COOKIE_NAME, '', {
+          domain:
+            process.env.NODE_ENV === 'production' ? '.cms.gov' : undefined,
+          maxAge: 0,
+          httpOnly: true,
+          sameSite: 'strict',
+          secure: process.env.NODE_ENV === 'production'
+        });
       }
 
       // Now call the original writeHead method

--- a/api/auth/session.test.js
+++ b/api/auth/session.test.js
@@ -124,7 +124,13 @@ tap.test('session functions', async tests => {
           res.writeHead('arg1', 'arg2');
 
           test.ok(
-            cookies.set.calledWith('token', '', { maxAge: 0, httpOnly: true }),
+            cookies.set.calledWith('token', '', {
+              domain: undefined,
+              maxAge: 0,
+              httpOnly: true,
+              sameSite: 'strict',
+              secure: false
+            }),
             'cookie is empty and expired'
           );
           test.ok(
@@ -151,9 +157,12 @@ tap.test('session functions', async tests => {
 
         test.ok(
           cookies.set.calledWith('token', sinon.match.string, {
+            domain: undefined,
             httpOnly: true,
             maxAge: 60000,
-            overwrite: true
+            overwrite: true,
+            sameSite: 'strict',
+            secure: false
           }),
           'sets the cookie'
         );
@@ -198,9 +207,12 @@ tap.test('session functions', async tests => {
 
           test.ok(
             cookies.set.calledWith('token', sinon.match.string, {
+              domain: undefined,
               httpOnly: true,
               maxAge: 60000,
-              overwrite: true
+              overwrite: true,
+              sameSite: 'strict',
+              secure: false
             }),
             'sets the cookie'
           );
@@ -238,7 +250,13 @@ tap.test('session functions', async tests => {
 
         test.same(req.session, {}, 'session is emptied');
         test.ok(
-          cookies.set.calledWith('token', '', { maxAge: 0, httpOnly: true }),
+          cookies.set.calledWith('token', '', {
+            domain: undefined,
+            maxAge: 0,
+            httpOnly: true,
+            sameSite: 'strict',
+            secure: false
+          }),
           'cookie is empty and expired'
         );
       }
@@ -259,7 +277,13 @@ tap.test('session functions', async tests => {
 
       test.same(req.session, {}, 'session is emptied');
       test.ok(
-        cookies.set.calledWith('token', '', { maxAge: 0, httpOnly: true }),
+        cookies.set.calledWith('token', '', {
+          domain: undefined,
+          maxAge: 0,
+          httpOnly: true,
+          sameSite: 'strict',
+          secure: false
+        }),
         'cookie is empty and expired'
       );
     });

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1627,12 +1627,19 @@
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "cookies": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.7.3.tgz",
-      "integrity": "sha512-+gixgxYSgQLTaTIilDHAdlNPZDENDQernEMiIcZpYYP14zgHsCt4Ce1FEjFtcp6GefhozebB6orvhAAWx/IS0A==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.8.0.tgz",
+      "integrity": "sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==",
       "requires": {
-        "depd": "~1.1.2",
-        "keygrip": "~1.0.3"
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        }
       }
     },
     "copy-descriptor": {
@@ -5100,9 +5107,12 @@
       }
     },
     "keygrip": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.3.tgz",
-      "integrity": "sha512-/PpesirAIfaklxUzp4Yb7xBper9MwP6hNRA6BGGUFCgbJ+BM5CKBtsoxinNXkLHAr+GXS1/lSlF2rP7cv5Fl+g=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "requires": {
+        "tsscmp": "1.0.6"
+      }
     },
     "kind-of": {
       "version": "6.0.2",
@@ -9062,6 +9072,11 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
       "dev": true
+    },
+    "tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/api/package.json
+++ b/api/package.json
@@ -55,7 +55,7 @@
     "aws-sdk": "^2.584.0",
     "body-parser": "^1.19.0",
     "compression": "^1.7.3",
-    "cookies": "^0.7.3",
+    "cookies": "^0.8.0",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",

--- a/api/routes/auth/logout.endpoint.js
+++ b/api/routes/auth/logout.endpoint.js
@@ -18,7 +18,7 @@ describe('logout endpoint | /auth/logout', () => {
         .every(
           cookie =>
             cookie ===
-            'token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; httponly'
+            'token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=strict; httponly'
         )
     ).toBeTruthy();
   });
@@ -36,7 +36,7 @@ describe('logout endpoint | /auth/logout', () => {
         .every(
           cookie =>
             cookie ===
-            'token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; httponly'
+            'token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; samesite=strict; httponly'
         )
     ).toBeTruthy();
   });


### PR DESCRIPTION
We won't be 100% sure this works until we push it out to staging... 😬

### This pull request changes...

- explicitly sets the auth cookie domain to `.cms.gov` in production environments so that it can be sent from `eapd.cms.gov` to `eapd-api.cms.gov` with a strict `SameSite`
- set the cookie `SameSite` to `strict` in every case
- set the cookie to secure in production environments; don't worry about it otherwise
- closes #1955

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~ N/A
- ~The change has been documented~ N/A
  - ~Associated OpenAPI documentation has been updated~ N/A
- [ ] Changelog is updated as appropriate