### PR TITLE
Auth cookie fix

### DIFF
--- a/api/auth/session.js
+++ b/api/auth/session.js
@@ -102,8 +102,8 @@ module.exports = ({ Cookies = defaultCookies } = {}) => {
             httpOnly: true,
             maxAge: sessionLifetimeMilliseconds,
             overwrite: true,
-            sameSite: 'none',
-            secure: process.env.NODE_ENV === 'production'
+            sameSite: process.env.DISABLE_SAME_SITE ? '' : 'none',
+            secure: !process.env.DISABLE_SECURE_COOKIE
           }
         );
       } else {
@@ -112,8 +112,8 @@ module.exports = ({ Cookies = defaultCookies } = {}) => {
         cookies.set(COOKIE_NAME, '', {
           maxAge: 0,
           httpOnly: true,
-          sameSite: 'none',
-          secure: process.env.NODE_ENV === 'production'
+          sameSite: process.env.DISABLE_SAME_SITE ? '' : 'none',
+          secure: !process.env.DISABLE_SECURE_COOKIE
         });
       }
 

--- a/api/auth/session.test.js
+++ b/api/auth/session.test.js
@@ -128,7 +128,7 @@ tap.test('session functions', async tests => {
               maxAge: 0,
               httpOnly: true,
               sameSite: 'none',
-              secure: false
+              secure: true
             }),
             'cookie is empty and expired'
           );
@@ -160,7 +160,7 @@ tap.test('session functions', async tests => {
             maxAge: 60000,
             overwrite: true,
             sameSite: 'none',
-            secure: false
+            secure: true
           }),
           'sets the cookie'
         );
@@ -209,7 +209,7 @@ tap.test('session functions', async tests => {
               maxAge: 60000,
               overwrite: true,
               sameSite: 'none',
-              secure: false
+              secure: true
             }),
             'sets the cookie'
           );
@@ -251,7 +251,7 @@ tap.test('session functions', async tests => {
             maxAge: 0,
             httpOnly: true,
             sameSite: 'none',
-            secure: false
+            secure: true
           }),
           'cookie is empty and expired'
         );
@@ -277,7 +277,7 @@ tap.test('session functions', async tests => {
           maxAge: 0,
           httpOnly: true,
           sameSite: 'none',
-          secure: false
+          secure: true
         }),
         'cookie is empty and expired'
       );

--- a/api/docker-compose.endpoint-tests.yml
+++ b/api/docker-compose.endpoint-tests.yml
@@ -23,6 +23,7 @@ services:
       - ENDPOINT_COVERAGE_CAPTURE=yes
       - FILE_STORE=local
       - FILE_PATH=test-data/files
+      - DISABLE_SECURE_COOKIE=yes
     command: npm start
     expose:
       - 8000

--- a/bin/preview-deploy/aws.user-data.sh
+++ b/bin/preview-deploy/aws.user-data.sh
@@ -162,7 +162,9 @@ echo "module.exports = {
       PBKDF2_ITERATIONS: '__PBKDF2_ITERATIONS__',
       PORT: '8000',
       DEV_DB_HOST: 'localhost',
-      SESSION_SECRET: '833daa028db9c8d05890206446f0e5e4156fa7ae34d526f7fab44f6b830c6c20'
+      SESSION_SECRET: '833daa028db9c8d05890206446f0e5e4156fa7ae34d526f7fab44f6b830c6c20',
+      DISABLE_SAME_SITE: 'yes',
+      DISABLE_SECURE_COOKIE: 'yes'
     },
   }]
 };" > ecosystem.config.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
       - DATABASE_URL=postgres://postgres:cms@db/hitech_apd
       - NODE_ENV=development
       - SESSION_SECRET=dadccbf1e3bcb63a4d533c3f184eecfc79fd07e76d0584f808078125a83bc40b6413829e5c690d391dd3f6cbca44406cef07b8193cd4db2f03bab355eea9cb2e
+      - DISABLE_SAME_SITE=yes
+      - DISABLE_SECURE_COOKIE=yes
     volumes:
       - type: bind
         source: ./api


### PR DESCRIPTION
Chrome pushed some changes recently that breaks our auth cookies in dev/preview environments. Opened #2100 to capture the need to eventually move away from cookies altogether.

### This pull request changes...

- disables the `samesite` and `secure` flags in dev/preview environments
  - In the preview environment, SSL is terminated at an nginx proxy; from the proxy to the API is over plain HTTP, so we need to disable the `secure` flag.
- updates Docker configuration to set appropriate environment variables

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author