### PR TITLE
Remove session secret keys from dev/preview environments

### DIFF
--- a/bin/preview-deploy/aws.user-data.sh
+++ b/bin/preview-deploy/aws.user-data.sh
@@ -162,7 +162,6 @@ echo "module.exports = {
       PBKDF2_ITERATIONS: '__PBKDF2_ITERATIONS__',
       PORT: '8000',
       DEV_DB_HOST: 'localhost',
-      SESSION_SECRET: '833daa028db9c8d05890206446f0e5e4156fa7ae34d526f7fab44f6b830c6c20',
       DISABLE_SAME_SITE: 'yes',
       DISABLE_SECURE_COOKIE: 'yes'
     },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,6 @@ services:
       - PORT=8000
       - DATABASE_URL=postgres://postgres:cms@db/hitech_apd
       - NODE_ENV=development
-      - SESSION_SECRET=dadccbf1e3bcb63a4d533c3f184eecfc79fd07e76d0584f808078125a83bc40b6413829e5c690d391dd3f6cbca44406cef07b8193cd4db2f03bab355eea9cb2e
       - DISABLE_SAME_SITE=yes
       - DISABLE_SECURE_COOKIE=yes
     volumes:


### PR DESCRIPTION
The session secret key is used to encrypt the authorization token. For the dev and preview environments, the key has been hard-coded into the docker-compose and build configuration scripts (respectively). From a security standpoint, this is fine because it can't be used to reveal any real data or access any real systems. However, GSA's bug bounty partner found these secret keys and raised them as a possible security concern (as they should, since they don't have the above context). To prevent them from raising the issue repeatedly, we can remove the secret key - our app will automatically generate random ones if none is provided, which should be fine for dev and preview.

### This pull request changes...

- restarting the API in dev environments will now require logging in again because the existing session token can not be decrypted

### This pull request is ready to merge when...

- [ ] This code has been reviewed by someone other than the original author