### PR TITLE
Remove domain from cookie

### DIFF
--- a/api/auth/session.js
+++ b/api/auth/session.js
@@ -97,8 +97,6 @@ module.exports = ({ Cookies = defaultCookies } = {}) => {
             }
           ),
           {
-            domain:
-              process.env.NODE_ENV === 'production' ? '.cms.gov' : undefined,
             httpOnly: true,
             maxAge: sessionLifetimeMilliseconds,
             overwrite: true,
@@ -110,8 +108,6 @@ module.exports = ({ Cookies = defaultCookies } = {}) => {
         // Else, write a cookie with an immediate expiration
         logger.silly('expiring/setting empty session cookie');
         cookies.set(COOKIE_NAME, '', {
-          domain:
-            process.env.NODE_ENV === 'production' ? '.cms.gov' : undefined,
           maxAge: 0,
           httpOnly: true,
           sameSite: 'none',

--- a/api/auth/session.test.js
+++ b/api/auth/session.test.js
@@ -125,7 +125,6 @@ tap.test('session functions', async tests => {
 
           test.ok(
             cookies.set.calledWith('token', '', {
-              domain: undefined,
               maxAge: 0,
               httpOnly: true,
               sameSite: 'none',
@@ -157,7 +156,6 @@ tap.test('session functions', async tests => {
 
         test.ok(
           cookies.set.calledWith('token', sinon.match.string, {
-            domain: undefined,
             httpOnly: true,
             maxAge: 60000,
             overwrite: true,
@@ -207,7 +205,6 @@ tap.test('session functions', async tests => {
 
           test.ok(
             cookies.set.calledWith('token', sinon.match.string, {
-              domain: undefined,
               httpOnly: true,
               maxAge: 60000,
               overwrite: true,
@@ -251,7 +248,6 @@ tap.test('session functions', async tests => {
         test.same(req.session, {}, 'session is emptied');
         test.ok(
           cookies.set.calledWith('token', '', {
-            domain: undefined,
             maxAge: 0,
             httpOnly: true,
             sameSite: 'none',
@@ -278,7 +274,6 @@ tap.test('session functions', async tests => {
       test.same(req.session, {}, 'session is emptied');
       test.ok(
         cookies.set.calledWith('token', '', {
-          domain: undefined,
           maxAge: 0,
           httpOnly: true,
           sameSite: 'none',


### PR DESCRIPTION
Instead of explicitly setting the cookie domain, let the browser infer it. Another staging fix...

### This pull request changes...

- does not set the cookie domain

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author