### PR TITLE
Tweak how we scan dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,7 +423,7 @@ jobs:
           name: vulnerability scan
           working_directory: ~/project/<< parameters.path >>
           command: |
-            npm audit
+            npx -p npm-audit-resolver check-audit
 
   owasp zap scan:
     machine:

--- a/web/audit-resolve.json
+++ b/web/audit-resolve.json
@@ -1,0 +1,11 @@
+{
+  "decisions": {
+    "961|node-sass": {
+      "decision": "ignore",
+      "madeAt": 1579036100908,
+      "expiresAt": 1581628077626
+    }
+  },
+  "rules": {},
+  "version": 1
+}


### PR DESCRIPTION
The `npm audit` command fails if there are *any* security vulnerabilities, even low-level ones, and does not provide a way to temporarily ignore a vulnerability. Since many of the vulnerabilities that pop up in our dependencies are in our development dependencies (and thus not a production concern), this becomes problematic. If a dev dependency has a low-severity vulnerability, we just can't merge a PR until it is fixed upstream, even though we really aren't concerned about it.

This PR switches from using `npm audit` directly to using `npm-audit-resolver`, which introduces the ability to ignore vulnerabilities for a period of time (similar to what Snyk allowed). That way when there are vulnerabilities without fixes or vulnerabilities that we don't care about and would require a lot of effort to fix, we can ignore them and keep moving.

`npm-audit-resolver`'s functionality may eventually be incorporated directly into npm. It's currently going through the RFC process, so this could set us up for a clean transition in the future.

### This pull request changes...

- changes dependency security scan to use `npm-audit-resolver`
- adds a short-term ignore for a `node-sass` vulnerability that we don't really care about because it doesn't have a fix yet
- updated wiki to include `npm-audit-resolver` as tech debt

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- [x] The change has been documented
  - ~Associated OpenAPI documentation has been updated~
- ~Changelog is updated as appropriate~

### This feature is done when...

- [ ] Product has approved the behavior
