### PR TITLE
Re-add stickybits to sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Anticipated release: December 16, 2019
 
 #### 🐛 Bugs fixed
 
+- Fixed an issue with the sidebar scrolling into the footer ([#1967])
+
 #### ⚙️ Behind the scenes
 
 # 2.1.0
@@ -206,3 +208,4 @@ Pilot release to select state partners
 [#1921]: https://github.com/18F/cms-hitech-apd/pull/1921
 [#1914]: https://github.com/18F/cms-hitech-apd/issues/1914
 [#1925]: https://github.com/18F/cms-hitech-apd/issues/1925
+[#1967]: https://github.com/18F/cms-hitech-apd/pull/1967

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -18828,9 +18828,9 @@
       "dev": true
     },
     "stickybits": {
-      "version": "3.6.7",
-      "resolved": "https://registry.npmjs.org/stickybits/-/stickybits-3.6.7.tgz",
-      "integrity": "sha512-kpoLLxeLd9gwL4CmMYv2p5VRTnK7JviGgieR6rybuesYRheJdL64DgAnHdn0xsJG5yaGR1hjfNT6inKsW9Bxpw=="
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/stickybits/-/stickybits-3.7.1.tgz",
+      "integrity": "sha512-SNig1hkRiCWC4N1miSdypn9+ykjV7qoRzC24DBUUaiMtAqo9tX70nCnWMyqViW87TsHwOdp7D3MW5ZTKF2CYTw=="
     },
     "stream-browserify": {
       "version": "2.0.2",

--- a/web/package.json
+++ b/web/package.json
@@ -81,7 +81,7 @@
     "redux": "^4.0.4",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
-    "stickybits": "^3.6.7",
+    "stickybits": "^3.7.1",
     "tinymce": "^5.1.1",
     "updeep": "^1.0.0",
     "zxcvbn": "^4.4.2"

--- a/web/src/containers/Sidebar.js
+++ b/web/src/containers/Sidebar.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
+import stickybits from 'stickybits';
 import VerticalNav from '@cmsgov/design-system-core/dist/components/VerticalNav/VerticalNav';
 
 import { t } from '../i18n';
@@ -10,6 +11,10 @@ import { selectActivitiesSidebar } from '../reducers/activities.selectors';
 import { selectActiveSection } from '../reducers/navigation';
 
 class Sidebar extends Component {
+  componentDidMount() {
+    stickybits('.site-sidebar');
+  }
+
   handleSelectClick = id => {
     const { jumpTo: action } = this.props;
     action(id);

--- a/web/src/styles/scss/layout.scss
+++ b/web/src/styles/scss/layout.scss
@@ -7,11 +7,11 @@
 }
 
 .site-sidebar {
-  top: 50px;
-  width: 212px;
+  width: 212px; // fix for IE
   position: fixed;
   max-height: 100vh;
   overflow-y: auto;
+  float: left;
   + .site-main {
     margin-left: 244px; // sidebar width plus $spacer-4
   }


### PR DESCRIPTION
Closes #1948 and essentially reverts #1830. Since we've decided IE11 is a yellow support browser, we can ignore the jumpiness of the sidebar in favor of making the experience great for green support browsers.

### This pull request changes...

- re-adds stickybits

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] Changelog is updated as appropriate

### This feature is done when...

- [ ] Product has approved the experience
