### PR TITLE
Add quarterly FFP table help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Anticipated release: April 6, 2020
 
 #### 🐛 Bugs fixed
 
+- Adds some explanation and help text to the estimated quarterly expenditure table ([#2110])
+
 #### ⚙️ Behind the scenes
 
 - Updated 3rd-party libraries to the latest versions
@@ -13,3 +15,5 @@ Anticipated release: April 6, 2020
 # Previous releases
 
 See our [release history](https://github.com/18F/cms-hitech-apd/releases)
+
+[#2110]: https://github.com/18F/cms-hitech-apd/issues/2110

--- a/web/src/i18n/locales/en/activities/costAllocate.yaml
+++ b/web/src/i18n/locales/en/activities/costAllocate.yaml
@@ -51,8 +51,20 @@ ffp:
   federalStateSplitInstruction:
     heading: Federal-State Split
   quarterlyFFPInstruction:
-    heading: Quarterly FFP
-    detail: Specify how much of the federal share the state wants to receive for each fiscal quarter.
+    heading: Estimated Quarterly Expenditure
+    detail: >-
+      For each quarter, enter the percentage of the total Medicaid FFP cost that
+      will be spent in each category. The auto-calculated dollar values for each
+      quarter should align with the state's quarterly FFP estimates for CMS. As
+      a reminder, In-house costs equals state staff + other state expenses.
+    helpText: >-
+      Input a higher percentage in quarters where there may be non-reoccurring
+      costs and adjust the other quarters downward to ensure the totals do not
+      exceed 100%. Examples of non-reoccurring costs may include a one-time
+      state equipment purchases (in-house costs) or payments on a contract
+      deliverable (private contractor costs). An example of a reoccurring cost
+      may include a salaried positions where the cost is equally divided into
+      each quarter.
   labels:
     other: Other Funding Amount
     fedStateSplit: Federal-State Split


### PR DESCRIPTION
### This pull request changes...

- adds detail and help text to the quarterly FFP table
- closes #2110

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- n/a ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- n/a ~The change has been documented~
- [x] Changelog is updated as appropriate

### This feature is done when...

- [ ] Product has approved the experience
