### PR TITLE
Captures activity other funding as attributable to each cost category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,17 @@
 # Next release
 
-Anticipated release: June 1, 2020
+Anticipated release: June 15, 2020
 
 #### 🚀 New features
-
-- Update Print Preview Layout ([#2182])
-- Make the "Saving" message persist for 750ms ([#2207])
-- Move the activity schedule information to the top of the Activity Overview section ([#2210])
 
 #### 🐛 Bugs fixed
 
 #### ⚙️ Behind the scenes
 
-- Tech Debt: Add Section test ([#2176])
-- [Tech debt] Add one more test case for the links context provider ([#2179])
-- [Tech Debt] Refactor API user serialization methods ([#2206])
+- Capture how much of an activity's other funding is attributable to each cost category, to be used to show the Medicaid total of each category separately
 
 # Previous releases
 
 See our [release history](https://github.com/18F/cms-hitech-apd/releases)
 
-[#2176]: https://github.com/18F/cms-hitech-apd/issues/2176
-[#2179]: https://github.com/18F/cms-hitech-apd/issues/2179
-[#2182]: https://github.com/18F/cms-hitech-apd/issues/2182
-[#2207]: https://github.com/18F/cms-hitech-apd/issues/2207
-[#2210]: https://github.com/18F/cms-hitech-apd/issues/2210
-[#2206]: https://github.com/18F/cms-hitech-apd/issues/2206
+[#2169]: https://github.com/18F/cms-hitech-apd/issues/2169

--- a/web/src/reducers/budget.js
+++ b/web/src/reducers/budget.js
@@ -341,12 +341,11 @@ const buildBudget = incomingBigState => {
         totalOtherFunding,
         costCategoryPercentages
       );
-      activityTotals.data.otherFunding[year].contractors =
-        otherFunderPerCostCategory[0];
-      activityTotals.data.otherFunding[year].expenses =
-        otherFunderPerCostCategory[1];
-      activityTotals.data.otherFunding[year].statePersonnel =
-        otherFunderPerCostCategory[2];
+      [
+        activityTotals.data.otherFunding[year].contractors,
+        activityTotals.data.otherFunding[year].expenses,
+        activityTotals.data.otherFunding[year].statePersonnel
+      ] = otherFunderPerCostCategory;
 
       // Compute the state and federal share for each cost category, based on
       // the federal and state shares and the percentages calculated above.

--- a/web/src/reducers/budget.test.js
+++ b/web/src/reducers/budget.test.js
@@ -614,6 +614,8 @@ describe('budget reducer', () => {
           }
         },
         '3': {
+          // Activity 3 is the Program Administration activity, so its state
+          // personnel costs will include key personnel as well.
           costsByFFY: {
             '1931': {
               federal: 2700,
@@ -1409,6 +1411,8 @@ describe('budget reducer', () => {
           }
         },
         {
+          // Activity 3 is the Program Administration activity, so its state
+          // personnel costs will include key personnel as well.
           id: 3,
           name: 'Program Administration',
           fundingSource: 'HIT',

--- a/web/src/reducers/budget.test.js
+++ b/web/src/reducers/budget.test.js
@@ -1428,8 +1428,8 @@ describe('budget reducer', () => {
               },
               '1933': {
                 contractors: 56,
-                expenses: 56,
-                statePersonnel: 888,
+                expenses: 55,
+                statePersonnel: 889,
                 total: 1000
               }
             },
@@ -1461,15 +1461,15 @@ describe('budget reducer', () => {
           data: {
             otherFunding: {
               '1931': {
-                contractors: 200,
+                contractors: 400,
                 expenses: 400,
-                statePersonnel: 400,
+                statePersonnel: 200,
                 total: 1000
               },
               '1932': {
-                contractors: 333,
+                contractors: 334,
                 expenses: 333,
-                statePersonnel: 334,
+                statePersonnel: 333,
                 total: 1000
               },
               '1933': {

--- a/web/src/reducers/budget.test.js
+++ b/web/src/reducers/budget.test.js
@@ -18,25 +18,33 @@ describe('budget reducer', () => {
       combined: { total: { total: 0, medicaid: 0, federal: 0, state: 0 } },
       contractors: { total: { total: 0, medicaid: 0, federal: 0, state: 0 } },
       expenses: { total: { total: 0, medicaid: 0, federal: 0, state: 0 } },
-      statePersonnel: { total: { total: 0, medicaid: 0, federal: 0, state: 0 } }
+      statePersonnel: {
+        total: { total: 0, medicaid: 0, federal: 0, state: 0 }
+      }
     },
     hit: {
       combined: { total: { total: 0, medicaid: 0, federal: 0, state: 0 } },
       contractors: { total: { total: 0, medicaid: 0, federal: 0, state: 0 } },
       expenses: { total: { total: 0, medicaid: 0, federal: 0, state: 0 } },
-      statePersonnel: { total: { total: 0, medicaid: 0, federal: 0, state: 0 } }
+      statePersonnel: {
+        total: { total: 0, medicaid: 0, federal: 0, state: 0 }
+      }
     },
     mmis: {
       combined: { total: { total: 0, medicaid: 0, federal: 0, state: 0 } },
       contractors: { total: { total: 0, medicaid: 0, federal: 0, state: 0 } },
       expenses: { total: { total: 0, medicaid: 0, federal: 0, state: 0 } },
-      statePersonnel: { total: { total: 0, medicaid: 0, federal: 0, state: 0 } }
+      statePersonnel: {
+        total: { total: 0, medicaid: 0, federal: 0, state: 0 }
+      }
     },
     hitAndHie: {
       combined: { total: { medicaid: 0, federal: 0, state: 0, total: 0 } },
       contractors: { total: { medicaid: 0, federal: 0, state: 0, total: 0 } },
       expenses: { total: { medicaid: 0, federal: 0, state: 0, total: 0 } },
-      statePersonnel: { total: { medicaid: 0, federal: 0, state: 0, total: 0 } }
+      statePersonnel: {
+        total: { medicaid: 0, federal: 0, state: 0, total: 0 }
+      }
     },
     mmisByFFP: {
       '50-50': { total: { medicaid: 0, federal: 0, state: 0, total: 0 } },
@@ -1318,6 +1326,26 @@ describe('budget reducer', () => {
           name: 'hieOne',
           fundingSource: 'HIE',
           data: {
+            otherFunding: {
+              '1931': {
+                contractors: 0,
+                expenses: 0,
+                statePersonnel: 0,
+                total: 0
+              },
+              '1932': {
+                contractors: 0,
+                expenses: 0,
+                statePersonnel: 0,
+                total: 0
+              },
+              '1933': {
+                contractors: 0,
+                expenses: 0,
+                statePersonnel: 0,
+                total: 0
+              }
+            },
             statePersonnel: {
               '1931': 1400,
               '1932': 1200,
@@ -1331,7 +1359,12 @@ describe('budget reducer', () => {
               total: 6000
             },
             expenses: { '1931': 2000, '1932': 2000, '1933': 2000, total: 6000 },
-            combined: { '1931': 5400, '1932': 5200, '1933': 4700, total: 15300 }
+            combined: {
+              '1931': 5400,
+              '1932': 5200,
+              '1933': 4700,
+              total: 15300
+            }
           }
         },
         {
@@ -1339,6 +1372,26 @@ describe('budget reducer', () => {
           name: 'hieTwo',
           fundingSource: 'HIE',
           data: {
+            otherFunding: {
+              '1931': {
+                contractors: 0,
+                expenses: 0,
+                statePersonnel: 0,
+                total: 0
+              },
+              '1932': {
+                contractors: 0,
+                expenses: 0,
+                statePersonnel: 0,
+                total: 0
+              },
+              '1933': {
+                contractors: 0,
+                expenses: 0,
+                statePersonnel: 0,
+                total: 0
+              }
+            },
             statePersonnel: {
               '1931': 1000,
               '1932': 1000,
@@ -1360,6 +1413,26 @@ describe('budget reducer', () => {
           name: 'Program Administration',
           fundingSource: 'HIT',
           data: {
+            otherFunding: {
+              '1931': {
+                contractors: 0,
+                expenses: 0,
+                statePersonnel: 0,
+                total: 0
+              },
+              '1932': {
+                contractors: 0,
+                expenses: 0,
+                statePersonnel: 0,
+                total: 0
+              },
+              '1933': {
+                contractors: 56,
+                expenses: 56,
+                statePersonnel: 888,
+                total: 1000
+              }
+            },
             statePersonnel: {
               '1931': 1000,
               '1932': 1450,
@@ -1386,6 +1459,26 @@ describe('budget reducer', () => {
           name: 'mmisOne',
           fundingSource: 'MMIS',
           data: {
+            otherFunding: {
+              '1931': {
+                contractors: 200,
+                expenses: 400,
+                statePersonnel: 400,
+                total: 1000
+              },
+              '1932': {
+                contractors: 333,
+                expenses: 333,
+                statePersonnel: 334,
+                total: 1000
+              },
+              '1933': {
+                contractors: 0,
+                expenses: 0,
+                statePersonnel: 0,
+                total: 0
+              }
+            },
             statePersonnel: {
               '1931': 500,
               '1932': 1000,
@@ -1407,6 +1500,26 @@ describe('budget reducer', () => {
           name: 'zero total',
           fundingSource: 'MMIS',
           data: {
+            otherFunding: {
+              '1931': {
+                contractors: 0,
+                expenses: 0,
+                statePersonnel: 0,
+                total: 0
+              },
+              '1932': {
+                contractors: 0,
+                expenses: 0,
+                statePersonnel: 0,
+                total: 0
+              },
+              '1933': {
+                contractors: 0,
+                expenses: 0,
+                statePersonnel: 0,
+                total: 0
+              }
+            },
             statePersonnel: {
               '1931': 0,
               '1932': 0,
@@ -1428,6 +1541,26 @@ describe('budget reducer', () => {
           name: 'no funding program',
           fundingSource: false,
           data: {
+            otherFunding: {
+              '1931': {
+                contractors: 0,
+                expenses: 0,
+                statePersonnel: 0,
+                total: 0
+              },
+              '1932': {
+                contractors: 0,
+                expenses: 0,
+                statePersonnel: 0,
+                total: 0
+              },
+              '1933': {
+                contractors: 0,
+                expenses: 0,
+                statePersonnel: 0,
+                total: 0
+              }
+            },
             statePersonnel: {
               '1931': 100,
               '1932': 100,


### PR DESCRIPTION
### This pull request changes...

- captures how much of the activity's other funding is attributed to each cost category
- closes #2169

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- N/A ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- [x] The change has been documented
- [x] Changelog is updated as appropriate