### PR TITLE
Give the header and sidebar fixed positions

### DIFF
--- a/web/src/components/ConsentBanner.js
+++ b/web/src/components/ConsentBanner.js
@@ -33,7 +33,7 @@ const ConsentBanner = ({ onAgree }) => {
   }
 
   return (
-    <div className="card--container">
+    <div className="card--container ds-u-margin-top--7">
       <div className="ds-l-container">
         <div className="ds-l-row card">
           <div className="ds-l-col--1 ds-u-margin-left--auto" />

--- a/web/src/components/Header.js
+++ b/web/src/components/Header.js
@@ -1,18 +1,21 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 
+import { selectIsSaving, selectLastSaved } from '../reducers/saving';
 import { getIsAdmin } from '../reducers/user.selector';
 import { t } from '../i18n';
 
 import DashboardButton from './DashboardButton';
 
 import Icon, {
+  Check,
   faChevronDown,
   faChevronLeft,
   faEdit,
-  faSignOutAlt
+  faSignOutAlt,
+  Spinner
 } from './Icons';
 
 class Header extends Component {
@@ -47,13 +50,20 @@ class Header extends Component {
   };
 
   render() {
-    const { authenticated, currentUser, isAdmin, showSiteTitle } = this.props;
+    const {
+      authenticated,
+      currentUser,
+      isAdmin,
+      isSaving,
+      lastSaved,
+      showSiteTitle
+    } = this.props;
     const { ariaExpanded } = this.state;
     return (
       <header ref={this.node}>
         <div className="ds-l-container">
           <div className="ds-l-row">
-            <div className="ds-l-col--12 ds-l-md-col--4 site-title">
+            <div className="ds-l-col--12 ds-l-md-col--3 site-title">
               {showSiteTitle || !authenticated ? (
                 <DashboardButton>{t('titleBasic')}</DashboardButton>
               ) : (
@@ -66,45 +76,65 @@ class Header extends Component {
               )}
             </div>
             {authenticated && (
-              <div className="ds-l-col--12 ds-l-md-col--8">
-                <ul className="nav--dropdown">
-                  <li>
-                    <button
-                      type="button"
-                      className="nav--dropdown__trigger ds-c-button ds-c-button--small ds-c-button--transparent"
-                      onClick={this.toggleDropdown}
-                      aria-expanded={ariaExpanded ? 'true' : 'false'}
-                      aria-haspopup="true"
-                      aria-label={`Logged in as ${currentUser.username}. Click to manage your account.`}
-                    >
-                      {currentUser ? currentUser.username : 'Your account'}
-                      <Icon icon={faChevronDown} style={{ width: '8px' }} />
-                    </button>
-                    <ul className="nav--submenu" aria-hidden={!ariaExpanded}>
-                      <li>
-                        <Link
-                          to="/me"
-                          onClick={this.toggleDropdown}
-                          className="nav--dropdown__action"
-                        >
-                          <Icon icon={faEdit} style={{ width: '14px' }} />
-                          Manage account
-                        </Link>
-                      </li>
-                      <li>
-                        <Link
-                          to="/logout"
-                          onClick={this.toggleDropdown}
-                          className="nav--dropdown__action"
-                        >
-                          <Icon icon={faSignOutAlt} style={{ width: '14px' }} />
-                          {t('logout')}
-                        </Link>
-                      </li>
-                    </ul>
-                  </li>
-                </ul>
-              </div>
+              <Fragment>
+                <div className="ds-l-col--12 ds-l-md-col--5">
+                  {!showSiteTitle && !isAdmin && (
+                    <span>
+                      {isSaving ? (
+                        <span>
+                          <Spinner spin /> Saving...
+                        </span>
+                      ) : (
+                        <span>
+                          <Check /> Saved {lastSaved}
+                        </span>
+                      )}
+                    </span>
+                  )}
+                </div>
+                <div className="ds-l-col--12 ds-l-md-col--4">
+                  <ul className="nav--dropdown">
+                    <li>
+                      <button
+                        type="button"
+                        className="nav--dropdown__trigger ds-c-button ds-c-button--small ds-c-button--transparent"
+                        onClick={this.toggleDropdown}
+                        aria-expanded={ariaExpanded ? 'true' : 'false'}
+                        aria-haspopup="true"
+                        aria-label={`Logged in as ${currentUser.username}. Click to manage your account.`}
+                      >
+                        {currentUser ? currentUser.username : 'Your account'}
+                        <Icon icon={faChevronDown} style={{ width: '8px' }} />
+                      </button>
+                      <ul className="nav--submenu" aria-hidden={!ariaExpanded}>
+                        <li>
+                          <Link
+                            to="/me"
+                            onClick={this.toggleDropdown}
+                            className="nav--dropdown__action"
+                          >
+                            <Icon icon={faEdit} style={{ width: '14px' }} />
+                            Manage account
+                          </Link>
+                        </li>
+                        <li>
+                          <Link
+                            to="/logout"
+                            onClick={this.toggleDropdown}
+                            className="nav--dropdown__action"
+                          >
+                            <Icon
+                              icon={faSignOutAlt}
+                              style={{ width: '14px' }}
+                            />
+                            {t('logout')}
+                          </Link>
+                        </li>
+                      </ul>
+                    </li>
+                  </ul>
+                </div>
+              </Fragment>
             )}
           </div>
         </div>
@@ -113,17 +143,13 @@ class Header extends Component {
   }
 }
 
-const mapStateToProps = state => ({
-  authenticated: state.auth.authenticated,
-  currentUser: state.auth.user,
-  isAdmin: getIsAdmin(state)
-});
-
 Header.propTypes = {
+  ariaExpanded: PropTypes.bool,
   authenticated: PropTypes.bool.isRequired,
   currentUser: PropTypes.object,
   isAdmin: PropTypes.bool.isRequired,
-  ariaExpanded: PropTypes.bool,
+  isSaving: PropTypes.bool.isRequired,
+  lastSaved: PropTypes.string.isRequired,
   showSiteTitle: PropTypes.bool.isRequired
 };
 
@@ -131,6 +157,14 @@ Header.defaultProps = {
   ariaExpanded: false,
   currentUser: null
 };
+
+const mapStateToProps = state => ({
+  authenticated: state.auth.authenticated,
+  currentUser: state.auth.user,
+  isAdmin: getIsAdmin(state),
+  isSaving: selectIsSaving(state),
+  lastSaved: selectLastSaved(state)
+});
 
 export default connect(mapStateToProps)(Header);
 

--- a/web/src/components/Header.test.js
+++ b/web/src/components/Header.test.js
@@ -126,21 +126,45 @@ describe('Header component', () => {
   });
 
   it('renders the state user home title when a state user is at a secondary page', () => {
-    const component = shallow(
-      <Header
-        authenticated
-        currentUser={{
-          role: 'admin',
-          state: { id: 'wa', name: 'Washington' },
-          username: 'frasiercrane@kacl.com'
-        }}
-        isAdmin={false}
-        pushRoute={() => {}}
-        ariaExpanded={false}
-        showSiteTitle={false}
-      />
-    );
-    expect(component).toMatchSnapshot();
+    // Not saving
+    expect(
+      shallow(
+        <Header
+          ariaExpanded={false}
+          authenticated
+          currentUser={{
+            role: 'admin',
+            state: { id: 'wa', name: 'Washington' },
+            username: 'frasiercrane@kacl.com'
+          }}
+          isAdmin={false}
+          isSaving={false}
+          lastSaved="last save date"
+          pushRoute={() => {}}
+          showSiteTitle={false}
+        />
+      )
+    ).toMatchSnapshot();
+
+    // Saving
+    expect(
+      shallow(
+        <Header
+          ariaExpanded={false}
+          authenticated
+          currentUser={{
+            role: 'admin',
+            state: { id: 'wa', name: 'Washington' },
+            username: 'frasiercrane@kacl.com'
+          }}
+          isAdmin={false}
+          isSaving
+          lastSaved="last save date"
+          pushRoute={() => {}}
+          showSiteTitle={false}
+        />
+      )
+    ).toMatchSnapshot();
   });
 
   it('maps state to props', () => {
@@ -150,6 +174,10 @@ describe('Header component', () => {
         user: {
           role: 'admin'
         }
+      },
+      saving: {
+        lastSaved: 'blorp',
+        saving: 'bloop'
       },
       user: {
         data: {
@@ -161,7 +189,9 @@ describe('Header component', () => {
     expect(mapStateToProps(state)).toEqual({
       authenticated: 'some value',
       currentUser: { role: 'admin' },
-      isAdmin: true
+      isAdmin: true,
+      isSaving: 'bloop',
+      lastSaved: 'blorp'
     });
   });
 });

--- a/web/src/components/Icons.js
+++ b/web/src/components/Icons.js
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 // to optimize bundle, explicitly importing only the icons used
 import {
   faArrowRight,
+  faCheck,
   faCheckCircle,
   faChevronDown,
   faChevronLeft,
@@ -27,12 +28,16 @@ import {
   faTimesCircle
 } from '@fortawesome/free-regular-svg-icons';
 
+const Check = ({ ...props }) => <FontAwesomeIcon icon={faCheck} {...props} />;
 const CheckCircle = ({ ...props }) => (
   <FontAwesomeIcon icon={faCheckCircle} {...props} />
 );
 const File = ({ ...props }) => <FontAwesomeIcon icon={faFileAlt} {...props} />;
 const FileDownload = () => <FontAwesomeIcon icon={faFileDownload} />;
 const LockIcon = () => <FontAwesomeIcon icon={faLock} />;
+const Spinner = ({ ...props }) => (
+  <FontAwesomeIcon icon={faSpinner} {...props} />
+);
 const TimesCircle = () => <FontAwesomeIcon icon={faTimesCircle} />;
 const UnlockIcon = () => <FontAwesomeIcon icon={faUnlock} />;
 
@@ -52,10 +57,12 @@ export {
   faSpinner,
   faTimesCircle,
   faUnlock,
+  Check,
   CheckCircle,
   File,
   FileDownload,
   LockIcon,
+  Spinner,
   TimesCircle,
   UnlockIcon,
   faUserCog,

--- a/web/src/components/__snapshots__/ConsentBanner.test.js.snap
+++ b/web/src/components/__snapshots__/ConsentBanner.test.js.snap
@@ -4,7 +4,7 @@ exports[`Consent banner component when there is a consent cookie calls onAgree p
 
 exports[`Consent banner component when there is no cookie renders the banner 1`] = `
 <div
-  className="card--container"
+  className="card--container ds-u-margin-top--7"
 >
   <div
     className="ds-l-container"
@@ -51,7 +51,7 @@ exports[`Consent banner component when there is no cookie renders the banner 1`]
 
 exports[`Consent banner component when there is no cookie toggles consent details on 1`] = `
 <div
-  className="card--container"
+  className="card--container ds-u-margin-top--7"
 >
   <div
     className="ds-l-container"
@@ -98,7 +98,7 @@ exports[`Consent banner component when there is no cookie toggles consent detail
 
 exports[`Consent banner component when there is no cookie toggles consent details on 2`] = `
 <div
-  className="card--container"
+  className="card--container ds-u-margin-top--7"
 >
   <div
     className="ds-l-container"

--- a/web/src/components/__snapshots__/Header.test.js.snap
+++ b/web/src/components/__snapshots__/Header.test.js.snap
@@ -9,14 +9,17 @@ exports[`Header component opens and closes the dropdown when clicked  1`] = `
       className="ds-l-row"
     >
       <div
-        className="ds-l-col--12 ds-l-md-col--4 site-title"
+        className="ds-l-col--12 ds-l-md-col--3 site-title"
       >
         <Connect(DashboardButton)>
           CMS HITECH APD
         </Connect(DashboardButton)>
       </div>
       <div
-        className="ds-l-col--12 ds-l-md-col--8"
+        className="ds-l-col--12 ds-l-md-col--5"
+      />
+      <div
+        className="ds-l-col--12 ds-l-md-col--4"
       >
         <ul
           className="nav--dropdown"
@@ -180,14 +183,17 @@ exports[`Header component renders correctly when the dropdown is closed and the 
       className="ds-l-row"
     >
       <div
-        className="ds-l-col--12 ds-l-md-col--4 site-title"
+        className="ds-l-col--12 ds-l-md-col--3 site-title"
       >
         <Connect(DashboardButton)>
           CMS HITECH APD
         </Connect(DashboardButton)>
       </div>
       <div
-        className="ds-l-col--12 ds-l-md-col--8"
+        className="ds-l-col--12 ds-l-md-col--5"
+      />
+      <div
+        className="ds-l-col--12 ds-l-md-col--4"
       >
         <ul
           className="nav--dropdown"
@@ -351,7 +357,7 @@ exports[`Header component renders the admin home title when an admin user is at 
       className="ds-l-row"
     >
       <div
-        className="ds-l-col--12 ds-l-md-col--4 site-title"
+        className="ds-l-col--12 ds-l-md-col--3 site-title"
       >
         <Connect(DashboardButton)>
           <FontAwesomeIcon
@@ -389,7 +395,10 @@ exports[`Header component renders the admin home title when an admin user is at 
         </Connect(DashboardButton)>
       </div>
       <div
-        className="ds-l-col--12 ds-l-md-col--8"
+        className="ds-l-col--12 ds-l-md-col--5"
+      />
+      <div
+        className="ds-l-col--12 ds-l-md-col--4"
       >
         <ul
           className="nav--dropdown"
@@ -553,7 +562,7 @@ exports[`Header component renders the state user home title when a state user is
       className="ds-l-row"
     >
       <div
-        className="ds-l-col--12 ds-l-md-col--4 site-title"
+        className="ds-l-col--12 ds-l-md-col--3 site-title"
       >
         <Connect(DashboardButton)>
           <FontAwesomeIcon
@@ -591,7 +600,232 @@ exports[`Header component renders the state user home title when a state user is
         </Connect(DashboardButton)>
       </div>
       <div
-        className="ds-l-col--12 ds-l-md-col--8"
+        className="ds-l-col--12 ds-l-md-col--5"
+      >
+        <span>
+          <span>
+            <Check />
+             Saved 
+            last save date
+          </span>
+        </span>
+      </div>
+      <div
+        className="ds-l-col--12 ds-l-md-col--4"
+      >
+        <ul
+          className="nav--dropdown"
+        >
+          <li>
+            <button
+              aria-expanded="false"
+              aria-haspopup="true"
+              aria-label="Logged in as frasiercrane@kacl.com. Click to manage your account."
+              className="nav--dropdown__trigger ds-c-button ds-c-button--small ds-c-button--transparent"
+              onClick={[Function]}
+              type="button"
+            >
+              frasiercrane@kacl.com
+              <FontAwesomeIcon
+                border={false}
+                className=""
+                fixedWidth={false}
+                flip={null}
+                icon={
+                  Object {
+                    "icon": Array [
+                      448,
+                      512,
+                      Array [],
+                      "f078",
+                      "M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z",
+                    ],
+                    "iconName": "chevron-down",
+                    "prefix": "fas",
+                  }
+                }
+                inverse={false}
+                listItem={false}
+                mask={null}
+                pull={null}
+                pulse={false}
+                rotation={null}
+                size={null}
+                spin={false}
+                style={
+                  Object {
+                    "width": "8px",
+                  }
+                }
+                swapOpacity={false}
+                symbol={false}
+                title=""
+                transform={null}
+              />
+            </button>
+            <ul
+              aria-hidden={true}
+              className="nav--submenu"
+            >
+              <li>
+                <Link
+                  className="nav--dropdown__action"
+                  onClick={[Function]}
+                  to="/me"
+                >
+                  <FontAwesomeIcon
+                    border={false}
+                    className=""
+                    fixedWidth={false}
+                    flip={null}
+                    icon={
+                      Object {
+                        "icon": Array [
+                          576,
+                          512,
+                          Array [],
+                          "f044",
+                          "M402.6 83.2l90.2 90.2c3.8 3.8 3.8 10 0 13.8L274.4 405.6l-92.8 10.3c-12.4 1.4-22.9-9.1-21.5-21.5l10.3-92.8L388.8 83.2c3.8-3.8 10-3.8 13.8 0zm162-22.9l-48.8-48.8c-15.2-15.2-39.9-15.2-55.2 0l-35.4 35.4c-3.8 3.8-3.8 10 0 13.8l90.2 90.2c3.8 3.8 10 3.8 13.8 0l35.4-35.4c15.2-15.3 15.2-40 0-55.2zM384 346.2V448H64V128h229.8c3.2 0 6.2-1.3 8.5-3.5l40-40c7.6-7.6 2.2-20.5-8.5-20.5H48C21.5 64 0 85.5 0 112v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V306.2c0-10.7-12.9-16-20.5-8.5l-40 40c-2.2 2.3-3.5 5.3-3.5 8.5z",
+                        ],
+                        "iconName": "edit",
+                        "prefix": "fas",
+                      }
+                    }
+                    inverse={false}
+                    listItem={false}
+                    mask={null}
+                    pull={null}
+                    pulse={false}
+                    rotation={null}
+                    size={null}
+                    spin={false}
+                    style={
+                      Object {
+                        "width": "14px",
+                      }
+                    }
+                    swapOpacity={false}
+                    symbol={false}
+                    title=""
+                    transform={null}
+                  />
+                  Manage account
+                </Link>
+              </li>
+              <li>
+                <Link
+                  className="nav--dropdown__action"
+                  onClick={[Function]}
+                  to="/logout"
+                >
+                  <FontAwesomeIcon
+                    border={false}
+                    className=""
+                    fixedWidth={false}
+                    flip={null}
+                    icon={
+                      Object {
+                        "icon": Array [
+                          512,
+                          512,
+                          Array [],
+                          "f2f5",
+                          "M497 273L329 441c-15 15-41 4.5-41-17v-96H152c-13.3 0-24-10.7-24-24v-96c0-13.3 10.7-24 24-24h136V88c0-21.4 25.9-32 41-17l168 168c9.3 9.4 9.3 24.6 0 34zM192 436v-40c0-6.6-5.4-12-12-12H96c-17.7 0-32-14.3-32-32V160c0-17.7 14.3-32 32-32h84c6.6 0 12-5.4 12-12V76c0-6.6-5.4-12-12-12H96c-53 0-96 43-96 96v192c0 53 43 96 96 96h84c6.6 0 12-5.4 12-12z",
+                        ],
+                        "iconName": "sign-out-alt",
+                        "prefix": "fas",
+                      }
+                    }
+                    inverse={false}
+                    listItem={false}
+                    mask={null}
+                    pull={null}
+                    pulse={false}
+                    rotation={null}
+                    size={null}
+                    spin={false}
+                    style={
+                      Object {
+                        "width": "14px",
+                      }
+                    }
+                    swapOpacity={false}
+                    symbol={false}
+                    title=""
+                    transform={null}
+                  />
+                  Log out
+                </Link>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</header>
+`;
+
+exports[`Header component renders the state user home title when a state user is at a secondary page 2`] = `
+<header>
+  <div
+    className="ds-l-container"
+  >
+    <div
+      className="ds-l-row"
+    >
+      <div
+        className="ds-l-col--12 ds-l-md-col--3 site-title"
+      >
+        <Connect(DashboardButton)>
+          <FontAwesomeIcon
+            border={false}
+            className=""
+            fixedWidth={false}
+            flip={null}
+            icon={
+              Object {
+                "icon": Array [
+                  320,
+                  512,
+                  Array [],
+                  "f053",
+                  "M34.52 239.03L228.87 44.69c9.37-9.37 24.57-9.37 33.94 0l22.67 22.67c9.36 9.36 9.37 24.52.04 33.9L131.49 256l154.02 154.75c9.34 9.38 9.32 24.54-.04 33.9l-22.67 22.67c-9.37 9.37-24.57 9.37-33.94 0L34.52 272.97c-9.37-9.37-9.37-24.57 0-33.94z",
+                ],
+                "iconName": "chevron-left",
+                "prefix": "fas",
+              }
+            }
+            inverse={false}
+            listItem={false}
+            mask={null}
+            pull={null}
+            pulse={false}
+            rotation={null}
+            size="sm"
+            spin={false}
+            swapOpacity={false}
+            symbol={false}
+            title=""
+            transform={null}
+          />
+          WA APD Home
+        </Connect(DashboardButton)>
+      </div>
+      <div
+        className="ds-l-col--12 ds-l-md-col--5"
+      >
+        <span>
+          <span>
+            <Spinner
+              spin={true}
+            />
+             Saving...
+          </span>
+        </span>
+      </div>
+      <div
+        className="ds-l-col--12 ds-l-md-col--4"
       >
         <ul
           className="nav--dropdown"

--- a/web/src/containers/Login.js
+++ b/web/src/containers/Login.js
@@ -63,6 +63,7 @@ const Login = ({
         title="Log in"
         legend="Log in"
         cancelable={false}
+        className="ds-u-margin-top--7"
         canSubmit={username.length && password.length}
         error={errorMessage}
         success={hasEverLoggedOn ? 'You have securely logged out.' : null}

--- a/web/src/containers/Sidebar.js
+++ b/web/src/containers/Sidebar.js
@@ -12,7 +12,7 @@ import { selectActiveSection } from '../reducers/navigation';
 
 class Sidebar extends Component {
   componentDidMount() {
-    stickybits('.site-sidebar');
+    stickybits('.site-sidebar', { stickyBitStickyOffset: 60 });
   }
 
   handleSelectClick = id => {

--- a/web/src/containers/StateDashboard.js
+++ b/web/src/containers/StateDashboard.js
@@ -10,7 +10,7 @@ import { t } from '../i18n';
 import { selectApdDashboard, selectApds } from '../reducers/apd.selectors';
 
 const Loading = ({ children }) => (
-  <div className="ds-h2 ds-u-padding--0 ds-u-padding-bottom--3 ds-u-text-align--center">
+  <div className="ds-h2 ds-u-margin-top--7 ds-u-padding--0 ds-u-padding-bottom--3 ds-u-text-align--center">
     <Icon icon={faSpinner} spin size="sm" className="ds-u-margin-right--1" />{' '}
     {children}
   </div>
@@ -49,15 +49,19 @@ const StateDashboard = (
   };
 
   if (isLoading) {
-    return <Loading>Loading your APD</Loading>;
+    return (
+      <div id="start-main-content">
+        x<Loading>Loading your APD</Loading>
+      </div>
+    );
   }
 
   return (
     <div
       id="start-main-content"
-      className="ds-l-container ds-u-margin-top--7 ds-u-margin-bottom--5"
+      className="ds-l-container ds-u-margin-bottom--5"
     >
-      <div className="ds-l-row">
+      <div className="ds-l-row ds-u-margin-top--7">
         <div className="ds-l-col--8 ds-u-margin-x--auto ">
           <h1 className="ds-h1">
             {t('stateDashboard.title', { state: state.name })}

--- a/web/src/containers/StateDashboard.js
+++ b/web/src/containers/StateDashboard.js
@@ -51,7 +51,7 @@ const StateDashboard = (
   if (isLoading) {
     return (
       <div id="start-main-content">
-        x<Loading>Loading your APD</Loading>
+        <Loading>Loading your APD</Loading>
       </div>
     );
   }

--- a/web/src/containers/__snapshots__/Login.test.js.snap
+++ b/web/src/containers/__snapshots__/Login.test.js.snap
@@ -25,6 +25,7 @@ exports[`login component renders correctly if logged in previously but not logge
   <withRouter(CardForm)
     canSubmit={0}
     cancelable={false}
+    className="ds-u-margin-top--7"
     error={false}
     footer={
       <p
@@ -87,6 +88,7 @@ exports[`login component renders correctly if not logged in and fetching data 1`
   <withRouter(CardForm)
     canSubmit={0}
     cancelable={false}
+    className="ds-u-margin-top--7"
     error={false}
     footer={
       <p
@@ -139,6 +141,7 @@ exports[`login component renders correctly if not logged in and there is an erro
   <withRouter(CardForm)
     canSubmit={0}
     cancelable={false}
+    className="ds-u-margin-top--7"
     error={false}
     footer={
       <p
@@ -191,6 +194,7 @@ exports[`login component renders correctly if not logged in, and never logged in
   <withRouter(CardForm)
     canSubmit={0}
     cancelable={false}
+    className="ds-u-margin-top--7"
     error={false}
     footer={
       <p
@@ -243,6 +247,7 @@ exports[`login component renders correctly if not logged in, and never logged in
   <withRouter(CardForm)
     canSubmit={0}
     cancelable={false}
+    className="ds-u-margin-top--7"
     error={false}
     footer={
       <p
@@ -295,6 +300,7 @@ exports[`login component renders correctly if not logged in, and never logged in
   <withRouter(CardForm)
     canSubmit={6}
     cancelable={false}
+    className="ds-u-margin-top--7"
     error={false}
     footer={
       <p

--- a/web/src/reducers/index.js
+++ b/web/src/reducers/index.js
@@ -9,6 +9,7 @@ import budget from './budget';
 import errors from './errors';
 import navigation from './navigation';
 import patch from './patch';
+import saving from './saving';
 import user from './user';
 import working from './working';
 
@@ -22,6 +23,7 @@ const rootReducer = history =>
     errors,
     navigation,
     patch,
+    saving,
     user,
     working,
     router: connectRouter(history)

--- a/web/src/reducers/index.test.js
+++ b/web/src/reducers/index.test.js
@@ -12,6 +12,7 @@ describe('root reducer', () => {
       'errors',
       'navigation',
       'patch',
+      'saving',
       'user',
       'working',
       'router'

--- a/web/src/reducers/saving.js
+++ b/web/src/reducers/saving.js
@@ -1,0 +1,58 @@
+import {
+  SAVE_APD_FAILURE,
+  SAVE_APD_REQUEST,
+  SAVE_APD_SUCCESS,
+  SELECT_APD
+} from '../actions/app';
+
+const initialState = {
+  error: false,
+  lastSaved: '',
+  saving: false
+};
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case SAVE_APD_FAILURE:
+      return { ...state, error: true, saving: false };
+    case SAVE_APD_REQUEST:
+      return { ...state, error: false, saving: true };
+    case SAVE_APD_SUCCESS:
+      return {
+        ...state,
+        error: false,
+        lastSaved: new Date(action.data.updated).toLocaleString(),
+        saving: false
+      };
+    case SELECT_APD:
+      return {
+        ...state,
+        error: false,
+        lastSaved: new Date(action.apd.updated).toLocaleString(),
+        saving: false
+      };
+    default:
+      return state;
+  }
+};
+
+/**
+ * Selects the saving error message from the provided state.
+ * @param {Object} state current redux state
+ * @returns {String|boolean} The error message, or false if there is no error.
+ */
+export const selectErrorMessage = ({ saving: { error } }) => error;
+
+/**
+ * Selects whether or not the APD is currently being saved.
+ * @param {Object} state current redux state
+ * @returns {boolean} Whether the APD is currently being saved.
+ */
+export const selectIsSaving = ({ saving: { saving } }) => saving;
+
+/**
+ * Select the datestamp of the most recent successful save.
+ * @param {Object} state current redux state
+ * @returns {String} Locale-specific date string of the last successful save
+ */
+export const selectLastSaved = ({ saving: { lastSaved } }) => lastSaved;

--- a/web/src/reducers/saving.test.js
+++ b/web/src/reducers/saving.test.js
@@ -1,0 +1,92 @@
+import {
+  SAVE_APD_FAILURE,
+  SAVE_APD_REQUEST,
+  SAVE_APD_SUCCESS,
+  SELECT_APD
+} from '../actions/app';
+
+import reducer, {
+  selectErrorMessage,
+  selectIsSaving,
+  selectLastSaved
+} from './saving';
+
+describe('saving state reducer and selectors', () => {
+  describe('the reducer', () => {
+    it('handles the default case', () => {
+      expect(reducer(undefined, {})).toEqual({
+        error: false,
+        lastSaved: '',
+        saving: false
+      });
+    });
+
+    it('updates when an APD fails to save', () => {
+      expect(
+        reducer({ error: 'nope', saving: true }, { type: SAVE_APD_FAILURE })
+      ).toEqual({ error: true, saving: false });
+    });
+
+    it('updates when an APD begins to save', () => {
+      expect(
+        reducer({ error: 'maybe', saving: false }, { type: SAVE_APD_REQUEST })
+      ).toEqual({
+        error: false,
+        saving: true
+      });
+    });
+
+    it('updates when an APD saves successfully', () => {
+      expect(
+        reducer(
+          { error: 'who can say', lastSaved: 'bob', saving: true },
+          {
+            type: SAVE_APD_SUCCESS,
+            // March 11, 2020, 10:53 AM CDT: When this test was written. Truly
+            // a red-letter day in science.
+            data: { updated: '2020-03-11T10:53:00-0500' }
+          }
+        )
+      ).toEqual({
+        error: false,
+        // The tests are run in the US locale, but in UTC timezone, so expect
+        // the time above (CDT) to be adjusted accordingly.
+        lastSaved: '3/11/2020, 3:53:00 PM',
+        saving: false
+      });
+    });
+
+    it('updates when an APD is selected', () => {
+      expect(
+        reducer(
+          { error: 'moop moop', lastSaved: 'builder', saving: true },
+          // Marie Curie is selected for the Nobel Prize for Chemistry,
+          // becoming the first person in history to receive two.
+          { type: SELECT_APD, apd: { updated: '1911-11-07T00:00:00Z' } }
+        )
+      ).toEqual({
+        error: false,
+        lastSaved: '11/7/1911, 12:00:00 AM',
+        saving: false
+      });
+    });
+  });
+
+  describe('the selectors', () => {
+    it('selects the error message', () => {
+      expect(
+        selectErrorMessage({ saving: { error: 'this is the error' } })
+      ).toEqual('this is the error');
+    });
+
+    it('selects whether the APD is currently saving', () => {
+      expect(selectIsSaving({ saving: { saving: 'yep' } })).toEqual('yep');
+    });
+
+    it('selects the last save date/tiem for the APD', () => {
+      expect(
+        selectLastSaved({ saving: { lastSaved: 'once upon a time' } })
+      ).toEqual('once upon a time');
+    });
+  });
+});

--- a/web/src/styles/scss/footer.scss
+++ b/web/src/styles/scss/footer.scss
@@ -5,6 +5,7 @@ footer {
   border-top: solid 2px $color-gray-light;
   padding-top: $spacer-6;
   margin-top: $spacer-6;
+  z-index: 10;
 
   .footer--logo-container {
     display: flex;

--- a/web/src/styles/scss/header.scss
+++ b/web/src/styles/scss/header.scss
@@ -4,6 +4,11 @@ header:not(.ds-c-dialog__header) {
   background-color: $color-primary-darkest;
   padding: $spacer-2 0;
   letter-spacing: 0.6px;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  z-index: 10;
 
   a,
   a:visited,

--- a/web/src/styles/scss/header.scss
+++ b/web/src/styles/scss/header.scss
@@ -2,6 +2,7 @@
 
 header:not(.ds-c-dialog__header) {
   background-color: $color-primary-darkest;
+  color: $color-white;
   padding: $spacer-2 0;
   letter-spacing: 0.6px;
   position: fixed;

--- a/web/src/styles/scss/layout.scss
+++ b/web/src/styles/scss/layout.scss
@@ -14,7 +14,9 @@
 
 .site-sidebar {
   width: 212px; // fix for IE
-  position: fixed;
+  position: sticky;
+  top: 60px;
+  bottom: 260px;
   max-height: 100vh;
   overflow-y: auto;
   float: left;
@@ -23,7 +25,9 @@
   }
 }
 
-.site-body {
+.site-body,
+#start-main-content {
+  margin-top: 60px !important;
   position: relative;
 }
 


### PR DESCRIPTION
Changes the header so that it stays at the top of the page at all times, and updates the sidebar so that it is sticky to both the top and bottom instead of only the top. Displays autosave status in the header.

### This pull request changes...

- closes #2087
- closes #2090 

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- N/A ~The change has been documented~
  - N/A N/A ~Associated OpenAPI documentation has been updated~
- [ ] Changelog is updated as appropriate

### This feature is done when...

- [ ] Design has approved the experience
- [ ] Product has approved the experience
