### PR TITLE
Left side navigation should not get stuck under the header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ Anticipated release: May 18, 2020
 
 #### 🐛 Bugs fixed
 
+- Left side navigation should not get stuck under the header ([#2187])
+
 #### ⚙️ Behind the scenes
 
 # Previous releases
 
 See our [release history](https://github.com/18F/cms-hitech-apd/releases)
+
+[#2187]: https://github.com/18F/cms-hitech-apd/issues/2187

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Anticipated release: April 20, 2020
 
 - fixed Header Alignment Issue ([#2122])
 - added padding for admin dashboard title ([2144])
+- Left side navigation should not get stuck under the header ([2187])
 
 #### ⚙️ Behind the scenes
 
@@ -26,3 +27,4 @@ See our [release history](https://github.com/18F/cms-hitech-apd/releases)
 [#2103]: https://github.com/18F/cms-hitech-apd/issues/2103
 [#2144]: https://github.com/18F/cms-hitech-apd/issues/2144
 [#2155]: https://github.com/18F/cms-hitech-apd/issues/2155
+[#2187]: https://github.com/18F/cms-hitech-apd/issues/2187

--- a/web/src/styles/scss/layout.scss
+++ b/web/src/styles/scss/layout.scss
@@ -23,7 +23,7 @@
   float: left;
   + .site-main {
     margin-left: 244px; // sidebar width plus $spacer-4
-    min-height: 800px; // min height of main content to prevent menu from pushing up under the header
+    min-height: 1100px; // min height of main content to prevent menu from pushing up under the header
   }
 }
 

--- a/web/src/styles/scss/layout.scss
+++ b/web/src/styles/scss/layout.scss
@@ -23,7 +23,14 @@
   float: left;
   + .site-main {
     margin-left: 244px; // sidebar width plus $spacer-4
-    min-height: 1100px; // min height of main content to prevent menu from pushing up under the header
+    /*
+    The state icon above the menu will push up under the header if the right side of the page is too short.
+    So we need a min-height for site-main to be at least the height of the menu (plus a little). 
+    Note: "Private Contractor costs" is a particularly short page where the effect can be seen.
+    Since there isn't an easy way to do relative heights of "unrelated" elements in CSS, just use a constant.
+    Remember to adjust it when adding new menu items that change the menu size.
+    */
+    min-height: 1100px;
   }
 }
 

--- a/web/src/styles/scss/layout.scss
+++ b/web/src/styles/scss/layout.scss
@@ -23,6 +23,7 @@
   float: left;
   + .site-main {
     margin-left: 244px; // sidebar width plus $spacer-4
+    min-height: 800px; // min height of main content to prevent menu from pushing up under the header
   }
 }
 


### PR DESCRIPTION
added min-height to css for main content div because short pages cause menu to push up under the header

### This pull request changes...

- css update for main content div
- closes #2187 

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
~~- [ ] The change has been documented~~
~~- [ ] Associated OpenAPI documentation has been updated~~
- [x] Changelog is updated as appropriate

### This feature is done when...

- [ ] Design has approved the experience
- [ ] Product has approved the experience
