### PR TITLE
Add SaveMessage component to Header

### DIFF
--- a/web/src/components/Header.js
+++ b/web/src/components/Header.js
@@ -87,8 +87,7 @@ class Header extends Component {
                         </span>
                       ) : (
                         <span>
-                          <Check />
-                          <SaveMessage lastSaved={lastSaved} />
+                          <Check /> <SaveMessage lastSaved={lastSaved} />
                         </span>
                       )}
                     </span>

--- a/web/src/components/Header.js
+++ b/web/src/components/Header.js
@@ -8,6 +8,7 @@ import { getIsAdmin } from '../reducers/user.selector';
 import { t } from '../i18n';
 
 import DashboardButton from './DashboardButton';
+import SaveMessage from './SaveMessage';
 
 import Icon, {
   Check,
@@ -86,7 +87,8 @@ class Header extends Component {
                         </span>
                       ) : (
                         <span>
-                          <Check /> Saved {lastSaved}
+                          <Check />
+                          <SaveMessage lastSaved={lastSaved} />
                         </span>
                       )}
                     </span>

--- a/web/src/components/SaveMessage.js
+++ b/web/src/components/SaveMessage.js
@@ -47,23 +47,24 @@ class SaveMessage extends React.Component {
     const { currentMoment } = this.state;
 
     const lastSavedMoment = moment(lastSaved);
-    const minutesOld = currentMoment.diff(lastSavedMoment, "minutes");
-    const minutesPerDay = 60 * 24;
-    const minutesPerYear = minutesPerDay * 365.25;
+    const difference = currentMoment.diff(lastSavedMoment);
+    const duration = moment.duration(difference);
     let result = "Last saved";
 
-    if (minutesOld < 1) return "Saved";
-    if (1 <= minutesOld && minutesOld < minutesPerDay) {
+    if (duration.asMinutes() < 1) return "Saved";
+
+    if (1 <= duration.asMinutes() && duration.asDays() < 1) {
       // https://momentjs.com/docs/#/displaying/format/
       result = `${result} ${lastSavedMoment.format("hh:mm a")}`;
     }
-    if (minutesPerDay <= minutesOld && minutesOld < minutesPerYear) {
+    if (1 <= duration.asDays() && duration.asYears() < 1) {
       result = `${result} ${lastSavedMoment.format("MMMM D")}`;
     }
-    if (minutesPerYear <= minutesOld) {
+    if (1 <= duration.asYears()) {
       result = `${result} ${lastSavedMoment.format("MMMM D, YYYY")}`;
     }
     result = `${result} (${lastSavedMoment.fromNow()})`;
+
     return result;
   }
 }

--- a/web/src/components/SaveMessage.js
+++ b/web/src/components/SaveMessage.js
@@ -1,0 +1,71 @@
+import React from "react";
+import moment from "moment";
+
+// Configure moment to display '1 time-unit ago' instead of 'a time-unit ago'
+// https://github.com/moment/moment/issues/3764
+moment.updateLocale("en", {
+  relativeTime: {
+    s: "seconds",
+    m: "1 minute",
+    mm: "%d minutes",
+    h: "1 hour",
+    hh: "%d hours",
+    d: "1 day",
+    dd: "%d days",
+    M: "1 month",
+    MM: "%d months",
+    y: "1 year",
+    yy: "%d years",
+  },
+});
+
+class SaveMessage extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      currentMoment: moment(),
+    };
+  }
+
+  componentDidMount() {
+    this.timerID = setInterval(() => this.updateClock(), 1000);
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.timerID);
+  }
+
+  updateClock() {
+    this.setState({
+      currentMoment: moment(),
+    });
+  }
+
+  render() {
+    const { lastSaved } = this.props;
+    const { currentMoment } = this.state;
+
+    const lastSavedMoment = moment(lastSaved);
+    const minutesOld = currentMoment.diff(lastSavedMoment, "minutes");
+    const minutesPerDay = 60 * 24;
+    const minutesPerYear = minutesPerDay * 365.25;
+    let result = "Last saved";
+
+    if (minutesOld < 1) return "Saved";
+    if (1 <= minutesOld && minutesOld < minutesPerDay) {
+      // https://momentjs.com/docs/#/displaying/format/
+      result = `${result} ${lastSavedMoment.format("hh:mm a")}`;
+    }
+    if (minutesPerDay <= minutesOld && minutesOld < minutesPerYear) {
+      result = `${result} ${lastSavedMoment.format("MMMM D")}`;
+    }
+    if (minutesPerYear <= minutesOld) {
+      result = `${result} ${lastSavedMoment.format("MMMM D, YYYY")}`;
+    }
+    result = `${result} (${lastSavedMoment.fromNow()})`;
+    return result;
+  }
+}
+
+export default SaveMessage;

--- a/web/src/components/SaveMessage.test.js
+++ b/web/src/components/SaveMessage.test.js
@@ -1,0 +1,115 @@
+import React from "react";
+import { shallow } from "enzyme";
+import moment from "moment";
+import SaveMessage from "./SaveMessage";
+
+describe("<SaveMessage />", () => {
+  let lastSaved, subject;
+
+  describe('when saved less than 1 minute ago, it displays "Saved"', () => {
+    [
+      ["1 second ago", 1],
+      ["2 seconds ago", 2],
+      ["30 seconds ago", 30],
+      ["59 seconds", 59],
+    ].forEach(([testName, seconds]) => {
+      test(testName, () => {
+        lastSaved = moment().subtract(seconds, "seconds");
+        subject = shallow(
+          <SaveMessage lastSaved={lastSaved} />
+        );
+        expect(subject.text()).toEqual("Saved");
+      });
+    });
+  });
+
+  describe("given current time is January 1, 2020 12:00 pm", () => {
+    let jan1AtNoon = new Date(2020, 0, 1, 12, 0);
+    let mockDateNow;
+
+    beforeEach(() => {
+      mockDateNow = jest
+        .spyOn(Date, "now")
+        .mockReturnValue(jan1AtNoon.getTime());
+    });
+
+    afterEach(() => {
+      mockDateNow.mockRestore();
+    });
+
+    describe("when saved 1 minute ago", () => {
+      it('displays "Last saved 11:59 am (1 minute ago)"', () => {
+        lastSaved = moment(jan1AtNoon).subtract(1, "minutes");
+        subject = shallow(
+          <SaveMessage lastSaved={lastSaved} />
+        );
+        expect(subject.text().startsWith("Last saved")).toEqual(true);
+        expect(subject.text().includes("11:59 am")).toEqual(true);
+        expect(subject.text().endsWith("(1 minute ago)")).toEqual(true);
+      });
+    });
+
+    describe("when saved 23 hours and 59 minutes ago", () => {
+      it('displays "Last saved 12:01 pm (1 day ago)"', () => {
+        lastSaved = moment(jan1AtNoon)
+          .subtract(23, "hours")
+          .subtract(59, "minutes");
+        subject = shallow(
+          <SaveMessage lastSaved={lastSaved} />
+        );
+        expect(subject.text().startsWith("Last saved")).toEqual(true);
+        expect(subject.text().includes("12:01 pm")).toEqual(true);
+        expect(subject.text().endsWith("(1 day ago)")).toEqual(true);
+      });
+    });
+
+    describe("when saved 24 hours ago", () => {
+      it('displays "Last saved December 30 (1 day ago)"', () => {
+        lastSaved = moment().subtract(1, "day");
+        subject = shallow(
+          <SaveMessage lastSaved={lastSaved} />
+        );
+        expect(subject.text().startsWith("Last saved")).toEqual(true);
+        expect(subject.text().includes("December 31")).toEqual(true);
+        expect(subject.text().endsWith("(1 day ago)")).toEqual(true);
+      });
+    });
+
+    describe("when saved 30 days ago", () => {
+      it('displays "Last saved December 30 (1 month ago)"', () => {
+        lastSaved = moment().subtract(30, "day");
+        subject = shallow(
+          <SaveMessage lastSaved={lastSaved} />
+        );
+        expect(subject.text().startsWith("Last saved")).toEqual(true);
+        expect(subject.text().includes("December 2")).toEqual(true);
+        expect(subject.text().endsWith("(1 month ago)")).toEqual(true);
+      });
+    });
+
+    describe("when saved 354 days ago", () => {
+      it('displays "Last saved January 2 (1 year ago)"', () => {
+        lastSaved = moment().subtract(364, "day");
+        subject = shallow(
+          <SaveMessage lastSaved={lastSaved} />
+        );
+        expect(subject.text().startsWith("Last saved")).toEqual(true);
+        expect(subject.text().includes("January 2")).toEqual(true);
+        expect(subject.text().includes("2019")).toEqual(false);
+        expect(subject.text().endsWith("(1 year ago)")).toEqual(true);
+      });
+    });
+
+    describe("when saved 3 years ago", () => {
+      it('displays "Last saved January 1, 2017 (3 years ago)"', () => {
+        lastSaved = moment().subtract(3, "years");
+        subject = shallow(
+          <SaveMessage lastSaved={lastSaved} />
+        );
+        expect(subject.text().startsWith("Last saved")).toEqual(true);
+        expect(subject.text().includes("January 1, 2017")).toEqual(true);
+        expect(subject.text().endsWith("(3 years ago)")).toEqual(true);
+      });
+    });
+  });
+});

--- a/web/src/components/SaveMessage.test.js
+++ b/web/src/components/SaveMessage.test.js
@@ -43,9 +43,9 @@ describe("<SaveMessage />", () => {
         subject = shallow(
           <SaveMessage lastSaved={lastSaved} />
         );
-        expect(subject.text().startsWith("Last saved")).toEqual(true);
-        expect(subject.text().includes("11:59 am")).toEqual(true);
-        expect(subject.text().endsWith("(1 minute ago)")).toEqual(true);
+        expect(subject.text()).toMatch(/^Last saved/);
+        expect(subject.text()).toMatch(/11:59 am/);
+        expect(subject.text()).toMatch(/\(1 minute ago\)$/);
       });
     });
 
@@ -57,46 +57,47 @@ describe("<SaveMessage />", () => {
         subject = shallow(
           <SaveMessage lastSaved={lastSaved} />
         );
-        expect(subject.text().startsWith("Last saved")).toEqual(true);
-        expect(subject.text().includes("12:01 pm")).toEqual(true);
-        expect(subject.text().endsWith("(1 day ago)")).toEqual(true);
+        expect(subject.text()).toMatch(/^Last saved/);
+        expect(subject.text()).toMatch(/12:01 pm/);
+        expect(subject.text()).toMatch(/\(1 day ago\)$/);
       });
     });
 
-    describe("when saved 24 hours ago", () => {
+    describe("when saved 1 day ago", () => {
       it('displays "Last saved December 30 (1 day ago)"', () => {
         lastSaved = moment().subtract(1, "day");
         subject = shallow(
           <SaveMessage lastSaved={lastSaved} />
         );
-        expect(subject.text().startsWith("Last saved")).toEqual(true);
-        expect(subject.text().includes("December 31")).toEqual(true);
-        expect(subject.text().endsWith("(1 day ago)")).toEqual(true);
+        expect(subject.text()).toMatch(/^Last saved/);
+        expect(subject.text()).toMatch(/December 31/);
+        expect(subject.text()).toMatch(/\(1 day ago\)$/);
       });
     });
 
     describe("when saved 30 days ago", () => {
-      it('displays "Last saved December 30 (1 month ago)"', () => {
+      it('displays "Last saved December 2 (1 month ago)"', () => {
         lastSaved = moment().subtract(30, "day");
         subject = shallow(
           <SaveMessage lastSaved={lastSaved} />
         );
-        expect(subject.text().startsWith("Last saved")).toEqual(true);
-        expect(subject.text().includes("December 2")).toEqual(true);
-        expect(subject.text().endsWith("(1 month ago)")).toEqual(true);
+        expect(subject.text()).toMatch(/^Last saved/);
+        expect(subject.text()).toMatch(/December 2/);
+        expect(subject.text()).not.toMatch(/2019/);
+        expect(subject.text()).toMatch(/\(1 month ago\)$/);
       });
     });
 
-    describe("when saved 354 days ago", () => {
+    describe("when saved 364 days ago", () => {
       it('displays "Last saved January 2 (1 year ago)"', () => {
         lastSaved = moment().subtract(364, "day");
         subject = shallow(
           <SaveMessage lastSaved={lastSaved} />
         );
-        expect(subject.text().startsWith("Last saved")).toEqual(true);
-        expect(subject.text().includes("January 2")).toEqual(true);
-        expect(subject.text().includes("2019")).toEqual(false);
-        expect(subject.text().endsWith("(1 year ago)")).toEqual(true);
+        expect(subject.text()).toMatch(/^Last saved/);
+        expect(subject.text()).toMatch(/January 2/);
+        expect(subject.text()).not.toMatch(/2019/);
+        expect(subject.text()).toMatch(/\(1 year ago\)$/);
       });
     });
 
@@ -106,9 +107,9 @@ describe("<SaveMessage />", () => {
         subject = shallow(
           <SaveMessage lastSaved={lastSaved} />
         );
-        expect(subject.text().startsWith("Last saved")).toEqual(true);
-        expect(subject.text().includes("January 1, 2017")).toEqual(true);
-        expect(subject.text().endsWith("(3 years ago)")).toEqual(true);
+        expect(subject.text()).toMatch(/^Last saved/);
+        expect(subject.text()).toMatch(/January 1, 2017/);
+        expect(subject.text()).toMatch(/\(3 years ago\)$/);
       });
     });
   });


### PR DESCRIPTION
Resolves #2104 

### This pull request changes...

- The 'Saved' message in the Header to be a dynamic string, dependent upon the amount of time that has passed since saving.

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate

### This feature is done when...

- [ ] Design has approved the experience
- [ ] Product has approved the experience
