### PR TITLE
Fix css cache busting

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14690,39 +14690,6 @@
         }
       }
     },
-    "html-webpack-tags-plugin": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/html-webpack-tags-plugin/-/html-webpack-tags-plugin-2.0.17.tgz",
-      "integrity": "sha512-TKT8hnumMni6ztKfWZpP+UBeA7+aUn+qQQ4c9wT/p1IGTO/QWoIc19E+ZrxCcToDMjBO1NMYWkUbW4c4NtlGvg==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.1.4",
-        "minimatch": "^3.0.4",
-        "slash": "^3.0.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "slash": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-          "dev": true
-        }
-      }
-    },
     "htmlparser2": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -111,7 +111,6 @@
     "eslint-plugin-react": "^7.18.3",
     "file-loader": "^4.3.0",
     "html-webpack-plugin": "^3.2.0",
-    "html-webpack-tags-plugin": "^2.0.17",
     "jest": "^25.1.0",
     "js-yaml": "^3.13.1",
     "json-loader": "^0.5.7",

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -2,7 +2,6 @@ const path = require('path');
 
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const HtmlWebpackTagsPlugin = require('html-webpack-tags-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 if (!process.env.IDLE_LOGOUT_TIME_MINUTES) {
@@ -112,11 +111,6 @@ const config = {
       minify: { removeComments: true },
       template: 'src/index.html'
     })
-    // new HtmlWebpackTagsPlugin({
-    //   tags: ['app.css'],
-    //   append: true,
-    //   hash: true
-    // })
   ]
 };
 

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -19,6 +19,7 @@ const config = {
   },
   output: {
     path: path.join(__dirname, 'dist'),
+    publicPath: '/',
 
     // Bust the cache with a hash!
     filename: '[name].[contenthash].js'
@@ -92,10 +93,11 @@ const config = {
       }
     ]
   },
-  // replaces "process.env.____" with the values defined in the actual
-  // environment at build time
   plugins: [
-    new MiniCssExtractPlugin(),
+    new MiniCssExtractPlugin({ filename: '[name].[contenthash].css' }),
+
+    // replaces "process.env.____" with the values defined in the actual
+    // environment at build time
     new webpack.EnvironmentPlugin({
       API_URL: null,
       IDLE_LOGOUT_TIME_MINUTES: 15
@@ -109,12 +111,12 @@ const config = {
     new HtmlWebpackPlugin({
       minify: { removeComments: true },
       template: 'src/index.html'
-    }),
-    new HtmlWebpackTagsPlugin({
-      tags: ['app.css'],
-      append: true,
-      hash: true
     })
+    // new HtmlWebpackTagsPlugin({
+    //   tags: ['app.css'],
+    //   append: true,
+    //   hash: true
+    // })
   ]
 };
 


### PR DESCRIPTION
We used two different Webpack plugins to inject CSS tags into our HTML. One of these added a content hash query parameter to bust the cache, but the other did not. Unfortunately, because of the ordering, the non-hashed one would load first and override the hashed one. This PR removes the plugin that added the hashed version and instead configures the other to also add a hash, as it probably should have been in the first place.

### This pull request changes...

- fixes CSS cache-busting
- closes #2118 

### This pull request is ready to merge when...

- n/a ~Tests have been updated (and all tests are passing)~
- [ ] This code has been reviewed by someone other than the original author
- n/a ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- n/a ~The change has been documented~
- n/a ~Changelog is updated as appropriate~