### PR TITLE
Fix a bug that prevents admins from changing a user's account without also changing the user's email address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Anticipated release: January 6, 2019
 
 #### 🐛 Bugs fixed
 
+- Fixed a bug where an admin could not edit a user's account without changing that user's email address ([#1973])
+
 #### ⚙️ Behind the scenes
 
 # 2.2.0
@@ -228,3 +230,4 @@ Pilot release to select state partners
 [#1947]: https://github.com/18F/cms-hitech-apd/issues/1947
 [#1957]: https://github.com/18F/cms-hitech-apd/pull/1957
 [#1967]: https://github.com/18F/cms-hitech-apd/pull/1967
+[#1973]: https://github.com/18F/cms-hitech-apd/issues/1973

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Next release
 
-Anticipated release: January 6, 2019
+Anticipated release: January 6, 2020
 
 #### 🚀 New features
 

--- a/api/db/users.js
+++ b/api/db/users.js
@@ -212,7 +212,7 @@ const updateUser = async (
   user,
   { db = knex, hash = defaultHash, validate = validateUser } = {}
 ) => {
-  await validate(user);
+  await validate({ ...user, id: userID });
 
   if (!Object.keys(user).length) {
     return;

--- a/api/db/users.test.js
+++ b/api/db/users.test.js
@@ -301,13 +301,23 @@ tap.test('database wrappers / users', async usersTests => {
     updateUserTests.test('with an invalid user', async test => {
       validate.rejects();
 
-      test.rejects(updateUser('user id', {}, { db, hash, validate }));
+      test.rejects(
+        updateUser('user id', { the: 'user' }, { db, hash, validate })
+      );
+      test.ok(
+        validate.calledWith({ id: 'user id', the: 'user' }),
+        'user ID is included in the validation call'
+      );
     });
 
     updateUserTests.test('with no updates', async test => {
       validate.resolves();
 
       test.resolves(updateUser('user id', {}, { db, hash, validate }));
+      test.ok(
+        validate.calledWith({ id: 'user id' }),
+        'user ID is included in the validation call'
+      );
     });
 
     updateUserTests.test('with updates', async test => {
@@ -333,6 +343,15 @@ tap.test('database wrappers / users', async usersTests => {
           },
           { db, hash, validate }
         )
+      );
+      test.ok(
+        validate.calledWith({
+          id: 'user id',
+          name: 'user name',
+          password: 'plain password',
+          phone: '123-456-7890'
+        }),
+        'user ID is included in the validation call'
       );
     });
   });

--- a/api/routes/users/__snapshots__/put.endpoint.js.snap
+++ b/api/routes/users/__snapshots__/put.endpoint.js.snap
@@ -32,4 +32,6 @@ Object {
 }
 `;
 
+exports[`users endpoint | PUT /users/:userID when authenticated when updating a valid user ID ...with new content but same email address 1`] = `undefined`;
+
 exports[`users endpoint | PUT /users/:userID when authenticated when updating a valid user ID ...with no content 1`] = `""`;

--- a/api/routes/users/put.js
+++ b/api/routes/users/put.js
@@ -79,7 +79,7 @@ module.exports = (
 
       if (Object.keys(update).length) {
         try {
-          await validateUser(update);
+          await validateUser({ ...update, id: targetID });
         } catch (e) {
           return res
             .status(400)

--- a/api/routes/users/put.test.js
+++ b/api/routes/users/put.test.js
@@ -107,6 +107,10 @@ tap.test('user PUT endpoint', async endpointTest => {
             updateUser.calledWith(2, { name: 'value' }),
             `auth_role is not updated`
           );
+          test.ok(
+            validateUser.calledWith({ id: 2, name: 'value' }),
+            'user ID is included in the validation call'
+          );
         }
       );
 
@@ -120,6 +124,10 @@ tap.test('user PUT endpoint', async endpointTest => {
           updateUser.calledWith(1, { email: 'value' }),
           `email is updated on user`
         );
+        test.ok(
+          validateUser.calledWith({ id: 1, email: 'value' }),
+          'user ID is included in the validation call'
+        );
       });
 
       propertyTests.test('state property becomes state_id', async test => {
@@ -131,6 +139,10 @@ tap.test('user PUT endpoint', async endpointTest => {
         test.ok(
           updateUser.calledWith(1, { state_id: 'value' }),
           `state is updated on user`
+        );
+        test.ok(
+          validateUser.calledWith({ id: 1, state_id: 'value' }),
+          'user ID is included in the validation call'
         );
       });
 
@@ -144,6 +156,10 @@ tap.test('user PUT endpoint', async endpointTest => {
           updateUser.calledWith(1, { state_id: null }),
           `state is updated on user`
         );
+        test.ok(
+          validateUser.calledWith({ id: 1, state_id: null }),
+          'user ID is included in the validation call'
+        );
       });
 
       propertyTests.test('role property becomes auth_role', async test => {
@@ -156,6 +172,10 @@ tap.test('user PUT endpoint', async endpointTest => {
           updateUser.calledWith(1, { auth_role: 'value' }),
           `role is updated on user`
         );
+        test.ok(
+          validateUser.calledWith({ id: 1, auth_role: 'value' }),
+          'user ID is included in the validation call'
+        );
       });
 
       propertyTests.test('empty role sets auth_role to null', async test => {
@@ -167,6 +187,10 @@ tap.test('user PUT endpoint', async endpointTest => {
         test.ok(
           updateUser.calledWith(1, { auth_role: null }),
           `state is updated on user`
+        );
+        test.ok(
+          validateUser.calledWith({ id: 1, auth_role: null }),
+          'user ID is included in the validation call'
         );
       });
 
@@ -184,6 +208,10 @@ tap.test('user PUT endpoint', async endpointTest => {
           test.ok(
             updateUser.calledWith(1, { [prop]: 'value' }),
             `${prop} is updated on user`
+          );
+          test.ok(
+            validateUser.calledWith({ id: 1, [prop]: 'value' }),
+            'user ID is included in the validation call'
           );
         })
       );
@@ -214,6 +242,17 @@ tap.test('user PUT endpoint', async endpointTest => {
           }),
 
           'all of the properties are updated'
+        );
+        test.ok(
+          validateUser.calledWith({
+            id: 1,
+            email: 'email-value',
+            name: 'name-value',
+            password: 'password-value',
+            position: 'position-value',
+            phone: 'phone-value'
+          }),
+          'user ID is included in the validation call'
         );
       });
 
@@ -258,6 +297,10 @@ tap.test('user PUT endpoint', async endpointTest => {
             res
           );
 
+          test.ok(
+            validateUser.calledWith({ id: 2, name: 'new name' }),
+            'user ID is included in the validation call'
+          );
           test.ok(res.status.calledWith(400), 'HTTP status set to 400');
           test.ok(
             res.send.calledWith({ error: 'edit-account.error message' }),
@@ -283,6 +326,10 @@ tap.test('user PUT endpoint', async endpointTest => {
           res
         );
 
+        test.ok(
+          validateUser.calledWith({ id: 2, name: 'new name' }),
+          'user ID is included in the validation call'
+        );
         test.ok(updateUser.calledOnce, 'user model is saved');
         test.ok(
           updateUser.calledAfter(validateUser),

--- a/web/src/containers/admin/EditAccount.js
+++ b/web/src/containers/admin/EditAccount.js
@@ -88,7 +88,7 @@ class EditAccount extends Component {
             id="modify_account_state"
             name="state"
             size="medium"
-            value={state.id}
+            value={state}
             onChange={this.handleEditAccount}
           >
             <option value="">None</option>
@@ -167,7 +167,7 @@ class EditAccount extends Component {
 
     const user = users.filter(u => u.id === +value).reduce((_, u) => u, null);
 
-    this.setState({ userID: +value, user });
+    this.setState({ userID: +value, user: { ...user, state: user.state.id } });
   };
 
   handleEditAccount = e => {


### PR DESCRIPTION
Our user validation function optionally accepts a user ID. When it checks it the email address being validated already exists in the database, it will also check the passed-in user ID. That way, if the user being edited has the same email address, it won't fail.

The user update endpoint was not sending the user ID into the validator, so the validation always failed. Furthermore, the database user update function calls the validator and also was not passing along the user ID. Both instances have been fixed.

Also fixed a bug where the admin had to change the user's state, too. This is because the user object in the application store has a full object for `state` rather than just a two-letter ID. The EditAccount component set the user's state to the value from the application store when a user is selected, and that gets sent to the API if the state is not changed. The problem is the API expects a two-letter ID, so it fails validation. The fix is simple: when selecting a user, set their state to the `state.id` from the application store.

### This pull request changes...

- admins can edit user accounts without having to edit their email addresses too
- closes #1973

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~ N/A
- ~The change has been documented~ N/A
  - ~Associated OpenAPI documentation has been updated~ N/A
- [x] Changelog is updated as appropriate