### PR TITLE
Added flag to support redircts for CircleCI artifacts

### DIFF
--- a/bin/prod-deploy/aws.user-data.sh
+++ b/bin/prod-deploy/aws.user-data.sh
@@ -37,7 +37,7 @@ npm i -g pm2
 
 # Get the built API code
 cd /app
-curl -o backend.zip __BUILDURL__
+curl -o -L backend.zip __BUILDURL__
 unzip backend.zip
 rm backend.zip
 cd api


### PR DESCRIPTION
CircleCI will be changing how it handles build artifacts soon. We rely on build artifacts for staging and production deployments and will be impacted by this change. 

### This pull request changes...

Adds the "-L" flag to the curl statement pulling artifacts from CircleCI

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated
- [ ] Changelog is updated as appropriate

### This feature is done when...

- [ ] Design has approved the experience
- [ ] Product has approved the experience
