### PR TITLE
Update the cost allocation instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Anticipated release: February 18, 2020
 - Fixed a bug where autosave happened too often, causing performance issues, and potentially inconsistent saved data.
 - Fixed a bug where the FFY subtotal for each cost category in the quarterly FFP table was based on the percent of funding requested, meaning it could be different from the actual activity total if the user requests more or less than 100%. ([#2056])
 - Fixed a bug that prevented creating new activities.
+- Fixed a typo in the cost allocation instructions
 
 #### ⚙️ Behind the scenes
 
@@ -40,3 +41,4 @@ See our [release history](https://github.com/18F/cms-hitech-apd/releases)
 [#2044]: https://github.com/18F/cms-hitech-apd/issues/2044
 [#2056]: https://github.com/18F/cms-hitech-apd/issues/2056
 [#2021]: https://github.com/18F/cms-hitech-apd/issues/2021
+[#2036]: https://github.com/18F/cms-hitech-apd/issues/2036

--- a/web/src/i18n/locales/en/activities/costAllocate.yaml
+++ b/web/src/i18n/locales/en/activities/costAllocate.yaml
@@ -17,13 +17,12 @@ instruction:
     sources including division of resources and activities across relevant
     payers, and relative benefit to the state Medicaid program.
 
-    Ensure cost allocations are current. Medicaid funds should be not be
-    sole contributor to Cost allocations should be current and ensure financial
-    participation of all parties so Medicaid funds are neither the
-    sole contributor at the onset, nor primary source of funding. Other
-    payers who may benefit must contribute their share from the outset.
-    The absence of ancillary payers is not sufficient cause for
-    Medicaid to be primary payer.
+    Ensure cost allocations are current. Cost allocations should be current and
+    ensure financial participation of all parties so Medicaid funds are neither
+    the sole contributor at the onset, nor primary source of funding. Other
+    payers who may benefit must contribute their share from the outset. The
+    absence of ancillary payers is not sufficient cause for Medicaid to be the
+    primary payer.
     [/ol]
   helpText: >-
     Include any participating non-Medicaid FTEs.

--- a/web/src/i18n/locales/en/activities/costAllocate.yaml
+++ b/web/src/i18n/locales/en/activities/costAllocate.yaml
@@ -19,7 +19,7 @@ instruction:
 
     Ensure cost allocations are current. Cost allocations should be current and
     ensure financial participation of all parties so Medicaid funds are neither
-    the sole contributor at the onset, nor primary source of funding. Other
+    the sole contributor at the onset, nor the primary source of funding. Other
     payers who may benefit must contribute their share from the outset. The
     absence of ancillary payers is not sufficient cause for Medicaid to be the
     primary payer.


### PR DESCRIPTION
### This pull request changes...

- fixes the typo
- closes #2036

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- N/A ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- N/A ~The change has been documented~
- [x] Changelog is updated as appropriate

### This feature is done when...

- [ ] Product has approved the experience
