### PR TITLE
Switch to token auth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -530,7 +530,7 @@ jobs:
             pip install --quiet awscli
             ./aws.cleanup.sh \
               --AWS_REGION "$PRODUCTION_API_AWS_REGION" \
-              --GH_BOT_PASSWORD "$GH_BOT_PASSWORD" \
+              --GH_BOT_TOKEN "$GH_BOT_TOKEN" \
               --GH_BOT_USER "$GH_BOT_USER"
 
   # Frontend production deployment.

--- a/bin/preview-deploy/aws.cleanup.sh
+++ b/bin/preview-deploy/aws.cleanup.sh
@@ -97,10 +97,10 @@ function terminateIfClosedPR() {
 #
 # $1 - pull request number
 function updateGithubComment() {
-  COMMENTS=$(curl -s -u "$GH_BOT_USER:$GH_BOT_PASSWORD" https://api.github.com/repos/18f/cms-hitech-apd/issues/$1/comments | jq -c -r '.[] | {id:.id,user:.user.login}' | grep "$GH_BOT_USER" || true)
+  COMMENTS=$(curl -s -H "Authorization: token $GH_BOT_PASSWORD" https://api.github.com/repos/18f/cms-hitech-apd/issues/$1/comments | jq -c -r '.[] | {id:.id,user:.user.login}' | grep "$GH_BOT_USER" || true)
   if [ "$COMMENTS" ]; then
     ID=$(echo "$COMMENTS" | jq -c -r .id)
-    curl -s -u "$GH_BOT_USER:$GH_BOT_PASSWORD" -d '{"body":"This deploy was cleaned up."}' -H "Content-Type: application/json" -X PATCH "https://api.github.com/repos/18f/cms-hitech-apd/issues/comments/$ID"
+    curl -s -H "Authorization: token $GH_BOT_PASSWORD" -d '{"body":"This deploy was cleaned up."}' -H "Content-Type: application/json" -X PATCH "https://api.github.com/repos/18f/cms-hitech-apd/issues/comments/$ID"
   fi
 }
 

--- a/bin/preview-deploy/aws.cleanup.sh
+++ b/bin/preview-deploy/aws.cleanup.sh
@@ -100,7 +100,11 @@ function updateGithubComment() {
   COMMENTS=$(curl -s -H "Authorization: token $GH_BOT_PASSWORD" https://api.github.com/repos/18f/cms-hitech-apd/issues/$1/comments | jq -c -r '.[] | {id:.id,user:.user.login}' | grep "$GH_BOT_USER" || true)
   if [ "$COMMENTS" ]; then
     ID=$(echo "$COMMENTS" | jq -c -r .id)
-    curl -s -H "Authorization: token $GH_BOT_PASSWORD" -d '{"body":"This deploy was cleaned up."}' -H "Content-Type: application/json" -X PATCH "https://api.github.com/repos/18f/cms-hitech-apd/issues/comments/$ID"
+    curl -s \
+      -H "Authorization: token $GH_BOT_PASSWORD" \
+      -H "Content-Type: application/json" \
+      -d '{"body":"This deploy was cleaned up."}' \
+      -X PATCH "https://api.github.com/repos/18f/cms-hitech-apd/issues/comments/$ID"
   fi
 }
 

--- a/bin/preview-deploy/aws.cleanup.sh
+++ b/bin/preview-deploy/aws.cleanup.sh
@@ -4,8 +4,8 @@
 #    --AWS_REGION <AWS region name>   | The AWS region the instance should be
 #                                     | created in
 #                                     |----------------------------------------
-#    --GH_BOT_PASSWORD <password>     | Password of the Github user to update
-#                                     | comments as
+#    --GH_BOT_TOKEN <token>           | Personal access token for the Github
+#                                     | user to update comments as
 #                                     |----------------------------------------
 #    --GH_BOT_USER <username>         | Username of the Github user to update
 #                                     | comments as. These are the comments
@@ -97,11 +97,11 @@ function terminateIfClosedPR() {
 #
 # $1 - pull request number
 function updateGithubComment() {
-  COMMENTS=$(curl -s -H "Authorization: token $GH_BOT_PASSWORD" https://api.github.com/repos/18f/cms-hitech-apd/issues/$1/comments | jq -c -r '.[] | {id:.id,user:.user.login}' | grep "$GH_BOT_USER" || true)
+  COMMENTS=$(curl -s -H "Authorization: token $GH_BOT_TOKEN" https://api.github.com/repos/18f/cms-hitech-apd/issues/$1/comments | jq -c -r '.[] | {id:.id,user:.user.login}' | grep "$GH_BOT_USER" || true)
   if [ "$COMMENTS" ]; then
     ID=$(echo "$COMMENTS" | jq -c -r .id)
     curl -s \
-      -H "Authorization: token $GH_BOT_PASSWORD" \
+      -H "Authorization: token $GH_BOT_TOKEN" \
       -H "Content-Type: application/json" \
       -d '{"body":"This deploy was cleaned up."}' \
       -X PATCH "https://api.github.com/repos/18f/cms-hitech-apd/issues/comments/$ID"

--- a/bin/preview-deploy/github-comment.sh
+++ b/bin/preview-deploy/github-comment.sh
@@ -14,15 +14,15 @@ function postOrUpdateComment() {
   local GIT_SHA=$3
 
   # Update the comment on Github, if there's one already.  This way we'll know the bot updated the thing.
-  COMMENTS=$(curl -s -u "$GH_BOT_USER:$GH_BOT_PASSWORD" https://api.github.com/repos/18f/cms-hitech-apd/issues/$PRNUM/comments | jq -c -r '.[] | {id:.id,user:.user.login}' | grep "$GH_BOT_USER" || true)
+  COMMENTS=$(curl -s -H "Authorization: token $GH_BOT_PASSWORD" https://api.github.com/repos/18f/cms-hitech-apd/issues/$PRNUM/comments | jq -c -r '.[] | {id:.id,user:.user.login}' | grep "$GH_BOT_USER" || true)
   if [ "$COMMENTS" ]; then
     ID=$(echo "$COMMENTS" | jq -c -r .id)
     # Use $ before the body to use ANSI encoding, which preserves the newlines.
     # Add the commit SHA so we know it deployed and when.
-    curl -s -u "$GH_BOT_USER:$GH_BOT_PASSWORD" -d $'{"body":"See this pull request in action: '"$PREVIEW_URL"'\n\n'"$GIT_SHA"'"}' -H "Content-Type: application/json" -X PATCH "https://api.github.com/repos/18f/cms-hitech-apd/issues/comments/$ID"
+    curl -s -H "Authorization: token $GH_BOT_PASSWORD" -d $'{"body":"See this pull request in action: '"$PREVIEW_URL"'\n\n'"$GIT_SHA"'"}' -H "Content-Type: application/json" -X PATCH "https://api.github.com/repos/18f/cms-hitech-apd/issues/comments/$ID"
   else
     # Post a new message if one doesn't already exist.
-    curl -s -u "$GH_BOT_USER:$GH_BOT_PASSWORD" -d '{"body":"See this pull request in action: '"$PREVIEW_URL"'"}' -H "Content-Type: application/json" -X POST "https://api.github.com/repos/18f/cms-hitech-apd/issues/$PRNUM/comments"
+    curl -s -H "Authorization: token $GH_BOT_PASSWORD" -d '{"body":"See this pull request in action: '"$PREVIEW_URL"'"}' -H "Content-Type: application/json" -X POST "https://api.github.com/repos/18f/cms-hitech-apd/issues/$PRNUM/comments"
   fi
 }
 

--- a/bin/preview-deploy/github-comment.sh
+++ b/bin/preview-deploy/github-comment.sh
@@ -19,10 +19,18 @@ function postOrUpdateComment() {
     ID=$(echo "$COMMENTS" | jq -c -r .id)
     # Use $ before the body to use ANSI encoding, which preserves the newlines.
     # Add the commit SHA so we know it deployed and when.
-    curl -s -H "Authorization: token $GH_BOT_PASSWORD" -d $'{"body":"See this pull request in action: '"$PREVIEW_URL"'\n\n'"$GIT_SHA"'"}' -H "Content-Type: application/json" -X PATCH "https://api.github.com/repos/18f/cms-hitech-apd/issues/comments/$ID"
+    curl -s \
+      -H "Authorization: token $GH_BOT_PASSWORD" \
+      -H "Content-Type: application/json" \
+      -d $'{"body":"See this pull request in action: '"$PREVIEW_URL"'\n\n'"$GIT_SHA"'"}' \
+      -X PATCH "https://api.github.com/repos/18f/cms-hitech-apd/issues/comments/$ID"
   else
     # Post a new message if one doesn't already exist.
-    curl -s -H "Authorization: token $GH_BOT_PASSWORD" -d '{"body":"See this pull request in action: '"$PREVIEW_URL"'"}' -H "Content-Type: application/json" -X POST "https://api.github.com/repos/18f/cms-hitech-apd/issues/$PRNUM/comments"
+    curl -s \
+      -H "Authorization: token $GH_BOT_PASSWORD" \
+      -H "Content-Type: application/json" \
+      -d '{"body":"See this pull request in action: '"$PREVIEW_URL"'"}' \
+      -X POST "https://api.github.com/repos/18f/cms-hitech-apd/issues/$PRNUM/comments"
   fi
 }
 

--- a/bin/preview-deploy/github-comment.sh
+++ b/bin/preview-deploy/github-comment.sh
@@ -7,27 +7,27 @@
 #
 # Expects global environment variables:
 #   GH_BOT_USER - The username of the Github user to post as
-#   GH_BOT_PASSWORD - The password for the Github user
+#   GH_BOT_TOKEN - The personal access token for the Github user
 function postOrUpdateComment() {
   local PRNUM=$1
   local PREVIEW_URL=$2
   local GIT_SHA=$3
 
   # Update the comment on Github, if there's one already.  This way we'll know the bot updated the thing.
-  COMMENTS=$(curl -s -H "Authorization: token $GH_BOT_PASSWORD" https://api.github.com/repos/18f/cms-hitech-apd/issues/$PRNUM/comments | jq -c -r '.[] | {id:.id,user:.user.login}' | grep "$GH_BOT_USER" || true)
+  COMMENTS=$(curl -s -H "Authorization: token $GH_BOT_TOKEN" https://api.github.com/repos/18f/cms-hitech-apd/issues/$PRNUM/comments | jq -c -r '.[] | {id:.id,user:.user.login}' | grep "$GH_BOT_USER" || true)
   if [ "$COMMENTS" ]; then
     ID=$(echo "$COMMENTS" | jq -c -r .id)
     # Use $ before the body to use ANSI encoding, which preserves the newlines.
     # Add the commit SHA so we know it deployed and when.
     curl -s \
-      -H "Authorization: token $GH_BOT_PASSWORD" \
+      -H "Authorization: token $GH_BOT_TOKEN" \
       -H "Content-Type: application/json" \
       -d $'{"body":"See this pull request in action: '"$PREVIEW_URL"'\n\n'"$GIT_SHA"'"}' \
       -X PATCH "https://api.github.com/repos/18f/cms-hitech-apd/issues/comments/$ID"
   else
     # Post a new message if one doesn't already exist.
     curl -s \
-      -H "Authorization: token $GH_BOT_PASSWORD" \
+      -H "Authorization: token $GH_BOT_TOKEN" \
       -H "Content-Type: application/json" \
       -d '{"body":"See this pull request in action: '"$PREVIEW_URL"'"}' \
       -X POST "https://api.github.com/repos/18f/cms-hitech-apd/issues/$PRNUM/comments"


### PR DESCRIPTION
Github is [deprecating basic authentication](https://developer.github.com/changes/2020-02-14-deprecating-password-auth/), which is how the @cms-eapd-bot posts preview URLs today. Instead, they recommend using a personal access token via header authentication. We had previously switched to using the access token, but did not switch to header authentication. This PR makes the switch complete so that Github will stop complaining to me. 😄

### This pull request changes...

- updates the script that posts and updates the Github message as new preview deploys are released
- updates the script that updates the Github message when a preview deploy is removed

#### TODO:

- need @NAretakis or @jeromeleecms to have their email addresses associated with the bot so that CMS can fully own it and get Github notifications when there is a problem. Unfortunately, Github only allows an email address to be associated with a single account, so if you happen to have a second CMS email address, that might work out perfectly...

### This pull request is ready to merge when...

- N/A ~Tests have been updated (and all tests are passing)~
- [ ] This code has been reviewed by someone other than the original author
- N/A ~The experience passes a basic manual accessibility audit (keyboard nav, screenreader, text scaling) OR an exemption is documented~
- N/A ~The change has been documented~
- N/A ~Changelog is updated as appropriate~