### PR TITLE
Update Actual Costs page to use "Actual Expenditures"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,20 @@
 # Next release
 
-Anticipated release: June 15, 2020
+Anticipated release: June 29, 2020
 
 #### 🚀 New features
 
-- Hide Create New APD button for users who don't have create permission ([#2198])
+- Update Actual Costs page to use "Actual Expenditures" ([#2291])
 
 #### 🐛 Bugs fixed
 
 #### ⚙️ Behind the scenes
 
-- Capture how much of an activity's other funding is attributable to each cost category, to be used to show the Medicaid total of each category separately
 - Prevent negative FTE values from being entered in State Cost forms ([#2229])
 
 # Previous releases
 
 See our [release history](https://github.com/18F/cms-hitech-apd/releases)
 
-[#2169]: https://github.com/18F/cms-hitech-apd/issues/2169
-[#2198]: https://github.com/18F/cms-hitech-apd/issues/2198
 [#2229]: https://github.com/18F/cms-hitech-apd/issues/2229
+[#2291]: https://github.com/18F/cms-hitech-apd/issues/2291

--- a/web/src/constants.js
+++ b/web/src/constants.js
@@ -23,7 +23,7 @@ export const DASHBOARD_TASK_BUTTON_TEXT = {
 };
 
 export const TABLE_HEADERS = {
-  actual: 'Actual',
+  actual: 'Actual Expenditures',
   approved: 'Approved',
   federal: (p = 90) => (
     <span>
@@ -31,11 +31,5 @@ export const TABLE_HEADERS = {
     </span>
   ),
   ffy: y => `FFY ${y}`,
-  total: (
-    <span>
-      Total computable
-      <br />
-      (Federal + state)
-    </span>
-  )
+  total: <span>Total computable (Federal + state)</span>
 };

--- a/web/src/containers/ApdPreviousActivityTable.js
+++ b/web/src/containers/ApdPreviousActivityTable.js
@@ -36,8 +36,14 @@ const ApdPreviousActivityTable = ({
           <th id="prev_act_hit_header_ffy">
             <span className="ds-u-visibility--screen-reader">Year</span>
           </th>
-          <th id="prev_act_hithie_total">{TABLE_HEADERS.total}</th>
-          <th colSpan="2" id="prev_act_hithie_federal">
+          <th id="prev_act_hithie_total" className="ds-u-text-align--right">
+            {TABLE_HEADERS.total}
+          </th>
+          <th
+            colSpan="2"
+            id="prev_act_hithie_federal"
+            className="ds-u-text-align--right"
+          >
             {TABLE_HEADERS.federal()}
           </th>
         </tr>

--- a/web/src/containers/ApdPreviousActivityTableMMIS.js
+++ b/web/src/containers/ApdPreviousActivityTableMMIS.js
@@ -86,8 +86,17 @@ const ApdPreviousActivityTableMMIS = ({
               <th id="prev_act_mmis_ffy">
                 <span className="ds-u-visibility--screen-reader">Year</span>
               </th>
-              <th id={`prev_act_mmis${level}_total`}>{TABLE_HEADERS.total}</th>
-              <th colSpan="2" id={`prev_act_mmis${level}_federal`}>
+              <th
+                id={`prev_act_mmis${level}_total`}
+                className="ds-u-text-align--right"
+              >
+                {TABLE_HEADERS.total}
+              </th>
+              <th
+                colSpan="2"
+                id={`prev_act_mmis${level}_federal`}
+                className="ds-u-text-align--right"
+              >
                 {TABLE_HEADERS.federal(level)}
               </th>
             </tr>

--- a/web/src/containers/ApdPreviousActivityTableTotal.js
+++ b/web/src/containers/ApdPreviousActivityTableTotal.js
@@ -10,7 +10,7 @@ const ApdPreviousActivityTableMMIS = ({ totals }) => {
   const years = Object.keys(totals);
 
   return (
-    <table className="budget-table budget-table--totals">
+    <table className="budget-table">
       <caption className="ds-h4">Grand totals: Federal HIT, HIE, MMIS</caption>
       <thead>
         <tr>
@@ -20,9 +20,8 @@ const ApdPreviousActivityTableMMIS = ({ totals }) => {
           <th id="prev_act_total_approved" className="ds-u-text-align--right">
             FFP Approved
           </th>
-
           <th id="prev_act_total_actual" className="ds-u-text-align--right">
-            FFP Actual
+            FFP Actual Expenditures
           </th>
         </tr>
       </thead>

--- a/web/src/containers/__snapshots__/ApdPreviousActivityTable.test.js.snap
+++ b/web/src/containers/__snapshots__/ApdPreviousActivityTable.test.js.snap
@@ -21,15 +21,15 @@ exports[`apd previous activity table, mmis component renders correctly 1`] = `
         </span>
       </th>
       <th
+        className="ds-u-text-align--right"
         id="prev_act_hithie_total"
       >
         <span>
-          Total computable
-          <br />
-          (Federal + state)
+          Total computable (Federal + state)
         </span>
       </th>
       <th
+        className="ds-u-text-align--right"
         colSpan="2"
         id="prev_act_hithie_federal"
       >
@@ -64,7 +64,7 @@ exports[`apd previous activity table, mmis component renders correctly 1`] = `
         className="ds-u-text-align--right"
         id="prev_act_hithie_federal_actual"
       >
-        Actual
+        Actual Expenditures
       </th>
     </tr>
   </thead>

--- a/web/src/containers/__snapshots__/ApdPreviousActivityTableMMIS.test.js.snap
+++ b/web/src/containers/__snapshots__/ApdPreviousActivityTableMMIS.test.js.snap
@@ -37,15 +37,15 @@ exports[`apd previous activity table, mmis component renders correctly 1`] = `
           </span>
         </th>
         <th
+          className="ds-u-text-align--right"
           id="prev_act_mmis90_total"
         >
           <span>
-            Total computable
-            <br />
-            (Federal + state)
+            Total computable (Federal + state)
           </span>
         </th>
         <th
+          className="ds-u-text-align--right"
           colSpan="2"
           id="prev_act_mmis90_federal"
         >
@@ -80,7 +80,7 @@ exports[`apd previous activity table, mmis component renders correctly 1`] = `
           className="ds-u-text-align--right"
           id="prev_act_mmis90_federal_actual"
         >
-          Actual
+          Actual Expenditures
         </th>
       </tr>
     </thead>
@@ -206,15 +206,15 @@ exports[`apd previous activity table, mmis component renders correctly 1`] = `
           </span>
         </th>
         <th
+          className="ds-u-text-align--right"
           id="prev_act_mmis75_total"
         >
           <span>
-            Total computable
-            <br />
-            (Federal + state)
+            Total computable (Federal + state)
           </span>
         </th>
         <th
+          className="ds-u-text-align--right"
           colSpan="2"
           id="prev_act_mmis75_federal"
         >
@@ -249,7 +249,7 @@ exports[`apd previous activity table, mmis component renders correctly 1`] = `
           className="ds-u-text-align--right"
           id="prev_act_mmis75_federal_actual"
         >
-          Actual
+          Actual Expenditures
         </th>
       </tr>
     </thead>
@@ -375,15 +375,15 @@ exports[`apd previous activity table, mmis component renders correctly 1`] = `
           </span>
         </th>
         <th
+          className="ds-u-text-align--right"
           id="prev_act_mmis50_total"
         >
           <span>
-            Total computable
-            <br />
-            (Federal + state)
+            Total computable (Federal + state)
           </span>
         </th>
         <th
+          className="ds-u-text-align--right"
           colSpan="2"
           id="prev_act_mmis50_federal"
         >
@@ -418,7 +418,7 @@ exports[`apd previous activity table, mmis component renders correctly 1`] = `
           className="ds-u-text-align--right"
           id="prev_act_mmis50_federal_actual"
         >
-          Actual
+          Actual Expenditures
         </th>
       </tr>
     </thead>

--- a/web/src/containers/__snapshots__/ApdPreviousActivityTableTotal.test.js.snap
+++ b/web/src/containers/__snapshots__/ApdPreviousActivityTableTotal.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`apd previous activity table, grand total component renders correctly 1`] = `
 <table
-  className="budget-table budget-table--totals"
+  className="budget-table"
 >
   <caption
     className="ds-h4"
@@ -30,7 +30,7 @@ exports[`apd previous activity table, grand total component renders correctly 1`
         className="ds-u-text-align--right"
         id="prev_act_total_actual"
       >
-        FFP Actual
+        FFP Actual Expenditures
       </th>
     </tr>
   </thead>

--- a/web/src/containers/viewOnly/PreviousActivities.js
+++ b/web/src/containers/viewOnly/PreviousActivities.js
@@ -15,7 +15,7 @@ const PreviousActivities = ({ previousActivitySummary }) => {
       <h2>Results of Previous Activities</h2>
       <div dangerouslySetInnerHTML={{ __html: previousActivitySummary }} />
       <hr className="subsection-rule" />
-      <h3>Actual Costs of Previous Activities</h3>
+      <h3>Actual Expenditures</h3>
       <ApdPreviousActivityTableHI isViewOnly />
       <ApdPreviousActivityTableMMIS isViewOnly />
       <ApdPreviousActivityTableTotal />

--- a/web/src/contexts/__snapshots__/LinksContextProvider.test.js.snap
+++ b/web/src/contexts/__snapshots__/LinksContextProvider.test.js.snap
@@ -57,7 +57,7 @@ Array [
       },
       Object {
         "id": "prev-activities-table",
-        "label": "Actual Costs",
+        "label": "Actual Expenditures",
       },
     ],
     "id": "previous-activities",
@@ -168,7 +168,7 @@ Array [
       },
       Object {
         "id": "prev-activities-table",
-        "label": "Actual Costs",
+        "label": "Actual Expenditures",
       },
     ],
     "id": "previous-activities",

--- a/web/src/i18n/locales/en/previousActivities.yaml
+++ b/web/src/i18n/locales/en/previousActivities.yaml
@@ -4,10 +4,10 @@ helpText: >-
   This includes both the current status of those activities and the costs associated
   with them.
 actualExpenses:
-  title: Actual Costs
+  title: Actual Expenditures
   instruction:
     detail: >-
-      Input the most recent approved and actual costs.
+      Input the most recent approved and actual expenditures.
 outline:
   title: Prior Activities Overview
   instruction:


### PR DESCRIPTION
change page according to before/after screenshots in #2291.  Closes #2291

### This pull request changes...

- Change from "costs" to expenditures, add expenditures to Actual on table
- Aligned headers in table
- Header of tables changed to "Actual Expenditures"

### This pull request is ready to merge when...

- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
~~- [ ] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~~
~~- [ ] The change has been documented~~
~~- [ ] Associated OpenAPI documentation has been updated~~
- [ ] Changelog is updated as appropriate

### This feature is done when...

- [ ] Design has approved the experience
- [ ] Product has approved the experience
