### PR TITLE
Add nightly dependency vulnerability scanning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,28 @@ workflows:
     jobs:
       - cleanup preview deploys
 
+  # Workflow to scan dependencies for vulnerabilities every night
+  nightly dependency vulnerability scan:
+    triggers:
+      - schedule:
+          cron: '0 0 * * *'
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - install dependencies
+      - dependency vulnerability scan:
+          name: backend dependency vulnerability scan
+          path: api
+          requires:
+            - install dependencies
+      - dependency vulnerability scan:
+          name: frontend dependency vulnerability scan
+          path: web
+          requires:
+            - install dependencies
+  
   # Workflow to test, build, and deploy the backend and frontend
   test, build, and deploy:
     jobs:


### PR DESCRIPTION
### This pull request changes...

- dependency vulnerability scans run daily at midnight UTC
- closes #1974 (hopefully; won't know for certain until after the midnight after it's merged)

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author