### PR TITLE
updated chrome green version (also added dependency vulnerability fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Anticipated release: May 18, 2020
 
 - Authenticate HTTP Clients via JWT presented in Authorization header ([#2100])
 - Update minimum Chrome version; add download link to Microsoft Edge ([#2145])
+- Set Minimum Green Browser Support for Chrome to Version 78 ([#2216])
 
 # Previous releases
 
@@ -23,3 +24,4 @@ See our [release history](https://github.com/18F/cms-hitech-apd/releases)
 [#2187]: https://github.com/18F/cms-hitech-apd/issues/2187
 [#2145]: https://github.com/18F/cms-hitech-apd/issues/2145
 [#2185]: https://github.com/18F/cms-hitech-apd/issues/2185
+[#2216]: https://github.com/18F/cms-hitech-apd/issues/2216

--- a/web/audit-resolve.json
+++ b/web/audit-resolve.json
@@ -105,6 +105,11 @@
       "decision": "ignore",
       "madeAt": 1588615312251,
       "expiresAt": 1589220067507
+    },
+    "1486|webpack-dev-server>http-proxy-middleware>http-proxy": {
+      "decision": "ignore",
+      "madeAt": 1589488195282,
+      "expiresAt": 1590092986555
     }
   },
   "rules": {},

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -20619,9 +20619,9 @@
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "tinymce": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.2.1.tgz",
-      "integrity": "sha512-X/riqIrSOyB/pF6J993ICuDbSU/dL89XfhSdmroojbdBIT73wZF2dMPTfwtL5Hn0G5vBLefMDqLwESVuiPLEPg=="
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.2.2.tgz",
+      "integrity": "sha512-G1KZOxHIrokeP/rhJuvwctmeAuHDAeH8AI1ubnVcdMZtmC6mUh3SfESqFJrFWoiF143OUMC61GkVhi920pIP0A=="
     },
     "tlds": {
       "version": "1.207.0",

--- a/web/package.json
+++ b/web/package.json
@@ -83,7 +83,7 @@
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",
     "stickybits": "^3.7.4",
-    "tinymce": "^5.2.1",
+    "tinymce": "^5.2.2",
     "updeep": "^1.2.0",
     "zxcvbn": "^4.4.2"
   },

--- a/web/src/util/browser.js
+++ b/web/src/util/browser.js
@@ -9,7 +9,7 @@ if (browser && browser.version) {
 // Green support is for browsers where we we intend all functionality to work as
 // well as all visual and style features to be correct.
 const browserIsGreen =
-  // Current major version as of April 2020.
+  // Current major version as of April 2020 is 80, but we need to support back to 78 because Jerome's work machine can't be updated.
   (browser.name === 'chrome' && browser.version >= 78) ||
   // Most recent Firefox extended support release as of April 2020.
   (browser.name === 'firefox' && browser.version >= 68) ||

--- a/web/src/util/browser.js
+++ b/web/src/util/browser.js
@@ -10,7 +10,7 @@ if (browser && browser.version) {
 // well as all visual and style features to be correct.
 const browserIsGreen =
   // Current major version as of April 2020.
-  (browser.name === 'chrome' && browser.version >= 80) ||
+  (browser.name === 'chrome' && browser.version >= 78) ||
   // Most recent Firefox extended support release as of April 2020.
   (browser.name === 'firefox' && browser.version >= 68) ||
   // First Chromium build of Edge. No longer support pre-Chromium builds.

--- a/web/src/util/browser.test.js
+++ b/web/src/util/browser.test.js
@@ -69,10 +69,10 @@ describe('browser support detection util', () => {
   });
 
   describe('indicates red for everything else', () => {
-    test('indicates red support for Chrome versions prior to 80', () => {
+    test('indicates red support for Chrome versions prior to 78', () => {
       detect.mockReturnValue({
         name: 'chrome',
-        version: '79.32.71'
+        version: '77.32.71'
       });
 
       // eslint-disable-next-line global-require


### PR DESCRIPTION
Set Minimum Green Browser Support for Chrome to Version 78

### This pull request changes...

- sets minimum green browser support for Chrome to version 78 (was 80)
- closes #2216 

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
~~- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~~
~~- [ ] The change has been documented~~
~~- [ ] Associated OpenAPI documentation has been updated~~
- [x] Changelog is updated as appropriate
