### PR TITLE
Split activity schedule from milestones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Anticipated release: February 3, 2020
 
 #### ⚙️ Behind the scenes
 
+- Split up some code components to make them more reusable ([#2005])
+
 # Previous releases
 
 See our [release history](https://github.com/18F/cms-hitech-apd/releases)
@@ -25,3 +27,4 @@ See our [release history](https://github.com/18F/cms-hitech-apd/releases)
 [#2015]: https://github.com/18F/cms-hitech-apd/pull/2015
 [#2023]: https://github.com/18F/cms-hitech-apd/issues/2023
 [#2020]: https://github.com/18F/cms-hitech-apd/pull/2028
+[#2005]: https://github.com/18F/cms-hitech-apd/issues/2005

--- a/web/src/containers/activity/EntryDetailsDialog.js
+++ b/web/src/containers/activity/EntryDetailsDialog.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import ContractorResources from './ContractorResources';
 import CostAllocate from './CostAllocate';
 import Costs from './Costs';
+import Milestones from './Milestones';
 import Overview from './Overview';
 import Objectives from './Objectives';
 import Schedule from './Schedule';
@@ -41,6 +42,7 @@ const ActivityDialog = props => {
         >
           <Objectives activityIndex={activityIndex} />
           <Schedule activityIndex={activityIndex} />
+          <Milestones activityIndex={activityIndex} />
         </TabPanel>
         <TabPanel
           id={`activity-cost-categories-${activityIndex}-tab`}

--- a/web/src/containers/activity/Milestones.js
+++ b/web/src/containers/activity/Milestones.js
@@ -1,0 +1,66 @@
+import PropTypes from 'prop-types';
+import React, { Fragment, useCallback } from 'react';
+import { connect } from 'react-redux';
+
+import FormAndReviewList from '../../components/FormAndReviewList';
+import { MilestoneForm, MilestoneReview } from './Milestone';
+
+import { addMilestone, removeMilestone } from '../../actions/editActivity';
+import { Subsection } from '../../components/Section';
+import { t } from '../../i18n';
+import { selectActivityByIndex } from '../../reducers/activities.selectors';
+
+const Milestone = ({ activity, activityIndex, add, remove }) => {
+  const handleAdd = useCallback(() => {
+    add(activityIndex);
+  });
+
+  const handleDelete = useCallback(key => {
+    activity.schedule.forEach(({ key: milestoneKey }, i) => {
+      if (milestoneKey === key) {
+        remove(activityIndex, i);
+      }
+    });
+  });
+
+  return (
+    <Subsection resource="activities.milestones">
+      <Fragment>
+        <div className="mb3">
+          <hr />
+
+          <FormAndReviewList
+            activityIndex={activityIndex}
+            addButtonText={t('activities.milestones.addMilestoneButtonText')}
+            list={activity.schedule}
+            collapsed={MilestoneReview}
+            expanded={MilestoneForm}
+            noDataMessage={t('activities.milestones.noMilestonesNotice')}
+            onAddClick={handleAdd}
+            onDeleteClick={handleDelete}
+          />
+        </div>
+      </Fragment>
+    </Subsection>
+  );
+};
+
+Milestone.propTypes = {
+  activity: PropTypes.object.isRequired,
+  activityIndex: PropTypes.number.isRequired,
+  add: PropTypes.func.isRequired,
+  remove: PropTypes.func.isRequired
+};
+
+const mapStateToProps = (state, { activityIndex }) => ({
+  activity: selectActivityByIndex(state, { activityIndex })
+});
+
+const mapDispatchToProps = {
+  add: addMilestone,
+  remove: removeMilestone
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(Milestone);
+
+export { Milestone as plain, mapStateToProps, mapDispatchToProps };

--- a/web/src/containers/activity/Milestones.test.js
+++ b/web/src/containers/activity/Milestones.test.js
@@ -1,0 +1,76 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import {
+  plain as Milestones,
+  mapDispatchToProps,
+  mapStateToProps
+} from './Milestones';
+import { addMilestone, removeMilestone } from '../../actions/editActivity';
+
+describe('the Milestones component', () => {
+  const props = {
+    activity: {
+      schedule: [
+        {
+          key: 'milestone 1',
+          milestone: 'Liberation Day',
+          // The Netherlands is liberated from Nazi control.
+          endDate: '1945-05-05'
+        }
+      ]
+    },
+    activityIndex: 7,
+    add: jest.fn(),
+    remove: jest.fn()
+  };
+
+  const component = shallow(<Milestones {...props} />);
+
+  beforeEach(() => {
+    props.add.mockClear();
+    props.remove.mockClear();
+  });
+
+  it('renders correctly', () => {
+    expect(component).toMatchSnapshot();
+  });
+
+  describe('events', () => {
+    const list = component.find('FormAndReviewList');
+    it('handles adding a new milestone', () => {
+      list.prop('onAddClick')();
+
+      expect(props.add).toHaveBeenCalledWith(7);
+    });
+
+    it('handles removing a milestone', () => {
+      list.prop('onDeleteClick')('milestone 1');
+
+      expect(props.remove).toHaveBeenCalledWith(7, 0);
+    });
+  });
+
+  describe('redux', () => {
+    it('map state to props', () => {
+      const state = {
+        apd: {
+          data: {
+            activities: ['activity 1', 'activity 2', 'activity 3']
+          }
+        }
+      };
+
+      expect(mapStateToProps(state, { activityIndex: 2 })).toEqual({
+        activity: 'activity 3'
+      });
+    });
+
+    it('map dispatch to props', () => {
+      expect(mapDispatchToProps).toEqual({
+        add: addMilestone,
+        remove: removeMilestone
+      });
+    });
+  });
+});

--- a/web/src/containers/activity/Schedule.js
+++ b/web/src/containers/activity/Schedule.js
@@ -2,48 +2,22 @@ import PropTypes from 'prop-types';
 import React, { Fragment, useCallback } from 'react';
 import { connect } from 'react-redux';
 
-import FormAndReviewList from '../../components/FormAndReviewList';
-import { MilestoneForm, MilestoneReview } from './Milestone';
-
 import {
-  addMilestone,
-  removeMilestone,
   setActivityEndDate,
   setActivityStartDate
 } from '../../actions/editActivity';
-import Instruction from '../../components/Instruction';
 import { Subsection } from '../../components/Section';
 import DateField from '../../components/DateField';
-import { t } from '../../i18n';
 import { selectActivityByIndex } from '../../reducers/activities.selectors';
 import { stateDateToDisplay } from '../../util';
 
-const Schedule = ({
-  activity,
-  activityIndex,
-  add,
-  remove,
-  setEndDate,
-  setStartDate
-}) => {
-  const handleAdd = useCallback(() => {
-    add(activityIndex);
-  });
-
+const Schedule = ({ activity, activityIndex, setEndDate, setStartDate }) => {
   const handleActivityStartChange = useCallback((_, dateStr) => {
     setStartDate(activityIndex, dateStr);
   });
 
   const handleActivityEndChange = useCallback((_, dateStr) => {
     setEndDate(activityIndex, dateStr);
-  });
-
-  const handleDelete = useCallback(key => {
-    activity.schedule.forEach(({ key: milestoneKey }, i) => {
-      if (milestoneKey === key) {
-        remove(activityIndex, i);
-      }
-    });
   });
 
   return (
@@ -72,25 +46,6 @@ const Schedule = ({
           </p>
           <hr />
         </div>
-        <div className="mb3">
-          <Instruction
-            source="activities.schedule.milestone.instruction"
-            headingDisplay={{ className: 'ds-h5', level: 'h6' }}
-          />
-
-          <hr />
-
-          <FormAndReviewList
-            activityIndex={activityIndex}
-            addButtonText={t('activities.schedule.addMilestoneButtonText')}
-            list={activity.schedule}
-            collapsed={MilestoneReview}
-            expanded={MilestoneForm}
-            noDataMessage={t('activities.schedule.noMilestonesNotice')}
-            onAddClick={handleAdd}
-            onDeleteClick={handleDelete}
-          />
-        </div>
       </Fragment>
     </Subsection>
   );
@@ -99,8 +54,6 @@ const Schedule = ({
 Schedule.propTypes = {
   activity: PropTypes.object.isRequired,
   activityIndex: PropTypes.number.isRequired,
-  add: PropTypes.func.isRequired,
-  remove: PropTypes.func.isRequired,
   setEndDate: PropTypes.func.isRequired,
   setStartDate: PropTypes.func.isRequired
 };
@@ -110,15 +63,10 @@ const mapStateToProps = (state, { activityIndex }) => ({
 });
 
 const mapDispatchToProps = {
-  add: addMilestone,
-  remove: removeMilestone,
   setEndDate: setActivityEndDate,
   setStartDate: setActivityStartDate
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Schedule);
+export default connect(mapStateToProps, mapDispatchToProps)(Schedule);
 
 export { Schedule as plain, mapStateToProps, mapDispatchToProps };

--- a/web/src/containers/activity/Schedule.test.js
+++ b/web/src/containers/activity/Schedule.test.js
@@ -7,8 +7,6 @@ import {
   mapStateToProps
 } from './Schedule';
 import {
-  addMilestone,
-  removeMilestone,
   setActivityEndDate,
   setActivityStartDate
 } from '../../actions/editActivity';
@@ -20,19 +18,9 @@ describe('the Schedule (milestones) component', () => {
       // Canadian forces successfully opened shipping routes to Antwerp, enabling
       // supplies to reach Allied forces in northwest Europe.
       plannedEndDate: '1944-11-08',
-      plannedStartDate: '1944-10-02',
-      schedule: [
-        {
-          key: 'milestone 1',
-          milestone: 'Liberation Day',
-          // The Netherlands is liberated from Nazi control.
-          endDate: '1945-05-05'
-        }
-      ]
+      plannedStartDate: '1944-10-02'
     },
     activityIndex: 7,
-    add: jest.fn(),
-    remove: jest.fn(),
     setEndDate: jest.fn(),
     setStartDate: jest.fn()
   };
@@ -40,8 +28,6 @@ describe('the Schedule (milestones) component', () => {
   const component = shallow(<Schedule {...props} />);
 
   beforeEach(() => {
-    props.add.mockClear();
-    props.remove.mockClear();
     props.setEndDate.mockClear();
     props.setStartDate.mockClear();
   });
@@ -51,19 +37,6 @@ describe('the Schedule (milestones) component', () => {
   });
 
   describe('events', () => {
-    const list = component.find('FormAndReviewList');
-    it('handles adding a new milestone', () => {
-      list.prop('onAddClick')();
-
-      expect(props.add).toHaveBeenCalledWith(7);
-    });
-
-    it('handles removing a milestone', () => {
-      list.prop('onDeleteClick')('milestone 1');
-
-      expect(props.remove).toHaveBeenCalledWith(7, 0);
-    });
-
     it('updates activity start date', () => {
       component
         .find('DateField')
@@ -98,8 +71,6 @@ describe('the Schedule (milestones) component', () => {
 
     it('map dispatch to props', () => {
       expect(mapDispatchToProps).toEqual({
-        add: addMilestone,
-        remove: removeMilestone,
         setEndDate: setActivityEndDate,
         setStartDate: setActivityStartDate
       });

--- a/web/src/containers/activity/__snapshots__/EntryDetailsDialog.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/EntryDetailsDialog.test.js.snap
@@ -35,6 +35,9 @@ exports[`the Activity Dialog component renders correctly 1`] = `
       <Connect(Schedule)
         activityIndex={2}
       />
+      <Connect(Milestone)
+        activityIndex={2}
+      />
     </TabPanel>
     <TabPanel
       id="activity-cost-categories-2-tab"

--- a/web/src/containers/activity/__snapshots__/Milestones.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/Milestones.test.js.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`the Milestones component renders correctly 1`] = `
+<Subsection
+  headerClassName={null}
+  id={null}
+  nested={false}
+  resource="activities.milestones"
+>
+  <div
+    className="mb3"
+  >
+    <hr />
+    <FormAndReviewList
+      activityIndex={7}
+      addButtonText="Add another milestone"
+      allowDeleteAll={false}
+      className={null}
+      collapsed={[Function]}
+      expanded={
+        Object {
+          "$$typeof": Symbol(react.memo),
+          "WrappedComponent": [Function],
+          "compare": null,
+          "displayName": "Connect(MilestoneForm)",
+          "type": [Function],
+        }
+      }
+      extraItemButtons={Array []}
+      list={
+        Array [
+          Object {
+            "endDate": "1945-05-05",
+            "key": "milestone 1",
+            "milestone": "Liberation Day",
+          },
+        ]
+      }
+      noDataMessage="Add milestones for this activity."
+      onAddClick={[Function]}
+      onDeleteClick={[Function]}
+    />
+  </div>
+</Subsection>
+`;

--- a/web/src/containers/activity/__snapshots__/Schedule.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/Schedule.test.js.snap
@@ -40,50 +40,5 @@ exports[`the Schedule (milestones) component renders correctly 1`] = `
     </p>
     <hr />
   </div>
-  <div
-    className="mb3"
-  >
-    <Instruction
-      args={null}
-      headingDisplay={
-        Object {
-          "className": "ds-h5",
-          "level": "h6",
-        }
-      }
-      reverse={false}
-      source="activities.schedule.milestone.instruction"
-    />
-    <hr />
-    <FormAndReviewList
-      activityIndex={7}
-      addButtonText="Add another milestone"
-      allowDeleteAll={false}
-      className={null}
-      collapsed={[Function]}
-      expanded={
-        Object {
-          "$$typeof": Symbol(react.memo),
-          "WrappedComponent": [Function],
-          "compare": null,
-          "displayName": "Connect(MilestoneForm)",
-          "type": [Function],
-        }
-      }
-      extraItemButtons={Array []}
-      list={
-        Array [
-          Object {
-            "endDate": "1945-05-05",
-            "key": "milestone 1",
-            "milestone": "Liberation Day",
-          },
-        ]
-      }
-      noDataMessage="Add milestones for this activity."
-      onAddClick={[Function]}
-      onDeleteClick={[Function]}
-    />
-  </div>
 </Subsection>
 `;

--- a/web/src/i18n/locales/en/activities/index.js
+++ b/web/src/i18n/locales/en/activities/index.js
@@ -3,6 +3,7 @@ import contractorResources from './contractorResources.yaml';
 import costAllocate from './costAllocate.yaml';
 import expenses from './expenses.yaml';
 import goals from './goals.yaml';
+import milestones from './milestones.yaml';
 import overview from './overview.yaml';
 import schedule from './schedule.yaml';
 import standardsAndConditions from './standardsAndConditions.yaml';
@@ -14,6 +15,7 @@ export default {
   costAllocate,
   expenses,
   goals,
+  milestones,
   overview,
   schedule,
   standardsAndConditions,

--- a/web/src/i18n/locales/en/activities/milestones.yaml
+++ b/web/src/i18n/locales/en/activities/milestones.yaml
@@ -1,0 +1,7 @@
+title: Milestones
+instruction:
+  detail: >-
+    List major milestones the state is working toward as part of this
+    activity. Include work occurring under previously approved APDs.
+noMilestonesNotice: Add milestones for this activity.
+addMilestoneButtonText: Add another milestone

--- a/web/src/i18n/locales/en/activities/schedule.yaml
+++ b/web/src/i18n/locales/en/activities/schedule.yaml
@@ -1,9 +1,1 @@
 title: Activity Schedule
-milestone:
-  instruction:
-    heading: Milestones
-    detail: >-
-      List major milestones the state is working toward as part of this
-      activity. Include work occurring under previously approved APDs.
-noMilestonesNotice: Add milestones for this activity.
-addMilestoneButtonText: Add another milestone


### PR DESCRIPTION
This only splits these two items into separate components. It does not rearrange them in the modal or in the tabs.

### This pull request changes...

- makes the activity schedule and milestones components separate
- closes #2005

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~ N/A
- ~The change has been documented~ N/A
  - ~Associated OpenAPI documentation has been updated~ N/A
- [x] Changelog is updated as appropriate
