### PR TITLE
Fix a bug where the rich text editor does not load correctly in the modal

### DIFF
--- a/web/src/components/RichText.js
+++ b/web/src/components/RichText.js
@@ -76,7 +76,8 @@ class RichText extends Component {
     super(props);
 
     this.state = {
-      content: props.content
+      content: props.content,
+      id: props.id || `rte-${generateKey()}`
     };
   }
 
@@ -87,8 +88,8 @@ class RichText extends Component {
   };
 
   render() {
-    const { id, onSync, uploadFile: upload } = this.props;
-    const { content } = this.state;
+    const { onSync, uploadFile: upload } = this.props;
+    const { content, id } = this.state;
 
     return (
       <div className="rte--wrapper">
@@ -122,16 +123,13 @@ RichText.propTypes = {
 
 RichText.defaultProps = {
   content: '',
-  id: `rte-${generateKey()}`,
+  id: '',
   onSync: () => {}
 };
 
 const mapDispatchToProps = { uploadFile };
 
-export default connect(
-  null,
-  mapDispatchToProps
-)(RichText);
+export default connect(null, mapDispatchToProps)(RichText);
 
 export {
   RichText as plain,


### PR DESCRIPTION
All of the rich text editors are given the same ID, which results in only the first one ever loading. If the ID is not provided, our wrapper creates a random one, but React `defaultProps` are only evaluated once so you can't use those for dynamic/random properties per instance. Instead, move that logic into our wrapper's constructor to ensure each instance gets a unique ID.

### This pull request changes...

- fixes RTE DOM IDs so all the editors can load

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author