### PR TITLE
Don't try to delete preview deployments that don't exist

### DIFF
--- a/bin/preview-deploy/aws.cleanup.sh
+++ b/bin/preview-deploy/aws.cleanup.sh
@@ -67,6 +67,12 @@ function terminateIfClosedPR() {
   INSTANCE_ID=$(echo ${BITS[0]} | tr -d '"')
   INSTANCE_PR=$(echo ${BITS[1]} | tr -d '"')
 
+  # If there's not an instance ID, bail out. This can happen if there aren't any
+  # active preview deployments.
+  if [ -z "$INSTANCE_ID" ]; then
+    return 0
+  fi
+
   echo "  ...instance $INSTANCE_ID is for PR $INSTANCE_PR";
 
   for PR in $2


### PR DESCRIPTION
Fixes an issue where the recurring hourly "cleanup" CI/CD task would attempt to delete an AWS EC2 instance with ID `""` if there were no preview deployments available. This causes the script to fail and results in an unhelpful message being posted to Slack.

### This pull request changes...

- fixes ☝️ that

### This pull request is ready to merge when...

- n/a ~Tests have been updated (and all tests are passing)~
- [x] This code has been reviewed by someone other than the original author
- n/a ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- n/a ~The change has been documented~
- n/a ~Changelog is updated as appropriate~