### PR TITLE
Update to latest airbnb eslint rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Anticipated release: January 20, 2020
 #### ⚙️ Behind the scenes
 
 - Added browser security headers to frontend web responses ([#1966])
+- Updated dependencies ([#1985])
 
 # 2.3.0
 
@@ -26,7 +27,6 @@ Released: January 6, 2020
 #### ⚙️ Behind the scenes
 
 - Updated to the latest version of the CMS Design System ([#1981])
-- Updated dependencies ([#1985])
 
 # 2.2.0
 
@@ -254,4 +254,3 @@ Pilot release to select state partners
 [#1973]: https://github.com/18F/cms-hitech-apd/issues/1973
 [#1981]: https://github.com/18F/cms-hitech-apd/issues/1981
 [#1985]: https://github.com/18F/cms-hitech-apd/issues/1985
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Anticipated release: January 6, 2020
 #### ⚙️ Behind the scenes
 
 - Updated to the latest version of the CMS Design System ([#1981])
-- Updated dependencies
+- Updated dependencies ([#1985])
 
 # 2.2.0
 
@@ -238,10 +238,6 @@ Pilot release to select state partners
 [#1947]: https://github.com/18F/cms-hitech-apd/issues/1947
 [#1957]: https://github.com/18F/cms-hitech-apd/pull/1957
 [#1967]: https://github.com/18F/cms-hitech-apd/pull/1967
-
-<<<<<<< HEAD
-[#1981]: https://github.com/18F/cms-hitech-apd/issues/1981
-=======
 [#1973]: https://github.com/18F/cms-hitech-apd/issues/1973
-
-> > > > > > > master
+[#1981]: https://github.com/18F/cms-hitech-apd/issues/1981
+[#1985]: https://github.com/18F/cms-hitech-apd/issues/1985

--- a/web/.eslintrc.json
+++ b/web/.eslintrc.json
@@ -23,6 +23,8 @@
 
     "react/forbid-prop-types": ["error", { "forbid": ["any"] }],
     "react/jsx-filename-extension": 0,
+    "react/jsx-fragments": 0,
+    "react/jsx-props-no-spreading": 0,
     "react/no-array-index-key": "warn"
   },
   "env": {

--- a/web/.eslintrc.json
+++ b/web/.eslintrc.json
@@ -23,7 +23,7 @@
 
     "react/forbid-prop-types": ["error", { "forbid": ["any"] }],
     "react/jsx-filename-extension": 0,
-    "react/jsx-fragments": 0,
+    "react/jsx-fragments": ["error", "element"],
     "react/jsx-props-no-spreading": 0,
     "react/no-array-index-key": "warn"
   },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -6879,9 +6879,9 @@
       }
     },
     "confusing-browser-globals": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.7.tgz",
-      "integrity": "sha512-cgHI1azax5ATrZ8rJ+ODDML9Fvu67PimB6aNxBrc/QwSaDaM9eTfIEUHx3bBLJJ82ioSb+/5zfsMCCEJax3ByQ==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz",
+      "integrity": "sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==",
       "dev": true
     },
     "connect-history-api-fallback": {
@@ -9104,23 +9104,23 @@
       }
     },
     "eslint-config-airbnb": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-17.1.1.tgz",
-      "integrity": "sha512-xCu//8a/aWqagKljt+1/qAM62BYZeNq04HmdevG5yUGWpja0I/xhqd6GdLRch5oetEGFiJAnvtGuTEAese53Qg==",
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-18.0.1.tgz",
+      "integrity": "sha512-hLb/ccvW4grVhvd6CT83bECacc+s4Z3/AEyWQdIT2KeTsG9dR7nx1gs7Iw4tDmGKozCNHFn4yZmRm3Tgy+XxyQ==",
       "dev": true,
       "requires": {
-        "eslint-config-airbnb-base": "^13.2.0",
+        "eslint-config-airbnb-base": "^14.0.0",
         "object.assign": "^4.1.0",
         "object.entries": "^1.1.0"
       }
     },
     "eslint-config-airbnb-base": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz",
-      "integrity": "sha512-1mg/7eoB4AUeB0X1c/ho4vb2gYkNH8Trr/EgCT/aGmKhhG+F6vF5s8+iRBlWAzFIAphxIdp3YfEKgEl0f9Xg+w==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.0.0.tgz",
+      "integrity": "sha512-2IDHobw97upExLmsebhtfoD3NAKhV4H0CJWP3Uprd/uk+cHuWYOczPVxQ8PxLFUAw7o3Th1RAU8u1DoUpr+cMA==",
       "dev": true,
       "requires": {
-        "confusing-browser-globals": "^1.0.5",
+        "confusing-browser-globals": "^1.0.7",
         "object.assign": "^4.1.0",
         "object.entries": "^1.1.0"
       }

--- a/web/package.json
+++ b/web/package.json
@@ -104,7 +104,7 @@
     "enzyme-adapter-react-16": "^1.15.2",
     "enzyme-to-json": "^3.4.3",
     "eslint": "^6.8.0",
-    "eslint-config-airbnb": "^17.1.1",
+    "eslint-config-airbnb": "^18.0.1",
     "eslint-config-prettier": "^6.9.0",
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-jsx-a11y": "^6.2.3",

--- a/web/src/components/ConsentBanner.js
+++ b/web/src/components/ConsentBanner.js
@@ -1,8 +1,8 @@
 import { Button } from '@cmsgov/design-system-core';
 import PropTypes from 'prop-types';
-import React, { Fragment, PureComponent } from 'react';
+import React, { Fragment, useState } from 'react';
 
-let cookie = name => {
+const cookie = name => {
   const cookieMap = (document.cookie || '').split(';').reduce((c, s) => {
     const bits = s.trim().split('=');
     if (bits.length === 2) {
@@ -11,116 +11,108 @@ let cookie = name => {
     return c;
   }, {});
 
-  cookie = n => cookieMap[n];
-
   return cookieMap[name];
 };
 
-class ConsentBanner extends PureComponent {
-  state = { showDetails: false };
+const ConsentBanner = ({ onAgree }) => {
+  const [showDetails, setShowDetails] = useState(false);
 
-  agreeAndContinue = () => {
-    const { onAgree } = this.props;
+  const agreeAndContinue = () => {
     document.cookie = 'gov.cms.eapd.hasConsented=true;max-age=259200'; // 3 days
     onAgree();
   };
 
-  toggleDetails = () => {
-    this.setState(prev => ({ showDetails: !prev.showDetails }));
+  const expandDetails = () => {
+    setShowDetails(true);
   };
 
-  render() {
-    const { showDetails } = this.state;
+  const hasConsented = cookie('gov.cms.eapd.hasConsented');
+  if (hasConsented) {
+    agreeAndContinue();
+    return null;
+  }
 
-    const hasConsented = cookie('gov.cms.eapd.hasConsented');
-    if (hasConsented) {
-      this.agreeAndContinue();
-      return null;
-    }
-
-    return (
-      <div className="card--container">
-        <div className="ds-l-container">
-          <div className="ds-l-row card">
-            <div className="ds-l-col--1 ds-u-margin-left--auto" />
-            <div className="ds-l-col--12 ds-l-sm-col--10 ds-l-lg-col--6">
-              <p>
-                This is a U.S. government service. Your use indicates your
-                consent to monitoring, recording, and no expectation of privacy.
-                Misuse is subject to criminal and civil penalties.
-                {showDetails ? null : (
-                  <Button
-                    size="small"
-                    variation="transparent"
-                    onClick={this.toggleDetails}
-                  >
-                    Read more details
-                  </Button>
-                )}
-              </p>
-              {showDetails ? (
-                <Fragment>
-                  <p>
-                    This warning banner provides privacy and security notices
-                    consistent with applicable federal laws, directives, and
-                    other federal guidance for accessing this Government system,
-                    which includes (1) this computer network, (2) all computers
-                    connected to this network, and (3) all devices and storage
-                    media attached to this network or to a computer on this
-                    network.
-                  </p>
-                  <p>
-                    This system is provided for Government authorized use only.
-                  </p>
-                  <p>
-                    Unauthorized or improper use of this system is prohibited
-                    and may result in disciplinary action and/or civil and
-                    criminal penalties.
-                  </p>
-                  <p>
-                    Personal use of social media and networking sites on this
-                    system is limited as to not interfere with official work
-                    duties and is subject to monitoring.
-                  </p>
-                  <p>
-                    By using this system, you understand and consent to the
-                    following:
-                  </p>
-                  <ul>
-                    <li>
-                      The Government may monitor, record, and audit your system
-                      usage, including usage of personal devices and email
-                      systems for official duties or to conduct HHS business.
-                      Therefore, you have no reasonable expectation of privacy
-                      regarding any communication or data transiting or stored
-                      on this system. At any time, and for any lawful Government
-                      purpose, the government may monitor, intercept, and search
-                      and seize any communication or data transiting or stored
-                      on this system.
-                    </li>
-                    <li>
-                      Any communication or data transiting or stored on this
-                      system may be disclosed or used for any lawful Government
-                      purpose. To continue, you must accept the terms and
-                      conditions. If you decline, your login will automatically
-                      be cancelled.
-                    </li>
-                  </ul>
-                </Fragment>
-              ) : null}
-              <div className="ds-u-text-align--center">
-                <Button variation="primary" onClick={this.agreeAndContinue}>
-                  Agree and continue
+  return (
+    <div className="card--container">
+      <div className="ds-l-container">
+        <div className="ds-l-row card">
+          <div className="ds-l-col--1 ds-u-margin-left--auto" />
+          <div className="ds-l-col--12 ds-l-sm-col--10 ds-l-lg-col--6">
+            <p>
+              This is a U.S. government service. Your use indicates your consent
+              to monitoring, recording, and no expectation of privacy. Misuse is
+              subject to criminal and civil penalties.
+              {showDetails ? null : (
+                <Button
+                  size="small"
+                  variation="transparent"
+                  onClick={expandDetails}
+                >
+                  Read more details
                 </Button>
-              </div>
+              )}
+            </p>
+            {showDetails ? (
+              <Fragment>
+                <p>
+                  This warning banner provides privacy and security notices
+                  consistent with applicable federal laws, directives, and other
+                  federal guidance for accessing this Government system, which
+                  includes (1) this computer network, (2) all computers
+                  connected to this network, and (3) all devices and storage
+                  media attached to this network or to a computer on this
+                  network.
+                </p>
+                <p>
+                  This system is provided for Government authorized use only.
+                </p>
+                <p>
+                  Unauthorized or improper use of this system is prohibited and
+                  may result in disciplinary action and/or civil and criminal
+                  penalties.
+                </p>
+                <p>
+                  Personal use of social media and networking sites on this
+                  system is limited as to not interfere with official work
+                  duties and is subject to monitoring.
+                </p>
+                <p>
+                  By using this system, you understand and consent to the
+                  following:
+                </p>
+                <ul>
+                  <li>
+                    The Government may monitor, record, and audit your system
+                    usage, including usage of personal devices and email systems
+                    for official duties or to conduct HHS business. Therefore,
+                    you have no reasonable expectation of privacy regarding any
+                    communication or data transiting or stored on this system.
+                    At any time, and for any lawful Government purpose, the
+                    government may monitor, intercept, and search and seize any
+                    communication or data transiting or stored on this system.
+                  </li>
+                  <li>
+                    Any communication or data transiting or stored on this
+                    system may be disclosed or used for any lawful Government
+                    purpose. To continue, you must accept the terms and
+                    conditions. If you decline, your login will automatically be
+                    cancelled.
+                  </li>
+                </ul>
+              </Fragment>
+            ) : null}
+            <div className="ds-u-text-align--center">
+              <Button variation="primary" onClick={agreeAndContinue}>
+                Agree and continue
+              </Button>
             </div>
-            <div className="ds-l-col--1 ds-u-margin-right--auto" />
           </div>
+          <div className="ds-l-col--1 ds-u-margin-right--auto" />
         </div>
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
 
 ConsentBanner.propTypes = {
   onAgree: PropTypes.func.isRequired

--- a/web/src/components/ConsentBanner.test.js
+++ b/web/src/components/ConsentBanner.test.js
@@ -2,14 +2,13 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import sinon from 'sinon';
 
+import ConsentBanner from './ConsentBanner';
+
 describe('Consent banner component', () => {
-  let ConsentBanner;
   const onAgree = sinon.spy();
 
   beforeEach(() => {
-    jest.resetModules();
     onAgree.resetHistory();
-    ConsentBanner = require('./ConsentBanner').default; // eslint-disable-line global-require
   });
 
   describe('when there is no cookie', () => {

--- a/web/src/components/PasswordWithMeter.js
+++ b/web/src/components/PasswordWithMeter.js
@@ -5,7 +5,10 @@ import zxcvbn from '../lazy/zxcvbn';
 import Choice from './Choice';
 
 class Password extends Component {
-  state = { showPassword: false, strength: 0 };
+  constructor() {
+    super();
+    this.state = { showPassword: false, strength: 0 };
+  }
 
   componentDidMount() {
     const { value } = this.props;

--- a/web/src/components/UpgradeBrowser.js
+++ b/web/src/components/UpgradeBrowser.js
@@ -39,12 +39,15 @@ const html = `<div class="ds-c-alert__body">
   </div>
 </div>`;
 
-const UpgradeBrowser = () => (
-  <div
-    className="ds-c-alert ds-c-alert--warn"
-    dangerouslySetInnerHTML={{ __html: html }}
-  />
-);
+const UpgradeBrowser = () => {
+  /* eslint-disable react/no-danger */
+  return (
+    <div
+      className="ds-c-alert ds-c-alert--warn"
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+};
 
 export default UpgradeBrowser;
 

--- a/web/src/containers/Login.js
+++ b/web/src/containers/Login.js
@@ -1,6 +1,6 @@
 import { TextField } from '@cmsgov/design-system-core';
 import PropTypes from 'prop-types';
-import React, { Component, Fragment } from 'react';
+import React, { Fragment, useState } from 'react';
 import { connect } from 'react-redux';
 import { Redirect } from 'react-router-dom';
 
@@ -9,98 +9,93 @@ import { login } from '../actions/auth';
 import CardForm from '../components/CardForm';
 import Password from '../components/PasswordWithMeter';
 
-class Login extends Component {
-  state = { showConsent: true, username: '', password: '' };
+const Login = ({
+  authenticated,
+  error,
+  fetching,
+  hasEverLoggedOn,
+  location,
+  login: action
+}) => {
+  const [showConsent, setShowConsent] = useState(true);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
 
-  handleChange = e => {
-    const { name, value } = e.target;
-    this.setState({ [name]: value });
-  };
+  const changeUsername = ({ target: { value } }) => setUsername(value);
+  const changePassword = ({ target: { value } }) => setPassword(value);
 
-  handleSubmit = e => {
+  const handleSubmit = e => {
     e.preventDefault();
-    const { login: action } = this.props;
-    const { username, password } = this.state;
     action(username, password);
   };
 
-  hideConsent = () => {
-    this.setState({ showConsent: false });
+  const hideConsent = () => {
+    setShowConsent(false);
   };
 
-  render() {
-    const {
-      authenticated,
-      error,
-      fetching,
-      hasEverLoggedOn,
-      location
-    } = this.props;
-    const { from } = location.state || { from: { pathname: '/' } };
-    const { showConsent, username, password } = this.state;
+  const { from } = location.state || { from: { pathname: '/' } };
 
-    if (authenticated) {
-      if (from.pathname !== '/logout') {
-        return <Redirect to={from} />;
-      }
-      return <Redirect to="/" />;
+  if (authenticated) {
+    if (from.pathname !== '/logout') {
+      return <Redirect to={from} />;
     }
+    return <Redirect to="/" />;
+  }
 
-    if (showConsent && !hasEverLoggedOn) {
-      return (
-        <Fragment>
-          <ConsentBanner onAgree={this.hideConsent} />
-        </Fragment>
-      );
-    }
-
-    let errorMessage = false;
-    if (error === 'Unauthorized') {
-      errorMessage = 'The email or password you’ve entered is incorrect.';
-    } else if (error === 'Unauthorized') {
-      errorMessage = 'Sorry! Something went wrong. Please try again.';
-    }
-
+  if (showConsent && !hasEverLoggedOn) {
     return (
       <Fragment>
-        <CardForm
-          title="Log in"
-          legend="Log in"
-          cancelable={false}
-          canSubmit={username.length && password.length}
-          error={errorMessage}
-          success={hasEverLoggedOn ? 'You have securely logged out.' : null}
-          working={fetching}
-          primaryButtonText={['Log in', 'Logging in']}
-          onSave={this.handleSubmit}
-          footer={
-            <p className="ds-u-padding-top--2">
-              Forgot your password? Contact{' '}
-              <a href="mailto:CMS-EAPD@cms.hhs.gov?subject=Password%20Recovery%20Request%20for%20eAPD">
-                CMS-EAPD@cms.hhs.gov
-              </a>
-            </p>
-          }
-        >
-          <TextField
-            id="username"
-            label="Email"
-            name="username"
-            ariaLabel="Enter the email associated with this account."
-            value={username}
-            onChange={this.handleChange}
-          />
-          <Password
-            title="Password"
-            ariaLabel="Enter the password for this account."
-            value={password}
-            onChange={this.handleChange}
-          />
-        </CardForm>
+        <ConsentBanner onAgree={hideConsent} />
       </Fragment>
     );
   }
-}
+
+  let errorMessage = false;
+  if (error === 'Unauthorized') {
+    errorMessage = 'The email or password you’ve entered is incorrect.';
+  } else if (error === 'Unauthorized') {
+    errorMessage = 'Sorry! Something went wrong. Please try again.';
+  }
+
+  return (
+    <Fragment>
+      <CardForm
+        title="Log in"
+        legend="Log in"
+        cancelable={false}
+        canSubmit={username.length && password.length}
+        error={errorMessage}
+        success={hasEverLoggedOn ? 'You have securely logged out.' : null}
+        working={fetching}
+        primaryButtonText={['Log in', 'Logging in']}
+        onSave={handleSubmit}
+        footer={
+          <p className="ds-u-padding-top--2">
+            Forgot your password? Contact{' '}
+            <a href="mailto:CMS-EAPD@cms.hhs.gov?subject=Password%20Recovery%20Request%20for%20eAPD">
+              CMS-EAPD@cms.hhs.gov
+            </a>
+          </p>
+        }
+      >
+        <TextField
+          id="username"
+          label="Email"
+          name="username"
+          ariaLabel="Enter the email associated with this account."
+          value={username}
+          onChange={changeUsername}
+        />
+        <Password
+          title="Password"
+          ariaLabel="Enter the password for this account."
+          value={password}
+          onChange={changePassword}
+        />
+      </CardForm>
+    </Fragment>
+  );
+};
 
 Login.propTypes = {
   authenticated: PropTypes.bool.isRequired,
@@ -122,9 +117,6 @@ const mapStateToProps = ({
 
 const mapDispatchToProps = { login };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Login);
+export default connect(mapStateToProps, mapDispatchToProps)(Login);
 
 export { Login as plain, mapStateToProps, mapDispatchToProps };

--- a/web/src/containers/SaveButton.js
+++ b/web/src/containers/SaveButton.js
@@ -1,6 +1,6 @@
 import { Alert, Button, Spinner } from '@cmsgov/design-system-core';
 import PropTypes from 'prop-types';
-import React, { Fragment, PureComponent } from 'react';
+import React, { Fragment, useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import stickybits from 'stickybits';
 
@@ -25,28 +25,29 @@ const getButtonContent = (dirty, working) => {
   return 'Save';
 };
 
-class SaveButton extends PureComponent {
-  state = {
-    hasFetched: false,
-    success: false
+const SaveButton = ({ error, needsSave, saveApd: action, working }) => {
+  const [hasFetched, setHasFetched] = useState(false);
+  const [success, setSuccess] = useState(false);
+
+  // Success has to be derived.  It can't be stored in the app state because
+  // if it was, then the next time this form was loaded, it would show the
+  // success state even though it wouldn't be accurate anymore.
+  if (hasFetched) {
+    const newSuccess = !working && !error;
+    if (newSuccess !== success) {
+      setSuccess(newSuccess);
+    }
+  }
+
+  useEffect(() => {
+    stickybits('#apd-save-button', { verticalPosition: 'bottom' });
+  }, []);
+
+  const clearFetched = () => {
+    setHasFetched(false);
   };
 
-  static getDerivedStateFromProps({ error, working }, { hasFetched }) {
-    // Success has to be derived.  It can't be stored in the app state because
-    // if it was, then the next time this form was loaded, it would show the
-    // success state even though it wouldn't be accurate anymore.
-    if (hasFetched) {
-      const success = !working && !error;
-      return { success };
-    }
-    return null;
-  }
-
-  componentDidMount() {
-    stickybits('#apd-save-button', { verticalPosition: 'bottom' });
-  }
-
-  setSuccessTimer = (() => {
+  const setSuccessTimer = (() => {
     let alertTimer = null;
     return () => {
       if (alertTimer) {
@@ -54,58 +55,48 @@ class SaveButton extends PureComponent {
         // success dialog when it runs out rather than five seconds from now
         clearTimeout(alertTimer);
       }
-      alertTimer = setTimeout(this.clearFetched, 5000);
+      alertTimer = setTimeout(clearFetched, 5000);
     };
   })();
 
-  clearFetched = () => {
-    this.setState({ hasFetched: false });
-  };
-
-  save = () => {
-    const { saveApd: action } = this.props;
-    this.setState({ hasFetched: true });
+  const save = () => {
+    setHasFetched(true);
     action();
   };
 
-  render() {
-    const { error, needsSave, working } = this.props;
-    const { hasFetched, success } = this.state;
-
-    let alert = null;
-    if (hasFetched) {
-      if (error) {
-        alert = (
-          <Alert variation="error" className="ds-u-margin-bottom--2">
-            {error}
-          </Alert>
-        );
-      }
-      if (success) {
-        alert = (
-          <Alert variation="success" className="ds-u-margin-bottom--2">
-            Save successful!
-          </Alert>
-        );
-        this.setSuccessTimer();
-      }
+  let alert = null;
+  if (hasFetched) {
+    if (error) {
+      alert = (
+        <Alert variation="error" className="ds-u-margin-bottom--2">
+          {error}
+        </Alert>
+      );
     }
-
-    const buttonVariant = needsSave ? 'primary' : 'success';
-
-    return (
-      <div
-        id="apd-save-button"
-        className="save-button--container ds-u-margin-bottom--3 visibility--screen"
-      >
-        <div className="save-button--alert">{alert}</div>
-        <Button variation={buttonVariant} onClick={this.save}>
-          {getButtonContent(needsSave, working)}
-        </Button>
-      </div>
-    );
+    if (success) {
+      alert = (
+        <Alert variation="success" className="ds-u-margin-bottom--2">
+          Save successful!
+        </Alert>
+      );
+      setSuccessTimer();
+    }
   }
-}
+
+  const buttonVariant = needsSave ? 'primary' : 'success';
+
+  return (
+    <div
+      id="apd-save-button"
+      className="save-button--container ds-u-margin-bottom--3 visibility--screen"
+    >
+      <div className="save-button--alert">{alert}</div>
+      <Button variation={buttonVariant} onClick={save}>
+        {getButtonContent(needsSave, working)}
+      </Button>
+    </div>
+  );
+};
 
 SaveButton.propTypes = {
   error: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]).isRequired,
@@ -122,9 +113,6 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = { saveApd };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(SaveButton);
+export default connect(mapStateToProps, mapDispatchToProps)(SaveButton);
 
 export { SaveButton as plain, mapStateToProps, mapDispatchToProps };

--- a/web/src/containers/SaveButton.js
+++ b/web/src/containers/SaveButton.js
@@ -1,6 +1,6 @@
 import { Alert, Button, Spinner } from '@cmsgov/design-system-core';
 import PropTypes from 'prop-types';
-import React, { Fragment, useEffect, useState } from 'react';
+import React, { Fragment, useEffect, useMemo, useState } from 'react';
 import { connect } from 'react-redux';
 import stickybits from 'stickybits';
 
@@ -27,17 +27,15 @@ const getButtonContent = (dirty, working) => {
 
 const SaveButton = ({ error, needsSave, saveApd: action, working }) => {
   const [hasFetched, setHasFetched] = useState(false);
-  const [success, setSuccess] = useState(false);
 
   // Success has to be derived.  It can't be stored in the app state because
   // if it was, then the next time this form was loaded, it would show the
   // success state even though it wouldn't be accurate anymore.
-  if (hasFetched) {
-    const newSuccess = !working && !error;
-    if (newSuccess !== success) {
-      setSuccess(newSuccess);
-    }
-  }
+  const success = useMemo(() => hasFetched && !working && !error, [
+    error,
+    hasFetched,
+    working
+  ]);
 
   useEffect(() => {
     stickybits('#apd-save-button', { verticalPosition: 'bottom' });

--- a/web/src/containers/activity/CostAllocateFFP.js
+++ b/web/src/containers/activity/CostAllocateFFP.js
@@ -46,12 +46,12 @@ class CostAllocateFFP extends Component {
                 <Dollars long>{total}</Dollars>
               </p>
               {isViewOnly ? (
-                <>
+                <Fragment>
                   <p className="ds-h4 ds-u-display--block">
                     {t('activities.costAllocate.ffp.labels.other')}
                   </p>
                   <Dollars long>{costAllocation[year].other}</Dollars>
-                </>
+                </Fragment>
               ) : (
                 <DollarField
                   label={t('activities.costAllocate.ffp.labels.other')}

--- a/web/src/containers/admin/CreateAccount.js
+++ b/web/src/containers/admin/CreateAccount.js
@@ -1,6 +1,6 @@
 import { FormLabel, Select, TextField } from '@cmsgov/design-system-core';
 import PropTypes from 'prop-types';
-import React, { Component, Fragment } from 'react';
+import React, { Fragment, useState } from 'react';
 import { connect } from 'react-redux';
 import CardForm from '../../components/CardForm';
 import Password from '../../components/PasswordWithMeter';
@@ -9,150 +9,127 @@ import { createUser as createUserDispatch } from '../../actions/admin';
 import { getAddAccountError } from '../../reducers/errors';
 import { getAddAccountWorking } from '../../reducers/working';
 
-class CreateUser extends Component {
-  state = {
-    hasFetched: false,
-    name: '',
-    email: '',
-    password: '',
-    role: '',
-    state: '',
-    success: false
-  };
+const CreateUser = ({ createUser, error, roles, working }) => {
+  const [email, setEmail] = useState('');
+  const [hasFetched, setHasFetched] = useState(false);
+  const [name, setName] = useState('');
+  const [password, setPassword] = useState('');
+  const [role, setRole] = useState('');
+  const [state, setState] = useState('');
+  const [success, setSuccess] = useState(false);
 
-  static getDerivedStateFromProps({ error, working }, { hasFetched }) {
-    // Success has to be derived.  It can't be stored in the app state because
-    // if it was, then the next time this form was loaded, it would show the
-    // success state even though it wouldn't be accurate anymore.
-    if (hasFetched) {
-      const update = { success: !working && !error };
+  // Success has to be derived.  It can't be stored in the app state because
+  // if it was, then the next time this form was loaded, it would show the
+  // success state even though it wouldn't be accurate anymore.
+  if (hasFetched) {
+    const newSuccess = !working && !error;
 
-      // And because this component is creating a new user, that user is stored
-      // in component state too - so in a success condition, where the user was
-      // saved, blank out the state so another new user can be created.  We
-      // also need to reset hasFetched or else every prop change would reset
-      // the user stored in component state.
-      if (update.success) {
-        update.hasFetched = false;
-        update.name = '';
-        update.email = '';
-        update.password = '';
-        update.role = '';
-        update.state = '';
+    // On a successful save, we need to blank out the local user state so
+    // we can start inputting another user.
+    if (newSuccess) {
+      setEmail('');
+      setHasFetched(false);
+      setName('');
+      setPassword('');
+      setRole('');
+      setState('');
+
+      if (!success) {
+        setSuccess(true);
       }
-      return update;
     }
-    return null;
   }
 
-  handleChange = e => {
-    const { name: key, value } = e.target;
-    const change = { [key]: value };
+  const changeEmail = ({ target: { value } }) => setEmail(value);
+  const changeName = ({ target: { value } }) => setName(value);
+  const changePassword = ({ target: { value } }) => setPassword(value);
+  const changeRole = ({ target: { value } }) => setRole(value);
+  const changeState = ({ target: { value } }) => setState(value);
 
-    this.setState(change);
-  };
-
-  handleSubmit = e => {
+  const handleSubmit = e => {
     e.preventDefault();
-
-    const { email, name, password, role, state } = this.state;
-
-    const { createUser } = this.props;
 
     // Once we've attempted to save these changes, it's valid to show success
     // or error messages.  Since error messages are persisted in app state,
     // it's possible there's an error sitting there from a previous instance
     // of this form.  This flag makes sure we don't show any error messages
     // until this instance of the form has tried to save.
-    this.setState({ hasFetched: true });
+    setHasFetched(true);
     createUser({ email, name, password, role, state });
   };
 
-  render() {
-    const { error, roles, working } = this.props;
-    const {
-      hasFetched,
-      name,
-      email,
-      password,
-      role,
-      state,
-      success
-    } = this.state;
+  return (
+    <Fragment>
+      <CardForm
+        title="Create account"
+        sectionName="administrator"
+        error={hasFetched && error}
+        success={success && 'Account created'}
+        working={working}
+        onSave={handleSubmit}
+      >
+        <TextField
+          label="Name"
+          name="name"
+          ariaLabel="please enter the user's full name"
+          value={name || ''}
+          onChange={changeName}
+        />
 
-    return (
-      <Fragment>
-        <CardForm
-          title="Create account"
-          sectionName="administrator"
-          error={hasFetched && error}
-          success={success && 'Account created'}
-          working={working}
-          onSave={this.handleSubmit}
+        <TextField
+          label="Email"
+          name="email"
+          value={email}
+          onChange={changeEmail}
+        />
+
+        <FormLabel component="label" fieldId="create_account_state">
+          State
+        </FormLabel>
+        <Select
+          id="create_account_state"
+          name="state"
+          size="medium"
+          value={state}
+          onChange={changeState}
         >
-          <TextField
-            label="Name"
-            name="name"
-            ariaLabel="please enter the user's full name"
-            value={name || ''}
-            onChange={this.handleChange}
-          />
+          <option value="">None</option>
+          {STATES.map(s => (
+            <option key={s.id} value={s.id}>
+              {s.name}
+            </option>
+          ))}
+        </Select>
 
-          <TextField
-            label="Email"
-            name="email"
-            value={email}
-            onChange={this.handleChange}
-          />
+        <FormLabel component="label" fieldId="create_account_role">
+          Authorization role
+        </FormLabel>
+        <Select
+          id="create_account_role"
+          name="role"
+          size="medium"
+          value={role || ''}
+          onChange={changeRole}
+        >
+          <option value="">None</option>
+          {roles.map(r => (
+            <option key={r.name} value={r.name}>
+              {toSentenceCase(r.name)}
+            </option>
+          ))}
+        </Select>
 
-          <FormLabel component="label" fieldId="create_account_state">
-            State
-          </FormLabel>
-          <Select
-            id="create_account_state"
-            name="state"
-            size="medium"
-            value={state}
-            onChange={this.handleChange}
-          >
-            <option value="">None</option>
-            {STATES.map(s => (
-              <option key={s.id} value={s.id}>
-                {s.name}
-              </option>
-            ))}
-          </Select>
-
-          <FormLabel component="label" fieldId="create_account_role">
-            Authorization role
-          </FormLabel>
-          <Select
-            id="create_account_role"
-            name="role"
-            size="medium"
-            value={role || ''}
-            onChange={this.handleChange}
-          >
-            <option value="">None</option>
-            {roles.map(r => (
-              <option key={r.name} value={r.name}>
-                {toSentenceCase(r.name)}
-              </option>
-            ))}
-          </Select>
-
-          <Password
-            value={password}
-            compareTo={[email, name]}
-            onChange={this.handleChange}
-            showMeter
-            className="mb2"
-          />
-        </CardForm>
-      </Fragment>
-    );
-  }
-}
+        <Password
+          value={password}
+          compareTo={[email, name]}
+          onChange={changePassword}
+          showMeter
+          className="mb2"
+        />
+      </CardForm>
+    </Fragment>
+  );
+};
 
 CreateUser.propTypes = {
   createUser: PropTypes.func.isRequired,
@@ -171,9 +148,6 @@ const mapDispatchToProps = {
   createUser: createUserDispatch
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(CreateUser);
+export default connect(mapStateToProps, mapDispatchToProps)(CreateUser);
 
 export { CreateUser as plain };

--- a/web/src/containers/admin/CreateAccount.js
+++ b/web/src/containers/admin/CreateAccount.js
@@ -1,6 +1,6 @@
 import { FormLabel, Select, TextField } from '@cmsgov/design-system-core';
 import PropTypes from 'prop-types';
-import React, { Fragment, useState } from 'react';
+import React, { Fragment, useMemo, useState } from 'react';
 import { connect } from 'react-redux';
 import CardForm from '../../components/CardForm';
 import Password from '../../components/PasswordWithMeter';
@@ -16,13 +16,12 @@ const CreateUser = ({ createUser, error, roles, working }) => {
   const [password, setPassword] = useState('');
   const [role, setRole] = useState('');
   const [state, setState] = useState('');
-  const [success, setSuccess] = useState(false);
 
   // Success has to be derived.  It can't be stored in the app state because
   // if it was, then the next time this form was loaded, it would show the
   // success state even though it wouldn't be accurate anymore.
-  if (hasFetched) {
-    const newSuccess = !working && !error;
+  const success = useMemo(() => {
+    const newSuccess = hasFetched && !working && !error;
 
     // On a successful save, we need to blank out the local user state so
     // we can start inputting another user.
@@ -33,12 +32,10 @@ const CreateUser = ({ createUser, error, roles, working }) => {
       setPassword('');
       setRole('');
       setState('');
-
-      if (!success) {
-        setSuccess(true);
-      }
     }
-  }
+
+    return newSuccess;
+  }, [error, hasFetched, working]);
 
   const changeEmail = ({ target: { value } }) => setEmail(value);
   const changeName = ({ target: { value } }) => setName(value);

--- a/web/src/containers/admin/EditAccount.js
+++ b/web/src/containers/admin/EditAccount.js
@@ -5,7 +5,7 @@ import {
   TextField
 } from '@cmsgov/design-system-core';
 import PropTypes from 'prop-types';
-import React, { Component, Fragment } from 'react';
+import React, { Fragment, useState } from 'react';
 import { connect } from 'react-redux';
 
 import { editAccount as editAccountDispatch } from '../../actions/admin';
@@ -17,32 +17,71 @@ import { getEditAccountError } from '../../reducers/errors';
 import { getEditAccountWorking } from '../../reducers/working';
 import { STATES, toSentenceCase } from '../../util';
 
-class EditAccount extends Component {
-  state = {
-    changePassword: false,
-    hasFetched: false,
-    success: false,
-    userID: '',
-    user: null
-  };
+const EditAccount = ({
+  currentUser,
+  editAccount,
+  error,
+  roles,
+  users,
+  working
+}) => {
+  const [changePassword, setChangePassword] = useState(false);
+  const [hasFetched, setHasFetched] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [userID, setUserID] = useState('');
+  const [user, setUser] = useState(null);
 
-  static getDerivedStateFromProps({ error, working }, { hasFetched }) {
-    // Success has to be derived.  It can't be stored in the app state because
-    // if it was, then the next time this form was loaded, it would show the
-    // success state even though it wouldn't be accurate anymore.
-
-    if (hasFetched) {
-      return {
-        success: !working && !error
-      };
+  // Success has to be derived.  It can't be stored in the app state because
+  // if it was, then the next time this form was loaded, it would show the
+  // success state even though it wouldn't be accurate anymore.
+  if (hasFetched) {
+    const newSuccess = !working && !error;
+    if (newSuccess !== success) {
+      setSuccess(newSuccess);
     }
-    return null;
   }
 
-  getForm = () => {
-    const { currentUser, roles } = this.props;
-    const { changePassword, user } = this.state;
+  const handlePickAccount = ({ target: { value } }) => {
+    const newUser = users
+      .filter(u => u.id === +value)
+      .reduce((_, u) => u, null);
+    setUserID(+value);
+    setUser({ ...newUser, state: newUser.state.id });
+  };
 
+  const changeUserEmail = ({ target: { value } }) =>
+    setUser({ ...user, username: value });
+  const changeUserName = ({ target: { value } }) =>
+    setUser({ ...user, name: value });
+  const changeUserPassword = ({ target: { value } }) =>
+    setUser({ ...user, password: value });
+  const changeUserPhone = ({ target: { value } }) =>
+    setUser({ ...user, phone: value });
+  const changeUserPosition = ({ target: { value } }) =>
+    setUser({ ...user, position: value });
+  const changeUserRole = ({ target: { value } }) =>
+    setUser({ ...user, role: value });
+
+  const changeUserState = ({ target: { value } }) =>
+    setUser({ ...user, state: value });
+
+  const saveAccount = e => {
+    e.preventDefault();
+    // Once we've attempted to save these changes, it's valid to show success
+    // or error messages.  Since error messages are persisted in app state,
+    // it's possible there's an error sitting there from a previous instance
+    // of this form.  This flag makes sure we don't show any error messages
+    // until this instance of the form has tried to save.
+    setHasFetched(true);
+    editAccount(user, changePassword);
+  };
+
+  const toggleChangePassword = e => {
+    e.preventDefault();
+    setChangePassword(!changePassword);
+  };
+
+  const getForm = () => {
     if (user) {
       const { name, password, phone, position, state, username, role } = user;
 
@@ -55,14 +94,14 @@ class EditAccount extends Component {
             label="Name"
             name="name"
             value={name || ''}
-            onChange={this.handleEditAccount}
+            onChange={changeUserName}
           />
 
           <TextField
             label="Email"
             name="username"
             value={username}
-            onChange={this.handleEditAccount}
+            onChange={changeUserEmail}
           />
 
           <TextField
@@ -71,14 +110,14 @@ class EditAccount extends Component {
             size="medium"
             mask="phone"
             value={phone || ''}
-            onChange={this.handleEditAccount}
+            onChange={changeUserPhone}
           />
 
           <TextField
             label="Position"
             name="position"
             value={position || ''}
-            onChange={this.handleEditAccount}
+            onChange={changeUserPosition}
           />
 
           <FormLabel component="label" fieldId="modify_account_state">
@@ -89,7 +128,7 @@ class EditAccount extends Component {
             name="state"
             size="medium"
             value={state}
-            onChange={this.handleEditAccount}
+            onChange={changeUserState}
           >
             <option value="">None</option>
             {STATES.map(s => (
@@ -107,7 +146,7 @@ class EditAccount extends Component {
             name="role"
             size="medium"
             value={role || ''}
-            onChange={this.handleEditAccount}
+            onChange={changeUserRole}
             disabled={currentUser.id === user.id}
           >
             <option value="">None</option>
@@ -138,7 +177,7 @@ class EditAccount extends Component {
                   }
                   variation="transparent"
                   className="ds-u-padding-y--0"
-                  onClick={this.toggleChangePassword}
+                  onClick={toggleChangePassword}
                   purpose="change password"
                 >
                   {changePassword ? <UnlockIcon /> : <LockIcon />} Change
@@ -152,7 +191,7 @@ class EditAccount extends Component {
               showMeter
               title="New password"
               value={password}
-              onChange={this.handleEditAccount}
+              onChange={changeUserPassword}
             />
           )}
         </Fragment>
@@ -161,79 +200,40 @@ class EditAccount extends Component {
     return null;
   };
 
-  handlePickAccount = e => {
-    const { users } = this.props;
-    const { value } = e.target;
+  const onSave = !!userID && saveAccount;
 
-    const user = users.filter(u => u.id === +value).reduce((_, u) => u, null);
-
-    this.setState({ userID: +value, user: { ...user, state: user.state.id } });
-  };
-
-  handleEditAccount = e => {
-    const { name, value } = e.target;
-
-    this.setState(prev => ({ user: { ...prev.user, [name]: value } }));
-  };
-
-  editAccount = e => {
-    e.preventDefault();
-    const { editAccount } = this.props;
-    const { changePassword, user } = this.state;
-
-    // Once we've attempted to save these changes, it's valid to show success
-    // or error messages.  Since error messages are persisted in app state,
-    // it's possible there's an error sitting there from a previous instance
-    // of this form.  This flag makes sure we don't show any error messages
-    // until this instance of the form has tried to save.
-    this.setState({ hasFetched: true });
-    editAccount(user, changePassword);
-  };
-
-  toggleChangePassword = e => {
-    e.preventDefault();
-    this.setState(prev => ({ changePassword: !prev.changePassword }));
-  };
-
-  render() {
-    const { error, users, working } = this.props;
-    const { hasFetched, success, userID } = this.state;
-
-    const onSave = !!userID && this.editAccount;
-
-    return (
-      <Fragment>
-        <CardForm
-          title="Manage accounts"
-          sectionName="administrator"
-          error={hasFetched && error}
-          success={success && 'Account saved'}
-          working={working}
-          onSave={onSave}
+  return (
+    <Fragment>
+      <CardForm
+        title="Manage accounts"
+        sectionName="administrator"
+        error={hasFetched && error}
+        success={success && 'Account saved'}
+        working={working}
+        onSave={onSave}
+      >
+        <FormLabel component="label" fieldId="modify_account_user">
+          Account to edit
+        </FormLabel>
+        <Select
+          id="modify_account_user"
+          name="userID"
+          value={`${userID}`}
+          onChange={handlePickAccount}
         >
-          <FormLabel component="label" fieldId="modify_account_user">
-            Account to edit
-          </FormLabel>
-          <Select
-            id="modify_account_user"
-            name="userID"
-            value={`${userID}`}
-            onChange={this.handlePickAccount}
-          >
-            <option value="">Select...</option>
-            {users.map(u => (
-              <option key={u.id} value={`${u.id}`}>
-                {`${u.name ? `${u.name} - ` : ''}${u.username}`}
-              </option>
-            ))}
-          </Select>
+          <option value="">Select...</option>
+          {users.map(u => (
+            <option key={u.id} value={`${u.id}`}>
+              {`${u.name ? `${u.name} - ` : ''}${u.username}`}
+            </option>
+          ))}
+        </Select>
 
-          {this.getForm()}
-        </CardForm>
-      </Fragment>
-    );
-  }
-}
+        {getForm()}
+      </CardForm>
+    </Fragment>
+  );
+};
 
 EditAccount.propTypes = {
   currentUser: PropTypes.object.isRequired,
@@ -254,9 +254,6 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = { editAccount: editAccountDispatch };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(EditAccount);
+export default connect(mapStateToProps, mapDispatchToProps)(EditAccount);
 
 export { EditAccount as plain, mapStateToProps, mapDispatchToProps };

--- a/web/src/containers/admin/EditAccount.js
+++ b/web/src/containers/admin/EditAccount.js
@@ -5,7 +5,7 @@ import {
   TextField
 } from '@cmsgov/design-system-core';
 import PropTypes from 'prop-types';
-import React, { Fragment, useState } from 'react';
+import React, { Fragment, useState, useMemo } from 'react';
 import { connect } from 'react-redux';
 
 import { editAccount as editAccountDispatch } from '../../actions/admin';
@@ -27,19 +27,17 @@ const EditAccount = ({
 }) => {
   const [changePassword, setChangePassword] = useState(false);
   const [hasFetched, setHasFetched] = useState(false);
-  const [success, setSuccess] = useState(false);
   const [userID, setUserID] = useState('');
   const [user, setUser] = useState(null);
 
   // Success has to be derived.  It can't be stored in the app state because
   // if it was, then the next time this form was loaded, it would show the
   // success state even though it wouldn't be accurate anymore.
-  if (hasFetched) {
-    const newSuccess = !working && !error;
-    if (newSuccess !== success) {
-      setSuccess(newSuccess);
-    }
-  }
+  const success = useMemo(() => hasFetched && !working && !error, [
+    error,
+    hasFetched,
+    working
+  ]);
 
   const handlePickAccount = ({ target: { value } }) => {
     const newUser = users

--- a/web/src/containers/admin/MyAccount.js
+++ b/web/src/containers/admin/MyAccount.js
@@ -1,6 +1,6 @@
 import { Button, TextField } from '@cmsgov/design-system-core';
 import PropTypes from 'prop-types';
-import React, { Fragment, useState } from 'react';
+import React, { Fragment, useMemo, useState } from 'react';
 import { connect } from 'react-redux';
 
 import { editSelf } from '../../actions/admin';
@@ -18,7 +18,6 @@ const MyAccount = ({
 }) => {
   const [changePassword, setChangePassword] = useState(false);
   const [hasFetched, setHasFetched] = useState(false);
-  const [success, setSuccess] = useState(false);
   const [user, setUser] = useState({
     name: initialName,
     password: '',
@@ -38,12 +37,11 @@ const MyAccount = ({
   // Success has to be derived.  It can't be stored in the app state because
   // if it was, then the next time this form was loaded, it would show the
   // success state even though it wouldn't be accurate anymore.
-  if (hasFetched) {
-    const newSuccess = !working && !error;
-    if (newSuccess !== success) {
-      setSuccess(newSuccess);
-    }
-  }
+  const success = useMemo(() => hasFetched && !working && !error, [
+    error,
+    hasFetched,
+    working
+  ]);
 
   const saveAccount = e => {
     e.preventDefault();

--- a/web/src/containers/admin/MyAccount.test.js
+++ b/web/src/containers/admin/MyAccount.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme';
 import React from 'react';
-import sinon from 'sinon';
 
 import {
   plain as MyAccount,
@@ -87,8 +86,8 @@ describe('my account page', () => {
       position: 'Table Cleaner'
     };
 
-    const editAccount = sinon.spy();
-    const preventDefault = sinon.spy();
+    const editAccount = jest.fn();
+    const preventDefault = jest.fn();
 
     const component = shallow(
       <MyAccount
@@ -104,8 +103,16 @@ describe('my account page', () => {
       .props()
       .onSave({ preventDefault });
 
-    expect(preventDefault.calledOnce).toEqual(true);
-    expect(editAccount.calledWith(user)).toEqual(true);
+    expect(preventDefault).toHaveBeenCalled();
+    expect(editAccount).toHaveBeenCalledWith(
+      {
+        name: 'Tina Belcher',
+        password: '',
+        phone: '1-800-BURGERS',
+        position: 'Table Cleaner'
+      },
+      false
+    );
 
     // When there is no error (thus, success)
     expect(component).toMatchSnapshot();

--- a/web/src/containers/viewOnly/ApdSummary.js
+++ b/web/src/containers/viewOnly/ApdSummary.js
@@ -10,6 +10,8 @@ const ApdSummary = ({
   narrativeMMIS,
   programOverview
 }) => {
+  /* eslint-disable react/no-danger */
+
   return (
     <div>
       <h2>Program summary</h2>

--- a/web/src/containers/viewOnly/PreviousActivities.js
+++ b/web/src/containers/viewOnly/PreviousActivities.js
@@ -9,16 +9,17 @@ import ApdPreviousActivityTableTotal from '../ApdPreviousActivityTableTotal';
 import { selectPreviousActivitySummary } from '../../reducers/apd.selectors';
 
 const PreviousActivities = ({ previousActivitySummary }) => {
+  /* eslint-disable react/no-danger */
   return (
     <div>
       <h2>Results of Previous Activities</h2>
-      <div dangerouslySetInnerHTML={{__html: previousActivitySummary}} />
+      <div dangerouslySetInnerHTML={{ __html: previousActivitySummary }} />
       <h3>Actual Costs of Previous Activities</h3>
-      <ApdPreviousActivityTableHI isViewOnly/>
+      <ApdPreviousActivityTableHI isViewOnly />
       <ApdPreviousActivityTableMMIS isViewOnly />
       <ApdPreviousActivityTableTotal isViewOnly />
     </div>
-  )
+  );
 };
 
 PreviousActivities.propTypes = {
@@ -29,6 +30,4 @@ const mapStateToProps = state => ({
   previousActivitySummary: selectPreviousActivitySummary(state)
 });
 
-export default connect(
-  mapStateToProps
-)(PreviousActivities);
+export default connect(mapStateToProps)(PreviousActivities);

--- a/web/src/containers/viewOnly/activities/Activity.js
+++ b/web/src/containers/viewOnly/activities/Activity.js
@@ -105,13 +105,13 @@ const Activity = ({ activity, activityIndex }) => {
             <li key={year}>
               <strong>{year} Costs:</strong> <Dollars>{cost}</Dollars>
               {contractor.hourly.useHourly === true && (
-                <>
+                <Fragment>
                   <p>Number of hours: {contractor.hourly.data[year].hours}</p>
                   <p>
                     Hourly rate:{' '}
                     <Dollars>{contractor.hourly.data[year].rate}</Dollars>
                   </p>
-                </>
+                </Fragment>
               )}
             </li>
           ))}

--- a/web/src/containers/viewOnly/activities/Activity.js
+++ b/web/src/containers/viewOnly/activities/Activity.js
@@ -124,6 +124,7 @@ const Activity = ({ activity, activityIndex }) => {
     );
   };
 
+  /* eslint-disable react/no-danger */
   return (
     <Fragment>
       <h2>

--- a/web/src/stories/FrozenTableStory.js
+++ b/web/src/stories/FrozenTableStory.js
@@ -1,3 +1,8 @@
+/* eslint-disable jsx-a11y/control-has-associated-label */
+// This rule throws a false-positive on empty table header cells, so just
+// disable it for now.
+// https://github.com/evcohen/eslint-plugin-jsx-a11y/issues/637
+
 import React, { Fragment } from 'react';
 
 import RenderViewbox from './RenderViewbox';

--- a/web/src/stories/content/Instruction.js
+++ b/web/src/stories/content/Instruction.js
@@ -4,7 +4,10 @@ import RenderViewbox from '../RenderViewbox';
 import Instruction from '../../components/Instruction';
 
 class InstructionStory extends Component {
-  state = { reverse: false };
+  constructor() {
+    super();
+    this.state = { reverse: false };
+  }
 
   toggle = () => this.setState(prev => ({ reverse: !prev.reverse }));
 


### PR DESCRIPTION
Updates to the most recent version of the airbnb eslint rules, and tweaks the code accordingly

### This pull request changes...

- The rules now require that component state initialization happen in a constructor. Added constructors where necessary, and converted to functional components where possible
- The Airbnb rules require using `<>` instead of `<Fragment>`. Inverted the rule so that we require `<Fragment>` instead of `<>`
- The rules forbid using prop spreads in components like `<Component ...props>`. However, we use that pattern a lot for wrapper components so we can just blindly pass properties along. Disabled this rule.
- Added local disables for the `no-dangerous` rule that warns about using `dangerouslySetInnerHTML` since we aware of those and they're intentional. We'll still get warnings about new ones, which is desirable
- closes #1985 

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [ ] Changelog is updated as appropriate
