### PR TITLE
Use 'Start date' and 'End date' consistently for date ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Anticipated release: June 29, 2020
 #### 🐛 Bugs fixed
 
 - Update copy for Milestones ([#2246])
+- Use consistent naming for Activity dates ([#2251])
 
 #### ⚙️ Behind the scenes
 
@@ -21,5 +22,6 @@ See our [release history](https://github.com/18F/cms-hitech-apd/releases)
 
 [#2229]: https://github.com/18F/cms-hitech-apd/issues/2229
 [#2246]: https://github.com/18F/cms-hitech-apd/issues/2246
+[#2251]: https://github.com/18F/cms-hitech-apd/issues/2251
 [#2290]: https://github.com/18F/cms-hitech-apd/issues/2290
 [#2291]: https://github.com/18F/cms-hitech-apd/issues/2291

--- a/web/src/containers/ExecutiveSummary.js
+++ b/web/src/containers/ExecutiveSummary.js
@@ -51,7 +51,7 @@ const ExecutiveSummary = ({ data, jumpAction, total, years }) => {
             {activity.summary && <p>{activity.summary}</p>}
             <ul className="ds-c-list--bare">
               <li>
-                <strong>Date:</strong> {activity.dateRange}
+                <strong>Start date - End date:</strong> {activity.dateRange}
               </li>
               <li>
                 <strong>Total cost of activity:</strong>{' '}

--- a/web/src/containers/__snapshots__/ExecutiveSummary.test.js.snap
+++ b/web/src/containers/__snapshots__/ExecutiveSummary.test.js.snap
@@ -38,7 +38,7 @@ exports[`executive summary component navigates to activities 1`] = `
       >
         <li>
           <strong>
-            Date:
+            Start date - End date:
           </strong>
            
         </li>
@@ -147,7 +147,7 @@ exports[`executive summary component navigates to activities 1`] = `
       >
         <li>
           <strong>
-            Date:
+            Start date - End date:
           </strong>
            
         </li>
@@ -381,7 +381,7 @@ exports[`executive summary component renders correctly 1`] = `
       >
         <li>
           <strong>
-            Date:
+            Start date - End date:
           </strong>
            
         </li>
@@ -490,7 +490,7 @@ exports[`executive summary component renders correctly 1`] = `
       >
         <li>
           <strong>
-            Date:
+            Start date - End date:
           </strong>
            
         </li>

--- a/web/src/containers/activity/ContractorResource/ContractorResourceForm.js
+++ b/web/src/containers/activity/ContractorResource/ContractorResourceForm.js
@@ -85,12 +85,12 @@ const ContractorResourceForm = ({
       <FormLabel>Contract Term</FormLabel>
       <div className="ds-c-choice__checkedChild ds-u-padding-y--0">
         <DateField
-          label="Start"
+          label="Start date"
           value={start}
           onChange={getDateHandler(setStartDate)}
         />
         <DateField
-          label="End"
+          label="End date"
           hint=""
           value={end}
           onChange={getDateHandler(setEndDate)}

--- a/web/src/containers/activity/ContractorResource/ContractorResourceForm.test.js
+++ b/web/src/containers/activity/ContractorResource/ContractorResourceForm.test.js
@@ -97,7 +97,7 @@ describe('the ContractorResourceForm component', () => {
   test('handles changing the contractor start date', () => {
     const component = shallow(<ContractorForm {...props} />);
     component
-      .findWhere(c => c.name() === 'DateField' && c.prop('label') === 'Start')
+      .findWhere(c => c.prop('label') === 'Start date')
       .simulate('change', 'ignored stuff', 'new start date');
 
     expect(props.setStartDate).toHaveBeenCalledWith(43, 1, 'new start date');
@@ -106,7 +106,7 @@ describe('the ContractorResourceForm component', () => {
   test('handles changing the contractor end date', () => {
     const component = shallow(<ContractorForm {...props} />);
     component
-      .findWhere(c => c.name() === 'DateField' && c.prop('label') === 'End')
+      .findWhere(c => c.prop('label') === 'End date')
       .simulate('change', 'ignored stuff', 'new end date');
 
     expect(props.setEndDate).toHaveBeenCalledWith(43, 1, 'new end date');

--- a/web/src/containers/activity/ContractorResource/__snapshots__/ContractorResourceForm.test.js.snap
+++ b/web/src/containers/activity/ContractorResource/__snapshots__/ContractorResourceForm.test.js.snap
@@ -26,13 +26,13 @@ exports[`the ContractorResourceForm component renders correctly 1`] = `
     className="ds-c-choice__checkedChild ds-u-padding-y--0"
   >
     <DateField
-      label="Start"
+      label="Start date"
       onChange={[Function]}
       value="1066-10-14"
     />
     <DateField
       hint=""
-      label="End"
+      label="End date"
       onChange={[Function]}
       value="1066-10-15"
     />
@@ -192,13 +192,13 @@ exports[`the ContractorResourceForm component renders if use hourly data is sele
     className="ds-c-choice__checkedChild ds-u-padding-y--0"
   >
     <DateField
-      label="Start"
+      label="Start date"
       onChange={[Function]}
       value="1066-10-14"
     />
     <DateField
       hint=""
-      label="End"
+      label="End date"
       onChange={[Function]}
       value="1066-10-15"
     />

--- a/web/src/containers/activity/Schedule.js
+++ b/web/src/containers/activity/Schedule.js
@@ -25,12 +25,12 @@ const Schedule = ({ activity, activityIndex, setEndDate, setStartDate }) => {
       <Fragment>
         <div className="ds-u-padding-y--0 visibility--screen">
           <DateField
-            label="Planned start date"
+            label="Start date"
             value={activity.plannedStartDate}
             onChange={handleActivityStartChange}
           />
           <DateField
-            label="Planned end date"
+            label="End date"
             value={activity.plannedEndDate}
             onChange={handleActivityEndChange}
           />

--- a/web/src/containers/activity/Schedule.js
+++ b/web/src/containers/activity/Schedule.js
@@ -37,11 +37,11 @@ const Schedule = ({ activity, activityIndex, setEndDate, setStartDate }) => {
         </div>
         <div className="visibility--print">
           <p>
-            <strong>Planned start date:</strong>{' '}
+            <strong>Start date:</strong>{' '}
             {stateDateToDisplay(activity.plannedStartDate)}
           </p>
           <p>
-            <strong>Planned end date:</strong>{' '}
+            <strong>End date:</strong>{' '}
             {stateDateToDisplay(activity.plannedEndDate)}
           </p>
           <hr />

--- a/web/src/containers/activity/__snapshots__/Schedule.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/Schedule.test.js.snap
@@ -26,14 +26,14 @@ exports[`the Schedule (milestones) component renders correctly 1`] = `
   >
     <p>
       <strong>
-        Planned start date:
+        Start date:
       </strong>
        
       10/2/1944
     </p>
     <p>
       <strong>
-        Planned end date:
+        End date:
       </strong>
        
       11/8/1944

--- a/web/src/containers/activity/__snapshots__/Schedule.test.js.snap
+++ b/web/src/containers/activity/__snapshots__/Schedule.test.js.snap
@@ -11,12 +11,12 @@ exports[`the Schedule (milestones) component renders correctly 1`] = `
     className="ds-u-padding-y--0 visibility--screen"
   >
     <DateField
-      label="Planned start date"
+      label="Start date"
       onChange={[Function]}
       value="1944-10-02"
     />
     <DateField
-      label="Planned end date"
+      label="End date"
       onChange={[Function]}
       value="1944-11-08"
     />

--- a/web/src/containers/viewOnly/ExecutiveSummary.js
+++ b/web/src/containers/viewOnly/ExecutiveSummary.js
@@ -61,7 +61,7 @@ class ExecutiveSummary extends PureComponent {
 
             <ul className="ds-c-list--bare">
               <li>
-                <strong>Date:</strong> {activity.dateRange}
+                <strong>Start date - End date:</strong> {activity.dateRange}
               </li>
               <li>
                 <strong>Total cost of activity:</strong>{' '}

--- a/web/src/containers/viewOnly/activities/Activity.js
+++ b/web/src/containers/viewOnly/activities/Activity.js
@@ -148,11 +148,11 @@ const Activity = ({ activity, activityIndex }) => {
         <strong>Activity Summary:</strong> {activity.summary}
       </p>
       <p>
-        <strong>Planned start date: </strong>
+        <strong>Start date: </strong>
         {activity.plannedStartDate || 'None provided'}
       </p>
       <p>
-        <strong>Planned end date: </strong>
+        <strong>End date: </strong>
         {activity.plannedEndDate || 'None provided'}
       </p>
       <hr className="subsection-rule" />

--- a/web/src/i18n/locales/en/scheduleSummary.yaml
+++ b/web/src/i18n/locales/en/scheduleSummary.yaml
@@ -11,5 +11,5 @@ main:
   table:
     activity: Activity
     milestone: Milestone
-    start: Planned start
-    end: Planned end
+    start: Start date
+    end: End date


### PR DESCRIPTION
Resolves #2251 

### This pull request changes the following Components...

- Schedule
- ContractorResourceForm
- ExecutiveSummary

### This pull request is ready to merge when...

- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [x] The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented
- [x] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated
- [x] Changelog is updated as appropriate

### This feature is done when...

- [x] Design has approved the experience
- [x] Product has approved the experience
