### PR TITLE
Remove extraneous whitespace from the top of the APD page

### DIFF
--- a/web/src/styles/scss/layout.scss
+++ b/web/src/styles/scss/layout.scss
@@ -25,7 +25,6 @@
   }
 }
 
-.site-body,
 #start-main-content {
   margin-top: 60px !important;
   position: relative;


### PR DESCRIPTION
There was a bunch of extra whitespace at the top of the page. This gets rid of that.

### This pull request changes...

- content top margin was applied twice, now just once
- closes #2119

### This pull request is ready to merge when...

- n/a ~Tests have been updated (and all tests are passing)~
- n/a ~This code has been reviewed by someone other than the original author~
- n/a ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- n/a ~The change has been documented~
- n/a/ ~Changelog is updated as appropriate~

### This feature is done when...

- [ ] Design or product have approved the experience
