### PR TITLE
Fix a bug where toggling the "show password" checkbox would change the user's entered password to "show password"

### DIFF
--- a/web/src/components/PasswordWithMeter.js
+++ b/web/src/components/PasswordWithMeter.js
@@ -31,7 +31,7 @@ class Password extends Component {
   };
 
   render() {
-    const { compareTo, title, value, showMeter, ...rest } = this.props;
+    const { className, title, value, showMeter } = this.props;
     const { showPassword, strength } = this.state;
 
     let passwordQuality = 'Password strength: Weak';
@@ -44,7 +44,7 @@ class Password extends Component {
     }
 
     return (
-      <div {...rest}>
+      <div className={className || undefined}>
         <div className="password-input">
           <Choice
             className="password-input--show-password ds-u-float--right"
@@ -93,6 +93,7 @@ class Password extends Component {
 }
 
 Password.propTypes = {
+  className: PropTypes.string,
   compareTo: PropTypes.arrayOf(PropTypes.string),
   onChange: PropTypes.func,
   title: PropTypes.string,
@@ -101,6 +102,7 @@ Password.propTypes = {
 };
 
 Password.defaultProps = {
+  className: '',
   compareTo: [],
   onChange: () => {},
   title: 'Password',

--- a/web/src/components/__snapshots__/PasswordWithMeter.test.js.snap
+++ b/web/src/components/__snapshots__/PasswordWithMeter.test.js.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PasswordWithmeter component renders with no props 1`] = `
-<div
-  onChange={[Function]}
->
+<div>
   <div
     className="password-input"
   >
@@ -31,9 +29,7 @@ exports[`PasswordWithmeter component renders with no props 1`] = `
 `;
 
 exports[`PasswordWithmeter component renders with various passwords 1`] = `
-<div
-  onChange={[Function]}
->
+<div>
   <div
     className="password-input"
   >
@@ -76,9 +72,7 @@ exports[`PasswordWithmeter component renders with various passwords 1`] = `
 `;
 
 exports[`PasswordWithmeter component renders with various passwords 2`] = `
-<div
-  onChange={[Function]}
->
+<div>
   <div
     className="password-input"
   >
@@ -121,9 +115,7 @@ exports[`PasswordWithmeter component renders with various passwords 2`] = `
 `;
 
 exports[`PasswordWithmeter component renders with various passwords 3`] = `
-<div
-  onChange={[Function]}
->
+<div>
   <div
     className="password-input"
   >
@@ -166,9 +158,7 @@ exports[`PasswordWithmeter component renders with various passwords 3`] = `
 `;
 
 exports[`PasswordWithmeter component renders with various passwords 4`] = `
-<div
-  onChange={[Function]}
->
+<div>
   <div
     className="password-input"
   >
@@ -211,9 +201,7 @@ exports[`PasswordWithmeter component renders with various passwords 4`] = `
 `;
 
 exports[`PasswordWithmeter component renders with various passwords 5`] = `
-<div
-  onChange={[Function]}
->
+<div>
   <div
     className="password-input"
   >
@@ -256,9 +244,7 @@ exports[`PasswordWithmeter component renders with various passwords 5`] = `
 `;
 
 exports[`PasswordWithmeter component shows the password 1`] = `
-<div
-  onChange={[Function]}
->
+<div>
   <div
     className="password-input"
   >

--- a/web/src/containers/Login.js
+++ b/web/src/containers/Login.js
@@ -86,12 +86,7 @@ const Login = ({
           value={username}
           onChange={changeUsername}
         />
-        <Password
-          title="Password"
-          ariaLabel="Enter the password for this account."
-          value={password}
-          onChange={changePassword}
-        />
+        <Password title="Password" value={password} onChange={changePassword} />
       </CardForm>
     </Fragment>
   );

--- a/web/src/containers/__snapshots__/Login.test.js.snap
+++ b/web/src/containers/__snapshots__/Login.test.js.snap
@@ -61,7 +61,7 @@ exports[`login component renders correctly if logged in previously but not logge
       value=""
     />
     <Password
-      ariaLabel="Enter the password for this account."
+      className=""
       compareTo={Array []}
       onChange={[Function]}
       showMeter={false}
@@ -123,7 +123,7 @@ exports[`login component renders correctly if not logged in and fetching data 1`
       value=""
     />
     <Password
-      ariaLabel="Enter the password for this account."
+      className=""
       compareTo={Array []}
       onChange={[Function]}
       showMeter={false}
@@ -175,7 +175,7 @@ exports[`login component renders correctly if not logged in and there is an erro
       value=""
     />
     <Password
-      ariaLabel="Enter the password for this account."
+      className=""
       compareTo={Array []}
       onChange={[Function]}
       showMeter={false}
@@ -227,7 +227,7 @@ exports[`login component renders correctly if not logged in, and never logged in
       value=""
     />
     <Password
-      ariaLabel="Enter the password for this account."
+      className=""
       compareTo={Array []}
       onChange={[Function]}
       showMeter={false}
@@ -279,7 +279,7 @@ exports[`login component renders correctly if not logged in, and never logged in
       value="bob"
     />
     <Password
-      ariaLabel="Enter the password for this account."
+      className=""
       compareTo={Array []}
       onChange={[Function]}
       showMeter={false}
@@ -331,7 +331,7 @@ exports[`login component renders correctly if not logged in, and never logged in
       value="bob"
     />
     <Password
-      ariaLabel="Enter the password for this account."
+      className=""
       compareTo={Array []}
       onChange={[Function]}
       showMeter={false}

--- a/web/src/containers/admin/__snapshots__/MyAccount.test.js.snap
+++ b/web/src/containers/admin/__snapshots__/MyAccount.test.js.snap
@@ -387,6 +387,7 @@ exports[`my account page renders 3`] = `
       </div>
     </div>
     <Password
+      className=""
       compareTo={Array []}
       onChange={[Function]}
       showMeter={true}


### PR DESCRIPTION
On any form with a password, toggling the "show password" checkbox would replace anything the user had entered into the password field with the literal text "Show password". This PR fixes that.

### This pull request changes...

- toggling the "show password" checkbox doesn't affect the contents of the password text box
- closes #2023

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~ N/A
- ~The change has been documented~ N/A
- [ ] Changelog is updated as appropriate