### PR TITLE
Make it so all the words aren't crooked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Anticipated release: January 20, 2020
 
 #### 🐛 Bugs fixed
 
+- Fixed a bug where everything was in italics. [(#1998)]
+
 #### ⚙️ Behind the scenes
 
 # 2.3.0
@@ -250,3 +252,4 @@ Pilot release to select state partners
 [#1967]: https://github.com/18F/cms-hitech-apd/pull/1967
 [#1981]: https://github.com/18F/cms-hitech-apd/issues/1981
 [#1973]: https://github.com/18F/cms-hitech-apd/issues/1973
+[#1998]: https://github.com/18F/cms-hitech-apd/issues/1998

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7195,9 +7195,9 @@
       }
     },
     "css-loader": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.4.0.tgz",
-      "integrity": "sha512-JornYo4RAXl1Mzt0lOSVPmArzAMV3rGY2VuwtaDc732WTWjdwTaeS19nCGWMcSCf305Q396lhhDAJEWWM0SgPQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.2.1.tgz",
+      "integrity": "sha512-q40kYdcBNzMvkIImCL2O+wk8dh+RGwPPV9Dfz3n7XtOYPXqe2Z6VgtvoxjkLHz02gmhepG9sOAJOUlx+3hHsBg==",
       "dev": true,
       "requires": {
         "camelcase": "^5.3.1",

--- a/web/package.json
+++ b/web/package.json
@@ -97,7 +97,7 @@
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-transform-require-context": "^0.1.1",
-    "css-loader": "^3.4.0",
+    "css-loader": "3.2.1",
     "cssnano": "^4.1.10",
     "d3-geo": "^1.11.9",
     "enzyme": "^3.11.0",

--- a/web/src/css-loader.test.js
+++ b/web/src/css-loader.test.js
@@ -1,0 +1,10 @@
+const pkg = require('../package.json');
+
+// This test can be deleted entirely when the issue is fixed and the library
+// can safely be upgraded.
+
+describe('make sure css-loader is fixed before updating', () => {
+  it('We cannot update css-loader until this issue is fixed: https://github.com/webpack-contrib/css-loader/issues/1039', () => {
+    expect(pkg.devDependencies['css-loader']).toEqual('3.2.1');
+  });
+});

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -38,16 +38,36 @@ const config = {
       },
       {
         test: /\.scss$/,
+
+        // Remember that these run in reverse, so start at the last item in the
+        // array and read up to understand what's going on.
         use: [
           {
+            // Extracts all that CSS into a file and plops it on the disk.
             loader: 'file-loader',
             options: { name: 'app.css' }
           },
+
+          // Converts the local disk paths from css-loader into their final
+          // paths relative to the dist directory.
           'extract-loader',
+
+          // Interprets any url() and @import statements and resolves them to
+          // their full path on the local disk.
           'css-loader',
+
+          // Doesn't do anything. Probably legacy? But leave it for now, and
+          // we can remove it later when we've got time to make sure it doesn't
+          // break anything.
           'resolve-url-loader',
+
+          // Handles resolving and importing all the CSS files, so we end up
+          // with one nice, big file to deal with. Also adds vendor prefixes
+          // as necessary for CSS rules that aren't yet widely supported.
           'postcss-loader',
+
           {
+            // Parse the Sass into CSS.
             loader: 'sass-loader',
             options: {
               sassOptions: {


### PR DESCRIPTION
The [`css-loader`](https://npm.im/css-loader) module changed in 3.3.0 and it now doesn't handle some of our font imports correctly. As a result, it was loading the wrong font files for various font definitions. This mostly manifested as the Open Sans Italic font file being loaded for the open-sans regular definition, so the whole site was in italics.

Opened [1039](https://github.com/webpack-contrib/css-loader/issues/1039) on the css-loader repo to track the issue. When that's resolved, we can update again.

### This pull request changes...

- reverts `css-loader` to 3.2.1
- closes #1998 

### This pull request is ready to merge when...

- [x] This code has been reviewed by someone other than the original author
- [x] Changelog is updated as appropriate