### PR TITLE
For budget calculations, only clone the necessary part of the state

### DIFF
--- a/web/src/reducers/budget.js
+++ b/web/src/reducers/budget.js
@@ -98,7 +98,7 @@ const n = x => +x || 0;
 
 const buildBudget = incomingBigState => {
   // Clone the incoming state, so we don't accidentally change anything.
-  const bigState = JSON.parse(JSON.stringify(incomingBigState));
+  const bigState = JSON.parse(JSON.stringify({ apd: incomingBigState.apd }));
 
   // Get a shell of our new state object.  This essentially guarantees
   // that all of the properties and stuff will exist, so we don't have


### PR DESCRIPTION
The full redux state has circular references and cannot be cloned. When attempting to clone it, there is an exception in the budget reducer, causing the page to fail to load.

### This pull request changes...

- only clone the part of the state we actually use instead of everything
- fixes #2055

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- N/A ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- N/A ~The change has been documented~
- N/A - bug was introduced in this sprint ~Changelog is updated as appropriate~