### PR TITLE
Fix a bug where text was missing in viewonly/print mode

### DIFF
--- a/web/src/containers/activity/CostAllocateFFP.js
+++ b/web/src/containers/activity/CostAllocateFFP.js
@@ -189,7 +189,7 @@ class CostAllocateFFP extends Component {
 
               {isViewOnly && (
                 <p className="ds-h4 ds-u-margin-y--2">
-                  {t('activities.costAllocate.ffp.medicaidShare')}:{' '}
+                  Medicaid Share:{' '}
                   <span className="ds-u-font-weight--normal">
                     <Dollars long>{medicaidShare}</Dollars>
                   </span>

--- a/web/src/containers/activity/CostAllocateFFPYearTotal.js
+++ b/web/src/containers/activity/CostAllocateFFPYearTotal.js
@@ -7,7 +7,7 @@ import { t } from '../../i18n';
 import { makeSelectCostAllocateFFPBudget } from '../../reducers/activities.selectors';
 
 const EXPENSE_NAME_DISPLAY = {
-  state: t('activities.costAllocate.quarterly.expenseNames.state'),
+  inHouse: t('activities.costAllocate.quarterly.expenseNames.state'),
   contractors: t('activities.costAllocate.quarterly.expenseNames.contractor'),
   combined: t('activities.costAllocate.quarterly.expenseNames.combined')
 };

--- a/web/src/containers/activity/__snapshots__/CostAllocateFFPYearTotal.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/CostAllocateFFPYearTotal.test.js.snap
@@ -11,6 +11,7 @@ exports[`the CostAllocateFFPYearTotal component renders correctly 1`] = `
     className="ds-h5"
     key="inHouse"
   >
+    In-House Costs
     :
      
     <span


### PR DESCRIPTION
### This pull request changes...

- The text "Medicaid share" was missing in the print view for the cost allocation/FFP section. This puts it back.

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- N/A - Given the simplicity of the fix, willing to forego code review on this one ~This code has been reviewed by someone other than the original author~
- N/A ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- N/A ~The change has been documented~
- N/A - Bug was introduced before production ~Changelog is updated as appropriate~

### This feature is done when...

- [ ] Product has approved the experience
