### PR TITLE
[Prototype] Show math

### DIFF
--- a/web/src/components/Dollars.js
+++ b/web/src/components/Dollars.js
@@ -52,7 +52,7 @@ const Dollars = ({ children, long }) => {
     return <Fragment>$0</Fragment>;
   }
 
-  if (long) {
+  if (true || long) {
     return <span>{formatLong(num)}</span>;
   }
 

--- a/web/src/containers/activity/CostAllocate.js
+++ b/web/src/containers/activity/CostAllocate.js
@@ -99,6 +99,34 @@ const CostAllocate = ({
       {true && (
         <CostAllocateFFP aKey={activity.key} activityIndex={activityIndex} />
       )}
+      <h5 className="ds-h2">
+        FFY {Object.keys(costSummary)[0]}-{Object.keys(costSummary).pop()}{' '}
+        Totals
+      </h5>
+      <p>
+        The total cost of the <strong>{activity.name}</strong> activity is{' '}
+        <strong>
+          <Dollars long>50000032</Dollars>
+        </strong>
+        . Because of other funding of{' '}
+        <strong>
+          <Dollars long>23423</Dollars>
+        </strong>
+        , the total cost to Medicaid is{' '}
+        <strong>
+          <Dollars long>234235236</Dollars>
+        </strong>
+        . This activity is using a <strong>90/10</strong> funding split,
+        resulting in a federal share of{' '}
+        <strong>
+          <Dollars long>234234234</Dollars>
+        </strong>{' '}
+        and a STATE_NAME share of{' '}
+        <strong>
+          <Dollars long>73734</Dollars>
+        </strong>
+        .
+      </p>
       {Object.keys(costSummary).map(ffy => (
         <Fragment key={ffy}>
           <h5 className="ds-h2">FFY {ffy}</h5>

--- a/web/src/containers/activity/CostAllocate.js
+++ b/web/src/containers/activity/CostAllocate.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 
 import CostAllocateFFP from './CostAllocateFFP';
@@ -10,11 +10,34 @@ import {
 import Instruction from '../../components/Instruction';
 import RichText from '../../components/RichText';
 import { Subsection } from '../../components/Section';
-import { selectActivityByIndex } from '../../reducers/activities.selectors';
+import {
+  selectActivityByIndex,
+  selectActivityCostSummary
+} from '../../reducers/activities.selectors';
+import Dollars from '../../components/Dollars';
+import DollarField from '../../components/DollarField';
+
+const CostSummaryRows = ({ items }) =>
+  items.map(({ description, totalCost, unitCost, units }) => (
+    <tr key={description}>
+      <td />
+      <td>{description}</td>
+      <td className="budget-table--number">
+        {unitCost !== null && <Dollars long>{unitCost}</Dollars>}
+      </td>
+      <td className="budget-table--number">{unitCost !== null && '×'}</td>
+      <td className="budget-table--number">{units}</td>
+      <td className="budget-table--number">{unitCost !== null && '='}</td>
+      <td className="budget-table--number">
+        <Dollars long>{totalCost}</Dollars>
+      </td>
+    </tr>
+  ));
 
 const CostAllocate = ({
   activity,
   activityIndex,
+  costSummary,
   setMethodology,
   setOtherFunding
 }) => {
@@ -43,7 +66,6 @@ const CostAllocate = ({
           editorClassName="rte-textarea-l"
         />
       </div>
-
       <div className="data-entry-box">
         <Instruction
           source="activities.costAllocate.otherFunding.instruction"
@@ -58,8 +80,116 @@ const CostAllocate = ({
           editorClassName="rte-textarea-l"
         />
       </div>
+      <div className="data-entry-box">
+        <h6 className="ds-h5">Other funding amount</h6>
+        <div className="ds-c-choice__checkedChild ds-u-padding-y--0">
+          <DollarField
+            className="ds-u-padding-y--2"
+            label={`FFY ${'2020'}`}
+            value="35"
+          />
+          <DollarField
+            className="ds-u-padding-y--2"
+            label={`FFY ${'2021'}`}
+            value="55"
+          />
+        </div>
+      </div>
       <hr />
-      <CostAllocateFFP aKey={activity.key} activityIndex={activityIndex} />
+      {true && (
+        <CostAllocateFFP aKey={activity.key} activityIndex={activityIndex} />
+      )}
+      {Object.keys(costSummary).map(ffy => (
+        <Fragment key={ffy}>
+          <h5 className="ds-h2">FFY {ffy}</h5>
+          <table className="budget-table">
+            <tbody>
+              <tr>
+                <th colSpan="7" style={{ backgroundColor: '#d6d7d9' }}>
+                  State Personnel (In-House)
+                </th>
+              </tr>
+              <CostSummaryRows items={costSummary[ffy].keyPersonnel} />
+              <CostSummaryRows items={costSummary[ffy].statePersonnel} />
+              <tr className="budget-table--subtotal budget-table--row__highlight">
+                <td />
+                <td>State Personnel Subtotal</td>
+                <td colSpan="4" />
+                <td className="budget-table--number">
+                  <Dollars long>5</Dollars>
+                </td>
+              </tr>
+              <tr>
+                <th colSpan="7" style={{ backgroundColor: '#d6d7d9' }}>
+                  Non-Personnel (In-House)
+                </th>
+              </tr>
+              <CostSummaryRows items={costSummary[ffy].nonPersonnel} />
+              <tr className="budget-table--subtotal budget-table--row__highlight">
+                <td />
+                <td>Non-Personnel Subtotal</td>
+                <td colSpan="4" />
+                <td className="budget-table--number">
+                  <Dollars long>5</Dollars>
+                </td>
+              </tr>
+              <tr>
+                <th colSpan="7" style={{ backgroundColor: '#d6d7d9' }}>
+                  Private Contractor
+                </th>
+              </tr>
+              <CostSummaryRows items={costSummary[ffy].contractorResources} />
+              <tr className="budget-table--subtotal budget-table--row__highlight">
+                <td />
+                <td>Private Contractor Subtotal</td>
+                <td colSpan="4" />
+                <td className="budget-table--number">
+                  <Dollars long>5</Dollars>
+                </td>
+              </tr>
+              <tr className="budget-table--subtotal">
+                <td colSpan="6">Activity Total Cost</td>
+                <td className="budget-table--number">
+                  <Dollars long>{costSummary[ffy].totalCost}</Dollars>
+                </td>
+              </tr>
+              <tr>
+                <td />
+                <td>Other Funding</td>
+                <td colSpan="3" />
+                <td>-</td>
+                <td className="budget-table--number">
+                  <Dollars long>{costSummary[ffy].otherFunding}</Dollars>
+                </td>
+              </tr>
+              <tr className="budget-table--subtotal budget-table--row__highlight">
+                <td />
+                <td>Medicaid Share</td>
+                <td colSpan="4" />
+                <td className="budget-table--number">
+                  <Dollars long>{costSummary[ffy].medicaidShare}</Dollars>
+                </td>
+              </tr>
+              <CostSummaryRows
+                items={[
+                  {
+                    description: 'Federal Share',
+                    totalCost: costSummary[ffy].federalShare,
+                    unitCost: costSummary[ffy].medicaidShare,
+                    units: '90%'
+                  },
+                  {
+                    description: 'State Share',
+                    totalCost: costSummary[ffy].stateShare,
+                    unitCost: costSummary[ffy].medicaidShare,
+                    units: '10%'
+                  }
+                ]}
+              />
+            </tbody>
+          </table>
+        </Fragment>
+      ))}
     </Subsection>
   );
 };
@@ -67,15 +197,15 @@ const CostAllocate = ({
 CostAllocate.propTypes = {
   activity: PropTypes.object.isRequired,
   activityIndex: PropTypes.number.isRequired,
+  costSummary: PropTypes.array.isRequired,
   setMethodology: PropTypes.func.isRequired,
   setOtherFunding: PropTypes.func.isRequired
 };
 
-export const mapStateToProps = (state, { activityIndex }) => {
-  return {
-    activity: selectActivityByIndex(state, { activityIndex })
-  };
-};
+export const mapStateToProps = (state, { activityIndex }) => ({
+  activity: selectActivityByIndex(state, { activityIndex }),
+  costSummary: selectActivityCostSummary(state, { activityIndex })
+});
 
 export const mapDispatchToProps = {
   setMethodology: setCostAllocationMethodology,
@@ -83,7 +213,4 @@ export const mapDispatchToProps = {
 };
 
 export { CostAllocate as CostAllocateRaw };
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(CostAllocate);
+export default connect(mapStateToProps, mapDispatchToProps)(CostAllocate);

--- a/web/src/containers/activity/CostAllocate.js
+++ b/web/src/containers/activity/CostAllocate.js
@@ -47,20 +47,6 @@ const CostAllocate = ({
   const syncMethodology = html => setMethodology(activityIndex, html);
   const syncOtherFunding = html => setOtherFunding(activityIndex, html);
 
-  const stateStaffExpanded = {};
-  const otherExpensesExpanded = {};
-  const contractorExpanded = {};
-  Object.keys(costSummary).forEach(ffy => {
-    const [staffValue, staffSet] = useState(false);
-    stateStaffExpanded[ffy] = { value: staffValue, set: staffSet };
-
-    const [otherValue, otherSet] = useState(false);
-    otherExpensesExpanded[ffy] = { value: otherValue, set: otherSet };
-
-    const [contractorValue, contractorSet] = useState(false);
-    contractorExpanded[ffy] = { value: contractorValue, set: contractorSet };
-  });
-
   return (
     <Subsection
       resource="activities.costAllocate"
@@ -151,25 +137,10 @@ const CostAllocate = ({
                   State Staff
                 </th>
               </tr>
-              {stateStaffExpanded[ffy].value && (
-                <Fragment>
-                  <CostSummaryRows items={costSummary[ffy].keyPersonnel} />
-                  <CostSummaryRows items={costSummary[ffy].statePersonnel} />
-                </Fragment>
-              )}
+              <CostSummaryRows items={costSummary[ffy].keyPersonnel} />
+              <CostSummaryRows items={costSummary[ffy].statePersonnel} />
               <tr className="budget-table--subtotal budget-table--row__highlight">
-                <td>
-                  <button
-                    type="button"
-                    onClick={() =>
-                      stateStaffExpanded[ffy].set(
-                        !stateStaffExpanded[ffy].value
-                      )
-                    }
-                  >
-                    {stateStaffExpanded[ffy].value ? '-' : '+'}
-                  </button>
-                </td>
+                <td />
                 <td>State Staff Subtotal</td>
                 <td colSpan="4" />
                 <td className="budget-table--number">
@@ -181,22 +152,9 @@ const CostAllocate = ({
                   Other State Expenses
                 </th>
               </tr>
-              {otherExpensesExpanded[ffy].value && (
-                <CostSummaryRows items={costSummary[ffy].nonPersonnel} />
-              )}
+              <CostSummaryRows items={costSummary[ffy].nonPersonnel} />
               <tr className="budget-table--subtotal budget-table--row__highlight">
-                <td>
-                  <button
-                    type="button"
-                    onClick={() =>
-                      otherExpensesExpanded[ffy].set(
-                        !otherExpensesExpanded[ffy].value
-                      )
-                    }
-                  >
-                    {otherExpensesExpanded[ffy].value ? '-' : '+'}
-                  </button>
-                </td>
+                <td />
                 <td>Other State Expenses Subtotal</td>
                 <td colSpan="4" />
                 <td className="budget-table--number">
@@ -208,22 +166,9 @@ const CostAllocate = ({
                   Private Contractor
                 </th>
               </tr>
-              {contractorExpanded[ffy].value && (
-                <CostSummaryRows items={costSummary[ffy].contractorResources} />
-              )}
+              <CostSummaryRows items={costSummary[ffy].contractorResources} />
               <tr className="budget-table--subtotal budget-table--row__highlight">
-                <td>
-                  <button
-                    type="button"
-                    onClick={() =>
-                      contractorExpanded[ffy].set(
-                        !contractorExpanded[ffy].value
-                      )
-                    }
-                  >
-                    {contractorExpanded[ffy].value ? '-' : '+'}
-                  </button>
-                </td>
+                <td />
                 <td>Private Contractor Subtotal</td>
                 <td colSpan="4" />
                 <td className="budget-table--number">

--- a/web/src/containers/activity/CostAllocate.js
+++ b/web/src/containers/activity/CostAllocate.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Fragment } from 'react';
+import React, { Fragment, useState } from 'react';
 import { connect } from 'react-redux';
 
 import CostAllocateFFP from './CostAllocateFFP';
@@ -46,6 +46,20 @@ const CostAllocate = ({
   } = activity;
   const syncMethodology = html => setMethodology(activityIndex, html);
   const syncOtherFunding = html => setOtherFunding(activityIndex, html);
+
+  const stateStaffExpanded = {};
+  const otherExpensesExpanded = {};
+  const contractorExpanded = {};
+  Object.keys(costSummary).forEach(ffy => {
+    const [staffValue, staffSet] = useState(false);
+    stateStaffExpanded[ffy] = { value: staffValue, set: staffSet };
+
+    const [otherValue, otherSet] = useState(false);
+    otherExpensesExpanded[ffy] = { value: otherValue, set: otherSet };
+
+    const [contractorValue, contractorSet] = useState(false);
+    contractorExpanded[ffy] = { value: contractorValue, set: contractorSet };
+  });
 
   return (
     <Subsection
@@ -134,14 +148,29 @@ const CostAllocate = ({
             <tbody>
               <tr>
                 <th colSpan="7" style={{ backgroundColor: '#d6d7d9' }}>
-                  State Personnel (In-House)
+                  State Staff
                 </th>
               </tr>
-              <CostSummaryRows items={costSummary[ffy].keyPersonnel} />
-              <CostSummaryRows items={costSummary[ffy].statePersonnel} />
+              {stateStaffExpanded[ffy].value && (
+                <Fragment>
+                  <CostSummaryRows items={costSummary[ffy].keyPersonnel} />
+                  <CostSummaryRows items={costSummary[ffy].statePersonnel} />
+                </Fragment>
+              )}
               <tr className="budget-table--subtotal budget-table--row__highlight">
-                <td />
-                <td>State Personnel Subtotal</td>
+                <td>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      stateStaffExpanded[ffy].set(
+                        !stateStaffExpanded[ffy].value
+                      )
+                    }
+                  >
+                    {stateStaffExpanded[ffy].value ? '-' : '+'}
+                  </button>
+                </td>
+                <td>State Staff Subtotal</td>
                 <td colSpan="4" />
                 <td className="budget-table--number">
                   <Dollars long>5</Dollars>
@@ -149,13 +178,26 @@ const CostAllocate = ({
               </tr>
               <tr>
                 <th colSpan="7" style={{ backgroundColor: '#d6d7d9' }}>
-                  Non-Personnel (In-House)
+                  Other State Expenses
                 </th>
               </tr>
-              <CostSummaryRows items={costSummary[ffy].nonPersonnel} />
+              {otherExpensesExpanded[ffy].value && (
+                <CostSummaryRows items={costSummary[ffy].nonPersonnel} />
+              )}
               <tr className="budget-table--subtotal budget-table--row__highlight">
-                <td />
-                <td>Non-Personnel Subtotal</td>
+                <td>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      otherExpensesExpanded[ffy].set(
+                        !otherExpensesExpanded[ffy].value
+                      )
+                    }
+                  >
+                    {otherExpensesExpanded[ffy].value ? '-' : '+'}
+                  </button>
+                </td>
+                <td>Other State Expenses Subtotal</td>
                 <td colSpan="4" />
                 <td className="budget-table--number">
                   <Dollars long>5</Dollars>
@@ -166,9 +208,22 @@ const CostAllocate = ({
                   Private Contractor
                 </th>
               </tr>
-              <CostSummaryRows items={costSummary[ffy].contractorResources} />
+              {contractorExpanded[ffy].value && (
+                <CostSummaryRows items={costSummary[ffy].contractorResources} />
+              )}
               <tr className="budget-table--subtotal budget-table--row__highlight">
-                <td />
+                <td>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      contractorExpanded[ffy].set(
+                        !contractorExpanded[ffy].value
+                      )
+                    }
+                  >
+                    {contractorExpanded[ffy].value ? '-' : '+'}
+                  </button>
+                </td>
                 <td>Private Contractor Subtotal</td>
                 <td colSpan="4" />
                 <td className="budget-table--number">

--- a/web/src/containers/activity/CostAllocate.js
+++ b/web/src/containers/activity/CostAllocate.js
@@ -1,8 +1,10 @@
+import { Dropdown } from '@cmsgov/design-system-core';
 import PropTypes from 'prop-types';
-import React, { Fragment, useState } from 'react';
+import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 
 import CostAllocateFFP from './CostAllocateFFP';
+import CostAllocateFFPQuarterly from './CostAllocateFFPQuarterly';
 import {
   setCostAllocationMethodology,
   setCostAllocationOtherFunding
@@ -99,43 +101,18 @@ const CostAllocate = ({
       {true && (
         <CostAllocateFFP aKey={activity.key} activityIndex={activityIndex} />
       )}
-      <h5 className="ds-h2">
-        FFY {Object.keys(costSummary)[0]}-{Object.keys(costSummary).pop()}{' '}
-        Totals
-      </h5>
-      <p>
-        The total cost of the <strong>{activity.name}</strong> activity is{' '}
-        <strong>
-          <Dollars long>50000032</Dollars>
-        </strong>
-        . Because of other funding of{' '}
-        <strong>
-          <Dollars long>23423</Dollars>
-        </strong>
-        , the total cost to Medicaid is{' '}
-        <strong>
-          <Dollars long>234235236</Dollars>
-        </strong>
-        . This activity is using a <strong>90/10</strong> funding split,
-        resulting in a federal share of{' '}
-        <strong>
-          <Dollars long>234234234</Dollars>
-        </strong>{' '}
-        and a STATE_NAME share of{' '}
-        <strong>
-          <Dollars long>73734</Dollars>
-        </strong>
-        .
-      </p>
+
       {Object.keys(costSummary).map(ffy => (
         <Fragment key={ffy}>
           <h5 className="ds-h2">FFY {ffy}</h5>
           <table className="budget-table">
             <tbody>
-              <tr>
-                <th colSpan="7" style={{ backgroundColor: '#d6d7d9' }}>
-                  State Staff
-                </th>
+              <tr style={{ backgroundColor: '#d6d7d9' }}>
+                <th colSpan="2">State Staff</th>
+                <th>Cost</th>
+                <td />
+                <th>FTEs</th>
+                <td colSpan="2" />
               </tr>
               <CostSummaryRows items={costSummary[ffy].keyPersonnel} />
               <CostSummaryRows items={costSummary[ffy].statePersonnel} />
@@ -181,6 +158,35 @@ const CostAllocate = ({
                   <Dollars long>{costSummary[ffy].totalCost}</Dollars>
                 </td>
               </tr>
+            </tbody>
+          </table>
+
+          <div className="data-entry-box ds-u-margin-bottom--5">
+            <Instruction
+              source="activities.costAllocate.ffp.otherFundingInstruction"
+              headingDisplay={{
+                level: 'p',
+                className: 'ds-h4'
+              }}
+            />
+            <DollarField
+              label={`FFY ${'2020'}`}
+              labelClassName="sr-only"
+              value="338414"
+            />
+          </div>
+
+          <table className="budget-table">
+            <tbody>
+              <tr
+                className="budget-table--subtotal"
+                style={{ backgroundColor: '#d6d7d9' }}
+              >
+                <th colSpan="6">Activity Total Cost</th>
+                <td className="budget-table--number">
+                  <Dollars long>{costSummary[ffy].totalCost}</Dollars>
+                </td>
+              </tr>
               <tr>
                 <td />
                 <td>Other Funding</td>
@@ -194,6 +200,41 @@ const CostAllocate = ({
                 <td />
                 <td>Medicaid Share</td>
                 <td colSpan="4" />
+                <td className="budget-table--number">
+                  <Dollars long>{costSummary[ffy].medicaidShare}</Dollars>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+
+          <div className="data-entry-box ds-u-margin-bottom--5">
+            <Instruction
+              source="activities.costAllocate.ffp.federalStateSplitInstruction"
+              headingDisplay={{
+                level: 'p',
+                className: 'ds-h4'
+              }}
+            />
+            <Dropdown
+              name={`ffp-${ffy}`}
+              label="federal-state split"
+              labelClassName="sr-only"
+              options={[
+                { label: '90-10', value: '90-10' },
+                { label: '75-25', value: '75-25' },
+                { label: '50-50', value: '50-50' }
+              ]}
+              value="90-10"
+            />
+          </div>
+
+          <table className="budget-table">
+            <tbody>
+              <tr
+                className="budget-table--subtotal"
+                style={{ backgroundColor: '#d6d7d9' }}
+              >
+                <th colSpan="6">Medicaid Share</th>
                 <td className="budget-table--number">
                   <Dollars long>{costSummary[ffy].medicaidShare}</Dollars>
                 </td>
@@ -216,8 +257,55 @@ const CostAllocate = ({
               />
             </tbody>
           </table>
+
+          <div className="data-entry-box ds-u-margin-bottom--5">
+            <Instruction
+              source="activities.costAllocate.ffp.quarterlyFFPInstruction"
+              headingDisplay={{
+                level: 'p',
+                className: 'ds-h4'
+              }}
+            />
+
+            <CostAllocateFFPQuarterly
+              activityIndex={activityIndex}
+              aKey={activity.key}
+              year={ffy}
+            />
+          </div>
+
+          <hr />
         </Fragment>
       ))}
+
+      <h5 className="ds-h2">
+        FFY {Object.keys(costSummary)[0]}-{Object.keys(costSummary).pop()}{' '}
+        Totals
+      </h5>
+      <p>
+        The total cost of the <strong>{activity.name}</strong> activity is{' '}
+        <strong>
+          <Dollars long>50000032</Dollars>
+        </strong>
+        . Because of other funding of{' '}
+        <strong>
+          <Dollars long>23423</Dollars>
+        </strong>
+        , the total cost to Medicaid is{' '}
+        <strong>
+          <Dollars long>234235236</Dollars>
+        </strong>
+        . This activity is using a <strong>90/10</strong> funding split,
+        resulting in a federal share of{' '}
+        <strong>
+          <Dollars long>234234234</Dollars>
+        </strong>{' '}
+        and a STATE_NAME share of{' '}
+        <strong>
+          <Dollars long>73734</Dollars>
+        </strong>
+        .
+      </p>
     </Subsection>
   );
 };

--- a/web/src/containers/activity/CostAllocateFFPQuarterly.js
+++ b/web/src/containers/activity/CostAllocateFFPQuarterly.js
@@ -55,25 +55,24 @@ const CostAllocateFFPQuarterly = ({
           <th>
             <span aria-hidden="true">{t('ffy', { year })}</span>
           </th>
-          <Fragment key={year}>
-            {QUARTERS.map(q => (
-              <th key={q} scope="col" className="ds-u-text-align--right">
-                <span className="ds-u-visibility--screen-reader">
-                  {t('ffy', { year })}
-                </span>
-                {t('table.quarter', { q })}
-              </th>
-            ))}
-            <th
-              scope="col"
-              className="budget-table--subtotal ds-u-text-align--right"
-            >
+          <th
+            colSpan="2"
+            scope="col"
+            className="budget-table--subtotal ds-u-text-align--right"
+          >
+            <span className="ds-u-visibility--screen-reader">
+              {t('ffy', { year })}
+            </span>
+            Total costs
+          </th>
+          {QUARTERS.map(q => (
+            <th key={q} scope="col" className="ds-u-text-align--right">
               <span className="ds-u-visibility--screen-reader">
                 {t('ffy', { year })}
               </span>
-              {t('table.subtotal')}
+              {t('table.quarter', { q })}
             </th>
-          </Fragment>
+          ))}
         </tr>
       </thead>
       <tbody>
@@ -81,50 +80,58 @@ const CostAllocateFFPQuarterly = ({
           <th rowSpan="2" scope="row">
             {t('activities.costAllocate.quarterly.expenseNames.state')}
           </th>
+          <td className="budget-table--number budget-table--subtotal">
+            <Dollars long>{quarterlyFFP[year].subtotal.state.dollars}</Dollars>
+          </td>
+          <td className="budget-table--number">×</td>
           {QUARTERS.map(q => (
             <td key={q}>
-              {isViewOnly ?
-                <p className="budget-table--number">{quarterlyFFP[year][q].state.percent * 100} %</p>
-              :
+              {isViewOnly ? (
+                <p className="budget-table--number">
+                  {quarterlyFFP[year][q].state.percent * 100} %
+                </p>
+              ) : (
                 <PercentField
-                className="budget-table--input-holder"
-                fieldClassName="budget-table--input__number"
-                label={`federal share for ffy ${year}, quarter ${q}, state`}
-                labelClassName="sr-only"
-                name={`ffp-${activityIndex}-${year}-${q}-state`}
-                onChange={setInHouse(q)}
-                value={quarterlyFFP[year][q].state.percent * 100}
-                aria-controls={`ffp-${activityIndex}-${year}-${q}-state-dollar-equivalent`}
+                  className="budget-table--input-holder"
+                  fieldClassName="budget-table--input__number"
+                  label={`federal share for ffy ${year}, quarter ${q}, state`}
+                  labelClassName="sr-only"
+                  name={`ffp-${activityIndex}-${year}-${q}-state`}
+                  onChange={setInHouse(q)}
+                  value={quarterlyFFP[year][q].state.percent * 100}
+                  aria-controls={`ffp-${activityIndex}-${year}-${q}-state-dollar-equivalent`}
                 />
-              }
+              )}
             </td>
           ))}
-          <td className="budget-table--number budget-table--subtotal">
-            {formatPerc(quarterlyFFP[year].subtotal.state.percent)}
-          </td>
         </tr>
         <tr>
-          <Fragment key={year}>
-            {QUARTERS.map(q => (
-              <td className="budget-table--number" key={q}>
-                <Dollars>{quarterlyFFP[year][q].state.dollars}</Dollars>
-              </td>
-            ))}
-            <td className="budget-table--number budget-table--subtotal">
-              <Dollars>{quarterlyFFP[year].subtotal.state.dollars}</Dollars>
+          <td />
+          <td className="budget-table--number">=</td>
+          {QUARTERS.map(q => (
+            <td className="budget-table--number" key={q}>
+              <Dollars long>{quarterlyFFP[year][q].state.dollars}</Dollars>
             </td>
-          </Fragment>
+          ))}
         </tr>
 
         <tr>
           <th rowSpan="2" scope="row">
             {t('activities.costAllocate.quarterly.expenseNames.contractor')}
           </th>
+          <td className="budget-table--number budget-table--subtotal">
+            <Dollars long>
+              {quarterlyFFP[year].subtotal.contractors.dollars}
+            </Dollars>
+          </td>
+          <td className="budget-table--number">×</td>
           {QUARTERS.map(q => (
             <td key={q}>
-              {isViewOnly ?
-                <p className="budget-table--number">{quarterlyFFP[year][q].contractors.percent * 100} %</p>
-              :
+              {isViewOnly ? (
+                <p className="budget-table--number">
+                  {quarterlyFFP[year][q].contractors.percent * 100} %
+                </p>
+              ) : (
                 <PercentField
                   className="budget-table--input-holder"
                   fieldClassName="budget-table--input__number"
@@ -135,42 +142,39 @@ const CostAllocateFFPQuarterly = ({
                   value={quarterlyFFP[year][q].contractors.percent * 100}
                   aria-controls={`ffp-${activityIndex}-${year}-${q}-contractors-dollar-equivalent`}
                 />
-              }
+              )}
             </td>
           ))}
-          <td className="budget-table--number budget-table--subtotal">
-            {formatPerc(quarterlyFFP[year].subtotal.contractors.percent)}
-          </td>
         </tr>
         <tr>
-          <Fragment key={year}>
-            {QUARTERS.map(q => (
-              <td className="budget-table--number" key={q}>
-                <Dollars>{quarterlyFFP[year][q].contractors.dollars}</Dollars>
-              </td>
-            ))}
-            <td className="budget-table--number budget-table--subtotal">
-              <Dollars>
-                {quarterlyFFP[year].subtotal.contractors.dollars}
+          <td />
+          <td className="budget-table--number">=</td>
+          {QUARTERS.map(q => (
+            <td className="budget-table--number" key={q}>
+              <Dollars long>
+                {quarterlyFFP[year][q].contractors.dollars}
               </Dollars>
             </td>
-          </Fragment>
+          ))}
         </tr>
 
         <tr className="budget-table--row__highlight">
           <th scope="row" className="budget-table--total">
             {EXPENSE_NAME_DISPLAY.combined}
           </th>
-          <Fragment key={year}>
-            {QUARTERS.map(q => (
+          <td className="budget-table--number budget-table--subtotal">
+            <Dollars long>
+              {quarterlyFFP[year].subtotal.combined.dollars}
+            </Dollars>
+          </td>
+          <td />
+          {QUARTERS.map(q => (
+            <Fragment key={q}>
               <td className="budget-table--number budget-table--total" key={q}>
-                <Dollars>{quarterlyFFP[year][q].combined.dollars}</Dollars>
+                <Dollars long>{quarterlyFFP[year][q].combined.dollars}</Dollars>
               </td>
-            ))}
-            <td className="budget-table--number budget-table--subtotal">
-              <Dollars>{quarterlyFFP[year].subtotal.combined.dollars}</Dollars>
-            </td>
-          </Fragment>
+            </Fragment>
+          ))}
         </tr>
       </tbody>
     </table>

--- a/web/src/containers/activity/CostAllocateFFPQuarterly.js
+++ b/web/src/containers/activity/CostAllocateFFPQuarterly.js
@@ -9,16 +9,9 @@ import {
 import { ariaAnnounceFFPQuarterly } from '../../actions/aria';
 import Dollars from '../../components/Dollars';
 import PercentField from '../../components/PercentField';
-import { t } from '../../i18n';
 import { makeSelectCostAllocateFFPBudget } from '../../reducers/activities.selectors';
-import { formatPerc } from '../../util/formats';
 
 const QUARTERS = [1, 2, 3, 4];
-const EXPENSE_NAME_DISPLAY = {
-  state: t('activities.costAllocate.quarterly.expenseNames.state'),
-  contractors: t('activities.costAllocate.quarterly.expenseNames.contractor'),
-  combined: t('activities.costAllocate.quarterly.expenseNames.combined')
-};
 
 const CostAllocateFFPQuarterly = ({
   activityIndex,
@@ -53,24 +46,20 @@ const CostAllocateFFPQuarterly = ({
       <thead>
         <tr>
           <th>
-            <span aria-hidden="true">{t('ffy', { year })}</span>
+            <span aria-hidden="true">FFY {year}</span>
           </th>
           <th
             colSpan="2"
             scope="col"
             className="budget-table--subtotal ds-u-text-align--right"
           >
-            <span className="ds-u-visibility--screen-reader">
-              {t('ffy', { year })}
-            </span>
+            <span className="ds-u-visibility--screen-reader">FFY {year}</span>
             Total costs
           </th>
           {QUARTERS.map(q => (
             <th key={q} scope="col" className="ds-u-text-align--right">
-              <span className="ds-u-visibility--screen-reader">
-                {t('ffy', { year })}
-              </span>
-              {t('table.quarter', { q })}
+              <span className="ds-u-visibility--screen-reader">FFY {year}</span>
+              Q{q}
             </th>
           ))}
         </tr>
@@ -78,7 +67,7 @@ const CostAllocateFFPQuarterly = ({
       <tbody>
         <tr>
           <th rowSpan="2" scope="row">
-            {t('activities.costAllocate.quarterly.expenseNames.state')}
+            State Costs
           </th>
           <td className="budget-table--number budget-table--subtotal">
             <Dollars long>{quarterlyFFP[year].subtotal.state.dollars}</Dollars>
@@ -117,7 +106,7 @@ const CostAllocateFFPQuarterly = ({
 
         <tr>
           <th rowSpan="2" scope="row">
-            {t('activities.costAllocate.quarterly.expenseNames.contractor')}
+            Private Contractor Costs
           </th>
           <td className="budget-table--number budget-table--subtotal">
             <Dollars long>
@@ -160,7 +149,7 @@ const CostAllocateFFPQuarterly = ({
 
         <tr className="budget-table--row__highlight">
           <th scope="row" className="budget-table--total">
-            {EXPENSE_NAME_DISPLAY.combined}
+            Total Enhanced FFP
           </th>
           <td className="budget-table--number budget-table--subtotal">
             <Dollars long>

--- a/web/src/containers/activity/StatePerson/StatePersonReview.js
+++ b/web/src/containers/activity/StatePerson/StatePersonReview.js
@@ -12,7 +12,7 @@ const StatePersonReview = ({
 }) => {
   return (
     <Review
-      heading={`${index + 1 || 'APD Key Personnel'}. ${title}`}
+      heading={`${index ? `${index + 1}. ` : 'APD Key Personnel: '} ${title}`}
       headingLevel={6}
       onDeleteClick={onDeleteClick}
       onEditClick={expand}

--- a/web/src/containers/activity/StatePerson/StatePersonReview.js
+++ b/web/src/containers/activity/StatePerson/StatePersonReview.js
@@ -12,7 +12,7 @@ const StatePersonReview = ({
 }) => {
   return (
     <Review
-      heading={`${index + 1}. ${title}`}
+      heading={`${index + 1 || 'APD Key Personnel'}. ${title}`}
       headingLevel={6}
       onDeleteClick={onDeleteClick}
       onEditClick={expand}

--- a/web/src/containers/activity/StatePersonnel.js
+++ b/web/src/containers/activity/StatePersonnel.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 
 import { addPersonnel, removePersonnel } from '../../actions/editActivity';
 import { selectActivityStatePersonnel } from '../../reducers/activities.selectors';
+import { selectKeyPersonnel } from '../../reducers/apd.selectors';
 
 import Instruction from '../../components/Instruction';
 import { t } from '../../i18n';
@@ -11,7 +12,13 @@ import { t } from '../../i18n';
 import FormAndReviewList from '../../components/FormAndReviewList';
 import { StatePersonForm, StatePersonReview } from './StatePerson';
 
-const StatePersonnel = ({ activityIndex, add, personnel, remove }) => {
+const StatePersonnel = ({
+  activityIndex,
+  add,
+  keyPersonnel,
+  personnel,
+  remove
+}) => {
   const handleDelete = useCallback(key => {
     personnel.forEach(({ key: personnelKey }, i) => {
       if (personnelKey === key) {
@@ -25,6 +32,10 @@ const StatePersonnel = ({ activityIndex, add, personnel, remove }) => {
   return (
     <Fragment>
       <Instruction source="activities.statePersonnel.instruction" />
+      {activityIndex === 0 &&
+        keyPersonnel.map(({ key, ...kp }) => (
+          <StatePersonReview key={key} item={kp} />
+        ))}
       <FormAndReviewList
         activityIndex={activityIndex}
         addButtonText={t('activities.statePersonnel.addButtonText')}
@@ -42,11 +53,29 @@ const StatePersonnel = ({ activityIndex, add, personnel, remove }) => {
 StatePersonnel.propTypes = {
   activityIndex: PropTypes.number.isRequired,
   add: PropTypes.func.isRequired,
+  keyPersonnel: PropTypes.array.isRequired,
   personnel: PropTypes.array.isRequired,
   remove: PropTypes.func.isRequired
 };
 
 const mapStateToProps = (state, { activityIndex }) => ({
+  keyPersonnel:
+    activityIndex === 0
+      ? selectKeyPersonnel(state).map(
+          ({ costs, key, name, percentTime, position }) => ({
+            description: position,
+            key,
+            title: name,
+            years: Object.keys(costs).reduce(
+              (prev, year) => ({
+                ...prev,
+                [year]: { amt: costs[year], perc: +percentTime / 100 }
+              }),
+              {}
+            )
+          })
+        )
+      : [],
   personnel: selectActivityStatePersonnel(state, { activityIndex })
 });
 
@@ -55,9 +84,6 @@ const mapDispatchToProps = {
   remove: removePersonnel
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(StatePersonnel);
+export default connect(mapStateToProps, mapDispatchToProps)(StatePersonnel);
 
 export { StatePersonnel as plain, mapStateToProps, mapDispatchToProps };

--- a/web/src/i18n/locales/en/activities/costAllocate.yaml
+++ b/web/src/i18n/locales/en/activities/costAllocate.yaml
@@ -49,6 +49,11 @@ ffp:
       contributions or donations from a third party. Other funding will be
       deducted from the total cost of the activity prior to calculating the
       Medicaid share.
+  federalStateSplitInstruction:
+    heading: Federal-State Split
+  quarterlyFFPInstruction:
+    heading: Quarterly FFP
+    detail: Specify how much of the federal share the state wants to receive for each fiscal quarter.
   labels:
     other: Other Funding Amount
     fedStateSplit: Federal-State Split

--- a/web/src/reducers/activities.selectors.js
+++ b/web/src/reducers/activities.selectors.js
@@ -86,7 +86,7 @@ export const selectActivityCostSummary = createSelector(
                 description: `${kp.name} (APD Key Personnel)`,
                 totalCost: kp.hasCosts ? kp.costs[ffy] : 0,
                 unitCost: null,
-                units: null
+                units: `${kp.percentTime}% time`
               }))
             : []
       }),


### PR DESCRIPTION
A prototype branch. Putting it in a PR so we can have a preview link to look at.

## Current state
- shows APD key personnel as uneditable entries in the Program Administration activity's state personnel expense section
- adds an activity cost summary table to the cost allocation table
  - incomplete; we don't have the sum costs for each expense type
- shows math symbols in the quarterly FFP table to help show where numbers are coming from
- adds a narrative paragraph for the activity total cost
  - incomplete; doesn't use real data