### PR TITLE
Send Slack notice when deploy fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -478,17 +478,19 @@ jobs:
           when: on_fail
           name: notify on deployment failure
           command: |
-            curl -X "POST" "${SLACK_WEBHOOK_URL}" \
-              -H "Content-Type: application/json; charset=utf-8" \
-              -d $'{
-                "attachments": [
-                  {
-                    "color": "#d83933",
-                    "fallback": "<< parameters.env >> backend deployment has failed",
-                    "text": "<< parameters.env >> backend deployment has failed"
-                  }
-                ]
-              }'
+            if [ -n "${SLACK_WEBHOOK_URL}" ]; then
+              curl -X "POST" "${SLACK_WEBHOOK_URL}" \
+                -H "Content-Type: application/json; charset=utf-8" \
+                -d $'{
+                  "attachments": [
+                    {
+                      "color": "#d83933",
+                      "fallback": "<< parameters.env >> backend deployment has failed",
+                      "text": "<< parameters.env >> backend deployment has failed"
+                    }
+                  ]
+                }'
+            fi
             false
 
   # Cleans up preview deploys that are no longer associated with open pull
@@ -535,17 +537,19 @@ jobs:
           when: on_fail
           name: notify on deployment failure
           command: |
-            curl -X "POST" "${SLACK_WEBHOOK_URL}" \
-              -H "Content-Type: application/json; charset=utf-8" \
-              -d $'{
-                "attachments": [
-                  {
-                    "color": "#d83933",
-                    "fallback": "<< parameters.env >> frontend deployment has failed",
-                    "text": "<< parameters.env >> frontend deployment has failed"
-                  }
-                ]
-              }'
+            if [ -n "${SLACK_WEBHOOK_URL}" ]; then
+              curl -X "POST" "${SLACK_WEBHOOK_URL}" \
+                -H "Content-Type: application/json; charset=utf-8" \
+                -d $'{
+                  "attachments": [
+                    {
+                      "color": "#d83933",
+                      "fallback": "<< parameters.env >> frontend deployment has failed",
+                      "text": "<< parameters.env >> frontend deployment has failed"
+                    }
+                  ]
+                }'
+            fi
             false
 
   # Preview deployment, used to put up preview links in pull requests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -474,6 +474,22 @@ jobs:
               --AWS_TARGET_GROUP "${<< parameters.env >>_API_AWS_TARGET_GROUP}" \
               --BUILD_URL "$(cat ../../build-url.txt)/backend.zip" \
               --ENVIRONMENT "$(echo '<< parameters.env >>' | tr '[:upper:]' '[:lower:]')"
+      - run:
+          when: on_fail
+          name: notify on deployment failure
+          command: |
+            curl -X "POST" "${SLACK_WEBHOOK_URL}" \
+              -H "Content-Type: application/json; charset=utf-8" \
+              -d $'{
+                "attachments": [
+                  {
+                    "color": "#d83933",
+                    "fallback": "<< parameters.env >> backend deployment has failed",
+                    "text": "<< parameters.env >> backend deployment has failed"
+                  }
+                ]
+              }'
+            false
 
   # Cleans up preview deploys that are no longer associated with open pull
   # requests.
@@ -515,7 +531,23 @@ jobs:
             # Copy up index.html separately, so we can set metadata on it to
             # disable client cacheing
             aws s3 cp web/dist/index.html "${<< parameters.env >>_WEB_AWS_S3_BUCKET}/index.html" --metadata '{"Cache-Control":"no-cache"}' --region ${<< parameters.env >>_WEB_AWS_REGION}
-  
+      - run:
+          when: on_fail
+          name: notify on deployment failure
+          command: |
+            curl -X "POST" "${SLACK_WEBHOOK_URL}" \
+              -H "Content-Type: application/json; charset=utf-8" \
+              -d $'{
+                "attachments": [
+                  {
+                    "color": "#d83933",
+                    "fallback": "<< parameters.env >> frontend deployment has failed",
+                    "text": "<< parameters.env >> frontend deployment has failed"
+                  }
+                ]
+              }'
+            false
+
   # Preview deployment, used to put up preview links in pull requests
   preview deploy:
     docker:


### PR DESCRIPTION
When a frontend or backend deployment to staging or production fails, send a message to Slack so we'll know about it. Relies on the `SLACK_WEBHOOK_URL` environment variable in CircleCI, which is currently set to a channel in the 18F/TTS Slack.

Note for CMS of the future: once you've got a webhook URL for a channel in your Slack, you can update the CircleCI environment variable and then you'll be done!

Note for 18F of the future: we can disable the webhook in Slack settings, so if the CircleCI environment variable doesn't get updated, it's okay, we don't have to worry about notifications going into an empty channel and being missed.

### This pull request changes...

- makes it so we know when deploys are failing

### This pull request is ready to merge when...

- [x] This code has been reviewed by someone other than the original author