### PR TITLE
Remove default costs from new activities and APDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Anticipated release: April 6, 2020
 
 #### 🐛 Bugs fixed
 
+- Fixed an issue where new APDs and activities came prepopulated with cost information ([#2129]) which could cause incorrect behavior in the activity cost summary table ([#2130])
+- Fixed an issue where adding an activity could make it impossible to save the APD ([#2148])
+
 #### ⚙️ Behind the scenes
 
 - Updated 3rd-party libraries to the latest versions
@@ -17,3 +20,6 @@ Anticipated release: April 6, 2020
 See our [release history](https://github.com/18F/cms-hitech-apd/releases)
 
 [#2104]: https://github.com/18F/cms-hitech-apd/issues/2104
+[#2129]: https://github.com/18F/cms-hitech-apd/issues/2129
+[#2130]: https://github.com/18F/cms-hitech-apd/issues/2130
+[#2148]: https://github.com/18F/cms-hitech-apd/pulls/2148

--- a/api/routes/apds/__snapshots__/post.endpoint.js.snap
+++ b/api/routes/apds/__snapshots__/post.endpoint.js.snap
@@ -5,32 +5,7 @@ Object {
   "activities": Array [
     Object {
       "alternatives": "",
-      "contractorResources": Array [
-        Object {
-          "description": "",
-          "end": "",
-          "hourly": Object {
-            "data": Object {
-              "2020": Object {
-                "hours": 0,
-                "rate": 0,
-              },
-              "2021": Object {
-                "hours": 0,
-                "rate": 0,
-              },
-            },
-            "useHourly": false,
-          },
-          "name": "",
-          "start": "",
-          "totalCost": 0,
-          "years": Object {
-            "2020": 0,
-            "2021": 0,
-          },
-        },
-      ],
+      "contractorResources": Array [],
       "costAllocation": Object {
         "2020": Object {
           "ffp": Object {
@@ -52,16 +27,7 @@ Object {
         "otherSources": "",
       },
       "description": "",
-      "expenses": Array [
-        Object {
-          "category": "",
-          "description": "",
-          "years": Object {
-            "2020": 0,
-            "2021": 0,
-          },
-        },
-      ],
+      "expenses": Array [],
       "fundingSource": "HIT",
       "name": "Program Administration",
       "objectives": Array [
@@ -126,22 +92,7 @@ Object {
         "doesNotSupport": "",
         "supports": "",
       },
-      "statePersonnel": Array [
-        Object {
-          "description": "",
-          "title": "",
-          "years": Object {
-            "2020": Object {
-              "amt": 0,
-              "perc": 0,
-            },
-            "2021": Object {
-              "amt": 0,
-              "perc": 0,
-            },
-          },
-        },
-      ],
+      "statePersonnel": Array [],
       "summary": "",
     },
   ],

--- a/api/routes/apds/post.data.js
+++ b/api/routes/apds/post.data.js
@@ -27,20 +27,7 @@ const getNewApd = () => {
     activities: [
       {
         alternatives: '',
-        contractorResources: [
-          {
-            description: '',
-            end: '',
-            hourly: {
-              data: forAllYears({ hours: 0, rate: 0 }),
-              useHourly: false
-            },
-            name: '',
-            start: '',
-            totalCost: 0,
-            years: forAllYears(0)
-          }
-        ],
+        contractorResources: [],
         costAllocation: forAllYears({
           ffp: { federal: 90, state: 10 },
           other: 0
@@ -50,13 +37,7 @@ const getNewApd = () => {
           otherSources: ''
         },
         description: '',
-        expenses: [
-          {
-            category: '',
-            description: '',
-            years: forAllYears(0)
-          }
-        ],
+        expenses: [],
         fundingSource: 'HIT',
         name: 'Program Administration',
         objectives: [
@@ -77,16 +58,7 @@ const getNewApd = () => {
           doesNotSupport: '',
           supports: ''
         },
-        statePersonnel: [
-          {
-            description: '',
-            title: '',
-            years: forAllYears({
-              amt: 0,
-              perc: 0
-            })
-          }
-        ],
+        statePersonnel: [],
         summary: '',
         quarterlyFFP: forAllYears({
           1: { contractors: 0, inHouse: 0 },

--- a/api/routes/apds/post.data.test.js
+++ b/api/routes/apds/post.data.test.js
@@ -24,23 +24,7 @@ tap.test('APD data initializer', async test => {
     activities: [
       {
         alternatives: '',
-        contractorResources: [
-          {
-            description: '',
-            end: '',
-            hourly: {
-              data: {
-                '1997': { hours: '', rate: '' },
-                '1998': { hours: '', rate: '' }
-              },
-              useHourly: false
-            },
-            name: '',
-            start: '',
-            totalCost: 0,
-            years: { '1997': 0, '1998': 0 }
-          }
-        ],
+        contractorResources: [],
         costAllocation: {
           '1997': { ffp: { federal: 90, state: 10 }, other: 0 },
           '1998': { ffp: { federal: 90, state: 10 }, other: 0 }
@@ -50,13 +34,7 @@ tap.test('APD data initializer', async test => {
           otherSources: ''
         },
         description: '',
-        expenses: [
-          {
-            category: '',
-            description: '',
-            years: { '1997': 0, '1998': 0 }
-          }
-        ],
+        expenses: [],
         fundingSource: 'HIT',
         objectives: [
           {
@@ -72,16 +50,7 @@ tap.test('APD data initializer', async test => {
           doesNotSupport: '',
           supports: ''
         },
-        statePersonnel: [
-          {
-            description: '',
-            title: '',
-            years: {
-              '1997': { amt: 0, perc: 0 },
-              '1998': { amt: 0, perc: 0 }
-            }
-          }
-        ],
+        statePersonnel: [],
         summary: '',
         quarterlyFFP: {
           '1997': {

--- a/api/routes/apds/post.test.js
+++ b/api/routes/apds/post.test.js
@@ -80,23 +80,7 @@ tap.test('apds POST endpoint', async endpointTest => {
         activities: [
           {
             alternatives: '',
-            contractorResources: [
-              {
-                description: '',
-                end: '',
-                hourly: {
-                  data: {
-                    '2004': { hours: '', rate: '' },
-                    '2005': { hours: '', rate: '' }
-                  },
-                  useHourly: false
-                },
-                name: '',
-                start: '',
-                totalCost: 0,
-                years: { '2004': 0, '2005': 0 }
-              }
-            ],
+            contractorResources: [],
             costAllocation: {
               '2004': { ffp: { federal: 90, state: 10 }, other: 0 },
               '2005': { ffp: { federal: 90, state: 10 }, other: 0 }
@@ -106,13 +90,7 @@ tap.test('apds POST endpoint', async endpointTest => {
               otherSources: ''
             },
             description: '',
-            expenses: [
-              {
-                category: '',
-                description: '',
-                years: { '2004': 0, '2005': 0 }
-              }
-            ],
+            expenses: [],
             fundingSource: 'HIT',
             objectives: [
               {
@@ -128,16 +106,7 @@ tap.test('apds POST endpoint', async endpointTest => {
               doesNotSupport: '',
               supports: ''
             },
-            statePersonnel: [
-              {
-                description: '',
-                title: '',
-                years: {
-                  '2004': { amt: 0, perc: 0 },
-                  '2005': { amt: 0, perc: 0 }
-                }
-              }
-            ],
+            statePersonnel: [],
             summary: '',
             quarterlyFFP: {
               '2004': {

--- a/api/schemas/apd.json
+++ b/api/schemas/apd.json
@@ -216,7 +216,7 @@
           },
           "fundingSource": {
             "$id": "#/properties/activities/items/properties/fundingSource",
-            "enum": ["HIE", "HIT", "MMIS"]
+            "enum": ["HIE", "HIT", "MMIS", false]
           },
           "name": {
             "$id": "#/properties/activities/items/properties/name",

--- a/web/src/reducers/activities.js
+++ b/web/src/reducers/activities.js
@@ -83,14 +83,14 @@ export const newActivity = ({
   years = []
 } = {}) => ({
   alternatives: '',
-  contractorResources: [newContractor(years)],
+  contractorResources: [],
   costAllocation: arrToObj(years, costAllocationEntry()),
   costAllocationNarrative: {
     methodology: '',
     otherSources: ''
   },
   description: '',
-  expenses: [newExpense(years)],
+  expenses: [],
   fundingSource,
   key: generateKey(),
   name,
@@ -98,7 +98,7 @@ export const newActivity = ({
   plannedStartDate: '',
   objectives: [newObjective()],
   schedule: [newMilestone()],
-  statePersonnel: [newStatePerson(years)],
+  statePersonnel: [],
   summary: '',
   standardsAndConditions: {
     doesNotSupport: '',

--- a/web/src/reducers/activities.test.js
+++ b/web/src/reducers/activities.test.js
@@ -81,38 +81,14 @@ describe('activities reducer helpers', () => {
   it('can create a new activity', () => {
     expect(newActivity({ years: ['2020'] })).toEqual({
       alternatives: '',
-      contractorResources: [
-        {
-          key: '--- key ---',
-          name: '',
-          description: '',
-          start: '',
-          end: '',
-          files: [],
-          totalCost: 0,
-          years: {
-            '2020': 0
-          },
-          hourly: {
-            useHourly: false,
-            data: { '2020': { hours: '', rate: '' } }
-          }
-        }
-      ],
+      contractorResources: [],
       costAllocation: { '2020': { other: 0, ffp: { federal: 90, state: 10 } } },
       costAllocationNarrative: {
         methodology: '',
         otherSources: ''
       },
       description: '',
-      expenses: [
-        {
-          key: '--- key ---',
-          category: 'Hardware, software, and licensing',
-          description: '',
-          years: { '2020': 0 }
-        }
-      ],
+      expenses: [],
       fundingSource: false,
       key: '--- key ---',
       name: '',
@@ -134,14 +110,7 @@ describe('activities reducer helpers', () => {
           endDate: ''
         }
       ],
-      statePersonnel: [
-        {
-          key: '--- key ---',
-          title: '',
-          description: '',
-          years: { '2020': { amt: '', perc: '' } }
-        }
-      ],
+      statePersonnel: [],
       summary: '',
       standardsAndConditions: {
         doesNotSupport: '',

--- a/web/src/reducers/apd.test.js
+++ b/web/src/reducers/apd.test.js
@@ -722,41 +722,13 @@ describe('APD reducer', () => {
             activities: [
               {
                 alternatives: '',
-                contractorResources: [
-                  {
-                    description: '',
-                    end: '',
-                    files: [],
-                    hourly: {
-                      data: {
-                        1787: { hours: '', rate: '' }
-                      },
-                      useHourly: false
-                    },
-                    key: expect.stringMatching(/^[a-f0-9]{8}$/),
-                    name: '',
-                    start: '',
-                    totalCost: 0,
-                    years: {
-                      1787: 0
-                    }
-                  }
-                ],
+                contractorResources: [],
                 costAllocation: {
                   1787: { ffp: { federal: 90, state: 10 }, other: 0 }
                 },
                 costAllocationNarrative: { methodology: '', otherSources: '' },
                 description: '',
-                expenses: [
-                  {
-                    category: 'Hardware, software, and licensing',
-                    description: '',
-                    key: expect.stringMatching(/^[a-f0-9]{8}$/),
-                    years: {
-                      1787: 0
-                    }
-                  }
-                ],
+                expenses: [],
                 fundingSource: false,
                 key: expect.stringMatching(/^[a-f0-9]{8}$/),
                 meta: { expanded: false },
@@ -796,16 +768,7 @@ describe('APD reducer', () => {
                   doesNotSupport: '',
                   supports: ''
                 },
-                statePersonnel: [
-                  {
-                    description: '',
-                    key: expect.stringMatching(/^[a-f0-9]{8}$/),
-                    title: '',
-                    years: {
-                      1787: { amt: '', perc: '' }
-                    }
-                  }
-                ],
+                statePersonnel: [],
                 summary: '',
                 years: ['1787']
               }


### PR DESCRIPTION
When creating a new activity, we will no longer create default state personnel, non-personnel, or contractor resource expenses with it. Same story with new APDs.

Also fixes a bug introduced in #2080 where APDs could not save after a new activity was created because the API required all activities to have a program type/funding source but new activities did not. A related bug (to be fixed in #2128) prevented any furthers saves after an initial error, so the practical upshot was that it became impossible to save an APD if you added an activity to it. Fixed in this PR because a) it was hampering my testing and b) it was super duper easy.

### This pull request changes...

- new APDs and activities do not have default costs
- adding an activity doesn't break the APD for all eternity
- closes #2129

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- n/a ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- n/a ~The change has been documented~
- [x] Changelog is updated as appropriate

### This feature is done when...

- [ ] Product has approved the experience
