### PR TITLE
Change the AMI query

### DIFF
--- a/bin/prod-deploy/aws.sh
+++ b/bin/prod-deploy/aws.sh
@@ -204,7 +204,7 @@ function findAMI() {
   aws ec2 describe-images \
     --query 'Images[*].{id:ImageId,name:Name,date:CreationDate}' \
     --filter 'Name=is-public,Values=false' \
-    --filter 'Name=name,Values=EAST-RH*' \
+    --filter 'Name=name,Values=EAST-RH 7-*Gold*(HVM)*' \
     | jq -r -c 'sort_by(.date)|last|.id'
 }
 


### PR DESCRIPTION
We dynamically pick the AWS machine image (AMI) that we use as the basis for our deployments. We do that so that we can stay up to date with the most recent gold image published by CMS (previously we were tied to a specific AMI ID, but AMIs are retired after 4 months, so we regularly had to manually go update the build).

The problem is that the filter I wrote to pick the image wasn't specific enough. It asked for the most recent image that began with the text `EAST-RH`. CMS publishes two RedHat gold images: 6.x and 7.x Furthermore, it publishes PV and HVM variations (this refers to the level of virtualization) of each one. We've been plain old lucky up to this point: the 7.x HVM image was always published last, a few seconds to a minute after the others, so that was the one we always got.

This time, though, the 6.x PV image was the last one published (by 67 seconds), so that's what our script picked up. PV images cannot use the `run-instances` command that we rely on for deploying, so everything broke.

This PR modifies the filter to look for images matching the name `EAST-RH 7-*Gold*(HVM)*` to ensure we get:
- version 7.x images
- gold (in case CMS ever starts publishing non-gold AMIs)
- HVM images

### This pull request changes...

- fixes the AMI filter

### This pull request is ready to merge when...

- N/A ~Tests have been updated (and all tests are passing)~
- [ ] This code has been reviewed by someone other than the original author
- N/A ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- N/A ~The change has been documented~
- N/A ~Changelog is updated as appropriate~