### PR TITLE
[Tech debt] Add one more test case for the links context provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Anticipated release: May 18, 2020
 - Authenticate HTTP Clients via JWT presented in Authorization header ([#2100])
 - Update minimum Chrome version; add download link to Microsoft Edge ([#2145])
 - Set Minimum Green Browser Support for Chrome to Version 78 ([#2216])
+- [Tech debt] Add one more test case for the links context provider ([#2179])
 
 # Previous releases
 
@@ -29,3 +30,4 @@ See our [release history](https://github.com/18F/cms-hitech-apd/releases)
 [#2185]: https://github.com/18F/cms-hitech-apd/issues/2185
 [#2216]: https://github.com/18F/cms-hitech-apd/issues/2216
 [#2214]: https://github.com/18F/cms-hitech-apd/issues/2214
+[#2179]: https://github.com/18F/cms-hitech-apd/issues/2179

--- a/web/src/contexts/LinksContextProvider.test.js
+++ b/web/src/contexts/LinksContextProvider.test.js
@@ -151,6 +151,24 @@ describe('LinksContextProvider', () => {
     expect(nextPrevLinks).toMatchSnapshot();
   });
 
+  it('returns next and previous links currectly when the selected link is the activity list', () => {
+    const activeSection = 'activities-list';
+    const nextPrevLinks = contextProvider.getPreviousNextLinks(
+      links,
+      activeSection
+    );
+    expect(nextPrevLinks).toMatchSnapshot();
+  });
+
+  it('returns next and previous links currectly when the selected link is one of the activities', () => {
+    const activeSection = 'activity-wz46yd39';
+    const nextPrevLinks = contextProvider.getPreviousNextLinks(
+      links,
+      activeSection
+    );
+    expect(nextPrevLinks).toMatchSnapshot();
+  });
+
   it('returns next and previous links currectly when the selected link is the first activity sub-section', () => {
     const activeSection = 'activity-aed63d97-overview';
     const nextPrevLinks = contextProvider.getPreviousNextLinks(

--- a/web/src/contexts/LinksContextProvider.test.js
+++ b/web/src/contexts/LinksContextProvider.test.js
@@ -106,6 +106,17 @@ describe('LinksContextProvider', () => {
     expect(nextPrevLinks).toMatchSnapshot();
   });
 
+  it('returns a list of links where the activities section is selected', () => {
+    const activityLinks = contextProvider.getTheLinks(
+      pageNavMock,
+      anchorNavMock,
+      'activities',
+      activities
+    );
+
+    expect(activityLinks).toMatchSnapshot();
+  });
+
   it('returns next and previous links currectly when the selected link is empty', () => {
     const activeSection = '';
     const nextPrevLinks = contextProvider.getPreviousNextLinks(

--- a/web/src/contexts/__snapshots__/LinksContextProvider.test.js.snap
+++ b/web/src/contexts/__snapshots__/LinksContextProvider.test.js.snap
@@ -186,6 +186,56 @@ Object {
 }
 `;
 
+exports[`LinksContextProvider returns next and previous links currectly when the selected link is one of the activities 1`] = `
+Object {
+  "hideNextLink": false,
+  "hidePreviousLink": false,
+  "nextLink": Object {
+    "id": "executive-summary",
+    "items": Array [
+      Object {
+        "id": "executive-summary-summary",
+        "label": "Activities Summary",
+      },
+      Object {
+        "id": "executive-summary-budget-table",
+        "label": "Program Budget Tables",
+      },
+    ],
+    "label": "Executive Summary",
+  },
+  "previousLink": Object {
+    "id": "apd-summary",
+    "label": "Program Summary",
+  },
+}
+`;
+
+exports[`LinksContextProvider returns next and previous links currectly when the selected link is the activity list 1`] = `
+Object {
+  "hideNextLink": false,
+  "hidePreviousLink": false,
+  "nextLink": Object {
+    "id": "executive-summary",
+    "items": Array [
+      Object {
+        "id": "executive-summary-summary",
+        "label": "Activities Summary",
+      },
+      Object {
+        "id": "executive-summary-budget-table",
+        "label": "Program Budget Tables",
+      },
+    ],
+    "label": "Executive Summary",
+  },
+  "previousLink": Object {
+    "id": "apd-summary",
+    "label": "Program Summary",
+  },
+}
+`;
+
 exports[`LinksContextProvider returns next and previous links currectly when the selected link is the first activity sub-section 1`] = `
 Object {
   "hideNextLink": false,

--- a/web/src/contexts/__snapshots__/LinksContextProvider.test.js.snap
+++ b/web/src/contexts/__snapshots__/LinksContextProvider.test.js.snap
@@ -136,6 +136,146 @@ Array [
 ]
 `;
 
+exports[`LinksContextProvider returns a list of links where the activities section is selected 1`] = `
+Array [
+  Object {
+    "children": Array [
+      Object {
+        "id": "apd-state-profile-office",
+        "label": "State Director and Office Address",
+      },
+      Object {
+        "id": "apd-state-profile-key-personnel",
+        "label": "Key Personnel and Program Management",
+      },
+    ],
+    "id": "apd-state-profile",
+    "label": "Key State Personnel",
+    "onClick": undefined,
+    "url": "#",
+  },
+  Object {
+    "id": "apd-summary",
+    "label": "Program Summary",
+    "onClick": undefined,
+    "url": "#",
+  },
+  Object {
+    "children": Array [
+      Object {
+        "id": "prev-activities-outline",
+        "label": "Prior Activities Overview",
+      },
+      Object {
+        "id": "prev-activities-table",
+        "label": "Actual Costs",
+      },
+    ],
+    "id": "previous-activities",
+    "label": "Results of Previous Activities",
+    "onClick": undefined,
+    "url": "#",
+  },
+  Object {
+    "children": Array [
+      Object {
+        "id": "activities-list",
+        "label": "Activity List",
+        "onClick": undefined,
+        "url": "activities",
+      },
+    ],
+    "id": "activities",
+    "items": Array [
+      Object {
+        "id": "activities-list",
+        "label": "Activity List",
+        "onClick": undefined,
+        "url": "activities",
+      },
+      Object {
+        "id": "activity-key-1234",
+        "items": null,
+        "label": "Activity 1",
+        "onClick": undefined,
+        "url": "activity/0",
+      },
+      Object {
+        "id": "activity-key-5678",
+        "items": null,
+        "label": "Activity 2",
+        "onClick": undefined,
+        "url": "activity/1",
+      },
+      Object {
+        "id": "activity-key-9012",
+        "items": null,
+        "label": "Activity 3",
+        "onClick": undefined,
+        "url": "activity/2",
+      },
+    ],
+    "label": "Program Activities",
+    "onClick": undefined,
+    "url": undefined,
+  },
+  Object {
+    "id": "schedule-summary",
+    "label": "Activity Schedule Summary",
+    "onClick": undefined,
+    "url": "#",
+  },
+  Object {
+    "children": Array [
+      Object {
+        "id": "budget-summary-table",
+        "label": "Summary Budget Table",
+      },
+      Object {
+        "id": "budget-federal-by-quarter",
+        "label": "Quarterly Federal Share",
+      },
+      Object {
+        "id": "budget-incentive-by-quarter",
+        "label": "Estimated Quarterly Incentive Payments",
+      },
+    ],
+    "id": "proposed-budget",
+    "label": "Proposed Budget",
+    "onClick": undefined,
+    "url": "#",
+  },
+  Object {
+    "id": "assurances-compliance",
+    "label": "Assurances and Compliance",
+    "onClick": undefined,
+    "url": "#",
+  },
+  Object {
+    "children": Array [
+      Object {
+        "id": "executive-summary-summary",
+        "label": "Activities Summary",
+      },
+      Object {
+        "id": "executive-summary-budget-table",
+        "label": "Program Budget Tables",
+      },
+    ],
+    "id": "executive-summary",
+    "label": "Executive Summary",
+    "onClick": undefined,
+    "url": "#",
+  },
+  Object {
+    "id": "export",
+    "label": "Export and Submit",
+    "onClick": undefined,
+    "url": "#",
+  },
+]
+`;
+
 exports[`LinksContextProvider returns next and previous links currectly when the selected link is a second-level item 1`] = `
 Object {
   "hideNextLink": false,


### PR DESCRIPTION
The links context provider tests currently misses the code path for returning the list of links when an activity (top level) or the activity list is selected

### This pull request changes...

- added a test case for when an top level activity is selected
- added a test case for when the activity list is selected
- closes #2179 

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
~~- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~~
~~- [ ] The change has been documented~~
~~- [ ] Associated OpenAPI documentation has been updated~~
- [x] Changelog is updated as appropriate
