### PR TITLE
Hotfix curl

### DIFF
--- a/bin/prod-deploy/aws.user-data.sh
+++ b/bin/prod-deploy/aws.user-data.sh
@@ -37,7 +37,7 @@ npm i -g pm2
 
 # Get the built API code
 cd /app
-curl -o -L backend.zip __BUILDURL__
+curl -o backend.zip -L __BUILDURL__
 unzip backend.zip
 rm backend.zip
 cd api


### PR DESCRIPTION
It appears the `-L` flag must come immediately before the URL that you're fetching, else it throws an error. That would prevent the backend code from being fetched and started up in staging/production.

### This pull request changes...

- moves the `-L` flag to right before the URL

### This pull request is ready to merge when...

- n/a ~Tests have been updated (and all tests are passing)~
- [ ] This code has been reviewed by someone other than the original author
- n/a/ ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- n/a ~The change has been documented~
- n/a ~Changelog is updated as appropriate~