### PR TITLE
Hide Create New APD button for users who don't have create permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,17 @@
 # Next release
 
-Anticipated release: June 1, 2020
+Anticipated release: June 15, 2020
 
 #### 🚀 New features
 
-- Update Print Preview Layout ([#2182])
-- Make the "Saving" message persist for 750ms ([#2207])
-- Move the activity schedule information to the top of the Activity Overview section ([#2210])
+- Hide Create New APD button for users who don't have create permission ([#2198])
 
 #### 🐛 Bugs fixed
 
 #### ⚙️ Behind the scenes
 
-- Tech Debt: Add Section test ([#2176])
-- [Tech debt] Add one more test case for the links context provider ([#2179])
-- [Tech Debt] Refactor API user serialization methods ([#2206])
-
 # Previous releases
 
 See our [release history](https://github.com/18F/cms-hitech-apd/releases)
 
-[#2176]: https://github.com/18F/cms-hitech-apd/issues/2176
-[#2179]: https://github.com/18F/cms-hitech-apd/issues/2179
-[#2182]: https://github.com/18F/cms-hitech-apd/issues/2182
-[#2207]: https://github.com/18F/cms-hitech-apd/issues/2207
-[#2210]: https://github.com/18F/cms-hitech-apd/issues/2210
-[#2206]: https://github.com/18F/cms-hitech-apd/issues/2206
+[#2198]: https://github.com/18F/cms-hitech-apd/issues/2198

--- a/api/db/users.js
+++ b/api/db/users.js
@@ -21,7 +21,10 @@ const populateUser = async (user, { db = knex } = {}) => {
 
     if (user.auth_role) {
       const authRole = await db('auth_roles')
-        .where('name', user.auth_role)
+        .where({
+          name: user.auth_role,
+          isActive: true
+        })
         .select('id')
         .first();
 
@@ -32,8 +35,11 @@ const populateUser = async (user, { db = knex } = {}) => {
         : [];
 
       const authActivityNames = await db('auth_activities')
-        // eslint-disable-next-line camelcase
-        .whereIn('id', authActivityIDs.map(({ activity_id }) => activity_id))
+        .whereIn(
+          'id',
+          // eslint-disable-next-line camelcase
+          authActivityIDs.map(({ activity_id }) => activity_id)
+        )
         .select('name');
 
       populatedUser.activities = authActivityNames.map(({ name }) => name);
@@ -163,10 +169,13 @@ const validateUser = async (
     logger.silly('checking auth role');
     if (
       !(await db('auth_roles')
-        .where('name', auth_role)
+        .where({
+          name: auth_role,
+          isActive: true
+        })
         .first())
     ) {
-      logger.verbose(`auth role is invalid [${auth_role}]`);
+      logger.verbose(`auth role is invalid or inactive [${auth_role}]`);
       throw new Error('invalid-role');
     }
     logger.silly('auth role is valid');

--- a/api/db/users.test.js
+++ b/api/db/users.test.js
@@ -185,7 +185,9 @@ tap.test('database wrappers / users', async usersTests => {
           const activities = dbMock('auth_activities');
           const states = dbMock('states');
 
-          roles.where.withArgs('name', 'user role').returnsThis();
+          roles.where
+            .withArgs({ name: 'user role', isActive: true })
+            .returnsThis();
           roles.select.withArgs('id').returnsThis();
           roles.first.resolves({ id: 'role id' });
 
@@ -423,7 +425,7 @@ tap.test('database wrappers / users', async usersTests => {
       zxcvbn.withArgs('password', []).returns({ score: 5 });
 
       const auth = dbMock('auth_roles');
-      auth.where.withArgs('name', 'role').returnsThis();
+      auth.where.withArgs({ name: 'role', isActive: true }).returnsThis();
       auth.first.resolves();
 
       try {
@@ -464,7 +466,7 @@ tap.test('database wrappers / users', async usersTests => {
       db.first.resolves({ email: 'mail mail', name: 'name name' });
 
       const auth = dbMock('auth_roles');
-      auth.where.withArgs('name', 'role').returnsThis();
+      auth.where.withArgs({ name: 'role', isActive: true }).returnsThis();
       auth.first.resolves({});
 
       const states = dbMock('states');
@@ -488,7 +490,7 @@ tap.test('database wrappers / users', async usersTests => {
         db.first.resolves({ email: 'mail mail', name: 'name name' });
 
         const auth = dbMock('auth_roles');
-        auth.where.withArgs('name', 'role').returnsThis();
+        auth.where.withArgs({ name: 'role', isActive: true }).returnsThis();
         auth.first.resolves({});
 
         const states = dbMock('states');

--- a/api/migrations/20200601145842_add-auth-roles-active-col.js
+++ b/api/migrations/20200601145842_add-auth-roles-active-col.js
@@ -1,0 +1,19 @@
+exports.up = async knex => {
+  await knex.schema.table('auth_roles', table => {
+    table
+      .boolean('isActive')
+      .notNullable()
+      .defaultTo(true);
+  });
+
+  await knex('auth_roles')
+    .whereIn('name', [
+      'federal analyst',
+      'federal leadership',
+      'federal SME',
+      'state SME'
+    ])
+    .update({ isActive: false });
+};
+
+exports.down = () => {};

--- a/api/routes/auth/roles/__snapshots__/get.endpoint.js.snap
+++ b/api/routes/auth/roles/__snapshots__/get.endpoint.js.snap
@@ -21,34 +21,14 @@ Array [
       "view-document",
     ],
     "id": 1101,
+    "isActive": true,
     "name": "admin",
-  },
-  Object {
-    "activities": Array [
-      "edit-roles",
-    ],
-    "id": 1102,
-    "name": "federal analyst",
-  },
-  Object {
-    "activities": Array [],
-    "id": 1103,
-    "name": "federal leadership",
-  },
-  Object {
-    "activities": Array [],
-    "id": 1104,
-    "name": "federal SME",
   },
   Object {
     "activities": Array [],
     "id": 1105,
+    "isActive": true,
     "name": "state coordinator",
-  },
-  Object {
-    "activities": Array [],
-    "id": 1106,
-    "name": "state SME",
   },
 ]
 `;

--- a/api/routes/auth/roles/__snapshots__/post.endpoint.js.snap
+++ b/api/routes/auth/roles/__snapshots__/post.endpoint.js.snap
@@ -1,5 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`auth roles endpoint | POST /auth/roles when authenticated with a valid inactive new role 1`] = `
+Object {
+  "activities": Array [
+    "view-users",
+    "add-users",
+  ],
+  "id": 2,
+  "isActive": false,
+  "name": "inactive-role",
+}
+`;
+
+exports[`auth roles endpoint | POST /auth/roles when authenticated with a valid inactive new role 2`] = `
+Array [
+  1001,
+  1002,
+]
+`;
+
 exports[`auth roles endpoint | POST /auth/roles when authenticated with a valid new role 1`] = `
 Object {
   "activities": Array [
@@ -7,6 +26,7 @@ Object {
     "add-users",
   ],
   "id": 1,
+  "isActive": true,
   "name": "new-role",
 }
 `;

--- a/api/routes/auth/roles/__snapshots__/put.endpoint.js.snap
+++ b/api/routes/auth/roles/__snapshots__/put.endpoint.js.snap
@@ -2,17 +2,35 @@
 
 exports[`auth roles endpoint | PUT /auth/roles/:roleID when authenticated when updating the role that the user belongs to 1`] = `""`;
 
-exports[`auth roles endpoint | PUT /auth/roles/:roleID when authenticated with a valid updated role 1`] = `
+exports[`auth roles endpoint | PUT /auth/roles/:roleID when authenticated with a valid updated role active flag 1`] = `
 Object {
   "activities": Array [
     "view-users",
   ],
   "id": 1102,
+  "isActive": false,
   "name": "new name",
 }
 `;
 
-exports[`auth roles endpoint | PUT /auth/roles/:roleID when authenticated with a valid updated role 2`] = `
+exports[`auth roles endpoint | PUT /auth/roles/:roleID when authenticated with a valid updated role active flag 2`] = `
+Array [
+  1001,
+]
+`;
+
+exports[`auth roles endpoint | PUT /auth/roles/:roleID when authenticated with a valid updated role name 1`] = `
+Object {
+  "activities": Array [
+    "view-users",
+  ],
+  "id": 1102,
+  "isActive": false,
+  "name": "new name",
+}
+`;
+
+exports[`auth roles endpoint | PUT /auth/roles/:roleID when authenticated with a valid updated role name 2`] = `
 Array [
   1001,
 ]
@@ -37,3 +55,15 @@ Object {
 `;
 
 exports[`auth roles endpoint | PUT /auth/roles/:roleID when authenticated with an invalid ID 1`] = `""`;
+
+exports[`auth roles endpoint | PUT /auth/roles/:roleID when authenticated with isActive that is not a boolean 1`] = `
+Object {
+  "error": "edit-role-invalid-isActive",
+}
+`;
+
+exports[`auth roles endpoint | PUT /auth/roles/:roleID when authenticated with name that is not a string 1`] = `
+Object {
+  "error": "edit-role-invalid-name",
+}
+`;

--- a/api/routes/auth/roles/get.js
+++ b/api/routes/auth/roles/get.js
@@ -1,13 +1,13 @@
 const logger = require('../../../logger')('auth roles route get');
-const { getAuthRoles: gr } = require('../../../db');
+const { getActiveAuthRoles: gr } = require('../../../db');
 const { can } = require('../../../middleware');
 
-module.exports = (app, { getAuthRoles = gr } = {}) => {
+module.exports = (app, { getActiveAuthRoles = gr } = {}) => {
   logger.silly('setting up GET /auth/roles route');
   app.get('/auth/roles', can('view-roles'), async (req, res) => {
     logger.silly(req, 'handling up GET /auth/roles route');
     try {
-      const roles = await getAuthRoles();
+      const roles = await getActiveAuthRoles();
 
       logger.silly(
         req,

--- a/api/routes/auth/roles/get.test.js
+++ b/api/routes/auth/roles/get.test.js
@@ -10,7 +10,7 @@ tap.test('auth roles GET endpoint', async endpointTest => {
     get: sandbox.stub()
   };
 
-  const getAuthRoles = sandbox.stub();
+  const getActiveAuthRoles = sandbox.stub();
 
   const res = {
     status: sandbox.stub(),
@@ -39,7 +39,7 @@ tap.test('auth roles GET endpoint', async endpointTest => {
   endpointTest.test('get roles handler', async handlerTest => {
     let handler;
     handlerTest.beforeEach(done => {
-      getEndpoint(app, { getAuthRoles });
+      getEndpoint(app, { getActiveAuthRoles });
       handler = app.get.args.find(args => args[0] === '/auth/roles')[2];
       done();
     });
@@ -47,7 +47,7 @@ tap.test('auth roles GET endpoint', async endpointTest => {
     handlerTest.test(
       'sends a server error code if there is a database error',
       async invalidTest => {
-        getAuthRoles.rejects();
+        getActiveAuthRoles.rejects();
 
         await handler({}, res);
 
@@ -60,7 +60,7 @@ tap.test('auth roles GET endpoint', async endpointTest => {
     handlerTest.test('sends back a list of roles', async validTest => {
       const roles = [{ name: 'one' }, { name: 'two' }, { name: 'three' }];
 
-      getAuthRoles.resolves(roles);
+      getActiveAuthRoles.resolves(roles);
 
       await handler({}, res);
 

--- a/api/routes/auth/roles/post.js
+++ b/api/routes/auth/roles/post.js
@@ -37,6 +37,15 @@ module.exports = (
 
         logger.silly('role name is valid and unique');
 
+        if (
+          typeof req.body.isActive !== 'undefined' &&
+          typeof req.body.isActive !== 'boolean'
+        ) {
+          logger.verbose('isActive is present but not a boolean');
+          throw new Error('invalid-isActive');
+        }
+        logger.silly('isActive is valid or not present');
+
         if (!Array.isArray(req.body.activities)) {
           logger.verbose('role activities is not an array');
           throw new Error('invalid-activities');
@@ -71,7 +80,11 @@ module.exports = (
 
       logger.silly(req, 'request is valid, creating new role');
 
-      const roleID = await createAuthRole(req.body.name, req.body.activities);
+      const roleID = await createAuthRole(
+        req.body.name,
+        req.body.isActive,
+        req.body.activities
+      );
 
       const activities = (
         await getAuthActivitiesByIDs(req.body.activities)
@@ -80,6 +93,8 @@ module.exports = (
       const role = {
         id: roleID,
         name: req.body.name,
+        isActive:
+          typeof req.body.isActive !== 'undefined' ? req.body.isActive : true,
         activities
       };
 

--- a/api/routes/auth/roles/post.test.js
+++ b/api/routes/auth/roles/post.test.js
@@ -126,6 +126,31 @@ tap.test('auth roles POST endpoint', async endpointTest => {
         res.send.calledWith({
           id: 'role id',
           name: 'new role',
+          isActive: true,
+          activities: ['one', 'two']
+        })
+      );
+    });
+
+    handlerTest.test('returns happily if role is inactive', async test => {
+      getAuthRoleByName.resolves(null);
+      getAuthActivitiesByIDs.resolves([
+        { id: 1, name: 'one' },
+        { id: 2, name: 'two' }
+      ]);
+      createAuthRole.resolves('role id');
+
+      await handler(
+        { body: { name: 'new role', isActive: false, activities: [1, 2] } },
+        res
+      );
+
+      test.ok(res.status.calledWith(201));
+      test.ok(
+        res.send.calledWith({
+          id: 'role id',
+          name: 'new role',
+          isActive: false,
           activities: ['one', 'two']
         })
       );

--- a/api/routes/auth/roles/put.test.js
+++ b/api/routes/auth/roles/put.test.js
@@ -103,7 +103,7 @@ tap.test('auth roles PUT endpoint', async endpointTest => {
           res
         );
 
-        returnsValidationFail(test, 'missing-name');
+        returnsValidationFail(test, 'invalid-name');
       }
     );
 
@@ -187,7 +187,7 @@ tap.test('auth roles PUT endpoint', async endpointTest => {
 
       await handler(
         {
-          body: { name: 'new role', activities: [1, 2] },
+          body: { name: 'new role', isActive: true, activities: [1, 2] },
           user: { role: 'role' },
           params: { id: 1 }
         },
@@ -198,6 +198,36 @@ tap.test('auth roles PUT endpoint', async endpointTest => {
         res.send.calledWith({
           id: 1,
           name: 'new role',
+          isActive: true,
+          activities: ['one', 'two']
+        })
+      );
+    });
+
+    handlerTest.test('returns happily if role is inactive', async test => {
+      getAuthRoleByID.resolves({ id: 'role id' });
+      getAuthRoleByName.withArgs('role').resolves({ id: 'other id' });
+      getAuthRoleByName.withArgs('new role').resolves(null);
+      getAuthActivitiesByIDs.resolves([
+        { id: 1, name: 'one' },
+        { id: 2, name: 'two' }
+      ]);
+      updateAuthRole.resolves();
+
+      await handler(
+        {
+          body: { name: 'new role', isActive: false, activities: [1, 2] },
+          user: { role: 'role' },
+          params: { id: 1 }
+        },
+        res
+      );
+
+      test.ok(
+        res.send.calledWith({
+          id: 1,
+          name: 'new role',
+          isActive: false,
           activities: ['one', 'two']
         })
       );

--- a/api/routes/users/put.endpoint.js
+++ b/api/routes/users/put.endpoint.js
@@ -16,8 +16,7 @@ describe('users endpoint | PUT /users/:userID', () => {
   unauthorizedTest('put', url(0));
 
   describe('when authenticated', () => {
-    const put = (id, data) =>
-      login().then(api => api.put(url(id), data))
+    const put = (id, data) => login().then(api => api.put(url(id), data));
 
     it('when sending a non-numeric ID', async () => {
       const response = await put('abc');
@@ -83,7 +82,7 @@ describe('users endpoint | PUT /users/:userID', () => {
           phone: '123',
           position: 'test position',
           state: 'hi',
-          role: 'state SME',
+          role: 'state coordinator',
           useless: 'is discarded'
         });
 
@@ -95,7 +94,7 @@ describe('users endpoint | PUT /users/:userID', () => {
           .first();
 
         expect(user).toMatchObject({
-          auth_role: 'state SME',
+          auth_role: 'state coordinator',
           email: 'all-permissions-no-state',
           name: 'test name',
           password: oldPasswordHash,
@@ -118,7 +117,7 @@ describe('users endpoint | PUT /users/:userID', () => {
           phone: '123',
           position: 'test position',
           state: 'hi',
-          role: 'state SME',
+          role: 'state coordinator',
           useless: 'is discarded'
         });
 
@@ -130,7 +129,7 @@ describe('users endpoint | PUT /users/:userID', () => {
           .first();
 
         expect(user).toMatchObject({
-          auth_role: 'state SME',
+          auth_role: 'state coordinator',
           email: 'test email',
           name: 'test name',
           password: expect.stringMatching(/.+/),

--- a/api/routes/users/validate.js
+++ b/api/routes/users/validate.js
@@ -63,10 +63,13 @@ module.exports = async (
     logger.silly('checking auth role');
     if (
       !(await db('auth_roles')
-        .where('name', auth_role)
+        .where({
+          name: auth_role,
+          isActive: true
+        })
         .first())
     ) {
-      logger.verbose(`auth role is invalid [${auth_role}]`);
+      logger.verbose(`auth role is invalid or inactive [${auth_role}]`);
       throw new Error('invalid-role');
     }
     logger.silly('auth role is valid');

--- a/api/seeds/shared/roles-and-activities.js
+++ b/api/seeds/shared/roles-and-activities.js
@@ -127,4 +127,12 @@ exports.seed = async knex => {
     activityIDs,
     roleToActivityMappings
   );
+  await knex('auth_roles')
+    .whereIn('name', [
+      'federal analyst',
+      'federal leadership',
+      'federal SME',
+      'state SME'
+    ])
+    .update({ isActive: false });
 };

--- a/api/seeds/test/roles.js
+++ b/api/seeds/test/roles.js
@@ -25,12 +25,32 @@ exports.seed = async knex => {
   await knex('auth_activities').insert({ id: 1014, name: 'delete-users' });
   await knex('auth_activities').insert({ id: 1015, name: 'view-document' });
 
-  await knex('auth_roles').insert({ id: 1101, name: 'admin' });
-  await knex('auth_roles').insert({ id: 1102, name: 'federal analyst' });
-  await knex('auth_roles').insert({ id: 1103, name: 'federal leadership' });
-  await knex('auth_roles').insert({ id: 1104, name: 'federal SME' });
-  await knex('auth_roles').insert({ id: 1105, name: 'state coordinator' });
-  await knex('auth_roles').insert({ id: 1106, name: 'state SME' });
+  await knex('auth_roles').insert({ id: 1101, name: 'admin', isActive: true });
+  await knex('auth_roles').insert({
+    id: 1102,
+    name: 'federal analyst',
+    isActive: false
+  });
+  await knex('auth_roles').insert({
+    id: 1103,
+    name: 'federal leadership',
+    isActive: false
+  });
+  await knex('auth_roles').insert({
+    id: 1104,
+    name: 'federal SME',
+    isActive: false
+  });
+  await knex('auth_roles').insert({
+    id: 1105,
+    name: 'state coordinator',
+    isActive: true
+  });
+  await knex('auth_roles').insert({
+    id: 1106,
+    name: 'state SME',
+    isActive: false
+  });
 
   // admin
   await knex('auth_role_activity_mapping').insert({


### PR DESCRIPTION
The approach we decided on to avoid the condition is to hide the roles which don't have create permission.  Rather than removing the roles from the database and having to remember what they were when we want to add them back, we added an active column to the roles table.

### This pull request changes...

- an isActive column was added to the roles table
- only active roles (admin, state coordinator) are displayed when adding or updating a user
- closes #2198 

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
~~- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~~
~~- [ ] The change has been documented~~
~~- [ ] Associated OpenAPI documentation has been updated~~
- [ ] Changelog is updated as appropriate

### This feature is done when...

~~- [ ] Design has approved the experience~~
- [ ] Product has approved the experience
